### PR TITLE
TIG-1223: Warn if accessing phaseConfig-> on nop phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ When creating a new actor, `create-new-actor.sh` will generate a new test case
 template to ensure the new actor can run against different MongoDB topologies,
 please update the template as needed so it uses the newly created actor.
 
+### Debugging
+
+IDEs can debug Genny if it is built with the `Debug` build type:
+
+```sh
+./scripts/lamp -DCMAKE_BUILD_TYPE=Debug
+```
+
 ## Running Genny Workloads
 
 First install mongodb and start a mongod process:

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -713,10 +713,10 @@ private:
  */
 struct CountDocumentsOperation : public BaseOperation {
     CountDocumentsOperation(YAML::Node opNode,
-                   bool onSession,
-                   mongocxx::collection collection,
-                   genny::DefaultRandom& rng,
-                   metrics::Operation operation)
+                            bool onSession,
+                            mongocxx::collection collection,
+                            genny::DefaultRandom& rng,
+                            metrics::Operation operation)
         : _onSession{onSession}, _collection{collection}, _rng{rng}, _operation{operation} {
         auto filterYaml = opNode["Filter"];
         if (!filterYaml) {

--- a/src/cast_core/test/CrudActor_test.cpp
+++ b/src/cast_core/test/CrudActor_test.cpp
@@ -108,8 +108,8 @@ TEST_CASE_METHOD(MongoTestFixture,
         try {
             genny::ActorHelper ah(config, 1, MongoTestFixture::connectionUri().to_string());
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            auto count =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 5)));
+            auto count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 5)));
             REQUIRE(count == 1);
         } catch (const std::exception& e) {
             auto diagInfo = boost::diagnostic_information(e);
@@ -144,10 +144,11 @@ TEST_CASE_METHOD(MongoTestFixture,
         try {
             genny::ActorHelper ah(config, 1, MongoTestFixture::connectionUri().to_string());
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            auto count =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 1)));
+            auto count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 1)));
             REQUIRE(count == 0);
-            count = db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 2)));
+            count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 2)));
             REQUIRE(count == 1);
         } catch (const std::exception& e) {
             auto diagInfo = boost::diagnostic_information(e);
@@ -221,8 +222,8 @@ TEST_CASE_METHOD(MongoTestFixture,
             genny::ActorHelper ah(
                 config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            auto count =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 5)));
+            auto count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 5)));
             REQUIRE(count == 1);
             REQUIRE(events.size() > 0);
             for (auto&& event : events) {
@@ -270,8 +271,8 @@ TEST_CASE_METHOD(MongoTestFixture,
         try {
             genny::ActorHelper ah(config, 1, MongoTestFixture::connectionUri().to_string());
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            auto count =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 1)));
+            auto count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 1)));
             REQUIRE(count == 3);
         } catch (const std::exception& e) {
             auto diagInfo = boost::diagnostic_information(e);
@@ -349,8 +350,8 @@ TEST_CASE_METHOD(MongoTestFixture,
             genny::ActorHelper ah(
                 config, 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            auto count =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 8)));
+            auto count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 8)));
             REQUIRE(count == 1);
             REQUIRE(events.size() > 0);
             for (auto&& event : events) {
@@ -786,10 +787,11 @@ TEST_CASE_METHOD(MongoTestFixture,
         try {
             genny::ActorHelper ah(config, 1, MongoTestFixture::connectionUri().to_string());
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            auto count =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 1)));
+            auto count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 1)));
             REQUIRE(count == 2);
-            count = db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("b", 1)));
+            count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("b", 1)));
             REQUIRE(count == 1);
             count = db.collection("test").count_documents(BasicBson::make_document());
             REQUIRE(count == 3);
