### PR TITLE
TIG-1202 Support Phase Range Syntax

### DIFF
--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <cmath>
 #include <sstream>
+#include <climits>
 
 #include <yaml-cpp/yaml.h>
 

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -114,7 +114,7 @@ std::unordered_map<PhaseNumber, std::unique_ptr<PhaseContext>> ActorContext::con
     if (!phases) {
         return out;
     }
-    int totalIndex = 0;
+    int lastPhaseNumber = 0;
     for (const auto& phase : *phases) {
         // If we don't have a node or we are a null type, then we are a NoOp
         if (!phase || phase.IsNull()) {
@@ -124,8 +124,9 @@ std::unordered_map<PhaseNumber, std::unique_ptr<PhaseContext>> ActorContext::con
             throw InvalidConfigurationException(ss.str());
         }
         PhaseRangeSpec configuredRange =
-            phase["Phase"].as<PhaseRangeSpec>(PhaseRangeSpec{IntegerSpec{totalIndex}});
-        for (int rangeIndex = configuredRange.start; rangeIndex <= configuredRange.end; rangeIndex++) {
+            phase["Phase"].as<PhaseRangeSpec>(PhaseRangeSpec{IntegerSpec{lastPhaseNumber}});
+        for (int rangeIndex = configuredRange.start; rangeIndex <= configuredRange.end;
+             rangeIndex++) {
             auto [it, success] =
                 out.try_emplace(rangeIndex, std::make_unique<PhaseContext>(phase, *actorContext));
             if (!success) {
@@ -133,7 +134,7 @@ std::unordered_map<PhaseNumber, std::unique_ptr<PhaseContext>> ActorContext::con
                 msg << "Duplicate phase " << rangeIndex;
                 throw InvalidConfigurationException(msg.str());
             }
-            totalIndex++;
+            lastPhaseNumber++;
         }
     }
     actorContext->orchestrator().phasesAtLeastTo(out.size() - 1);

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -114,8 +114,7 @@ std::unordered_map<PhaseNumber, std::unique_ptr<PhaseContext>> ActorContext::con
     if (!phases) {
         return out;
     }
-
-    int index = 0;
+    int totalIndex = 0;
     for (const auto& phase : *phases) {
         // If we don't have a node or we are a null type, then we are a NoOp
         if (!phase || phase.IsNull()) {
@@ -124,16 +123,18 @@ std::unordered_map<PhaseNumber, std::unique_ptr<PhaseContext>> ActorContext::con
                   "Every phase should have at least be an empty map.";
             throw InvalidConfigurationException(ss.str());
         }
-
-        auto configuredIndex = phase["Phase"].as<PhaseNumber>(index);
-        auto [it, success] =
-            out.try_emplace(configuredIndex, std::make_unique<PhaseContext>(phase, *actorContext));
-        if (!success) {
-            std::stringstream msg;
-            msg << "Duplicate phase " << configuredIndex;
-            throw InvalidConfigurationException(msg.str());
+        PhaseRangeSpec configuredRange =
+            phase["Phase"].as<PhaseRangeSpec>(PhaseRangeSpec{IntegerSpec{totalIndex}});
+        for (int rangeIndex = configuredRange.start; rangeIndex <= configuredRange.end; rangeIndex++) {
+            auto [it, success] =
+                out.try_emplace(rangeIndex, std::make_unique<PhaseContext>(phase, *actorContext));
+            if (!success) {
+                std::stringstream msg;
+                msg << "Duplicate phase " << rangeIndex;
+                throw InvalidConfigurationException(msg.str());
+            }
+            totalIndex++;
         }
-        ++index;
     }
     actorContext->orchestrator().phasesAtLeastTo(out.size() - 1);
     return out;

--- a/src/gennylib/test/conventions_test.cpp
+++ b/src/gennylib/test/conventions_test.cpp
@@ -138,6 +138,10 @@ TEST_CASE("genny::PhaseRangeSpec conversions") {
         REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().start == 0);
         REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().end == 100);
 
+        yaml = YAML::Load("Phase: 10 .. 1e2");
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().start == 10);
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().end == 100);
+
         yaml = YAML::Load("Phase: 12");
         REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().start == 12);
         REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().end == 12);
@@ -146,8 +150,13 @@ TEST_CASE("genny::PhaseRangeSpec conversions") {
     SECTION("Barfs on invalid values") {
         REQUIRE_THROWS(YAML::Load("0....20").as<PhaseRangeSpec>());
         REQUIRE_THROWS(YAML::Load("0.1").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("-1..1").as<PhaseRangeSpec>());
         REQUIRE_THROWS(YAML::Load("0abc..20").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("0abc .. 20").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("10..4294967296").as<PhaseRangeSpec>());  // uint_max + 1
+        REQUIRE_THROWS(YAML::Load("4294967296..4294967296").as<PhaseRangeSpec>());
         REQUIRE_THROWS(YAML::Load("20..25abc").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("-10").as<PhaseRangeSpec>());
         REQUIRE_THROWS(YAML::Load("12abc").as<PhaseRangeSpec>());
         REQUIRE_THROWS(YAML::Load("{foo}").as<PhaseRangeSpec>());
         REQUIRE_THROWS(YAML::Load("").as<PhaseRangeSpec>());

--- a/src/gennylib/test/conventions_test.cpp
+++ b/src/gennylib/test/conventions_test.cpp
@@ -124,5 +124,42 @@ TEST_CASE("genny::RateSpec conversions") {
     }
 }
 
+TEST_CASE("genny::PhaseRangeSpec conversions") {
+    SECTION("Can convert to genny::PhaseRangeSpec") {
+        auto yaml = YAML::Load("Phase: 0..20");
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().start == 0);
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().end == 20);
+
+        yaml = YAML::Load("Phase: 2..2");
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().start == 2);
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().end == 2);
+
+        yaml = YAML::Load("Phase: 0..1e2");
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().start == 0);
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().end == 100);
+
+        yaml = YAML::Load("Phase: 12");
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().start == 12);
+        REQUIRE(yaml["Phase"].as<PhaseRangeSpec>().end == 12);
+    }
+
+    SECTION("Barfs on invalid values") {
+        REQUIRE_THROWS(YAML::Load("0....20").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("0.1").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("0abc..20").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("20..25abc").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("12abc").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("{foo}").as<PhaseRangeSpec>());
+        REQUIRE_THROWS(YAML::Load("").as<PhaseRangeSpec>());
+    }
+
+    SECTION("Can encode") {
+        YAML::Node n;
+        n["Phase"] = PhaseRangeSpec{0, 10};
+        REQUIRE(n["Phase"].as<PhaseRangeSpec>().start == 0);
+        REQUIRE(n["Phase"].as<PhaseRangeSpec>().end == 10);
+    }
+}
+
 }  // namespace
 }  // namespace genny


### PR DESCRIPTION
Added `PhaseRangeSpec` to handle the `..` syntax. `PhaseRangeSpec` handles both `IntegerSpec..IntegerSpec` and `IntegerSpec` formats. The `..` syntax is inclusive and resembles Ruby's `..`. 

Note that the `decode` method for `PhaseRangeSpec` was  implemented to throw if a user inputted invalid syntax, but the correct behavior should be to return false instead and let the caller decide whether to throw or have other behavior. I've kept the current behavior to be consistent with how the other specs have been implemented, and opened up [TIG-1507](https://jira.mongodb.org/browse/TIG-1507) to fix them all at once. 