### PR TITLE
SERVER-36673: Add Secondary Allowed workload

### DIFF
--- a/src/driver/test/SecondaryAllowed.yml
+++ b/src/driver/test/SecondaryAllowed.yml
@@ -1,57 +1,54 @@
 SchemaVersion: 2018-07-01
-
 Actors:
-- Name: Loader
-  Type: Loader
-  Threads: 1
-  Database: test
-  CollectionCount: 1
-  DocumentCount: 100
-  BatchSize: 100
-  Document:
-      x: {$randomint: {min: 0, max: 20}}
-  Indexes:
-  - keys: {x: 1}
-  Phases:
-  - Repeat: 1
-  - Operation:
-      OperationName: Nop
-- Name: SecondaryPreferredRead
-  Type: RunCommand
-  Threads: 1
-  ExecutionStrategy:
-      Retries: 3
-  Database: test
-  Phases:
-  - Operation:
-      OperationName: Nop
-  - Phase: 1
-    Repeat: 1
-    Operation: &find_one
-      MetricsName: "Find"
-      OperationName: RunCommand
-      OperationMinPeriod: 100 microseconds
-      OperationCommand:
-            find: Collection0
-            # readConcern: { level: local }
-            # readPreference: primary
-# - Name: SecondaryAllowedInserts
-#   Type: RunCommand
-#   Threads: 1
-#   Phases:
-#   - Repeat: 1
-#     Database: test
-#     Operations:
-#     - OperationName: RunCommand
-#       OperationCommand:
-#           insert: testCollection 
-#           documents: [{rating: 9}, {rating: 10}, {rating: 8}, {rating: 4}, {rating: 3}]
-#     - OperationMetricsName: Find
-#       OperationCommand: 
-#           find: ratings
-#           filter: {rating: { $gte: 8 }}
-#           readPreference: secondaryPreferred
-#       OperationName: RunCommand
+    - Name: StepdownCommand
+      Type: AdminCommand
+      Threads: 1
+      ExecutionStrategy:
+          Retries: 0
+          ThrowOnFailure: false
+      Phases:
+        - NoOp: true
+        - Phase: 1
+          Repeat: 1
+          Operation:
+              OperationMetricsName: "Stepdown"
+              OperationName: AdminCommand
+              OperationSleepBefore: 30 seconds
+              OperationCommand:
+                  replSetStepDown: 60
+    - Name: SecondaryPreferredRead
+      Type: RunCommand
+      Threads: 10
+      ExecutionStrategy:
+          Retries: 0
+          ThrowOnFailure: false
+      Database: test
+      Phases:
+        - NoOp: true
+        - Phase: 1
+          Operation: &find_one
+              OperationMetricsName: "Find"
+              OperationName: RunCommand
+              OperationIsQuiet: yes
+              OperationMinPeriod: 100 microseconds
+              OperationCommand:
+                  find: Collection0
+                  readConcern: { level: local }
+                  $readPreference: { mode: secondary }
+    - Name: Loader
+      Type: Loader
+      Threads: 1
+      Database: test
+      CollectionCount: 1
+      DocumentCount: 100
+      BatchSize: 100
+      Document:
+          x: {$randomint: {min: 0, max: 20}}
+      Indexes:
+        - keys: {x: 1}
+      Phases:
+        - Phase: 0
+        - NoOp: true
       
           
         

--- a/src/driver/test/SecondaryAllowed.yml
+++ b/src/driver/test/SecondaryAllowed.yml
@@ -1,0 +1,57 @@
+SchemaVersion: 2018-07-01
+
+Actors:
+- Name: Loader
+  Type: Loader
+  Threads: 1
+  Database: test
+  CollectionCount: 1
+  DocumentCount: 100
+  BatchSize: 100
+  Document:
+      x: {$randomint: {min: 0, max: 20}}
+  Indexes:
+  - keys: {x: 1}
+  Phases:
+  - Repeat: 1
+  - Operation:
+      OperationName: Nop
+- Name: SecondaryPreferredRead
+  Type: RunCommand
+  Threads: 1
+  ExecutionStrategy:
+      Retries: 3
+  Database: test
+  Phases:
+  - Operation:
+      OperationName: Nop
+  - Phase: 1
+    Repeat: 1
+    Operation: &find_one
+      MetricsName: "Find"
+      OperationName: RunCommand
+      OperationMinPeriod: 100 microseconds
+      OperationCommand:
+            find: Collection0
+            # readConcern: { level: local }
+            # readPreference: primary
+# - Name: SecondaryAllowedInserts
+#   Type: RunCommand
+#   Threads: 1
+#   Phases:
+#   - Repeat: 1
+#     Database: test
+#     Operations:
+#     - OperationName: RunCommand
+#       OperationCommand:
+#           insert: testCollection 
+#           documents: [{rating: 9}, {rating: 10}, {rating: 8}, {rating: 4}, {rating: 3}]
+#     - OperationMetricsName: Find
+#       OperationCommand: 
+#           find: ratings
+#           filter: {rating: { $gte: 8 }}
+#           readPreference: secondaryPreferred
+#       OperationName: RunCommand
+      
+          
+        

--- a/src/driver/test/SecondaryAllowed.yml
+++ b/src/driver/test/SecondaryAllowed.yml
@@ -49,6 +49,3 @@ Actors:
       Phases:
         - Phase: 0
         - NoOp: true
-      
-          
-        

--- a/src/driver/test/service-architecture/SecondaryAllowed.yml
+++ b/src/driver/test/service-architecture/SecondaryAllowed.yml
@@ -1,4 +1,9 @@
 SchemaVersion: 2018-07-01
+Pool:
+    QueryOptions:
+        maxPoolSize: 1000
+        socketTimeoutMS: 5000
+        connectTimeoutMS: 5000
 Actors:
     - Name: StepdownCommand
       Type: AdminCommand
@@ -16,9 +21,10 @@ Actors:
               OperationSleepBefore: 30 seconds
               OperationCommand:
                   replSetStepDown: 60
+              OperationAwaitStepdown: yes
     - Name: SecondaryPreferredRead
       Type: RunCommand
-      Threads: 10
+      Threads: 100
       ExecutionStrategy:
           Retries: 0
           ThrowOnFailure: false

--- a/src/driver/test/service-architecture/SecondaryAllowed.yml
+++ b/src/driver/test/service-architecture/SecondaryAllowed.yml
@@ -19,6 +19,7 @@ Actors:
               OperationMetricsName: "Stepdown"
               OperationName: AdminCommand
               OperationSleepBefore: 30 seconds
+              OperationSleepAfter: 30 seconds
               OperationCommand:
                   replSetStepDown: 60
               OperationAwaitStepdown: yes
@@ -49,7 +50,7 @@ Actors:
       DocumentCount: 100
       BatchSize: 100
       Document:
-          x: {$randomint: {min: 0, max: 20}}
+          x: {^RandomInt: {min: 0, max: 20}}
       Indexes:
         - keys: {x: 1}
       Phases:


### PR DESCRIPTION
Currently the workload only runs a stepdown command to trigger an election. 