### PR TITLE
PERF-1472: Basic CMake and driver to read yaml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ set_property(TARGET boost PROPERTY
 add_definitions(-DBOOST_ALL_DYN_LINK)
 # </Boost>
 
+# <Yaml CPP>
+set(YAMLCPP_STATIC_LIBRARY FALSE)
+find_package(yaml-cpp REQUIRED)
+# </Yaml CPP>
+
 # <Misc 3rd Party Integrations>
 set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
 # </Misc 3rd Party Integrations>

--- a/src/driver/src/main.cpp
+++ b/src/driver/src/main.cpp
@@ -1,12 +1,33 @@
+#include <fstream>
 #include <iostream>
 #include <optional>
 #include <string>
 
+#include <yaml-cpp/yaml.h>
+
 #include <gennylib/version.hpp>
 
-int main() {
+int main(int argc, char**argv) {
     // basically just a test that we're using c++17
     auto v { std::make_optional(genny::getVersion()) };
     std::cout << u8"🧞 Genny" << " Version " << v.value_or("ERROR") << u8" 💝🐹🌇⛔" << std::endl;
+
+    if (argc <= 2) {
+        return 0;
+    }
+
+    // test we can load yaml (just smoke-testing yaml for now, this will be real soon!)
+    const char* fileName = argv[1];
+    if (argc >= 3 && strncmp("--debug", argv[2], 100) != 0) {
+        fileName = argv[2];
+        auto yamlFile = std::ifstream {fileName, std::ios_base::binary};
+        std::cout << "YAML File" << fileName << ":" << std::endl << yamlFile.rdbuf();
+    }
+
+    auto config = YAML::LoadFile(fileName);
+
+    std::cout << std::endl << "Using Schema Version:" << std::endl
+              << config["SchemaVersion"].as<std::string>() << std::endl;
+
     return 0;
 }

--- a/src/driver/test/Workload.yml
+++ b/src/driver/test/Workload.yml
@@ -1,0 +1,2 @@
+SchemaVersion: 2018-06-22
+

--- a/src/gennylib/CMakeLists.txt
+++ b/src/gennylib/CMakeLists.txt
@@ -14,14 +14,17 @@ target_include_directories(gennylib
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
         ${Boost_INCLUDE_DIR}
+        ${YAML_CPP_INCLUDE_DIR}
     PRIVATE
         src
 )
 
 
-# Depend on a library that we defined in the top-level file
+# Depend on libraries that we defined in the top-level CMakeLists.txt file
 target_link_libraries(gennylib
-    PUBLIC ${Boost_LIBRARIES}
+    PUBLIC
+        ${Boost_LIBRARIES}
+        ${YAML_CPP_LIBRARIES}
 )
 
 # 'make install' to the correct locations (provided by GNUInstallDirs).


### PR DESCRIPTION
First step to configuring actors with config files is to read config files. Then once #4 is merged can construct the actors from the config.

Haven't yet tested this on Evergreen or Ubuntu; that will come after merging #4 and working out kinks there.