### PR TITLE
Perf 1759: Adjust BigUpdate workload to be sub-saturation

### DIFF
--- a/src/driver/test/BigUpdate.yml
+++ b/src/driver/test/BigUpdate.yml
@@ -13,7 +13,7 @@ Actors:
     Type: Loader
     Threads: 10
     Database: &DB test
-    CollectionCount: &CollectionCount 10000
+    CollectionCount: &CollectionCount 1000
     DocumentCount: 10000
     BatchSize: 1000
     Document:  # Documents are approximately 1 KiB in size


### PR DESCRIPTION
Patch build here: https://evergreen.mongodb.com/version/5c1aab432a60ed3e8c7ebb05

I'm running for 10 test phase for 10 minutes. The target was 20-30% below unthrottled performance. I did that my adjusting the minimum cycle time for the requests. Also, using 1000 collections, which seems to work. 10k fails. The workload seems to be CPU limited. Assuming max CPU is 50% (because of numactl) and doing some math on that, we have about ~20% headroom on the 3 node replica set, 30% headroom on the 1 node replica set, and ~44% headroom on the standalone node. Because of the throttling, all 3 achieve the same throughput for the queries and updates. 

Note that the tasks report a measure on latency. I'm going to use this new workload to drive some Expanded Metrics conversations. Right now it's reporting average latency, in (I believe) nanoseconds. 

The tasks themselves take about an hour. A large portion of that is the validation afterwards. I believe the large number of collections are making that worse. 