### PR TITLE
Allow config values to be absent when calling `context.get()`

### DIFF
--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -117,7 +117,7 @@ OutV get_helper(const ConfigPath& parent, const Current& curr) {
             error << "Invalid key at path [" << parent << "]";
             throw InvalidConfigurationException(error.str());
         } else {
-            return std::make_optional<Out>();
+            return std::nullopt;
         }
     }
     try {
@@ -169,7 +169,7 @@ OutV get_helper(ConfigPath& parent,
                   << curr << "].";
             throw InvalidConfigurationException(error.str());
         } else {
-            return std::make_optional<Out>();
+            return std::nullopt;
         }
     }
     return V1::get_helper<Out, Current, Required>(parent, next, std::forward<PathRest>(rest)...);

--- a/src/gennylib/test/context_test.cpp
+++ b/src/gennylib/test/context_test.cpp
@@ -102,12 +102,12 @@ Actors:
         gives<int>("Some Ints: [1,2,[3,4]]", 3, "Some Ints", 2, 0);
         gives<int>("Some Ints: [1,2,[3,4]]", 4, "Some Ints", 2, 1);
 
-        gives<int, false>("A: 1", make_optional<int>(), "B");
+        gives<int, false>("A: 1", std::nullopt, "B");
         gives<int, false>("A: 2", make_optional<int>(2), "A");
         gives<int, false>("A: {B: [1,2,3]}", make_optional<int>(2), "A", "B", 1);
 
-        gives<int, false>("A: {B: [1,2,3]}", make_optional<int>(), "A", "B", 30);
-        gives<int, false>("A: {B: [1,2,3]}", make_optional<int>(), "B");
+        gives<int, false>("A: {B: [1,2,3]}", std::nullopt, "A", "B", 30);
+        gives<int, false>("A: {B: [1,2,3]}", std::nullopt, "B");
     }
 
     SECTION("Empty Yaml") {


### PR DESCRIPTION
Allow `context.get()` to return a `std::optional<T>` for values that are allowed to be missing from config.

This is a requirement to implement optional `Repeat` functionality in PERF-1620.