### PR TITLE
TIG-1209: Add Simple YAML to BSON Conversion in testlib

### DIFF
--- a/src/testlib/include/testlib/yamlToBson.hpp
+++ b/src/testlib/include/testlib/yamlToBson.hpp
@@ -1,0 +1,40 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HEADER_765C17F3_36B6_4EDC_BA8C_61DD618CCA80_INCLUDED
+#define HEADER_765C17F3_36B6_4EDC_BA8C_61DD618CCA80_INCLUDED
+
+#include <exception>
+
+#include <bsoncxx/document/view_or_value.hpp>
+#include <bsoncxx/array/view_or_value.hpp>
+#include <bsoncxx/types.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+namespace genny::testing {
+
+class InvalidYAMLToBsonException : public std::invalid_argument {
+    using std::invalid_argument::invalid_argument;
+};
+
+bsoncxx::document::view_or_value toDocumentBson(const YAML::Node& node);
+
+bsoncxx::array::view_or_value toArrayBson(const YAML::Node& node);
+
+}
+
+
+
+#endif  // HEADER_765C17F3_36B6_4EDC_BA8C_61DD618CCA80_INCLUDED

--- a/src/testlib/include/testlib/yamlToBson.hpp
+++ b/src/testlib/include/testlib/yamlToBson.hpp
@@ -17,8 +17,8 @@
 
 #include <exception>
 
-#include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/array/view_or_value.hpp>
+#include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/types.hpp>
 
 #include <yaml-cpp/yaml.h>
@@ -29,12 +29,21 @@ class InvalidYAMLToBsonException : public std::invalid_argument {
     using std::invalid_argument::invalid_argument;
 };
 
+/**
+ * @param node yaml map node
+ * @return bson representation of it.
+ * @throws InvalidYAMLToBsonException if node isn't a map
+ */
 bsoncxx::document::view_or_value toDocumentBson(const YAML::Node& node);
 
+
+/**
+ * @param node yaml list node
+ * @return bson representation of it.
+ * @throws InvalidYAMLToBsonException if node isn't a list (sequence)
+ */
 bsoncxx::array::view_or_value toArrayBson(const YAML::Node& node);
 
-}
-
-
+}  // namespace genny::testing
 
 #endif  // HEADER_765C17F3_36B6_4EDC_BA8C_61DD618CCA80_INCLUDED

--- a/src/testlib/include/testlib/yamlToBson.hpp
+++ b/src/testlib/include/testlib/yamlToBson.hpp
@@ -34,7 +34,7 @@ class InvalidYAMLToBsonException : public std::invalid_argument {
  * @return bson representation of it.
  * @throws InvalidYAMLToBsonException if node isn't a map
  */
-bsoncxx::document::view_or_value toDocumentBson(const YAML::Node& node);
+bsoncxx::document::value toDocumentBson(const YAML::Node& node);
 
 
 /**
@@ -42,7 +42,7 @@ bsoncxx::document::view_or_value toDocumentBson(const YAML::Node& node);
  * @return bson representation of it.
  * @throws InvalidYAMLToBsonException if node isn't a list (sequence)
  */
-bsoncxx::array::view_or_value toArrayBson(const YAML::Node& node);
+bsoncxx::array::value toArrayBson(const YAML::Node& node);
 
 }  // namespace genny::testing
 

--- a/src/testlib/src/yamlToBson.cpp
+++ b/src/testlib/src/yamlToBson.cpp
@@ -150,7 +150,7 @@ void appendToBuilder(const YAML::Node& node, bsoncxx::builder::basic::array& arr
 }  // namespace
 }  // namespace genny::testing
 