@@ -948,8 +950,8 @@ TEST_CASE_METHOD(MongoTestFixture,
         try {
             genny::ActorHelper ah(config, 1, MongoTestFixture::connectionUri().to_string());
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            auto count =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 1)));
+            auto count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 1)));
             REQUIRE(count == 1);
         } catch (const std::exception& e) {
             auto diagInfo = boost::diagnostic_information(e);
@@ -982,8 +984,8 @@ TEST_CASE_METHOD(MongoTestFixture,
         try {
             genny::ActorHelper ah(config, 1, MongoTestFixture::connectionUri().to_string());
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            auto countOldDoc =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 1)));
+            auto countOldDoc = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 1)));
             auto countNew = db.collection("test").count_documents(
                 BasicBson::make_document(BasicBson::kvp("newfile", "test")));
             REQUIRE(countOldDoc == 0);
@@ -1019,10 +1021,10 @@ TEST_CASE_METHOD(MongoTestFixture,
         try {
             genny::ActorHelper ah(config, 1, MongoTestFixture::connectionUri().to_string());
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            auto countOldDoc =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 1)));
-            auto countUpdated =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 10)));
+            auto countOldDoc = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 1)));
+            auto countUpdated = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 10)));
             REQUIRE(countOldDoc == 0);
             REQUIRE(countUpdated == 1);
         } catch (const std::exception& e) {
@@ -1061,8 +1063,8 @@ TEST_CASE_METHOD(MongoTestFixture,
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
             auto countOldDocs = db.collection("test").count_documents(BasicBson::make_document(
                 BasicBson::kvp("a", BasicBson::make_document(BasicBson::kvp("$gte", 5)))));
-            auto countUpdated =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 2)));
+            auto countUpdated = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 2)));
             REQUIRE(countOldDocs == 0);
             REQUIRE(countUpdated == 2);
         } catch (const std::exception& e) {
@@ -1091,12 +1093,13 @@ TEST_CASE_METHOD(MongoTestFixture,
           )");
         try {
             db.collection("test").insert_one(BasicBson::make_document(BasicBson::kvp("a", 1)));
-            auto count =
-                db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 1)));
+            auto count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 1)));
             REQUIRE(count == 1);
             genny::ActorHelper ah(config, 1, MongoTestFixture::connectionUri().to_string());
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            count = db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 1)));
+            count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 1)));
             REQUIRE(count == 0);
         } catch (const std::exception& e) {
             auto diagInfo = boost::diagnostic_information(e);
@@ -1129,7 +1132,8 @@ TEST_CASE_METHOD(MongoTestFixture,
             REQUIRE(count == 2);
             genny::ActorHelper ah(config, 1, MongoTestFixture::connectionUri().to_string());
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            count = db.collection("test").count_documents(BasicBson::make_document(BasicBson::kvp("a", 1)));
+            count = db.collection("test").count_documents(
+                BasicBson::make_document(BasicBson::kvp("a", 1)));
             REQUIRE(count == 0);
         } catch (const std::exception& e) {
             auto diagInfo = boost::diagnostic_information(e);

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -25,8 +25,8 @@
 #include <unordered_map>
 #include <utility>
 
-#include <boost/throw_exception.hpp>
 #include <boost/exception/exception.hpp>
+#include <boost/throw_exception.hpp>
 
 #include <gennylib/InvalidConfigurationException.hpp>
 #include <gennylib/Orchestrator.hpp>
@@ -308,9 +308,8 @@ public:
                Args&&... args)
         : _orchestrator{orchestrator},
           _currentPhase{currentPhase},
-          _value{!phaseContext.isNop()
-                     ? std::make_unique<T>(std::forward<Args>(args)...)
-                     : nullptr},
+          _value{!phaseContext.isNop() ? std::make_unique<T>(std::forward<Args>(args)...)
+                                       : nullptr},
           _iterationCheck{std::make_unique<IterationChecker>(phaseContext)} {
         static_assert(std::is_constructible_v<T, Args...>);
     }

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -309,8 +309,8 @@ public:
         : _orchestrator{orchestrator},
           _currentPhase{currentPhase},
           _value{!phaseContext.isNop()
-                     ? std::make_optional<>(std::make_unique<T>(std::forward<Args>(args)...))
-                     : std::nullopt},
+                     ? std::make_unique<T>(std::forward<Args>(args)...)
+                     : nullptr},
           _iterationCheck{std::make_unique<IterationChecker>(phaseContext)} {
         static_assert(std::is_constructible_v<T, Args...>);
     }
