### PR TITLE
Add context.getPlural

### DIFF
--- a/src/gennylib/test/context_test.cpp
+++ b/src/gennylib/test/context_test.cpp
@@ -514,6 +514,13 @@ Actors: [{}]
         REQUIRE(c.getPlural<AnotherInt>("Foo", "Foos")[0].value == 5);
     });
 
+    onContext(createYaml("{}"), [](ActorContext& c) {
+        REQUIRE_THROWS_WITH(
+                [&]() {
+                    c.getPlural<int>("Foo","Foos");
+                }(),
+                Matches("Either 'Foo' or 'Foos' required."));
+    });
     onContext(createYaml("Foo: 81"), [](ActorContext& c) {
         REQUIRE_THROWS_WITH(
             [&]() {


### PR DESCRIPTION
We have a few occasions where we want to support both a singular and a plural syntax. Notably `Operation` and `Operations` but probably others too. This adds `context.getPlural` to simplify the calling code.