### PR TITLE
Don't use structured-binding for PhaseLoopIterator

### DIFF
--- a/src/cast_core/src/actors/HelloWorld.cpp
+++ b/src/cast_core/src/actors/HelloWorld.cpp
@@ -15,7 +15,7 @@ struct HelloWorld::PhaseConfig {
 };
 
 void HelloWorld::run() {
-    for (auto&& [phase, config] : _loop) {
+    for (auto&& config : _loop) {
         for (auto _ : config) {
             auto ctx = this->_operation.start();
             BOOST_LOG_TRIVIAL(info) << config->message;

--- a/src/cast_core/src/actors/Insert.cpp
+++ b/src/cast_core/src/actors/Insert.cpp
@@ -27,7 +27,7 @@ struct Insert::PhaseConfig {
 };
 
 void Insert::run() {
-    for (auto&& [phase, config] : _loop) {
+    for (auto&& config : _loop) {
         for (const auto&& _ : config) {
             auto op = _insertTimer.raii();
             bsoncxx::builder::stream::document mydoc{};

--- a/src/cast_core/src/actors/InsertRemove.cpp
+++ b/src/cast_core/src/actors/InsertRemove.cpp
@@ -33,7 +33,7 @@ struct InsertRemove::PhaseConfig {
 };
 
 void InsertRemove::run() {
-    for (auto&& [phase, config] : _loop) {
+    for (auto&& config : _loop) {
         for (auto&& _ : config) {
             BOOST_LOG_TRIVIAL(info) << " Inserting and then removing";
             {

--- a/src/cast_core/src/actors/Loader.cpp
+++ b/src/cast_core/src/actors/Loader.cpp
@@ -55,7 +55,7 @@ struct Loader::PhaseConfig {
 };
 
 void genny::actor::Loader::run() {
-    for (auto&& [phase, config] : _loop) {
+    for (auto&& config : _loop) {
         for (auto&& _ : config) {
             for (uint i = config->collectionOffset;
                  i < config->collectionOffset + config->numCollections;

--- a/src/cast_core/src/actors/MultiCollectionQuery.cpp
+++ b/src/cast_core/src/actors/MultiCollectionQuery.cpp
@@ -36,7 +36,7 @@ struct MultiCollectionQuery::PhaseConfig {
 };
 
 void MultiCollectionQuery::run() {
-    for (auto&& [phase, config] : _loop) {
+    for (auto&& config : _loop) {
         for (auto&& _ : config) {
             // Take a timestamp -- remove after TIG-1155
             auto startTime = std::chrono::steady_clock::now();

--- a/src/cast_core/src/actors/MultiCollectionUpdate.cpp
+++ b/src/cast_core/src/actors/MultiCollectionUpdate.cpp
@@ -41,7 +41,7 @@ struct MultiCollectionUpdate::PhaseConfig {
 };
 
 void MultiCollectionUpdate::run() {
-    for (auto&& [phase, config] : _loop) {
+    for (auto&& config : _loop) {
         for (auto&& _ : config) {
             // Take a timestamp -- remove after TIG-1155
             auto startTime = std::chrono::steady_clock::now();

--- a/src/cast_core/src/actors/RunCommand.cpp
+++ b/src/cast_core/src/actors/RunCommand.cpp
@@ -101,7 +101,7 @@ struct genny::actor::RunCommand::PhaseConfig {
 };
 
 void genny::actor::RunCommand::run() {
-    for (auto&& [phase, config] : _loop) {
+    for (auto&& config : _loop) {
         for (auto&& _ : config) {
             for (auto&& runCommand : config->runCommandConfigs) {
                 runCommand->run();

--- a/src/driver/test/Driver_test.cpp
+++ b/src/driver/test/Driver_test.cpp
@@ -81,9 +81,9 @@ struct Fails : public genny::Actor {
         return "Fails";
     }
     void run() override {
-        for (auto&& [phase, config] : loop) {
+        for (auto&& config : loop) {
             for (auto&& _ : config) {
-                state.didReachPhase(phase);
+                state.didReachPhase(config.phaseNumber());
 
                 if (config->mode == "NoException") {
                     continue;

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -298,6 +298,10 @@ public:
         return (*_value).operator*();
     }
 
+    PhaseNumber phaseNumber() const {
+        return _currentPhase;
+    }
+
 private:
     Orchestrator& _orchestrator;
     const PhaseNumber _currentPhase;
@@ -337,7 +341,7 @@ public:
           _currentPhase{0},
           _awaitingPlusPlus{false} {}
 
-    std::pair<PhaseNumber, ActorPhase<T>&> operator*() /* cannot be const */ {
+    ActorPhase<T>& operator*() /* cannot be const */ {
         assert(!_awaitingPlusPlus);
         // Intentionally don't bother with cases where user didn't call operator++()
         // between invocations of operator*() and vice-versa.
@@ -358,7 +362,7 @@ public:
             msg << "No phase config found for PhaseNumber=[" << _currentPhase << "]";
             throw InvalidConfigurationException(msg.str());
         }
-        return {_currentPhase, found->second};
+        return found->second;
     }
 
     PhaseLoopIterator& operator++() {

--- a/src/gennylib/test/PhaseLoop_benchmark.cpp
+++ b/src/gennylib/test/PhaseLoop_benchmark.cpp
@@ -40,7 +40,7 @@ struct IncrementsActor : public Actor {
     IncrementsActor(ActorContext& ctx) : Actor(ctx), _loop{ctx} {}
 
     void run() override {
-        for (auto&& [phase, config] : _loop) {
+        for (auto&& config : _loop) {
             for (auto&& _ : config) {
                 ++increments;
             }

--- a/src/gennylib/test/PhaseLoop_test.cpp
+++ b/src/gennylib/test/PhaseLoop_test.cpp
@@ -250,7 +250,7 @@ TEST_CASE("Actual Actor Example") {
         //                        param.
 
         void run() override {
-            for (auto&& [num, cfg] : _loop) {
+            for (auto&& cfg : _loop) {
                 for (auto&& _ : cfg) {
                     ++this->_counters[cfg->_key];
                 }
@@ -293,7 +293,8 @@ TEST_CASE("Actual Actor Example") {
                 : IncrementsMapValues(actorContext, counters) {}
 
             void run() override {
-                for (auto&& [num, cfg] : _loop) {
+                for (auto&& cfg : _loop) {
+                    auto num = cfg.phaseNumber();
                     // This is just for testing purposes. Actors *should* not place any commands
                     // between the top level for-loop and the inner loop.
                     check(num, this->_counters);

--- a/src/gennylib/test/context_test.cpp
+++ b/src/gennylib/test/context_test.cpp
@@ -380,7 +380,7 @@ TEST_CASE("Actors Share WorkloadContext State") {
               _iCounter{WorkloadContext::getActorSharedState<DummyInsert, InsertCounter>()} {}
 
         void run() override {
-            for (auto&& [_, cfg] : _loop) {
+            for (auto&& cfg : _loop) {
                 for (auto&& _ : cfg) {
                     BOOST_LOG_TRIVIAL(info) << "Inserting document at: " << _iCounter;
                     ++_iCounter;
@@ -407,7 +407,7 @@ TEST_CASE("Actors Share WorkloadContext State") {
         }
 
         void run() override {
-            for (auto&& [_, cfg] : _loop) {
+            for (auto&& cfg : _loop) {
                 for (auto&& _ : cfg) {
                     BOOST_LOG_TRIVIAL(info) << "Finding document lower than: " << _iCounter;
                 }


### PR DESCRIPTION
This came up as a part of #68.

This is "nomerge" until #68 decides it wants to go this route.

Turns out we were rarely actually using the `p` in `for(auto&& [p,h] : _loop)`. And since this destructured-binding causes problems if you try to use `p` or `h` inside a lambda, may as well just not use it.