### PR TITLE
PERF-1816: Increase run time for Insert remove test

### DIFF
--- a/src/cast_core/src/InsertRemove.cpp
+++ b/src/cast_core/src/InsertRemove.cpp
@@ -69,7 +69,7 @@ struct InsertRemove::PhaseConfig {
 void InsertRemove::run() {
     for (auto&& config : _loop) {
         for (auto&& _ : config) {
-            BOOST_LOG_TRIVIAL(info) << " Inserting and then removing";
+            BOOST_LOG_TRIVIAL(debug) << " Inserting and then removing";
             _insertStrategy.run(
                 [&](metrics::OperationContext& ctx) {
                     // First we insert

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -12,6 +12,4 @@ Actors:
     Database: test
     Phases:
       - Collection: inserts
-        Duration: 100 milliseconds
-      - Collection: inserts
-        Count: 179
+        Duration: 3 minutes


### PR DESCRIPTION
Need to open a ticket, but here's the change. I changed the log message to debug while here. 
Sys-perf patch here: https://evergreen.mongodb.com/version/5c9241775623433487e7d6bd

I assume it will break history. That's fine. 