### PR TITLE
TIG-1328 Migrate all Actors from previous metrics types to metrics::Operation

### DIFF
--- a/src/cast_core/include/cast_core/actors/Loader.hpp
+++ b/src/cast_core/include/cast_core/actors/Loader.hpp
@@ -49,9 +49,9 @@ private:
     /** @private */
     struct PhaseConfig;
     genny::DefaultRandom _rng;
-    metrics::Timer _totalBulkLoadTimer;
-    metrics::Timer _individualBulkLoadTimer;
-    metrics::Timer _indexBuildTimer;
+    metrics::Operation _totalBulkLoad;
+    metrics::Operation _individualBulkLoad;
+    metrics::Operation _indexBuild;
     mongocxx::pool::entry _client;
     PhaseLoop<PhaseConfig> _loop;
 };

--- a/src/cast_core/include/cast_core/actors/MultiCollectionQuery.hpp
+++ b/src/cast_core/include/cast_core/actors/MultiCollectionQuery.hpp
@@ -46,8 +46,7 @@ private:
     /** @private */
     struct PhaseConfig;
     genny::DefaultRandom _rng;
-    metrics::Timer _queryTimer;
-    metrics::Counter _documentCount;
+    metrics::Operation _queryOp;
     mongocxx::pool::entry _client;
     PhaseLoop<PhaseConfig> _loop;
 };

--- a/src/cast_core/include/cast_core/actors/MultiCollectionUpdate.hpp
+++ b/src/cast_core/include/cast_core/actors/MultiCollectionUpdate.hpp
@@ -49,8 +49,7 @@ private:
     struct PhaseConfig;
     genny::DefaultRandom _rng;
 
-    metrics::Timer _updateTimer;
-    metrics::Counter _updateCount;
+    metrics::Operation _updateOp;
     mongocxx::pool::entry _client;
     PhaseLoop<PhaseConfig> _loop;
 };

