### PR TITLE
TIG-1209: Add findRepoRoot to assist with loading test fixtures

### DIFF
--- a/.genny-root
+++ b/.genny-root
@@ -1,0 +1,2 @@
+This is a "dummy" file used by `findRepoRoot` to find the "root" of the Genny
+repository by successively looking up the directory tree from cwd.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ find_package(
         1.68
         REQUIRED
         COMPONENTS
+        filesystem
         log_setup
         log
         program_options

--- a/src/testlib/CMakeLists.txt
+++ b/src/testlib/CMakeLists.txt
@@ -22,6 +22,7 @@ CreateGennyTargets(
         MongoCxx::mongocxx
         MongoCxx::bsoncxx
         Boost::boost
+        Boost::filesystem
         Boost::log
         catch2
         yaml-cpp

--- a/src/testlib/include/testlib/findRepoRoot.hpp
+++ b/src/testlib/include/testlib/findRepoRoot.hpp
@@ -1,0 +1,30 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HEADER_00E808D9_C909_4A88_99A5_C0B5E8596E84_INCLUDED
+#define HEADER_00E808D9_C909_4A88_99A5_C0B5E8596E84_INCLUDED
+
+#include <string>
+
+namespace genny {
+
+    /**
+     * @return the path to the Genny repository's root directory by looking 'up' the directory tree.
+     * @throws invalid_argument if not inside the genny repository
+     */
+    std::string findRepoRoot();
+
+}
+
+#endif  // HEADER_00E808D9_C909_4A88_99A5_C0B5E8596E84_INCLUDED

--- a/src/testlib/include/testlib/findRepoRoot.hpp
+++ b/src/testlib/include/testlib/findRepoRoot.hpp
@@ -19,12 +19,12 @@
 
 namespace genny {
 
-    /**
-     * @return the path to the Genny repository's root directory by looking 'up' the directory tree.
-     * @throws invalid_argument if not inside the genny repository
-     */
-    std::string findRepoRoot();
+/**
+ * @return the path to the Genny repository's root directory by looking 'up' the directory tree.
+ * @throws invalid_argument if not inside the genny repository
+ */
+std::string findRepoRoot();
 
-}
+}  // namespace genny
 
 #endif  // HEADER_00E808D9_C909_4A88_99A5_C0B5E8596E84_INCLUDED

--- a/src/testlib/src/findRepoRoot.cpp
+++ b/src/testlib/src/findRepoRoot.cpp
@@ -1,0 +1,53 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <testlib/findRepoRoot.hpp>
+
+#include <boost/filesystem.hpp>
+#include <sstream>
+
+namespace genny {
+
+namespace {
+
+constexpr auto ROOT_FILE = ".genny-root";
+
+}  // namespace
+
+
+//
+// Note this function doesn't have any automated testing. Be careful when changing.
+//
+std::string findRepoRoot() {
+    using namespace boost::filesystem;
+
+    auto fileSystemRoot = path("/");
+
+    auto curr = current_path();
+    const auto start = curr;
+
+    while (!exists(curr / ROOT_FILE)) {
+        curr = curr / "..";
+        if (curr == fileSystemRoot) {
+            std::stringstream msg;
+            msg << "Cannot find '" << ROOT_FILE << "' in '" << start << "'";
+            throw std::invalid_argument(msg.str());
+        }
+    }
+
+    return curr.string();
+}
+
+
+}  // namespace genny


### PR DESCRIPTION
I'm writing a test that wants to load up a yaml file but the cwd of the test binary isn't really well-defined. This lets us look for a special ".genny-root" file by checking `.` then `./..` and then `./../..` etc.

I considered looking for `.git` but that seems a bit cheeky and I think could break if we ever add submodules or something.