### PR TITLE
TIG-1404: Force --reporter=junit in ParseAndAddCatchTests()

### DIFF
--- a/cmake/ParseAndAddCatchTests.cmake
+++ b/cmake/ParseAndAddCatchTests.cmake
@@ -173,7 +173,8 @@ function(ParseFile SourceFile TestTarget)
             endif()
 
             # Add the test and set its properties
-            add_test(NAME "\"${CTestName}\"" COMMAND ${OptionalCatchTestLauncher} ${TestTarget} ${Name} ${AdditionalCatchParameters} --out ${CTestName}.junit.xml)
+            add_test(NAME "\"${CTestName}\"" COMMAND ${OptionalCatchTestLauncher} ${TestTarget} ${Name} ${AdditionalCatchParameters}
+                     --reporter junit --out ${CTestName}.junit.xml)
             set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
                 LABELS "${Labels}")
         endif()


### PR DESCRIPTION
I had noticed for my patch build that [the "Test Results" pane only showed the sentinel report on Amazon Linux 2](https://evergreen.mongodb.com/task/genny_amazon2_t_cmake_test_patch_504a7e0528d2c2422b5485462f7354b10f73fd8c_5c6c3c1f3627e0236e5c0911_19_02_19_17_25_52) despite the `metrics_test:example metrics usage` test having failed. [The "Test Results" pane is empty when all of the tests are passing](https://evergreen.mongodb.com/task/genny_amazon2_t_cmake_test_504a7e0528d2c2422b5485462f7354b10f73fd8c_19_02_19_17_17_01). The task logs mentioned

```
[2019/02/19 17:25:56.882] Running command 'attach.xunit_results' in "f_report_test_results" (step 1.1 of 2)
[2019/02/19 17:25:56.882] Command failed: error parsing xunit file: EOF
```

which suggested to me that something was malformed about the generated XML. Running `./scripts/lamp cmake-test; cat build/src/*/*.junit.xml` locally showed that we were running with `--reporter=console` (the default) based on the "All tests passed" messages. Since we're hardcoding a `.junit.xml` filename in `ParseAndAddCatchTests()` for `--out`, it seems like we should also be hardcoding `--reporter junit` there too.