@@ -349,7 +349,7 @@ public:
             BOOST_THROW_EXCEPTION(std::logic_error("Trying to dereference -> a T in a Nop phase."));
         }
 #endif
-        return (*_value).operator->();
+        return _value.operator->();
     }
 
     // Could use `auto` for return-type of operator-> and operator*, but
@@ -365,7 +365,7 @@ public:
             BOOST_THROW_EXCEPTION(std::logic_error("Trying to dereference -> a T in a Nop phase."));
         }
 #endif
-        return (*_value).operator*();
+        return _value.operator*();
     }
 
     PhaseNumber phaseNumber() const {
@@ -375,7 +375,7 @@ public:
 private:
     Orchestrator& _orchestrator;
     const PhaseNumber _currentPhase;
-    const std::optional<std::unique_ptr<T>> _value;  // Is nullopt iff operation is Nop
+    const std::unique_ptr<T> _value;  // nullptr iff operation is Nop
     const std::unique_ptr<IterationChecker> _iterationCheck;
 
 };  // class ActorPhase

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -346,7 +346,7 @@ public:
     typename std::add_pointer_t<std::remove_reference_t<T>> operator->() const noexcept {
 #ifndef NDEBUG
         if (!_value) {
-            BOOST_THROW_EXCEPTION(std::logic_error("Trying to dereference -> a T in a Nop phase."));
+            BOOST_THROW_EXCEPTION(std::logic_error("Trying to dereference via -> in a Nop phase."));
         }
 #endif
         return _value.operator->();
@@ -362,7 +362,7 @@ public:
     typename std::add_lvalue_reference_t<T> operator*() const {
 #ifndef NDEBUG
         if (!_value) {
-            BOOST_THROW_EXCEPTION(std::logic_error("Trying to dereference -> a T in a Nop phase."));
+            BOOST_THROW_EXCEPTION(std::logic_error("Trying to dereference via * in a Nop phase."));
         }
 #endif
         return _value.operator*();

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -25,6 +25,9 @@
 #include <unordered_map>
 #include <utility>
 
+#include <boost/throw_exception.hpp>
+#include <boost/exception/exception.hpp>
+
 #include <gennylib/InvalidConfigurationException.hpp>
 #include <gennylib/Orchestrator.hpp>
 #include <gennylib/context.hpp>
@@ -341,7 +344,11 @@ public:
     // BUT: this is just duplicated from the signature of `std::unique_ptr<T>::operator->()`
     //      so we trust the STL to do the right thing™️
     typename std::add_pointer_t<std::remove_reference_t<T>> operator->() const noexcept {
-        assert(_value);
+#ifndef NDEBUG
+        if (!_value) {
+            BOOST_THROW_EXCEPTION(std::logic_error("Trying to dereference -> a T in a Nop phase."));
+        }
+#endif
         return (*_value).operator->();
     }
 
@@ -353,7 +360,11 @@ public:
     // BUT: this is just duplicated from the signature of `std::unique_ptr<T>::operator*()`
     //      so we trust the STL to do the right thing™️
     typename std::add_lvalue_reference_t<T> operator*() const {
-        assert(_value);
+#ifndef NDEBUG
+        if (!_value) {
+            BOOST_THROW_EXCEPTION(std::logic_error("Trying to dereference -> a T in a Nop phase."));
+        }
+#endif
         return (*_value).operator*();
     }
 


### PR DESCRIPTION
Decided in pointing to defer TIG-1223 and instead just warn for now.

This is our first real use for `NDEBUG`. I don't know if the server does something fancier that we may want to adopt?

Also changed to use vanilla `unique_ptr<T>` rather than `optional<unique_ptr<T>>`.