### PR TITLE
Don't use string_view::to_string

### DIFF
--- a/src/gennylib/src/value_generators/generators-private.cpp
+++ b/src/gennylib/src/value_generators/generators-private.cpp
@@ -207,7 +207,7 @@ std::string valAsString(view_or_value val) {
             return (std::to_string(elem.get_double().value));
             break;
         case bsoncxx::type::k_utf8:
-            return (elem.get_utf8().value.to_string());
+            return (std::string{elem.get_utf8().value});
             break;
         case bsoncxx::type::k_document:
         case bsoncxx::type::k_array:


### PR DESCRIPTION
So. Depending on how the C++ driver is built, it can use either STL's `string_view` or a polyfill. So the polyfill is now buggy. The polyfill has `std::string_view::to_string` bu the STL doesn't (I think it was removed from the spec).

I don't know why this only came up when trying to build on Arch linux. It builds fine on OS X and Docker-based Ubuntu 18.04. ¯\\\_(ツ)\_/¯

This PR removes the calls to `to_string()` in favor of user-constructing `std::string`s.

Tested on Vagrant-based Arch (thanks to Jim for doing the hard work of getting that dev env up).

```sh
cmake \
    -DCMAKE_CXX_FLAGS=-pthread \
     ..
```