### PR TITLE
Comment out broken OS X Builder

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -57,16 +57,17 @@ buildvariants:
   tasks:
   - name: t_test
 
-- name: macos-1012
-  display_name: OS X Sierra
-  modules: ~
-  run_on:
-  - macos-1012
-  expansions:
-    path: "/Applications/CMake.app/Contents/bin"
-    cmake_cxx_flags: ""
-  tasks:
-  - name: t_test
+# TODO: TIG-1056 the OS X image doesn't have a recent CMake or C++ compiler
+# - name: macos-1012
+#   display_name: OS X Sierra
+#   modules: ~
+#   run_on:
+#   - macos-1012
+#   expansions:
+#     path: "/Applications/CMake.app/Contents/bin"
+#     cmake_cxx_flags: ""
+#   tasks:
+#   - name: t_test
 
 
 ##                ⚡️ Tasks ⚡️


### PR DESCRIPTION
Per [TIG-1056](https://jira.mongodb.org/browse/TIG-1056), the OS X machines aren't sufficient for building Genny (cmake and compiler aren't current; need to add some brew formulae as well). Rather than letting it fail and waste cycles just comment it out for now until we can focus on it in TIG-1056.

The archlinux builder works great, running tests on OSX is just nice-to-have since it's a common development platform.