### PR TITLE
TIG-1548: Fix handling of ${is_patch} expansion

### DIFF
--- a/src/python/genny/cedar_report.py
+++ b/src/python/genny/cedar_report.py
@@ -75,7 +75,7 @@ class _Config(object):
         self.task_id = env['task_id']
         self.execution_number = int(env['execution'])
         # This env var is either the string "true" or unset.
-        self.mainline = not (env['is_patch'] == 'true')
+        self.mainline = not (env.get('is_patch', '') == 'true')
 
         # We set these for convenience.
         self.test_name = env['test_name']
@@ -288,7 +288,7 @@ def main__cedar_report(argv=sys.argv[1:], env=None, cert_retriever_cls=CertRetri
 
     if not env:
         with open(args.expansions_file, 'r') as f:
-            env = yaml.load(f)
+            env = yaml.safe_load(f)
 
     if args.test_name:
         env['test_name'] = args.test_name

--- a/src/python/tests/cedar_report_test.py
+++ b/src/python/tests/cedar_report_test.py
@@ -33,7 +33,7 @@ class CedarReportTest(unittest.TestCase):
         mock_env = {
             'task_name': 'my_task_name',
             'project': 'my_project',
-            'version': 'my_version',
+            'version_id': 'my_version',
             'build_variant': 'my_variant',
             'task_id': 'my_task_id',
             'execution': '1',

--- a/src/python/tests/cedar_report_test.py
+++ b/src/python/tests/cedar_report_test.py
@@ -82,7 +82,7 @@ class CedarReportTest(unittest.TestCase):
                     'created_at': MatchAnyString(),
                     'completed_at': MatchAnyString(),
                     'artifacts': [{
-                        'bucket': 'genny',
+                        'bucket': 'genny-metrics',
                         'path': 'HelloWorld-Greetings',
                         'tags': [],
                         'local_path': MatchAnyString(),
@@ -101,7 +101,7 @@ class CedarReportTest(unittest.TestCase):
                     'created_at': MatchAnyString(),
                     'completed_at': MatchAnyString(),
                     'artifacts': [{
-                        'bucket': 'genny',
+                        'bucket': 'genny-metrics',
                         'path': 'InsertRemove-Insert',
                         'tags': [],
                         'local_path': MatchAnyString(),
@@ -120,7 +120,7 @@ class CedarReportTest(unittest.TestCase):
                     'created_at': MatchAnyString(),
                     'completed_at': MatchAnyString(),
                     'artifacts': [{
-                        'bucket': 'genny',
+                        'bucket': 'genny-metrics',
                         'path': 'InsertRemove-Remove',
                         'tags': [],
                         'local_path': MatchAnyString(),
@@ -136,7 +136,7 @@ class CedarReportTest(unittest.TestCase):
                 'api_secret': 'my_aws_secret',
                 'api_token': None,
                 'region': 'us-east-1',
-                'name': 'genny',
+                'name': 'genny-metrics',
                 'prefix': 'my_task_id_1'
             }
         }


### PR DESCRIPTION
It isn't defined in mainline builds and therefore won't be serialized out by the expansions.write command.

Also addresses an unrelated warning from PyYAML about using `load()` and unsafe code execution.