--- a/src/cast_core/src/HelloWorld.cpp
+++ b/src/cast_core/src/HelloWorld.cpp
@@ -45,7 +45,7 @@ void HelloWorld::run() {
 
 HelloWorld::HelloWorld(genny::ActorContext& context)
     : Actor(context),
-      _operation{context.operation("op", HelloWorld::id())},
+      _operation{context.operation("Op", HelloWorld::id())},
       _helloCounter{WorkloadContext::getActorSharedState<HelloWorld, HelloWorldCounter>()},
       _loop{context} {}
 

--- a/src/cast_core/src/Insert.cpp
+++ b/src/cast_core/src/Insert.cpp
@@ -64,7 +64,7 @@ void Insert::run() {
 Insert::Insert(genny::ActorContext& context)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _strategy{context.operation("insert", Insert::id())},
+      _strategy{context.operation("Insert", Insert::id())},
       _client{std::move(context.client())},
       _loop{context, (*_client)[context.get<std::string>("Database")]} {}
 

--- a/src/cast_core/src/InsertRemove.cpp
+++ b/src/cast_core/src/InsertRemove.cpp
@@ -93,8 +93,8 @@ void InsertRemove::run() {
 InsertRemove::InsertRemove(genny::ActorContext& context)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _insertStrategy{context.operation("insert", InsertRemove::id())},
-      _removeStrategy{context.operation("remove", InsertRemove::id())},
+      _insertStrategy{context.operation("Insert", InsertRemove::id())},
+      _removeStrategy{context.operation("Remove", InsertRemove::id())},
       _client{std::move(context.client())},
       _loop{context, _rng, _client, InsertRemove::id()} {}
 

--- a/src/cast_core/src/Loader.cpp
+++ b/src/cast_core/src/Loader.cpp
@@ -84,7 +84,7 @@ void genny::actor::Loader::run() {
                 // Insert the documents
                 uint remainingInserts = config->numDocuments;
                 {
-                    auto totalOp = _totalBulkLoadTimer.raii();
+                    auto totalOpCtx = _totalBulkLoad.start();
                     while (remainingInserts > 0) {
                         // insert the next batch
                         int64_t numberToInsert =
@@ -96,11 +96,13 @@ void genny::actor::Loader::run() {
                             docs.push_back(std::move(newDoc));
                         }
                         {
-                            auto individualOp = _individualBulkLoadTimer.raii();
+                            auto individualOpCtx = _individualBulkLoad.start();
                             auto result = collection.insert_many(std::move(docs));
                             remainingInserts -= result->inserted_count();
+                            individualOpCtx.success();
                         }
                     }
+                    totalOpCtx.success();
                 }
                 // For each index
                 for (auto&& [keys, options] : config->indexes) {
@@ -112,11 +114,13 @@ void genny::actor::Loader::run() {
                         auto indexOptions = (*options)->evaluate(_rng).getDocument();
                         BOOST_LOG_TRIVIAL(debug)
                             << "With options " << bsoncxx::to_json(indexOptions.view());
-                        auto op = _indexBuildTimer.raii();
+                        auto indexOpCtx = _indexBuild.start();
                         collection.create_index(std::move(indexKey), std::move(indexOptions));
+                        indexOpCtx.success();
                     } else {
-                        auto op = _indexBuildTimer.raii();
+                        auto indexOpCtx = _indexBuild.start();
                         collection.create_index(std::move(indexKey));
+                        indexOpCtx.success();
                     }
                 }
             }
@@ -128,9 +132,9 @@ void genny::actor::Loader::run() {
 Loader::Loader(genny::ActorContext& context, uint thread)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _totalBulkLoadTimer{context.timer("totalBulkInsertTime", Loader::id())},
-      _individualBulkLoadTimer{context.timer("individualBulkInsertTime", Loader::id())},
-      _indexBuildTimer{context.timer("indexBuildTime", Loader::id())},
+      _totalBulkLoad{context.operation("totalBulkInsert", Loader::id())},
+      _individualBulkLoad{context.operation("individualBulkInsert", Loader::id())},
+      _indexBuild{context.operation("indexBuild", Loader::id())},
       _client{std::move(context.client())},
       _loop{context, _client, thread} {}
 

--- a/src/cast_core/src/Loader.cpp
+++ b/src/cast_core/src/Loader.cpp
@@ -132,9 +132,9 @@ void genny::actor::Loader::run() {
 Loader::Loader(genny::ActorContext& context, uint thread)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _totalBulkLoad{context.operation("totalBulkInsert", Loader::id())},
-      _individualBulkLoad{context.operation("individualBulkInsert", Loader::id())},
-      _indexBuild{context.operation("indexBuild", Loader::id())},
+      _totalBulkLoad{context.operation("TotalBulkInsert", Loader::id())},
+      _individualBulkLoad{context.operation("IndividualBulkInsert", Loader::id())},
+      _indexBuild{context.operation("IndexBuild", Loader::id())},
       _client{std::move(context.client())},
       _loop{context, _client, thread} {}
 

--- a/src/cast_core/src/MultiCollectionQuery.cpp
+++ b/src/cast_core/src/MultiCollectionQuery.cpp
@@ -88,7 +88,7 @@ void MultiCollectionQuery::run() {
 MultiCollectionQuery::MultiCollectionQuery(genny::ActorContext& context)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _queryOp{context.operation("query", MultiCollectionQuery::id())},
+      _queryOp{context.operation("Query", MultiCollectionQuery::id())},
       _client{std::move(context.client())},
       _loop{context, _client} {}
 

--- a/src/cast_core/src/MultiCollectionQuery.cpp
+++ b/src/cast_core/src/MultiCollectionQuery.cpp
@@ -70,7 +70,7 @@ void MultiCollectionQuery::run() {
             // BOOST_LOG_TRIVIAL(info) << "Collection Name is " << collectionName;
             {
                 // Only time the actual update, not the setup of arguments
-                auto op = _queryTimer.raii();
+                auto opCtx = _queryOp.start();
                 auto cursor = collection.find(std::move(filter), config->options);
                 // exhaust the cursor
                 uint count = 0;
@@ -78,7 +78,8 @@ void MultiCollectionQuery::run() {
                     doc.length();
                     count++;
                 }
-                _documentCount.incr(count);
+                opCtx.addOps(count);
+                opCtx.success();
             }
         }
     }
@@ -87,8 +88,7 @@ void MultiCollectionQuery::run() {
 MultiCollectionQuery::MultiCollectionQuery(genny::ActorContext& context)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _queryTimer{context.timer("queryTime", MultiCollectionQuery::id())},
-      _documentCount{context.counter("returnedDocuments", MultiCollectionQuery::id())},
+      _queryOp{context.operation("queryOperation", MultiCollectionQuery::id())},
       _client{std::move(context.client())},
       _loop{context, _client} {}
 

--- a/src/cast_core/src/MultiCollectionQuery.cpp
+++ b/src/cast_core/src/MultiCollectionQuery.cpp
@@ -88,7 +88,7 @@ void MultiCollectionQuery::run() {
 MultiCollectionQuery::MultiCollectionQuery(genny::ActorContext& context)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _queryOp{context.operation("queryOperation", MultiCollectionQuery::id())},
+      _queryOp{context.operation("query", MultiCollectionQuery::id())},
       _client{std::move(context.client())},
       _loop{context, _client} {}
 

--- a/src/cast_core/src/MultiCollectionUpdate.cpp
+++ b/src/cast_core/src/MultiCollectionUpdate.cpp
@@ -83,7 +83,7 @@ void MultiCollectionUpdate::run() {
 MultiCollectionUpdate::MultiCollectionUpdate(genny::ActorContext& context)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _updateOp{context.operation("update", MultiCollectionUpdate::id())},
+      _updateOp{context.operation("Update", MultiCollectionUpdate::id())},
       _client{std::move(context.client())},
       _loop{context, _client} {}
 

--- a/src/cast_core/src/MultiCollectionUpdate.cpp
+++ b/src/cast_core/src/MultiCollectionUpdate.cpp
@@ -71,9 +71,10 @@ void MultiCollectionUpdate::run() {
             // BOOST_LOG_TRIVIAL(info) << "Collection Name is " << collectionName;
             {
                 // Only time the actual update, not the setup of arguments
-                auto op = _updateTimer.raii();
+                auto opCtx = _updateOp.start();
                 auto result = collection.update_many(std::move(filter), std::move(update));
-                _updateCount.incr(result->modified_count());
+                opCtx.addOps(result->modified_count());
+                opCtx.success();
             }
         }
     }
@@ -82,8 +83,7 @@ void MultiCollectionUpdate::run() {
 MultiCollectionUpdate::MultiCollectionUpdate(genny::ActorContext& context)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _updateTimer{context.timer("updateTime", MultiCollectionUpdate::id())},
-      _updateCount{context.counter("updatedDocuments", MultiCollectionUpdate::id())},
+      _updateOp{context.operation("updateOperation", MultiCollectionUpdate::id())},
       _client{std::move(context.client())},
       _loop{context, _client} {}
 

--- a/src/cast_core/src/MultiCollectionUpdate.cpp
+++ b/src/cast_core/src/MultiCollectionUpdate.cpp
@@ -83,7 +83,7 @@ void MultiCollectionUpdate::run() {
 MultiCollectionUpdate::MultiCollectionUpdate(genny::ActorContext& context)
     : Actor(context),
       _rng{context.workload().createRNG()},
-      _updateOp{context.operation("updateOperation", MultiCollectionUpdate::id())},
+      _updateOp{context.operation("update", MultiCollectionUpdate::id())},
       _client{std::move(context.client())},
       _loop{context, _client} {}
 

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -88,10 +88,9 @@ genny::driver::DefaultDriver::OutcomeCode doRunLogic(
 
     auto actorSetup = metrics.timer("Genny.Setup");
     auto setupTimer = actorSetup.start();
-    auto phaseNumberGauge = metrics.gauge("Genny.PhaseNumber");
 
     auto yaml = loadConfig(options.workloadSource, options.workloadSourceType);
-    auto orchestrator = Orchestrator{phaseNumberGauge};
+    auto orchestrator = Orchestrator{};
 
     auto workloadContext =
         WorkloadContext{yaml, metrics, orchestrator, options.mongoUri, globalCast()};

--- a/src/gennylib/benchmark/orchestrator_benchmark.cpp
+++ b/src/gennylib/benchmark/orchestrator_benchmark.cpp
@@ -31,7 +31,7 @@ TEST_CASE("Orchestrator Perf", "[benchmark]") {
     const auto dur = milliseconds{200};
 
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(2);
 
     atomic_long regIters(0);

--- a/src/gennylib/include/gennylib/Orchestrator.hpp
+++ b/src/gennylib/include/gennylib/Orchestrator.hpp
@@ -33,7 +33,7 @@ using PhaseNumber = unsigned int;
 class Orchestrator {
 
 public:
-    explicit Orchestrator(metrics::Gauge phaseNumberGauge) : _phaseNumberGauge{phaseNumberGauge} {}
+    explicit Orchestrator(metrics::v1::Gauge phaseNumberGauge) : _phaseNumberGauge{phaseNumberGauge} {}
 
     /**
      * @return the current phase number
@@ -107,7 +107,7 @@ private:
     PhaseNumber _current = 0;
 
     // _phaseNumberGauge should keep up to date with _current.
-    metrics::Gauge _phaseNumberGauge;
+    metrics::v1::Gauge _phaseNumberGauge;
 
     // Having this lets us avoid locking on _mutex for every call of
     // continueRunning(). This gave two orders of magnitude speedup.

--- a/src/gennylib/include/gennylib/Orchestrator.hpp
+++ b/src/gennylib/include/gennylib/Orchestrator.hpp
@@ -33,7 +33,7 @@ using PhaseNumber = unsigned int;
 class Orchestrator {
 
 public:
-    explicit Orchestrator(metrics::v1::Gauge phaseNumberGauge) : _phaseNumberGauge{phaseNumberGauge} {}
+    explicit Orchestrator() {}
 
     /**
      * @return the current phase number
@@ -105,9 +105,6 @@ private:
 
     PhaseNumber _max = 0;
     PhaseNumber _current = 0;
-
-    // _phaseNumberGauge should keep up to date with _current.
-    metrics::v1::Gauge _phaseNumberGauge;
 
     // Having this lets us avoid locking on _mutex for every call of
     // continueRunning(). This gave two orders of magnitude speedup.

--- a/src/gennylib/src/Orchestrator.cpp
+++ b/src/gennylib/src/Orchestrator.cpp
@@ -131,7 +131,6 @@ bool Orchestrator::awaitPhaseEnd(bool block, int removeTokens) {
 
     if (_currentTokens <= 0) {
         ++_current;
-        _phaseNumberGauge.set(_current);
         _phaseChange.notify_all();
         state = State::PhaseEnded;
     } else {

--- a/src/gennylib/test/Cast_test.cpp
+++ b/src/gennylib/test/Cast_test.cpp
@@ -66,7 +66,7 @@ private:
     Cast::Registration _registration;
     YAML::Node _node;
     metrics::Registry _registry;
-    metrics::Gauge _orchestratorGauge;
+    metrics::v1::Gauge _orchestratorGauge;
     Orchestrator _orchestrator;
     WorkloadContext _workloadContext;
 };

--- a/src/gennylib/test/Cast_test.cpp
+++ b/src/gennylib/test/Cast_test.cpp
@@ -48,8 +48,7 @@ public:
           _registration{globalCast().registerCustom(_producer)},
           _node{createWorkloadYaml(name, actorYaml)},
           _registry{},
-          _orchestratorGauge{_registry.gauge("Genny.Orchestrator")},
-          _orchestrator{_orchestratorGauge},
+          _orchestrator{},
           _workloadContext{
               _node, _registry, _orchestrator, "mongodb://localhost:27017", genny::globalCast()} {}
 
@@ -66,7 +65,6 @@ private:
     Cast::Registration _registration;
     YAML::Node _node;
     metrics::Registry _registry;
-    metrics::v1::Gauge _orchestratorGauge;
     Orchestrator _orchestrator;
     WorkloadContext _workloadContext;
 };

--- a/src/gennylib/test/PhaseLoop_test.cpp
+++ b/src/gennylib/test/PhaseLoop_test.cpp
@@ -47,7 +47,7 @@ optional<TimeSpec> operator""_ts(unsigned long long v) {
 
 TEST_CASE("Correctness for N iterations") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
 
     SECTION("Loops 0 Times") {
         v1::ActorPhase<int> loop{
@@ -77,7 +77,7 @@ TEST_CASE("Correctness for N iterations") {
 
 TEST_CASE("Correctness for N milliseconds") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     SECTION("Loops 0 milliseconds so zero times") {
         v1::ActorPhase<int> loop{
             o, std::make_unique<v1::IterationChecker>(0_ts, nullopt, false), 0};
@@ -106,7 +106,7 @@ TEST_CASE("Correctness for N milliseconds") {
 
 TEST_CASE("Combinations of duration and iterations") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     SECTION("Loops 0 milliseconds but 100 times") {
         v1::ActorPhase<int> loop{
             o, std::make_unique<v1::IterationChecker>(0_ts, 100_uis, false), 0};
@@ -147,7 +147,7 @@ TEST_CASE("Combinations of duration and iterations") {
 
 TEST_CASE("Can do without either iterations or duration") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     v1::ActorPhase<int> actorPhase{
         o, std::make_unique<v1::IterationChecker>(nullopt, nullopt, false), 0};
     auto iters = 0;
@@ -164,7 +164,7 @@ TEST_CASE("Can do without either iterations or duration") {
 
 TEST_CASE("Iterator concept correctness") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     v1::ActorPhase<int> loop{o, std::make_unique<v1::IterationChecker>(nullopt, 1_uis, false), 0};
 
     // can deref

--- a/src/gennylib/test/context_test.cpp
+++ b/src/gennylib/test/context_test.cpp
@@ -43,7 +43,7 @@ static constexpr std::string_view mongoUri = "mongodb://localhost:27017";
 template <class Out, class... Args>
 void errors(const string& yaml, string message, Args... args) {
     genny::metrics::Registry metrics;
-    genny::Orchestrator orchestrator{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator orchestrator{};
     string modified = "SchemaVersion: 2018-07-01\nActors: []\n" + yaml;
     auto read = YAML::Load(modified);
     auto test = [&]() {
@@ -58,7 +58,7 @@ template <class Out,
           class... Args>
 void gives(const string& yaml, OutV expect, Args... args) {
     genny::metrics::Registry metrics;
-    genny::Orchestrator orchestrator{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator orchestrator{};
     string modified = "SchemaVersion: 2018-07-01\nActors: []\n" + yaml;
     auto read = YAML::Load(modified);
     auto test = [&]() {
@@ -89,7 +89,7 @@ struct OpProducer : public ActorProducer {
 
 TEST_CASE("loads configuration okay") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator orchestrator{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator orchestrator{};
 
     auto cast = Cast{
         {"NoOp", std::make_shared<NoOpProducer>()},
@@ -246,7 +246,7 @@ Actors:
 
 void onContext(YAML::Node yaml, std::function<void(ActorContext&)> op) {
     genny::metrics::Registry metrics;
-    genny::Orchestrator orchestrator{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator orchestrator{};
 
     auto cast = Cast{
         {"Op", std::make_shared<OpProducer>(op)},
@@ -350,7 +350,7 @@ TEST_CASE("Duplicate Phase Numbers") {
     )");
 
     metrics::Registry metrics;
-    genny::Orchestrator orchestrator{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator orchestrator{};
 
     auto cast = Cast{
         {"NoOp", std::make_shared<NoOpProducer>()},
@@ -728,7 +728,7 @@ Actors:
 
 TEST_CASE("If no producer exists for an actor, then we should throw an error") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator orchestrator{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator orchestrator{};
 
     auto cast = Cast{
         {"Foo", std::make_shared<NoOpProducer>()},

--- a/src/gennylib/test/orchestrator_test.cpp
+++ b/src/gennylib/test/orchestrator_test.cpp
@@ -93,7 +93,7 @@ bool advancePhase(Orchestrator& o) {
 
 TEST_CASE("Non-Blocking start") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(2);
 
     // 2 tokens but we only count down 1 so normally would block
@@ -103,7 +103,7 @@ TEST_CASE("Non-Blocking start") {
 
 TEST_CASE("Non-Blocking end (background progression)") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(2);
 
     auto bgIters = 0;
@@ -136,7 +136,7 @@ TEST_CASE("Non-Blocking end (background progression)") {
 
 TEST_CASE("Can add more tokens at start") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(2);
 
     auto t1 = start(o, 0, false, 2);
@@ -155,7 +155,7 @@ TEST_CASE("Can add more tokens at start") {
 
 TEST_CASE("Set minimum number of phases") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     REQUIRE(o.currentPhase() == 0);
     o.phasesAtLeastTo(1);
     REQUIRE(advancePhase(o));  // 0->1
@@ -181,7 +181,7 @@ TEST_CASE("Set minimum number of phases") {
 
 TEST_CASE("Orchestrator") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(2);
     o.phasesAtLeastTo(1);
 
@@ -262,7 +262,7 @@ std::unordered_map<PhaseNumber, v1::ActorPhase<int>> makePhaseConfig(
 
 TEST_CASE("Two non-blocking Phases") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(1);
     o.phasesAtLeastTo(1);
 
@@ -287,7 +287,7 @@ TEST_CASE("Two non-blocking Phases") {
 
 TEST_CASE("Single Blocking Phase") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(1);
 
     std::unordered_set<PhaseNumber> seen{};
@@ -302,7 +302,7 @@ TEST_CASE("Single Blocking Phase") {
 
 TEST_CASE("single-threaded range-based for loops all phases blocking") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(1);
     o.phasesAtLeastTo(2);
 
@@ -329,7 +329,7 @@ TEST_CASE("single-threaded range-based for loops all phases blocking") {
 
 TEST_CASE("single-threaded range-based for loops no phases blocking") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(1);
     o.phasesAtLeastTo(2);
 
@@ -356,7 +356,7 @@ TEST_CASE("single-threaded range-based for loops no phases blocking") {
 
 TEST_CASE("single-threaded range-based for loops non-blocking then blocking") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(1);
     o.phasesAtLeastTo(1);
 
@@ -380,7 +380,7 @@ TEST_CASE("single-threaded range-based for loops non-blocking then blocking") {
 
 TEST_CASE("single-threaded range-based for loops blocking then non-blocking") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(1);
     o.phasesAtLeastTo(1);
 
@@ -406,7 +406,7 @@ TEST_CASE("single-threaded range-based for loops blocking then non-blocking") {
 
 TEST_CASE("single-threaded range-based for loops blocking then blocking") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(1);
     o.phasesAtLeastTo(1);
 
@@ -432,7 +432,7 @@ TEST_CASE("single-threaded range-based for loops blocking then blocking") {
 
 TEST_CASE("Range-based for stops when Orchestrator says Phase is done") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(2);
 
     std::atomic_bool blockingDone = false;
@@ -467,7 +467,7 @@ TEST_CASE("Range-based for stops when Orchestrator says Phase is done") {
 
 TEST_CASE("Multi-threaded Range-based for loops") {
     genny::metrics::Registry metrics;
-    genny::Orchestrator o{metrics.gauge("PhaseNumber")};
+    genny::Orchestrator o{};
     o.addRequiredTokens(2);
     o.phasesAtLeastTo(1);
 

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -269,6 +269,8 @@ private:
 };
 
 /**
+ * Counter is deprecated in favor of Operation.
+ *
  * A Counter lets callers indicate <b>deltas</b> of a value at a particular time.
  * A Counter has an (internal, hidden) current value that can be incremented or
  * decremented over time.
@@ -303,6 +305,8 @@ private:
 
 
 /**
+ * Gauge is deprecated in favor of Operation.
+ *
  * A Gauge lets you record a known value. E.g. the number
  * of active sessions, how many threads are waiting on something, etc.
  * It is defined by each metric what the value is interpreted to be
@@ -420,7 +424,9 @@ private:
     const time_point _started;
 };
 
-
+/**
+ * Timer is deprecated in favor of Operation.
+ */
 class Timer {
 
 public:

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -86,8 +86,9 @@ using gauged_at_time = std::pair<time_point, gauged_type>;
 
 class Reporter;
 // The v1 namespace is here for two reasons:
-// 1) it's a step towards an ABI. These classes are basically the pimpls of the outer classes
-// 2) it prevents auto-completion of metrics::{X}Impl when you really want metrics::{X}
+// 1) it's a step towards an ABI. These classes are basically the pimpls of the outer classes.
+// 2) it prevents auto-completion of metrics::{X}Impl when you really want metrics::{X}.
+// 3) Counter, Timer and Guage have been deprecated. Use Operation instead when writing actors.
 /**
  * @namespace genny::metrics::v1 this namespace is private and only intended to be used by Genny's
  * internals. Actors should never have to type `genny::*::v1` into any types.
@@ -266,10 +267,6 @@ private:
     CounterImpl* _docs;
     CounterImpl* _bytes;
 };
-
-
-}  // namespace v1
-
 
 /**
  * A Counter lets callers indicate <b>deltas</b> of a value at a particular time.
@@ -463,6 +460,8 @@ private:
     v1::TimerImpl* _timer;
 };
 
+}  // namespace v1
+
 class OperationContext {
 
 public:
@@ -505,7 +504,7 @@ private:
     }
 
     v1::OperationImpl* _op;
-    const time_point _started;
+    time_point _started;
     count_type _totalBytes = 0;
     count_type _totalOps = 0;
     bool _isClosed = false;
@@ -555,14 +554,14 @@ class Registry {
 public:
     explicit Registry() = default;
 
-    Counter counter(const std::string& name) {
-        return Counter{this->_counters[name]};
+    v1::Counter counter(const std::string& name) {
+        return v1::Counter{this->_counters[name]};
     }
-    Timer timer(const std::string& name) {
-        return Timer{this->_timers[name]};
+    v1::Timer timer(const std::string& name) {
+        return v1::Timer{this->_timers[name]};
     }
-    Gauge gauge(const std::string& name) {
-        return Gauge{this->_gauges[name]};
+    v1::Gauge gauge(const std::string& name) {
+        return v1::Gauge{this->_gauges[name]};
     }
     Operation operation(const std::string& name) {
         auto op = v1::OperationImpl(name,

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -88,7 +88,9 @@ class Reporter;
 // The v1 namespace is here for two reasons:
 // 1) it's a step towards an ABI. These classes are basically the pimpls of the outer classes.
 // 2) it prevents auto-completion of metrics::{X}Impl when you really want metrics::{X}.
-// 3) Counter, Timer and Guage have been deprecated. Use Operation instead when writing actors.
+//
+// Note: Counter, Timer and Guage have been deprecated. Use Operation instead when writing actors.
+
 /**
  * @namespace genny::metrics::v1 this namespace is private and only intended to be used by Genny's
  * internals. Actors should never have to type `genny::*::v1` into any types.

--- a/src/testlib/src/ActorHelper.cpp
+++ b/src/testlib/src/ActorHelper.cpp
@@ -36,7 +36,7 @@ ActorHelper::ActorHelper(const YAML::Node& config,
 
     _registry = std::make_unique<genny::metrics::Registry>();
 
-    _orchestrator = std::make_unique<genny::Orchestrator>(_registry->gauge("PhaseNumber"));
+    _orchestrator = std::make_unique<genny::Orchestrator>();
     _orchestrator->addRequiredTokens(tokenCount);
 
     _cast = std::make_unique<Cast>(castInitializer);
@@ -54,7 +54,7 @@ ActorHelper::ActorHelper(const YAML::Node& config,
 
     _registry = std::make_unique<genny::metrics::Registry>();
 
-    _orchestrator = std::make_unique<genny::Orchestrator>(_registry->gauge("PhaseNumber"));
+    _orchestrator = std::make_unique<genny::Orchestrator>();
     _orchestrator->addRequiredTokens(tokenCount);
 
     _wlc = std::make_unique<WorkloadContext>(


### PR DESCRIPTION
Please check that I correctly deprecated the previous metrics types. 

Some existing genny classes are still using metrics::registry and metrics::guage (such as orchestrator.hpp). Not sure if we'll want to do that at some point or not. But all of the actors in cast_core are now using metrics::operation. 