### PR TITLE
nomerge: TIG-1209: Make ValueGenerators typed internally

### DIFF
--- a/src/value_generators/include/value_generators/value_generators.hpp
+++ b/src/value_generators/include/value_generators/value_generators.hpp
@@ -400,14 +400,14 @@ public:
 
     static UniqueExpression parse(YAML::Node node);
 
-    explicit FastRandomStringExpression(UniqueExpression length);
+    explicit FastRandomStringExpression(UniqueTypedExpression<ValueType::Integer> length);
     Value evaluate(genny::DefaultRandom& rng) const override;
     ValueType valueType() const override {
         return ValueType::String;
     }
 
 private:
-    const UniqueExpression _length;
+    const UniqueTypedExpression<ValueType::Integer> _length;
 };
 
 }  // namespace genny::value_generators

--- a/src/value_generators/include/value_generators/value_generators.hpp
+++ b/src/value_generators/include/value_generators/value_generators.hpp
@@ -378,7 +378,7 @@ public:
 
     static UniqueExpression parse(YAML::Node node);
 
-    RandomStringExpression(UniqueExpression length, std::optional<std::string> alphabet);
+    RandomStringExpression(UniqueTypedExpression<ValueType::Integer> length, std::optional<std::string> alphabet);
     Value evaluate(genny::DefaultRandom& rng) const override;
     ValueType valueType() const override {
         return ValueType::String;
@@ -386,7 +386,7 @@ public:
 
 
 private:
-    const UniqueExpression _length;
+    const UniqueTypedExpression<ValueType::Integer> _length;
     const std::optional<std::string> _alphabet;
 };
 

--- a/src/value_generators/include/value_generators/value_generators.hpp
+++ b/src/value_generators/include/value_generators/value_generators.hpp
@@ -173,6 +173,15 @@ public:
 
     virtual ~Expression() = default;
 