-bsoncxx::document::view_or_value genny::testing::toDocumentBson(const YAML::Node& node) {
+bsoncxx::document::value genny::testing::toDocumentBson(const YAML::Node& node) {
     if (!node.IsMap()) {
         std::stringstream msg;
         msg << "Wanted map got " << node.Type() << ": " << to_string(node);
@@ -164,7 +164,7 @@ bsoncxx::document::view_or_value genny::testing::toDocumentBson(const YAML::Node
     return doc.extract();
 }
 
-bsoncxx::array::view_or_value genny::testing::toArrayBson(const YAML::Node& node) {
+bsoncxx::array::value genny::testing::toArrayBson(const YAML::Node& node) {
     if (!node.IsSequence()) {
         std::stringstream msg;
         msg << "Wanted sequence got " << node.Type() << ": " << to_string(node);

--- a/src/testlib/src/yamlToBson.cpp
+++ b/src/testlib/src/yamlToBson.cpp
@@ -22,6 +22,7 @@
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
+#include <bsoncxx/types.hpp>
 
 namespace genny::testing {
 
@@ -87,14 +88,8 @@ public:
     }
 
 private:
-    using VariantType = std::variant<bool,
-                                     int32_t,
-                                     int64_t,
-                                     double,
-                                     std::string,
-                                     bsoncxx::types::b_null,
-                                     bsoncxx::document::view_or_value,
-                                     bsoncxx::array::view_or_value>;
+    using VariantType =
+        std::variant<bool, int32_t, int64_t, double, std::string, bsoncxx::types::b_null>;
     VariantType _value;
 };
 

--- a/src/testlib/src/yamlToBson.cpp
+++ b/src/testlib/src/yamlToBson.cpp
@@ -26,32 +26,64 @@
 namespace genny::testing {
 
 namespace {
+
+
+// Helper type cribbed from value_generators
+// The value_generators version will likely disappear soon.
 class Value {
 public:
-    //
-    // Constructors
-    //
-
     explicit Value(bool value) : _value{value} {}
-
     explicit Value(int32_t value) : _value{value} {}
-
     explicit Value(int64_t value) : _value{value} {}
-
     explicit Value(double value) : _value{value} {}
-
     explicit Value(std::string value) : _value{value} {}
-
     explicit Value(bsoncxx::types::b_null value) : _value{value} {}
-
     void appendToBuilder(bsoncxx::builder::basic::document& doc, std::string key) {
         std::visit(
             [&](auto&& arg) { doc.append(bsoncxx::builder::basic::kvp(std::move(key), arg)); },
             std::move(_value));
     }
-
     void appendToBuilder(bsoncxx::builder::basic::array& arr) {
         std::visit([&](auto&& arg) { arr.append(arg); }, std::move(_value));
+    }
+
+    static Value parseScalar(const YAML::Node& node) {
+        if (!node.IsScalar() && !node.IsNull()) {
+            std::stringstream msg;
+            msg << "Expected scalar or null got " << node.Type();
+            BOOST_THROW_EXCEPTION(InvalidYAMLToBsonException(msg.str()));
+        }
+
+        if (node.Type() == YAML::NodeType::Null) {
+            return Value{bsoncxx::types::b_null{}};
+        }
+
+        // `YAML::Node::Tag() == "!"` means that the scalar value is quoted. In that case, we want
+        // to avoid converting any numeric string values to numbers. See
+        // https://github.com/jbeder/yaml-cpp/issues/261 for more details.
+        if (node.Tag() != "!") {
+            try {
+                return Value{node.as<int32_t>()};
+            } catch (const YAML::BadConversion& e) {
+            }
+
+            try {
+                return Value{node.as<int64_t>()};
+            } catch (const YAML::BadConversion& e) {
+            }
+
+            try {
+                return Value{node.as<double>()};
+            } catch (const YAML::BadConversion& e) {
+            }
+
+            try {
+                return Value{node.as<bool>()};
+            } catch (const YAML::BadConversion& e) {
+            }
+        }
+
+        return Value{node.as<std::string>()};
     }
 
 private:
@@ -63,7 +95,6 @@ private:
                                      bsoncxx::types::b_null,
                                      bsoncxx::document::view_or_value,
                                      bsoncxx::array::view_or_value>;
-
     VariantType _value;
 };
 
@@ -73,47 +104,6 @@ std::string to_string(const YAML::Node& node) {
     e << node;
     return std::string{e.c_str()};
 }
-
-
-Value parseScalar(const YAML::Node& node) {
-    if (!node.IsScalar() && !node.IsNull()) {
-        std::stringstream msg;
-        msg << "Expected scalar or null got " << node.Type();
-        BOOST_THROW_EXCEPTION(InvalidYAMLToBsonException(msg.str()));
-    }
-
-    if (node.Type() == YAML::NodeType::Null) {
-        return Value{bsoncxx::types::b_null{}};
-    }
-
-    // `YAML::Node::Tag() == "!"` means that the scalar value is quoted. In that case, we want to
-    // avoid converting any numeric string values to numbers. See
-    // https://github.com/jbeder/yaml-cpp/issues/261 for more details.
-    if (node.Tag() != "!") {
-        try {
-            return Value{node.as<int32_t>()};
-        } catch (const YAML::BadConversion& e) {
-        }
-
-        try {
-            return Value{node.as<int64_t>()};
-        } catch (const YAML::BadConversion& e) {
-        }
-
-        try {
-            return Value{node.as<double>()};
-        } catch (const YAML::BadConversion& e) {
-        }
-
-        try {
-            return Value{node.as<bool>()};
-        } catch (const YAML::BadConversion& e) {
-        }
-    }
-
-    return Value{node.as<std::string>()};
-}
-
 
 void appendToBuilder(const YAML::Node& node,
                      const std::string& key,
@@ -128,7 +118,7 @@ void appendToBuilder(const YAML::Node& node,
         case YAML::NodeType::Undefined:
         case YAML::NodeType::Scalar:
         case YAML::NodeType::Null: {
-            Value val = parseScalar(node);
+            Value val = Value::parseScalar(node);
             val.appendToBuilder(doc, key);
             return;
         }
@@ -136,7 +126,6 @@ void appendToBuilder(const YAML::Node& node,
 
     std::abort();
 }
-
 
 void appendToBuilder(const YAML::Node& node, bsoncxx::builder::basic::array& arr) {
     switch (node.Type()) {
@@ -149,7 +138,7 @@ void appendToBuilder(const YAML::Node& node, bsoncxx::builder::basic::array& arr
         case YAML::NodeType::Undefined:
         case YAML::NodeType::Scalar:
         case YAML::NodeType::Null: {
-            Value val = parseScalar(node);
+            Value val = Value::parseScalar(node);
             val.appendToBuilder(arr);
             return;
         }
@@ -160,7 +149,6 @@ void appendToBuilder(const YAML::Node& node, bsoncxx::builder::basic::array& arr
 
 }  // namespace
 }  // namespace genny::testing
-
 
 bsoncxx::document::view_or_value genny::testing::toDocumentBson(const YAML::Node& node) {
     if (!node.IsMap()) {

--- a/src/testlib/src/yamlToBson.cpp
+++ b/src/testlib/src/yamlToBson.cpp
@@ -1,0 +1,330 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <testlib/yamlToBson.hpp>
+
+#include <optional>
+#include <variant>
+
+#include <boost/throw_exception.hpp>
+
+#include <bsoncxx/builder/basic/array.hpp>
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/json.hpp>
+
+namespace genny::testing {
+
+namespace {
+class Value {
+public:
+    //
+    // Constructors
+    //
+
+    explicit Value(bool value);
+
+    explicit Value(int32_t value);
+
+    explicit Value(int64_t value);
+
+    explicit Value(double value);
+
+    explicit Value(std::string value);
+
+    explicit Value(bsoncxx::types::b_null value);
+
+    explicit Value(bsoncxx::document::view_or_value value);
+
+    explicit Value(bsoncxx::array::view_or_value value);
+
+    //
+    // Getters
+    //
+
+    bool getBool() const;
+
+    int32_t getInt32() const;
+
+    int64_t getInt64() const;
+
+    double getDouble() const;
+
+    std::string getString() const;
+
+    bsoncxx::types::b_null getNull() const;
+
+    bsoncxx::document::view_or_value getDocument() const;
+
+    bsoncxx::array::view_or_value getArray() const;
+
+    /**
+     * Return `_value` as an int64_t if it is of type int32_t or int64_t, or std::nullopt if it is
+     * some other type.
+     */
+    std::optional<int64_t> tryAsInt64() const;
+
+    /**
+     * Append the underlying `_value` to the document `doc` using the field name `key`.
+     *
+     * @warning
+     *  After calling appendToBuilder() it is illegal to call any methods on this instance, unless
+     *  it is subsequently moved into.
+     */
+    void appendToBuilder(bsoncxx::builder::basic::document& doc, std::string key);
+
+    /**
+     * Append the underlying `_value` to the array `arr`.
+     *
+     * @warning
+     *  After calling appendToBuilder() it is illegal to call any methods on this instance, unless
+     *  it is subsequently moved into.
+     */
+    void appendToBuilder(bsoncxx::builder::basic::array& arr);
+
+private:
+    using VariantType = std::variant<bool,
+                                     int32_t,
+                                     int64_t,
+                                     double,
+                                     std::string,
+                                     bsoncxx::types::b_null,
+                                     bsoncxx::document::view_or_value,
+                                     bsoncxx::array::view_or_value>;
+
+    friend std::ostream& operator<<(std::ostream& out, const Value& value);
+
+    VariantType _value;
+};
+
+Value::Value(bool value) : _value(value) {}
+
+Value::Value(int32_t value) : _value(value) {}
+
+Value::Value(int64_t value) : _value(value) {}
+
+Value::Value(double value) : _value(value) {}
+
+Value::Value(std::string value) : _value(std::move(value)) {}
+
+Value::Value(bsoncxx::types::b_null value) : _value(std::move(value)) {}
+
+Value::Value(bsoncxx::document::view_or_value value) : _value(std::move(value)) {}
+
+Value::Value(bsoncxx::array::view_or_value value) : _value(std::move(value)) {}
+
+bool Value::getBool() const {
+    return std::get<bool>(_value);
+}
+
+int32_t Value::getInt32() const {
+    return std::get<int32_t>(_value);
+}
+
+int64_t Value::getInt64() const {
+    return std::get<int64_t>(_value);
+}
+
+double Value::getDouble() const {
+    return std::get<double>(_value);
+}
+
+std::string Value::getString() const {
+    return std::get<std::string>(_value);
+}
+
+bsoncxx::types::b_null Value::getNull() const {
+    return std::get<bsoncxx::types::b_null>(_value);
+}
+
+bsoncxx::document::view_or_value Value::getDocument() const {
+    return std::get<bsoncxx::document::view_or_value>(_value);
+}
+
+bsoncxx::array::view_or_value Value::getArray() const {
+    return std::get<bsoncxx::array::view_or_value>(_value);
+}
+
+template <class... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+
+template <class... Ts>
+overloaded(Ts...)->overloaded<Ts...>;
+
+std::optional<int64_t> Value::tryAsInt64() const {
+    std::optional<int64_t> ret;
+
+    std::visit(overloaded{[&](int32_t arg) { ret = arg; },
+                          [&](int64_t arg) { ret = arg; },
+                          [&](auto&& arg) {}},
+               _value);
+
+    return ret;
+}
+
+void Value::appendToBuilder(bsoncxx::builder::basic::document& doc, std::string key) {
+    std::visit([&](auto&& arg) { doc.append(bsoncxx::builder::basic::kvp(std::move(key), arg)); },
+               std::move(_value));
+}
+
+void Value::appendToBuilder(bsoncxx::builder::basic::array& arr) {
+    std::visit([&](auto&& arg) { arr.append(arg); }, std::move(_value));
+}
+
+std::ostream& operator<<(std::ostream& out, const Value& value) {
+    std::visit(overloaded{
+                   [&](bool arg) { out << arg; },
+                   [&](int32_t arg) { out << arg; },
+                   [&](int64_t arg) { out << arg; },
+                   [&](double arg) { out << arg; },
+                   [&](const std::string& arg) { out << arg; },
+                   [&](bsoncxx::types::b_null arg) { out << "null"; },
+                   [&](const bsoncxx::document::value& arg) {
+                       out << bsoncxx::to_json(arg.view(), bsoncxx::ExtendedJsonMode::k_canonical);
+                   },
+                   [&](bsoncxx::document::view arg) {
+                       out << bsoncxx::to_json(arg, bsoncxx::ExtendedJsonMode::k_canonical);
+                   },
+                   [&](const bsoncxx::array::value& arg) {
+                       out << bsoncxx::to_json(arg.view(), bsoncxx::ExtendedJsonMode::k_canonical);
+                   },
+                   [&](bsoncxx::array::view arg) {
+                       out << bsoncxx::to_json(arg, bsoncxx::ExtendedJsonMode::k_canonical);
+                   },
+               },
+               value._value);
+
+    return out;
+}
+
+std::string to_string(const YAML::Node& node) {
+    YAML::Emitter e;
+    e << node;
+    return std::string{e.c_str()};
+}
+
+
+Value parseScalar(const YAML::Node& node) {
+    if (!node.IsScalar() && !node.IsNull()) {
+        std::stringstream msg;
+        msg << "Expected scalar or null got " << node.Type();
+        BOOST_THROW_EXCEPTION(InvalidYAMLToBsonException(msg.str()));
+    }
+
+    if (node.Type() == YAML::NodeType::Null) {
+        return Value{bsoncxx::types::b_null{}};
+    }
+
+    // `YAML::Node::Tag() == "!"` means that the scalar value is quoted. In that case, we want to
+    // avoid converting any numeric string values to numbers. See
+    // https://github.com/jbeder/yaml-cpp/issues/261 for more details.
+    if (node.Tag() != "!") {
+        try {
+            return Value{node.as<int32_t>()};
+        } catch (const YAML::BadConversion& e) {
+        }
+
+        try {
+            return Value{node.as<int64_t>()};
+        } catch (const YAML::BadConversion& e) {
+        }
+
+        try {
+            return Value{node.as<double>()};
+        } catch (const YAML::BadConversion& e) {
+        }
+
+        try {
+            return Value{node.as<bool>()};
+        } catch (const YAML::BadConversion& e) {
+        }
+    }
+
+    return Value{node.as<std::string>()};
+}
+
+void appendToBuilder(const YAML::Node& node,
+                     const std::string& key,
+                     bsoncxx::builder::basic::document& doc) {
+    switch (node.Type()) {
+        case YAML::NodeType::Map:
+            doc.append(bsoncxx::builder::basic::kvp(key, toDocumentBson(node)));
+            return;
+        case YAML::NodeType::Sequence:
+            doc.append(bsoncxx::builder::basic::kvp(key, toArrayBson(node)));
+            return;
+        case YAML::NodeType::Undefined:
+        case YAML::NodeType::Scalar:
+        case YAML::NodeType::Null: {
+            Value val = parseScalar(node);
+            val.appendToBuilder(doc, key);
+            return;
+        }
+    }
+
+    std::abort();
+}
+
+void appendToBuilder(const YAML::Node& node, bsoncxx::builder::basic::array& arr) {
+    switch (node.Type()) {
+        case YAML::NodeType::Map:
+            arr.append(toDocumentBson(node));
+            return;
+        case YAML::NodeType::Sequence:
+            arr.append(toArrayBson(node));
+            return;
+        case YAML::NodeType::Undefined:
+        case YAML::NodeType::Scalar:
+        case YAML::NodeType::Null: {
+            Value val = parseScalar(node);
+            val.appendToBuilder(arr);
+            return;
+        }
+    }
+
+    std::abort();
+}
+
+}  // namespace
+}  // namespace genny::testing
+
+
+bsoncxx::document::view_or_value genny::testing::toDocumentBson(const YAML::Node& node) {
+    if (!node.IsMap()) {
+        std::stringstream msg;
+        msg << "Wanted map got " << node.Type() << ": " << to_string(node);
+        BOOST_THROW_EXCEPTION(InvalidYAMLToBsonException(msg.str()));
+    }
+
+    bsoncxx::builder::basic::document doc{};
+    for (auto&& kvp : node) {
+        appendToBuilder(kvp.second, kvp.first.as<std::string>(), doc);
+    }
+    return doc.extract();
+}
+
+bsoncxx::array::view_or_value genny::testing::toArrayBson(const YAML::Node& node) {
+    if (!node.IsSequence()) {
+        std::stringstream msg;
+        msg << "Wanted sequence got " << node.Type() << ": " << to_string(node);
+        BOOST_THROW_EXCEPTION(InvalidYAMLToBsonException(msg.str()));
+    }
+
+    bsoncxx::builder::basic::array arr{};
+    for (auto&& elt : node) {
+        appendToBuilder(elt, arr);
+    }
+    return arr.extract();
+}

--- a/src/testlib/test/yamlToBson_test.cpp
+++ b/src/testlib/test/yamlToBson_test.cpp
@@ -75,7 +75,6 @@ TEST_CASE("YAML To BSON Simple") {
 
     test("foo: [10.1]", R"({"foo":[10.1]})");
     test("foo: [10.1,]", R"({"foo":[10.1]})");
-
 }
 
 TEST_CASE("YAML To BSON Nested") {

--- a/src/testlib/test/yamlToBson_test.cpp
+++ b/src/testlib/test/yamlToBson_test.cpp
@@ -52,7 +52,6 @@ void test(const std::string& yaml, const std::string& json) {
 }
 
 
-
 TEST_CASE("YAML To BSON Simple") {
     test("foo: bar", R"({"foo":"bar"})");
     test("foo: '0'", R"({"foo":"0"})");

--- a/src/testlib/test/yamlToBson_test.cpp
+++ b/src/testlib/test/yamlToBson_test.cpp
@@ -1,0 +1,87 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ios>
+#include <string>
+
+#include <yaml-cpp/yaml.h>
+
+#include <bsoncxx/json.hpp>
+
+#include <iostream>
+#include <testlib/helpers.hpp>
+#include <testlib/yamlToBson.hpp>
+
+namespace genny::testing {
+
+using Catch::Matchers::Matches;
+
+namespace {
+bsoncxx::document::view_or_value bson(const std::string& json) {
+    return bsoncxx::from_json(json);
+}
+std::string json(const bsoncxx::document::view_or_value& doc) {
+    return bsoncxx::to_json(doc, bsoncxx::ExtendedJsonMode::k_canonical);
+}
+YAML::Node yaml(const std::string& str) {
+    return YAML::Load(str);
+}
+bsoncxx::document::view_or_value fromYaml(const std::string& yamlStr) {
+    return toDocumentBson(yaml(yamlStr));
+}
+
+void test(const std::string& yaml, const std::string& json) {
+    try {
+        auto actual = fromYaml(yaml);
+        auto expect = bson(json);
+        INFO(bsoncxx::to_json(expect) << bsoncxx::to_json(actual));
+        REQUIRE(expect == actual);
+    } catch (const std::exception& x) {
+        WARN(yaml << " => " << json << " ==> " << x.what());
+        throw;
+    }
+}
+}  // namespace
+
+
+TEST_CASE("YAML To BSON Simple") {
+    test("foo: bar", R"({"foo":"bar"})");
+    test("foo: 1", R"({"foo":1})");
+    test("foo: null", R"({"foo":null})");
+    test("foo: true", R"({"foo":true})");
+
+    test("foo: {}", R"({"foo":{}})");
+    test("foo: []", R"({"foo":[]})");
+    test("foo: [[]]", R"({"foo":[[]]})");
+    test("foo: [{}]", R"({"foo":[{}]})");
+    test("foo: [1,{}]", R"({"foo":[1,{}]})");
+
+    test("foo: [10.1]", R"({"foo":[10.1]})");
+    test("foo: [10.1,]", R"({"foo":[10.1]})");
+
+}
+
+TEST_CASE("YAML To BSON Nested") {
+    test(R"(
+foo:
+  bar:
+  - some
+  - mixed: [list]
+)",
+         R"(
+{ "foo" : { "bar" : [ "some", { "mixed" : [ "list" ] } ] } }
+)");
+}
+
+}  // namespace genny::testing

--- a/src/testlib/test/yamlToBson_test.cpp
+++ b/src/testlib/test/yamlToBson_test.cpp
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <ios>
 #include <string>
 
 #include <yaml-cpp/yaml.h>
 
 #include <bsoncxx/json.hpp>
 
-#include <iostream>
 #include <testlib/helpers.hpp>
 #include <testlib/yamlToBson.hpp>
 

--- a/src/testlib/test/yamlToBson_test.cpp
+++ b/src/testlib/test/yamlToBson_test.cpp
@@ -28,7 +28,7 @@ namespace genny::testing {
 using Catch::Matchers::Matches;
 
 namespace {
-bsoncxx::document::view_or_value bson(const std::string& json) {
+bsoncxx::document::value bson(const std::string& json) {
     return bsoncxx::from_json(json);
 }
 std::string json(const bsoncxx::document::view_or_value& doc) {
@@ -37,7 +37,7 @@ std::string json(const bsoncxx::document::view_or_value& doc) {
 YAML::Node yaml(const std::string& str) {
     return YAML::Load(str);
 }
-bsoncxx::document::view_or_value fromYaml(const std::string& yamlStr) {
+bsoncxx::document::value fromYaml(const std::string& yamlStr) {
     return toDocumentBson(yaml(yamlStr));
 }
 
@@ -46,7 +46,7 @@ void test(const std::string& yaml, const std::string& json) {
         auto actual = fromYaml(yaml);
         auto expect = bson(json);
         INFO(bsoncxx::to_json(expect) << " == " << bsoncxx::to_json(actual));
-        REQUIRE(expect == actual);
+        REQUIRE(expect.view() == actual.view());
     } catch (const std::exception& x) {
         WARN(yaml << " => " << json << " ==> " << x.what());
         throw;

--- a/src/testlib/test/yamlToBson_test.cpp
+++ b/src/testlib/test/yamlToBson_test.cpp
@@ -45,7 +45,7 @@ void test(const std::string& yaml, const std::string& json) {
     try {
         auto actual = fromYaml(yaml);
         auto expect = bson(json);
-        INFO(bsoncxx::to_json(expect) << bsoncxx::to_json(actual));
+        INFO(bsoncxx::to_json(expect) << " == " << bsoncxx::to_json(actual));
         REQUIRE(expect == actual);
     } catch (const std::exception& x) {
         WARN(yaml << " => " << json << " ==> " << x.what());
@@ -57,9 +57,15 @@ void test(const std::string& yaml, const std::string& json) {
 
 TEST_CASE("YAML To BSON Simple") {
     test("foo: bar", R"({"foo":"bar"})");
+    test("foo: '0'", R"({"foo":"0"})");
     test("foo: 1", R"({"foo":1})");
+    test("foo: 1.0", R"({"foo":1.0})");
     test("foo: null", R"({"foo":null})");
     test("foo: true", R"({"foo":true})");
+    test("foo: false", R"({"foo":false})");
+    test("foo: yes", R"({"foo":true})");
+    test("foo: off", R"({"foo":false})");
+
 
     test("foo: {}", R"({"foo":{}})");
     test("foo: []", R"({"foo":[]})");
@@ -81,6 +87,19 @@ foo:
 )",
          R"(
 { "foo" : { "bar" : [ "some", { "mixed" : [ "list" ] } ] } }
+)");
+}
+
+TEST_CASE("YAML with Anchors") {
+    test(R"(
+included: &inc
+  Frodo: Baggins
+  Gimli: Son of Glóin
+foo: *inc
+)",
+         R"(
+{ "included" : { "Frodo" : "Baggins", "Gimli" : "Son of Glóin" },
+  "foo" : { "Frodo" : "Baggins", "Gimli" : "Son of Glóin" } }
 )");
 }
 

--- a/src/testlib/test/yamlToBson_test.cpp
+++ b/src/testlib/test/yamlToBson_test.cpp
@@ -50,7 +50,7 @@ void test(const std::string& yaml, const std::string& json) {
         throw;
     }
 }
-}  // namespace
+
 
 
 TEST_CASE("YAML To BSON Simple") {
@@ -100,4 +100,5 @@ foo: *inc
 )");
 }
 
+}  // namespace
 }  // namespace genny::testing


### PR DESCRIPTION
Tests want to write bson but it's painful with the builders. This cribs Max's work on `Value` to build a simple utility to convert yaml to bson.

There's already `bsoncxx::from_json` so tests could write bson in the form of json and some should probably do just that, but I've got an idea to put a whole suite of tests for overhauled value-generators into a yaml file and I want to be able to write the `expected` case as yaml not a stringified json or something....