### PR TITLE
TIG-1384 'InsertActor respects writeConcern' fails if not run on a replset

### DIFF
--- a/src/cast_core/test/CrudActor_test.cpp
+++ b/src/cast_core/test/CrudActor_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE_METHOD(MongoTestFixture,
                  "[standalone][single_node_replset][three_node_replset][CrudActor]") {
 
     dropAllDatabases();
-    MongoTestFixture::clearEvents();
+    auto events = ApmEvents{};
     auto db = client.database("mydb");
 
     SECTION("Inserts and updates document in the database.") {
@@ -203,14 +203,15 @@ TEST_CASE_METHOD(MongoTestFixture,
                     BypassDocumentValidation: true
           )");
         try {
+            auto apmCallback = makeApmCallback(events);
             genny::ActorHelper ah(
-                config, 1, MongoTestFixture::connectionUri().to_string(), MongoTestFixture::apmCallback);
+                config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
             auto count =
                 db.collection("test").count(BasicBson::make_document(BasicBson::kvp("a", 5)));
             REQUIRE(count == 1);
-            REQUIRE(MongoTestFixture::events.size() > 0);
-            for (auto&& event : MongoTestFixture::events) {
+            REQUIRE(events.size() > 0);
+            for (auto&& event : events) {
                 REQUIRE(event.command["ordered"]);
                 auto isOrdered = event.command["ordered"].get_bool().value;
                 REQUIRE(isOrdered == false);
@@ -330,14 +331,15 @@ TEST_CASE_METHOD(MongoTestFixture,
                       Timeout: 6000 milliseconds
           )");
         try {
+            auto apmCallback = makeApmCallback(events);
             genny::ActorHelper ah(
-                config, 1, MongoTestFixture::connectionUri().to_string(), MongoTestFixture::apmCallback);
+                config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
             auto count =
                 db.collection("test").count(BasicBson::make_document(BasicBson::kvp("a", 8)));
             REQUIRE(count == 1);
-            REQUIRE(MongoTestFixture::events.size() > 0);
-            for (auto&& event : MongoTestFixture::events) {
+            REQUIRE(events.size() > 0);
+            for (auto&& event : events) {
                 REQUIRE(event.command["writeConcern"]);
                 auto writeConcernLevel = event.command["writeConcern"]["w"].get_utf8().value;
                 REQUIRE(std::string(writeConcernLevel) == "majority");
@@ -358,7 +360,7 @@ TEST_CASE_METHOD(MongoTestFixture,
                  "[standalone][single_node_replset][three_node_replset][CrudActor]") {
 
     dropAllDatabases();
-    MongoTestFixture::clearEvents();
+    auto events = ApmEvents{};
     auto db = client.database("mydb");
 
     SECTION("Write concern majority with timeout.") {
@@ -388,11 +390,12 @@ TEST_CASE_METHOD(MongoTestFixture,
                         Timeout: 5000 milliseconds
             )");
         try {
+            auto apmCallback = makeApmCallback(events);
             genny::ActorHelper ah(
-                config, 1, MongoTestFixture::connectionUri().to_string(), MongoTestFixture::apmCallback);
+                config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            REQUIRE(MongoTestFixture::events.size() > 0);
-            for (auto&& event : MongoTestFixture::events) {
+            REQUIRE(events.size() > 0);
+            for (auto&& event : events) {
                 REQUIRE(event.command["writeConcern"]);
                 auto writeConcernLevel = event.command["writeConcern"]["w"].get_utf8().value;
                 REQUIRE(std::string(writeConcernLevel) == "majority");
@@ -435,11 +438,12 @@ TEST_CASE_METHOD(MongoTestFixture,
                       Journal: true
           )");
         try {
+            auto apmCallback = makeApmCallback(events);
             genny::ActorHelper ah(
-                config, 1, MongoTestFixture::connectionUri().to_string(), MongoTestFixture::apmCallback);
+                config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            REQUIRE(MongoTestFixture::events.size() > 0);
-            for (auto&& event : MongoTestFixture::events) {
+            REQUIRE(events.size() > 0);
+            for (auto&& event : events) {
                 REQUIRE(event.command["writeConcern"]);
                 auto writeConcernLevel = event.command["writeConcern"]["w"].get_int32().value;
                 REQUIRE(writeConcernLevel == 1);
@@ -485,11 +489,12 @@ TEST_CASE_METHOD(MongoTestFixture,
                       Journal: false
           )");
         try {
+            auto apmCallback = makeApmCallback(events);
             genny::ActorHelper ah(
-                config, 1, MongoTestFixture::connectionUri().to_string(), MongoTestFixture::apmCallback);
+                config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            REQUIRE(MongoTestFixture::events.size() > 0);
-            for (auto&& event : MongoTestFixture::events) {
+            REQUIRE(events.size() > 0);
+            for (auto&& event : events) {
                 REQUIRE(event.command["writeConcern"]);
                 auto writeConcernLevel = event.command["writeConcern"]["w"].get_int32().value;
                 REQUIRE(writeConcernLevel == 0);
@@ -587,7 +592,7 @@ TEST_CASE_METHOD(MongoTestFixture,
                  "[standalone][single_node_replset][three_node_replset][CrudActor]") {
 
     dropAllDatabases();
-    MongoTestFixture::clearEvents();
+    auto events = ApmEvents{};
     auto db = client.database("mydb");
 
     SECTION("Read preference is 'secondaryPreferred'.") {
@@ -611,11 +616,12 @@ TEST_CASE_METHOD(MongoTestFixture,
                       ReadMode: secondaryPreferred
           )");
         try {
+            auto apmCallback = makeApmCallback(events);
             genny::ActorHelper ah(
-                config, 1, MongoTestFixture::connectionUri().to_string(), MongoTestFixture::apmCallback);
+                config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            REQUIRE(MongoTestFixture::events.size() > 0);
-            for (auto&& event : MongoTestFixture::events) {
+            REQUIRE(events.size() > 0);
+            for (auto&& event : events) {
                 REQUIRE(event.command["$readPreference"]);
                 REQUIRE(event.command["$readPreference"]["mode"]);
                 auto readMode = event.command["$readPreference"]["mode"].get_utf8().value;
@@ -650,11 +656,12 @@ TEST_CASE_METHOD(MongoTestFixture,
                       MaxStaleness: 100 seconds
           )");
         try {
+            auto apmCallback = makeApmCallback(events);
             genny::ActorHelper ah(
-                config, 1, MongoTestFixture::connectionUri().to_string(), MongoTestFixture::apmCallback);
+                config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            REQUIRE(MongoTestFixture::events.size() > 0);
-            for (auto&& event : MongoTestFixture::events) {
+            REQUIRE(events.size() > 0);
+            for (auto&& event : events) {
                 REQUIRE(event.command["$readPreference"]);
                 REQUIRE(event.command["$readPreference"]["mode"]);
                 auto readMode = event.command["$readPreference"]["mode"].get_utf8().value;
@@ -785,7 +792,7 @@ TEST_CASE_METHOD(MongoTestFixture,
                  "[standalone][single_node_replset][three_node_replset][CrudActor]") {
 
     dropAllDatabases();
-    MongoTestFixture::clearEvents();
+    auto events = ApmEvents{};
     auto db = client.database("mydb");
 
     SECTION("The 'test' collection is dropped.") {
@@ -838,11 +845,12 @@ TEST_CASE_METHOD(MongoTestFixture,
         try {
             db.create_collection("test");
             REQUIRE(db.has_collection("test"));
+            auto apmCallback = makeApmCallback(events);
             genny::ActorHelper ah(
-                config, 1, MongoTestFixture::connectionUri().to_string(), MongoTestFixture::apmCallback);
+                config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
             REQUIRE(db.has_collection("test") == false);
-            for (auto&& event : MongoTestFixture::events) {
+            for (auto&& event : events) {
                 auto writeConcernLevel = event.command["writeConcern"]["w"].get_utf8().value;
                 REQUIRE(std::string(writeConcernLevel) == "majority");
             }
@@ -859,7 +867,7 @@ TEST_CASE_METHOD(MongoTestFixture,
                  "[standalone][single_node_replset][three_node_replset][CrudActor]") {
 
     dropAllDatabases();
-    MongoTestFixture::clearEvents();
+    auto events = ApmEvents{};
     auto db = client.database("mydb");
 
     SECTION("Perform a count on the collection.") {
@@ -880,11 +888,12 @@ TEST_CASE_METHOD(MongoTestFixture,
                   Filter: { a: 1 }
           )");
         try {
+            auto apmCallback = makeApmCallback(events);
             genny::ActorHelper ah(
-                config, 1, MongoTestFixture::connectionUri().to_string(), MongoTestFixture::apmCallback);
+                config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            REQUIRE(MongoTestFixture::events.size() > 0);
-            auto countEvent = MongoTestFixture::events[0].command;
+            REQUIRE(events.size() > 0);
+            auto countEvent = events[0].command;
             auto collection = countEvent["count"].get_utf8().value;
             REQUIRE(std::string(collection) == "test");
             REQUIRE(countEvent["query"].get_document().view() ==

--- a/src/cast_core/test/RunCommandActor_test.cpp
+++ b/src/cast_core/test/RunCommandActor_test.cpp
@@ -141,8 +141,7 @@ TEST_CASE_METHOD(MongoTestFixture, "InsertActor respects writeConcern.", "[three
         }(yamlConfig["Actors"][0]["Phases"][0]);
 
         auto apmCallback = makeApmCallback(events);
-        ActorHelper ah(yamlConfig, 1, MongoTestFixture::connectionUri().to_string(),
-            apmCallback);
+        ActorHelper ah(yamlConfig, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
         ah.run();
         auto coll = MongoTestFixture::client["test"]["testCollection"];
         REQUIRE(events.size() > 0);

--- a/src/testlib/include/testlib/MongoTestFixture.hpp
+++ b/src/testlib/include/testlib/MongoTestFixture.hpp
@@ -30,7 +30,7 @@ public:
 
 private:
     mongocxx::instance& instance;
-    
+
 protected:
     class ApmEvent {
     public:
@@ -41,7 +41,7 @@ protected:
         bsoncxx::document::value value;
         bsoncxx::document::view command;
     };
-    
+
     using ApmCallback = std::function<void(const mongocxx::events::command_started_event&)>;
     using ApmEvents = std::vector<ApmEvent>;
     static ApmCallback makeApmCallback(ApmEvents& events);

--- a/src/testlib/include/testlib/MongoTestFixture.hpp
+++ b/src/testlib/include/testlib/MongoTestFixture.hpp
@@ -29,8 +29,11 @@ public:
     static mongocxx::uri connectionUri();
 
 private:
+    mongocxx::instance& instance;
+    
+protected:
     class ApmEvent {
-        public:
+    public:
         ApmEvent(const std::string& command_name_, const bsoncxx::document::value& document_)
             : command_name(command_name_), value(document_), command(value.view()) {}
 
@@ -38,28 +41,12 @@ private:
         bsoncxx::document::value value;
         bsoncxx::document::view command;
     };
-    mongocxx::instance& instance;
+    
+    using ApmCallback = std::function<void(const mongocxx::events::command_started_event&)>;
+    using ApmEvents = std::vector<ApmEvent>;
+    static ApmCallback makeApmCallback(ApmEvents& events);
 
-protected:
     mongocxx::client client;
-    std::vector<ApmEvent> events;
-    std::function<void(const mongocxx::events::command_started_event&)> apmCallback =
-        [&](const mongocxx::events::command_started_event& event) {
-            std::string command_name{event.command_name().data()};
-
-            // Ignore auth commands like "saslStart", and handshakes with "isMaster".
-            std::string sasl{"sasl"};
-            if (event.command_name().substr(0, sasl.size()).compare(sasl) == 0 ||
-                command_name.compare("isMaster") == 0) {
-                return;
-            }
-
-            events.emplace_back(command_name, bsoncxx::document::value(event.command()));
-        };
-    void clearEvents(){
-        events.clear();
-    };
-
 };
 }  // namespace genny::testing
 

--- a/src/testlib/include/testlib/MongoTestFixture.hpp
+++ b/src/testlib/include/testlib/MongoTestFixture.hpp
@@ -32,6 +32,8 @@ private:
     mongocxx::instance& instance;
 
 protected:
+    // This was copied from
+    // github.com/mongodb/mongo-cxx-driver/blob/r3.4.0/src/mongocxx/test/client_session.cpp#L285
     class ApmEvent {
     public:
         ApmEvent(const std::string& command_name_, const bsoncxx::document::value& document_)

--- a/src/testlib/src/MongoTestFixture.cpp
+++ b/src/testlib/src/MongoTestFixture.cpp
@@ -45,7 +45,8 @@ void MongoTestFixture::dropAllDatabases() {
     }
 };
 
-MongoTestFixture::ApmCallback MongoTestFixture::makeApmCallback(MongoTestFixture::ApmEvents& events) {
+MongoTestFixture::ApmCallback MongoTestFixture::makeApmCallback(
+    MongoTestFixture::ApmEvents& events) {
     return [&](const mongocxx::events::command_started_event& event) {
         std::string command_name{event.command_name().data()};
 

--- a/src/testlib/src/MongoTestFixture.cpp
+++ b/src/testlib/src/MongoTestFixture.cpp
@@ -47,6 +47,8 @@ void MongoTestFixture::dropAllDatabases() {
 
 MongoTestFixture::ApmCallback MongoTestFixture::makeApmCallback(
     MongoTestFixture::ApmEvents& events) {
+    // This was copied from
+    // github.com/mongodb/mongo-cxx-driver/blob/r3.4.0/src/mongocxx/test/client_session.cpp#L224
     return [&](const mongocxx::events::command_started_event& event) {
         std::string command_name{event.command_name().data()};
 

--- a/src/testlib/src/MongoTestFixture.cpp
+++ b/src/testlib/src/MongoTestFixture.cpp
@@ -43,6 +43,21 @@ void MongoTestFixture::dropAllDatabases() {
             client.database(dbName).drop();
         }
     }
+};
+
+MongoTestFixture::ApmCallback MongoTestFixture::makeApmCallback(MongoTestFixture::ApmEvents& events) {
+    return [&](const mongocxx::events::command_started_event& event) {
+        std::string command_name{event.command_name().data()};
+
+        // Ignore auth commands like "saslStart", and handshakes with "isMaster".
+        std::string sasl{"sasl"};
+        if (event.command_name().substr(0, sasl.size()).compare(sasl) == 0 ||
+            command_name.compare("isMaster") == 0) {
+            return;
+        }
+
+        events.emplace_back(command_name, bsoncxx::document::value(event.command()));
+    };
 }
 
 }  // namespace genny::testing


### PR DESCRIPTION
Besides the title I also added the ApmEvent class to MongoTestFixture and updated other tests that used it. 