+    enum class ValueType {
+        Integer,
+        String,
+        Array,
+        Document,
+    };
+
+    virtual ValueType valueType() const = 0;
+
     /**
      * Generate a possibly randomized value.
      *
@@ -192,6 +201,8 @@ public:
 
     explicit ConstantExpression(Value value);
     Value evaluate(genny::DefaultRandom& rng) const override;
+    // TODO: I don't think this is right - may need a ConstantExpression for each ValueType
+    ValueType valueType() const override { return ValueType::Document; }
 
 private:
     const Value _value;
@@ -211,6 +222,8 @@ public:
     explicit DocumentExpression(std::vector<ElementType> elements);
     Value evaluate(genny::DefaultRandom& rng) const override;
 
+    ValueType valueType() const override { return ValueType::Document; }
+
 private:
     const std::vector<ElementType> _elements;
 };
@@ -228,6 +241,9 @@ public:
 
     explicit ArrayExpression(std::vector<ElementType> elements);
     Value evaluate(genny::DefaultRandom& rng) const override;
+    ValueType valueType() const override { return ValueType::Array; }
+
+
 
 private:
     const std::vector<ElementType> _elements;
@@ -240,6 +256,7 @@ private:
 class RandomIntExpression : public Expression {
 public:
     static UniqueExpression parse(YAML::Node node);
+    virtual ValueType valueType() const override { return ValueType::Integer; }
 };
 
 
@@ -252,7 +269,6 @@ class UniformIntExpression : public RandomIntExpression {
 public:
     UniformIntExpression(UniqueExpression min, UniqueExpression max);
     Value evaluate(genny::DefaultRandom& rng) const override;
-
 private:
     const UniqueExpression _min;
     const UniqueExpression _max;
@@ -268,7 +284,6 @@ class BinomialIntExpression : public RandomIntExpression {
 public:
     BinomialIntExpression(UniqueExpression t, double p);
     Value evaluate(genny::DefaultRandom& rng) const override;
-
 private:
     const UniqueExpression _t;
     const double _p;
@@ -284,7 +299,6 @@ class NegativeBinomialIntExpression : public RandomIntExpression {
 public:
     NegativeBinomialIntExpression(UniqueExpression k, double p);
     Value evaluate(genny::DefaultRandom& rng) const override;
-
 private:
     const UniqueExpression _k;
     const double _p;
@@ -335,6 +349,8 @@ public:
 
     RandomStringExpression(UniqueExpression length, std::optional<std::string> alphabet);
     Value evaluate(genny::DefaultRandom& rng) const override;
+    ValueType valueType() const override { return ValueType::String; }
+
 
 private:
     const UniqueExpression _length;
@@ -353,6 +369,7 @@ public:
 
     explicit FastRandomStringExpression(UniqueExpression length);
     Value evaluate(genny::DefaultRandom& rng) const override;
+    ValueType valueType() const override { return ValueType::String; }
 
 private:
     const UniqueExpression _length;

--- a/src/value_generators/src/value_generators.cpp
+++ b/src/value_generators/src/value_generators.cpp
@@ -420,7 +420,14 @@ UniqueExpression RandomIntExpression::parse(YAML::Node node) {
 }
 
 UniformIntExpression::UniformIntExpression(UniqueExpression min, UniqueExpression max)
-    : _min(std::move(min)), _max(std::move(max)) {}
+    : _min(std::move(min)), _max(std::move(max)) {
+    if (_min->valueType() != ValueType::Integer || _max->valueType() != ValueType::Integer) {
+        std::stringstream error;
+        // TODO: print expression as json or something?
+        error << "Invalid min/max value";
+        throw InvalidValueGeneratorSyntax(error.str());
+    }
+}
 
 Value UniformIntExpression::evaluate(genny::DefaultRandom& rng) const {
     auto min = getInt64Parameter(_min->evaluate(rng), "min");
@@ -431,7 +438,14 @@ Value UniformIntExpression::evaluate(genny::DefaultRandom& rng) const {
 }
 
 BinomialIntExpression::BinomialIntExpression(UniqueExpression t, double p)
-    : _t(std::move(t)), _p(p) {}
+    : _t(std::move(t)), _p(p) {
+    if (_t->valueType() != ValueType::Integer) {
+        std::stringstream error;
+        // TODO: print expression as json or something?
+        error << "Invalid min/max value";
+        throw InvalidValueGeneratorSyntax(error.str());
+    }
+}
 
 Value BinomialIntExpression::evaluate(genny::DefaultRandom& rng) const {
     auto t = getInt64Parameter(_t->evaluate(rng), "t");
@@ -441,7 +455,15 @@ Value BinomialIntExpression::evaluate(genny::DefaultRandom& rng) const {
 }
 
 NegativeBinomialIntExpression::NegativeBinomialIntExpression(UniqueExpression k, double p)
-    : _k(std::move(k)), _p(p) {}
+    : _k(std::move(k)), _p(p) {
+
+    if (_k->valueType() != ValueType::Integer) {
+        std::stringstream error;
+        // TODO: print expression as json or something?
+        error << "Invalid k value";
+        throw InvalidValueGeneratorSyntax(error.str());
+    }
+}
 
 Value NegativeBinomialIntExpression::evaluate(genny::DefaultRandom& rng) const {
     auto k = getInt64Parameter(_k->evaluate(rng), "k");
@@ -466,7 +488,14 @@ Value PoissonIntExpression::evaluate(genny::DefaultRandom& rng) const {
 
 RandomStringExpression::RandomStringExpression(UniqueExpression length,
                                                std::optional<std::string> alphabet)
-    : _length(std::move(length)), _alphabet(std::move(alphabet)) {}
+    : _length(std::move(length)), _alphabet(std::move(alphabet)) {
+    if (_length->valueType() != ValueType::Integer) {
+        std::stringstream error;
+        // TODO: print expression as json or something?
+        error << "Invalid length value";
+        throw InvalidValueGeneratorSyntax(error.str());
+    }
+}
 
 UniqueExpression RandomStringExpression::parse(YAML::Node node) {
     UniqueExpression length;
@@ -508,7 +537,14 @@ Value RandomStringExpression::evaluate(genny::DefaultRandom& rng) const {
 }
 
 FastRandomStringExpression::FastRandomStringExpression(UniqueExpression length)
-    : _length(std::move(length)) {}
+    : _length(std::move(length)) {
+    if (_length->valueType() != ValueType::Integer) {
+        std::stringstream error;
+        // TODO: print expression as json or something?
+        error << "Invalid length value";
+        throw InvalidValueGeneratorSyntax(error.str());
+    }
+}
 
 UniqueExpression FastRandomStringExpression::parse(YAML::Node node) {
     UniqueExpression length;

--- a/src/value_generators/src/value_generators.cpp
+++ b/src/value_generators/src/value_generators.cpp
@@ -526,15 +526,8 @@ Value RandomStringExpression::evaluate(genny::DefaultRandom& rng) const {
     return Value{str};
 }
 
-FastRandomStringExpression::FastRandomStringExpression(UniqueExpression length)
-    : _length(std::move(length)) {
-    if (_length->valueType() != ValueType::Integer) {
-        std::stringstream error;
-        // TODO: print expression as json or something?
-        error << "Invalid length value";
-        throw InvalidValueGeneratorSyntax(error.str());
-    }
-}
+FastRandomStringExpression::FastRandomStringExpression(UniqueTypedExpression<ValueType::Integer> length)
+    : _length(std::move(length)) {}
 
 UniqueExpression FastRandomStringExpression::parse(YAML::Node node) {
     UniqueExpression length;
@@ -545,7 +538,9 @@ UniqueExpression FastRandomStringExpression::parse(YAML::Node node) {
         throw InvalidValueGeneratorSyntax("Expected 'length' parameter for fast random string");
     }
 
-    return std::make_unique<FastRandomStringExpression>(std::move(length));
+    UniqueTypedExpression<ValueType::Integer> lengthT =
+        std::make_unique<TypedExpression<ValueType::Integer>>(std::move(length));
+    return std::make_unique<FastRandomStringExpression>(std::move(lengthT));
 }
 
 Value FastRandomStringExpression::evaluate(genny::DefaultRandom& rng) const {

--- a/src/value_generators/src/value_generators.cpp
+++ b/src/value_generators/src/value_generators.cpp
@@ -476,16 +476,9 @@ Value PoissonIntExpression::evaluate(genny::DefaultRandom& rng) const {
     return Value{distribution(rng)};
 }
 
-RandomStringExpression::RandomStringExpression(UniqueExpression length,
+RandomStringExpression::RandomStringExpression(UniqueTypedExpression<ValueType::Integer> length,
                                                std::optional<std::string> alphabet)
-    : _length(std::move(length)), _alphabet(std::move(alphabet)) {
-    if (_length->valueType() != ValueType::Integer) {
-        std::stringstream error;
-        // TODO: print expression as json or something?
-        error << "Invalid length value";
-        throw InvalidValueGeneratorSyntax(error.str());
-    }
-}
+    : _length(std::move(length)), _alphabet(std::move(alphabet)) {}
 
 UniqueExpression RandomStringExpression::parse(YAML::Node node) {
     UniqueExpression length;
@@ -507,7 +500,11 @@ UniqueExpression RandomStringExpression::parse(YAML::Node node) {
         }
     }
 
-    return std::make_unique<RandomStringExpression>(std::move(length), std::move(alphabet));
+    UniqueTypedExpression<ValueType::Integer> lengthT =
+        std::make_unique<TypedExpression<ValueType::Integer>>(std::move(length));
+
+    // TODO: does this want to be `optional`?
+    return std::make_unique<RandomStringExpression>(std::move(lengthT), std::move(alphabet));
 }
 
 Value RandomStringExpression::evaluate(genny::DefaultRandom& rng) const {

--- a/src/value_generators/test/expression_test.cpp
+++ b/src/value_generators/test/expression_test.cpp
@@ -238,6 +238,13 @@ TEST_CASE("Expression parsing with ConstantExpression::parse") {
     genny::DefaultRandom rng{};
     rng.seed(269849313357703264LL);
 
+    SECTION("recursive application caught at setup time") {
+        auto yaml = YAML::Load(R"(
+{^RandomInt: {min: [7], max: 100}}
+        )");
+        REQUIRE_THROWS(Expression::parseExpression(yaml));
+    }
+
     SECTION("valid syntax") {
         auto yaml = YAML::Load(R"(
 1


### PR DESCRIPTION
Wasn't so bad to pass type information through the various `parse` statics.

This adds a new `UniqueTypedExpression<T>` type and uses it internally wherever `Expression`s want recursive/sub-expressions.

Assuming okay with this approach I'll 

1. hide all of the current implementation(s) behind a `v1` namespace
2. expose various `UniqueTypedExpression<T>` aliases/wrappers so calling code never has to see `UniqueExpression` and will instead only see things like `IntGenerator`, `DocGenerator`, etc. These will have the various `operator T()` conversions on them.
3. See if we still need `UniqueExpression` or if we can get away with just `UniqueTypedExpression`.
4. add more testing for all of the above
