### PR TITLE
TIG-1363: Use '^' and Pascal case for names of value generator types

### DIFF
--- a/src/cast_core/src/actors/MultiCollectionQuery.cpp
+++ b/src/cast_core/src/actors/MultiCollectionQuery.cpp
@@ -58,7 +58,7 @@ void MultiCollectionQuery::run() {
 
             // Select a collection
             // This area is ripe for defining a collection generator, based off a string generator.
-            // It could look like: collection: {@concat: [Collection, @randomint: {min: 0, max:
+            // It could look like: collection: {@Concat: [Collection, @RandomInt: {min: 0, max:
             // *CollectionCount]} Requires a string concat generator, and a translation of a string
             // to a collection
             auto collectionNumber = config->uniformDistribution(_rng);

--- a/src/cast_core/src/actors/MultiCollectionQuery.cpp
+++ b/src/cast_core/src/actors/MultiCollectionQuery.cpp
@@ -58,7 +58,7 @@ void MultiCollectionQuery::run() {
 
             // Select a collection
             // This area is ripe for defining a collection generator, based off a string generator.
-            // It could look like: collection: {@Concat: [Collection, @RandomInt: {min: 0, max:
+            // It could look like: collection: {^Concat: [Collection, ^RandomInt: {min: 0, max:
             // *CollectionCount]} Requires a string concat generator, and a translation of a string
             // to a collection
             auto collectionNumber = config->uniformDistribution(_rng);

--- a/src/driver/test/AuthNInsert.yml
+++ b/src/driver/test/AuthNInsert.yml
@@ -18,5 +18,5 @@ Actors:
   - Phase: 0
     Repeat: 100
     Collection: "Inserts"
-    Document: {"a": {@RandomInt: {min: 50, max: 60}}}
+    Document: {"a": {^RandomInt: {min: 50, max: 60}}}
 

--- a/src/driver/test/AuthNInsert.yml
+++ b/src/driver/test/AuthNInsert.yml
@@ -18,5 +18,5 @@ Actors:
   - Phase: 0
     Repeat: 100
     Collection: "Inserts"
-    Document: {"a": {$randomint: {min: 50, max: 60}}}
+    Document: {"a": {@RandomInt: {min: 50, max: 60}}}
 

--- a/src/driver/test/BigUpdate.yml
+++ b/src/driver/test/BigUpdate.yml
@@ -17,12 +17,12 @@ Actors:
     DocumentCount: 1e4
     BatchSize: 1000
     Document:  # Documents are approximately 1 KiB in size
-      t: {@RandomInt: {min: 0, max: 10}}
-      w: {@RandomInt: {distribution: geometric, p: 0.1}}
+      t: {^RandomInt: {min: 0, max: 10}}
+      w: {^RandomInt: {distribution: geometric, p: 0.1}}
       x: 0
-      y: {@RandomInt: {min: 0, max: 1000}}
-      z: {@RandomInt: {min: 0, max: 2147483647}}  # This is for max int for low probability of conflicts
-      int0: &int {@RandomInt: {distribution: binomial, t: 200, p: 0.5}}
+      y: {^RandomInt: {min: 0, max: 1000}}
+      z: {^RandomInt: {min: 0, max: 2147483647}}  # This is for max int for low probability of conflicts
+      int0: &int {^RandomInt: {distribution: binomial, t: 200, p: 0.5}}
       int1: *int
       int2: *int
       int3: *int
@@ -44,7 +44,7 @@ Actors:
         - 7000
         - 8000
         - 9000
-      string0: &string {@RandomString: {length: {@RandomInt: {min: 5, max: 15}}}}
+      string0: &string {^RandomString: {length: {^RandomInt: {min: 5, max: 15}}}}
       string1: *string
       string2: *string
       string3: *string
@@ -54,8 +54,8 @@ Actors:
       string7: *string
       string8: *string
       string9: *string
-      stringShort: {@RandomString: {length: 1}}
-      stringLong: {@RandomString: {length: 100}}
+      stringShort: {^RandomString: {length: 1}}
+      stringLong: {^RandomString: {length: 100}}
       compressibleStringArray:
         - &cstring AAAAAAAAAAAAAAAAAAAA
         - *cstring
@@ -91,7 +91,7 @@ Actors:
     Threads: 100
     Database: *DB
     CollectionCount: 10  # This is specifically 1% of collections
-    UpdateFilter: {y: {@RandomInt: {distribution: poisson, mean: 100}}}
+    UpdateFilter: {y: {^RandomInt: {distribution: poisson, mean: 100}}}
     Update: {$inc: {x: 1}}
     Phases:
       - Operation:
@@ -103,7 +103,7 @@ Actors:
     Threads: 100
     Database: *DB
     CollectionCount: 100  # This is specifically 10% of collections.
-    Filter: {y: {@RandomInt: {distribution: poisson, mean: 100}}}
+    Filter: {y: {^RandomInt: {distribution: poisson, mean: 100}}}
     Limit: 20
     Phases:
       - Operation:

--- a/src/driver/test/BigUpdate.yml
+++ b/src/driver/test/BigUpdate.yml
@@ -17,12 +17,12 @@ Actors:
     DocumentCount: 1e4
     BatchSize: 1000
     Document:  # Documents are approximately 1 KiB in size
-      t: {$randomint: {min: 0, max: 10}}
-      w: {$randomint: {distribution: geometric, p: 0.1}}
+      t: {@RandomInt: {min: 0, max: 10}}
+      w: {@RandomInt: {distribution: geometric, p: 0.1}}
       x: 0
-      y: {$randomint: {min: 0, max: 1000}}
-      z: {$randomint: {min: 0, max: 2147483647}}  # This is for max int for low probability of conflicts
-      int0: &int {$randomint: {distribution: binomial, t: 200, p: 0.5}}
+      y: {@RandomInt: {min: 0, max: 1000}}
+      z: {@RandomInt: {min: 0, max: 2147483647}}  # This is for max int for low probability of conflicts
+      int0: &int {@RandomInt: {distribution: binomial, t: 200, p: 0.5}}
       int1: *int
       int2: *int
       int3: *int
@@ -44,7 +44,7 @@ Actors:
         - 7000
         - 8000
         - 9000
-      string0: &string {$randomstring: {length: {$randomint: {min: 5, max: 15}}}}
+      string0: &string {@RandomString: {length: {@RandomInt: {min: 5, max: 15}}}}
       string1: *string
       string2: *string
       string3: *string
@@ -54,8 +54,8 @@ Actors:
       string7: *string
       string8: *string
       string9: *string
-      stringShort: {$randomstring: {length: 1}}
-      stringLong: {$randomstring: {length: 100}}
+      stringShort: {@RandomString: {length: 1}}
+      stringLong: {@RandomString: {length: 100}}
       compressibleStringArray:
         - &cstring AAAAAAAAAAAAAAAAAAAA
         - *cstring
@@ -91,7 +91,7 @@ Actors:
     Threads: 100
     Database: *DB
     CollectionCount: 10  # This is specifically 1% of collections
-    UpdateFilter: {y: {$randomint: {distribution: poisson, mean: 100}}}
+    UpdateFilter: {y: {@RandomInt: {distribution: poisson, mean: 100}}}
     Update: {$inc: {x: 1}}
     Phases:
       - Operation:
@@ -103,7 +103,7 @@ Actors:
     Threads: 100
     Database: *DB
     CollectionCount: 100  # This is specifically 10% of collections.
-    Filter: {y: {$randomint: {distribution: poisson, mean: 100}}}
+    Filter: {y: {@RandomInt: {distribution: poisson, mean: 100}}}
     Limit: 20
     Phases:
       - Operation:

--- a/src/driver/test/CollScan.yml
+++ b/src/driver/test/CollScan.yml
@@ -13,11 +13,11 @@ Actors:
     DocumentCount: 10000000 # 10M
     BatchSize: 1000
     Document:  # Documents are approximately 18 - 108 bytes in size
-      x: {@RandomInt: {distribution: geometric, p: 0.1}}
-      string0: {@RandomString: {length: {@RandomInt: {min: 5, max: 50}}}}
-      y: {@RandomInt: {min: 0, max: 2147483647}}
-      string1: {@RandomString: {length: {@RandomInt: {min: 5, max: 50}}}}
-      z: {@RandomInt: {min: 0, max: 2147483647}}
+      x: {^RandomInt: {distribution: geometric, p: 0.1}}
+      string0: {^RandomString: {length: {^RandomInt: {min: 5, max: 50}}}}
+      y: {^RandomInt: {min: 0, max: 2147483647}}
+      string1: {^RandomString: {length: {^RandomInt: {min: 5, max: 50}}}}
+      z: {^RandomInt: {min: 0, max: 2147483647}}
     Indexes:
       - keys: {y: 1}
     Phases:

--- a/src/driver/test/CollScan.yml
+++ b/src/driver/test/CollScan.yml
@@ -13,11 +13,11 @@ Actors:
     DocumentCount: 10000000 # 10M
     BatchSize: 1000
     Document:  # Documents are approximately 18 - 108 bytes in size
-      x: {$randomint: {distribution: geometric, p: 0.1}}
-      string0: {$randomstring: {length: {$randomint: {min: 5, max: 50}}}}
-      y: {$randomint: {min: 0, max: 2147483647}}
-      string1: {$randomstring: {length: {$randomint: {min: 5, max: 50}}}}
-      z: {$randomint: {min: 0, max: 2147483647}}
+      x: {@RandomInt: {distribution: geometric, p: 0.1}}
+      string0: {@RandomString: {length: {@RandomInt: {min: 5, max: 50}}}}
+      y: {@RandomInt: {min: 0, max: 2147483647}}
+      string1: {@RandomString: {length: {@RandomInt: {min: 5, max: 50}}}}
+      z: {@RandomInt: {min: 0, max: 2147483647}}
     Indexes:
       - keys: {y: 1}
     Phases:

--- a/src/driver/test/InsertWithNop.yml
+++ b/src/driver/test/InsertWithNop.yml
@@ -12,14 +12,14 @@ Actors:
     Phases:
       - Operation: Nop
       - Collection: "inserts"
-        Document: {"a": {@RandomInt: {min: 50, max: 60}}}
+        Document: {"a": {^RandomInt: {min: 50, max: 60}}}
       - Operation: Nop
       - Operation: Nop
       - Collection: "inserts"
-        Document: {"b": {@RandomString: {length: {@RandomInt: {min: 5, max: 15}}, alphabet: abcde}}}
+        Document: {"b": {^RandomString: {length: {^RandomInt: {min: 5, max: 15}}, alphabet: abcde}}}
       - Collection: "inserts"
-        Document: {"a": {@RandomInt: {min: 63, max: 70}}}
+        Document: {"a": {^RandomInt: {min: 63, max: 70}}}
       - Operation: Nop
       - Collection: "inserts"
-        Document: {"b": {@RandomString: {length: {@RandomInt: {min: 15, max: 25}}, alphabet: abcde}}}
+        Document: {"b": {^RandomString: {length: {^RandomInt: {min: 15, max: 25}}, alphabet: abcde}}}
       - Operation: Nop

--- a/src/driver/test/InsertWithNop.yml
+++ b/src/driver/test/InsertWithNop.yml
@@ -12,14 +12,14 @@ Actors:
     Phases:
       - Operation: Nop
       - Collection: "inserts"
-        Document: {"a": {$randomint: {min: 50, max: 60}}}
+        Document: {"a": {@RandomInt: {min: 50, max: 60}}}
       - Operation: Nop
       - Operation: Nop
       - Collection: "inserts"
-        Document: {"b": {$randomstring: {length: {$randomint: {min: 5, max: 15}}, alphabet: abcde}}}
+        Document: {"b": {@RandomString: {length: {@RandomInt: {min: 5, max: 15}}, alphabet: abcde}}}
       - Collection: "inserts"
-        Document: {"a": {$randomint: {min: 63, max: 70}}}
+        Document: {"a": {@RandomInt: {min: 63, max: 70}}}
       - Operation: Nop
       - Collection: "inserts"
-        Document: {"b": {$randomstring: {length: {$randomint: {min: 15, max: 25}}, alphabet: abcde}}}
+        Document: {"b": {@RandomString: {length: {@RandomInt: {min: 15, max: 25}}, alphabet: abcde}}}
       - Operation: Nop

--- a/src/driver/test/RunCommand.yml
+++ b/src/driver/test/RunCommand.yml
@@ -15,7 +15,7 @@ Actors:
     - OperationName: RunCommand
       OperationCommand:
         insert: myCollection
-        documents: [{name: {$randomstring: {length: {$randomint: {min: 2, max: 5}}}}, rating: 10, address: someAddress, cuisine: italian}]
+        documents: [{name: {@RandomString: {length: {@RandomInt: {min: 2, max: 5}}}}, rating: 10, address: someAddress, cuisine: italian}]
     - OperationMetricsName: Find
       OperationCommand:
         find: restaurants

--- a/src/driver/test/RunCommand.yml
+++ b/src/driver/test/RunCommand.yml
@@ -15,7 +15,7 @@ Actors:
     - OperationName: RunCommand
       OperationCommand:
         insert: myCollection
-        documents: [{name: {@RandomString: {length: {@RandomInt: {min: 2, max: 5}}}}, rating: 10, address: someAddress, cuisine: italian}]
+        documents: [{name: {^RandomString: {length: {^RandomInt: {min: 2, max: 5}}}}, rating: 10, address: someAddress, cuisine: italian}]
     - OperationMetricsName: Find
       OperationCommand:
         find: restaurants

--- a/src/driver/test/Workload.yml
+++ b/src/driver/test/Workload.yml
@@ -15,6 +15,6 @@ Actors:
     Database: "test"
     Phases:
       - Collection: "inserts"
-        Document: {"a": {@RandomInt: {min: 50, max: 60}}}
+        Document: {"a": {^RandomInt: {min: 50, max: 60}}}
       - Collection: "inserts"
-        Document: {"b": {@RandomString: {length: {@RandomInt: {min: 5, max: 15}}, alphabet: abcde}}}
+        Document: {"b": {^RandomString: {length: {^RandomInt: {min: 5, max: 15}}, alphabet: abcde}}}

--- a/src/driver/test/Workload.yml
+++ b/src/driver/test/Workload.yml
@@ -15,6 +15,6 @@ Actors:
     Database: "test"
     Phases:
       - Collection: "inserts"
-        Document: {"a": {$randomint: {min: 50, max: 60}}}
+        Document: {"a": {@RandomInt: {min: 50, max: 60}}}
       - Collection: "inserts"
-        Document: {"b": {$randomstring: {length: {$randomint: {min: 5, max: 15}}, alphabet: abcde}}}
+        Document: {"b": {@RandomString: {length: {@RandomInt: {min: 5, max: 15}}, alphabet: abcde}}}

--- a/src/gennylib/src/value_generators/generators-private.cpp
+++ b/src/gennylib/src/value_generators/generators-private.cpp
@@ -30,10 +30,10 @@ using bsoncxx::builder::stream::open_document;
 
 namespace {
 
-constexpr std::string_view kRandomIntType = "@RandomInt";
-constexpr std::string_view kRandomStringType = "@RandomString";
-constexpr std::string_view kFastRandomStringType = "@FastRandomString";
-constexpr std::string_view kUseValueType = "@UseValue";
+constexpr std::string_view kRandomIntType = "^RandomInt";
+constexpr std::string_view kRandomStringType = "^RandomString";
+constexpr std::string_view kFastRandomStringType = "^FastRandomString";
+constexpr std::string_view kUseValueType = "^UseValue";
 const std::unordered_set<std::string_view> kGeneratorTypes{
     kFastRandomStringType,
     kRandomIntType,

--- a/src/gennylib/src/value_generators/generators-private.hh
+++ b/src/gennylib/src/value_generators/generators-private.hh
@@ -27,7 +27,6 @@ protected:
     genny::DefaultRandom& _rng;
 };
 
-const std::set<std::string> getGeneratorTypes();
 std::unique_ptr<ValueGenerator> makeUniqueValueGenerator(YAML::Node, genny::DefaultRandom&);
 std::unique_ptr<ValueGenerator> makeUniqueValueGenerator(YAML::Node, std::string, genny::DefaultRandom&);
 std::string valAsString(view_or_value);

--- a/src/gennylib/src/value_generators/parser.cpp
+++ b/src/gennylib/src/value_generators/parser.cpp
@@ -66,7 +66,7 @@ std::string quoteIfNeeded(std::string value) {
 
 void checkTemplates(std::string key,
                     YAML::Node& entry,
-                    std::set<std::string>& templates,
+                    const std::unordered_set<std::string_view>& templates,
                     std::string prefix,
                     std::vector<std::tuple<std::string, std::string, YAML::Node>>& overrides) {
     if (templates.count(key) > 0) {
@@ -88,7 +88,7 @@ void checkTemplates(std::string key,
 
 bsoncxx::document::value parseMap(
     YAML::Node node,
-    std::set<std::string> templates,
+    std::unordered_set<std::string_view> templates,
     std::string prefix,
     std::vector<std::tuple<std::string, std::string, YAML::Node>>& overrides) {
     bsoncxx::builder::stream::document docbuilder{};
@@ -124,14 +124,14 @@ bsoncxx::document::value parseMap(
 
 bsoncxx::document::value parseMap(YAML::Node node) {
     // empty templates, and will throw away overrides
-    std::set<std::string> templates;
+    std::unordered_set<std::string_view> templates;
     std::vector<std::tuple<std::string, std::string, YAML::Node>> overrides;
     return (parseMap(node, templates, "", overrides));
 }
 
 bsoncxx::array::value parseSequence(
     YAML::Node node,
-    std::set<std::string> templates,
+    std::unordered_set<std::string_view> templates,
     std::string prefix,
     std::vector<std::tuple<std::string, std::string, YAML::Node>>& overrides) {
     bsoncxx::builder::stream::array arraybuilder{};
@@ -153,7 +153,7 @@ bsoncxx::array::value parseSequence(
 
 bsoncxx::array::value parseSequence(YAML::Node node) {
     // empty templates, and will throw away overrides
-    std::set<std::string> templates;
+    std::unordered_set<std::string_view> templates;
     std::vector<std::tuple<std::string, std::string, YAML::Node>> overrides;
     return (parseSequence(node, templates, "", overrides));
 }

--- a/src/gennylib/src/value_generators/parser.cpp
+++ b/src/gennylib/src/value_generators/parser.cpp
@@ -88,7 +88,7 @@ void checkTemplates(std::string key,
 
 bsoncxx::document::value parseMap(
     YAML::Node node,
-    std::unordered_set<std::string_view> templates,
+    const std::unordered_set<std::string_view>& templates,
     std::string prefix,
     std::vector<std::tuple<std::string, std::string, YAML::Node>>& overrides) {
     bsoncxx::builder::stream::document docbuilder{};
@@ -131,7 +131,7 @@ bsoncxx::document::value parseMap(YAML::Node node) {
 
 bsoncxx::array::value parseSequence(
     YAML::Node node,
-    std::unordered_set<std::string_view> templates,
+    const std::unordered_set<std::string_view>& templates,
     std::string prefix,
     std::vector<std::tuple<std::string, std::string, YAML::Node>>& overrides) {
     bsoncxx::builder::stream::array arraybuilder{};

--- a/src/gennylib/src/value_generators/parser.hh
+++ b/src/gennylib/src/value_generators/parser.hh
@@ -16,13 +16,13 @@ bool isBool(std::string);
 std::string quoteIfNeeded(std::string);
 bsoncxx::array::value yamlToValue(YAML::Node);
 bsoncxx::document::value parseMap(YAML::Node,
-                                  std::unordered_set<std::string_view>,
+                                  const std::unordered_set<std::string_view>&,
                                   std::string,
                                   std::vector<std::tuple<std::string, std::string, YAML::Node>>&);
 bsoncxx::document::value parseMap(YAML::Node);
 bsoncxx::array::value parseSequence(YAML::Node node);
 bsoncxx::array::value parseSequence(YAML::Node node,
-                                    std::unordered_set<std::string_view>,
+                                    const std::unordered_set<std::string_view>&,
                                     std::string,
                                     std::vector<std::tuple<std::string, std::string, YAML::Node>>&);
 }  // namespace genny::value_generators::parser

--- a/src/gennylib/src/value_generators/parser.hh
+++ b/src/gennylib/src/value_generators/parser.hh
@@ -2,7 +2,8 @@
 #ifndef HEADER_555BBB4B_4C7D_434E_8CB9_67990FAF0947
 #define HEADER_555BBB4B_4C7D_434E_8CB9_67990FAF0947
 
-#include <set>
+#include <string_view>
+#include <unordered_set>
 
 #include <bsoncxx/builder/stream/array.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
@@ -15,13 +16,13 @@ bool isBool(std::string);
 std::string quoteIfNeeded(std::string);
 bsoncxx::array::value yamlToValue(YAML::Node);
 bsoncxx::document::value parseMap(YAML::Node,
-                                  std::set<std::string>,
+                                  std::unordered_set<std::string_view>,
                                   std::string,
                                   std::vector<std::tuple<std::string, std::string, YAML::Node>>&);
 bsoncxx::document::value parseMap(YAML::Node);
 bsoncxx::array::value parseSequence(YAML::Node node);
 bsoncxx::array::value parseSequence(YAML::Node node,
-                                    std::set<std::string>,
+                                    std::unordered_set<std::string_view>,
                                     std::string,
                                     std::vector<std::tuple<std::string, std::string, YAML::Node>>&);
 }  // namespace genny::value_generators::parser

--- a/src/gennylib/test/RunCommandActor_test.cpp
+++ b/src/gennylib/test/RunCommandActor_test.cpp
@@ -290,8 +290,8 @@ TEST_CASE_METHOD(MongoTestFixture,
                   OperationName: RunCommand
                   OperationCommand:
                     findAndModify: testCollection
-                    query: {rating: {@RandomInt: {min: 1, max: 4}}}
-                    update: {$set: {rating: {@RandomInt: {min: 5, max: 10}}}}
+                    query: {rating: {^RandomInt: {min: 1, max: 4}}}
+                    update: {$set: {rating: {^RandomInt: {min: 5, max: 10}}}}
                     upsert: true
         )");
         auto builder = bson_stream::document{};
@@ -482,7 +482,7 @@ TEST_CASE_METHOD(MongoTestFixture,
                 - OperationName: RunCommand
                   OperationCommand:
                     insert: testCollection
-                    documents: [{rating: {@RandomInt: {min: 1, max: 5}}, name: y}, {rating: 10, name: x}]
+                    documents: [{rating: {^RandomInt: {min: 1, max: 5}}, name: y}, {rating: 10, name: x}]
         )");
         auto builder = bson_stream::document{};
         bsoncxx::document::value doc_value = builder << "rating" << 10 << bson_stream::finalize;

--- a/src/gennylib/test/RunCommandActor_test.cpp
+++ b/src/gennylib/test/RunCommandActor_test.cpp
@@ -290,8 +290,8 @@ TEST_CASE_METHOD(MongoTestFixture,
                   OperationName: RunCommand
                   OperationCommand:
                     findAndModify: testCollection
-                    query: {rating: {$randomint: {min: 1, max: 4}}}
-                    update: {$set: {rating: {$randomint: {min: 5, max: 10}}}}
+                    query: {rating: {@RandomInt: {min: 1, max: 4}}}
+                    update: {$set: {rating: {@RandomInt: {min: 5, max: 10}}}}
                     upsert: true
         )");
         auto builder = bson_stream::document{};
@@ -482,7 +482,7 @@ TEST_CASE_METHOD(MongoTestFixture,
                 - OperationName: RunCommand
                   OperationCommand:
                     insert: testCollection
-                    documents: [{rating: {$randomint: {min: 1, max: 5}}, name: y}, {rating: 10, name: x}]
+                    documents: [{rating: {@RandomInt: {min: 1, max: 5}}, name: y}, {rating: 10, name: x}]
         )");
         auto builder = bson_stream::document{};
         bsoncxx::document::value doc_value = builder << "rating" << 10 << bson_stream::finalize;

--- a/src/gennylib/test/document_test.cpp
+++ b/src/gennylib/test/document_test.cpp
@@ -68,7 +68,7 @@ TEST_CASE("Documents are created", "[documents]") {
         auto doc = makeDoc(YAML::Load(R"yaml(
         x :
           y : b
-        z : {@RandomInt: {min: 50, max: 60}}
+        z : {^RandomInt: {min: 50, max: 60}}
     )yaml"),
                            rng);
         // Test that the document is an override document, and gives the right values.
@@ -79,7 +79,7 @@ TEST_CASE("Documents are created", "[documents]") {
     }
     SECTION("DefaultRandom string") {
         auto doc = makeDoc(YAML::Load(R"yaml(
-      string: {@RandomString: {length : 15}}
+      string: {^RandomString: {length : 15}}
     )yaml"),
                            rng);
 

--- a/src/gennylib/test/document_test.cpp
+++ b/src/gennylib/test/document_test.cpp
@@ -68,7 +68,7 @@ TEST_CASE("Documents are created", "[documents]") {
         auto doc = makeDoc(YAML::Load(R"yaml(
         x :
           y : b
-        z : {$randomint: {min: 50, max: 60}}
+        z : {@RandomInt: {min: 50, max: 60}}
     )yaml"),
                            rng);
         // Test that the document is an override document, and gives the right values.
@@ -79,7 +79,7 @@ TEST_CASE("Documents are created", "[documents]") {
     }
     SECTION("DefaultRandom string") {
         auto doc = makeDoc(YAML::Load(R"yaml(
-      string: {$randomstring: {length : 15}}
+      string: {@RandomString: {length : 15}}
     )yaml"),
                            rng);
 


### PR DESCRIPTION
Also changes to use a `std::unordered_set<std::string_view>` instead of a `std::set<std::string>` to eliminate some (but far from all) string copies happening when parsing the templates.

----

@rtimmons, the design document calls for using the `'@'` character as the prefix for the typename of all value generators; however, [the `'@'` character is reserved in the YAML 1.2 specification](https://yaml.org/spec/1.2/spec.html#c-reserved) and therefore cannot be used unquoted. I think it'd be an inconvenience for genny users to need to remember to quote the typenames for the value generators that I'd rather pick a different character. I recall the motivation to use a different character than `'$'` as being due to how `'$'`-prefixed keys are special from a MongoDB perspective and wanting to avoid conflicts. I've put forth the `'^'` character as another option.