### PR TITLE
Truncate metrics output file

### DIFF
--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -99,7 +99,7 @@ int genny::driver::DefaultDriver::run(const genny::driver::ProgramOptions& optio
     const auto reporter = genny::metrics::Reporter{metrics};
 
     std::ofstream metricsOutput;
-    metricsOutput.open(options.metricsOutputFileName, std::ofstream::out | std::ofstream::app);
+    metricsOutput.open(options.metricsOutputFileName, std::ofstream::out | std::ofstream::trunc);
     reporter.report(metricsOutput, options.metricsFormat);
     metricsOutput.close();
 


### PR DESCRIPTION
Does what it says on the tin.

- this was arguably a bug since the beginning
- lets us get rid of [some cruft in DSI](https://github.com/10gen/dsi/blob/master/configurations/test_control/test_control.genny_workloads.yml#L16-L19)
- may be the source of two tickets [BF-11098](https://jira.mongodb.org/browse/BF-11098) and [TIG-1198](https://jira.mongodb.org/browse/TIG-1198) although that's speculative

Verified locally that the metrics file is created anew for each run.