### PR TITLE
TIG-1205 Error if No Actors Produced for an Actor YAML Block

### DIFF
--- a/src/gennylib/src/Cast.cpp
+++ b/src/gennylib/src/Cast.cpp
@@ -31,7 +31,7 @@ void Cast::add(const std::string_view& castName, std::shared_ptr<ActorProducer> 
 }
 
 std::ostream& Cast::streamProducersTo(std::ostream& out) const {
-    for (const auto& [castName, producer] : globalCast().getProducers()) {
+    for (const auto& [castName, producer] : _producers) {
         out << castName << " is " << producer->name() << std::endl;
     }
     return out;

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -91,8 +91,7 @@ ActorVector WorkloadContext::_constructActors(const Cast& cast,
     } catch (const std::out_of_range&) {
         std::ostringstream stream;
         stream << "Unable to construct actors: No producer for '" << name << "'." << std::endl;
-        cast.streamProducersTo(stream);
-        throw std::out_of_range(stream.str());
+        throw InvalidConfigurationException(stream.str());
     }
 
     for (auto&& actor : producer->produce(*actorContext)) {

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -91,6 +91,7 @@ ActorVector WorkloadContext::_constructActors(const Cast& cast,
     } catch (const std::out_of_range&) {
         std::ostringstream stream;
         stream << "Unable to construct actors: No producer for '" << name << "'." << std::endl;
+        cast.streamProducersTo(stream);
         throw InvalidConfigurationException(stream.str());
     }
 

--- a/src/gennylib/test/context_test.cpp
+++ b/src/gennylib/test/context_test.cpp
@@ -725,3 +725,27 @@ Actors:
         });
     }
 }
+
+TEST_CASE("If no producer exists for an actor, then we should throw an error") {
+    genny::metrics::Registry metrics;
+    genny::Orchestrator orchestrator{metrics.gauge("PhaseNumber")};
+
+    auto cast = Cast{
+        {"Foo", std::make_shared<NoOpProducer>()},
+    };
+
+    auto yaml = YAML::Load(R"(
+    SchemaVersion: 2018-07-01
+    Database: test
+    Actors:
+    - Name: Actor1
+      Type: Bar
+    )");
+
+    SECTION("Incorrect type value inputted") {
+        auto test = [&]() {
+            WorkloadContext w(yaml, metrics, orchestrator, mongoUri.data(), cast);
+        };
+        REQUIRE_THROWS_WITH(test(), Matches("Unable to construct actors: No producer for 'Bar'.\n"));
+    }
+}

--- a/src/gennylib/test/context_test.cpp
+++ b/src/gennylib/test/context_test.cpp
@@ -746,6 +746,6 @@ TEST_CASE("If no producer exists for an actor, then we should throw an error") {
         auto test = [&]() {
             WorkloadContext w(yaml, metrics, orchestrator, mongoUri.data(), cast);
         };
-        REQUIRE_THROWS_WITH(test(), Matches("Unable to construct actors: No producer for 'Bar'.\n"));
+        REQUIRE_THROWS_WITH(test(), Matches(R"(Unable to construct actors: No producer for 'Bar'(.*\n*)*)"));
     }
 }


### PR DESCRIPTION
Added a test to check that producing an actor with a mistyped 'Type' will result in an InvalidConfigurationException. 