### PR TITLE
TIG-1563 Improve metrics parsing performance and log csv parsing progress

### DIFF
--- a/src/python/genny/cedar.py
+++ b/src/python/genny/cedar.py
@@ -179,6 +179,9 @@ def split_into_actor_csv_files(data_reader, out_dir):
     cur_actor = (None, None)
     output_files = []
 
+    # Print progress to prevent the CI task from timing out.
+    counter = 0
+
     for line, actor in data_reader:
         if actor != cur_actor:
             cur_actor = actor
@@ -197,6 +200,10 @@ def split_into_actor_csv_files(data_reader, out_dir):
             cur_out_csv.writerow(IntermediateCSVColumns.default_columns())
 
         cur_out_csv.writerow(line)
+
+        counter += 1
+        if not (counter % 1e6):
+            print('Parsed {} metrics'.format(counter))
 
     cur_out_fh.close()
 

--- a/src/python/genny/cedar.py
+++ b/src/python/genny/cedar.py
@@ -202,7 +202,7 @@ def split_into_actor_csv_files(data_reader, out_dir):
         cur_out_csv.writerow(line)
 
         counter += 1
-        if not (counter % 1e6):
+        if counter % 1e6 == 0:
             print('Parsed {} metrics'.format(counter))
 
     cur_out_fh.close()

--- a/src/python/genny/cedar_report.py
+++ b/src/python/genny/cedar_report.py
@@ -286,26 +286,30 @@ def main__cedar_report(argv=sys.argv[1:], env=None, cert_retriever_cls=CertRetri
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    if not env:
-        with open(args.expansions_file, 'r') as f:
-            env = yaml.safe_load(f)
-
-    if args.test_name:
-        env['test_name'] = args.test_name
-    else:
-        env['test_name'] = env['task_name']
+    # if not env:
+    #     with open(args.expansions_file, 'r') as f:
+    #         env = yaml.safe_load(f)
+    #
+    # if args.test_name:
+    #     env['test_name'] = args.test_name
+    # else:
+    #     env['test_name'] = env['task_name']
 
     metrics_file_names, test_run_time = cedar.run(args)
-    config = _Config(env, metrics_file_names, test_run_time)
+    # config = _Config(env, metrics_file_names, test_run_time)
+    #
+    # report_dict = build_report(config)
+    #
+    # with open(args.report_file, 'w') as f:
+    #     json.dump(report_dict, f, cls=RFCDateTimeEncoder)
+    #
+    # jira_user = env['perf_jira_user']
+    # jira_pwd = env['perf_jira_pw']
+    #
+    # cr = cert_retriever_cls(jira_user, jira_pwd)
+    # runner = ShellCuratorRunner(cr, args.report_file)
+    # runner.run(runner.get_command())
 
-    report_dict = build_report(config)
 
-    with open(args.report_file, 'w') as f:
-        json.dump(report_dict, f, cls=RFCDateTimeEncoder)
-
-    jira_user = env['perf_jira_user']
-    jira_pwd = env['perf_jira_pw']
-
-    cr = cert_retriever_cls(jira_user, jira_pwd)
-    runner = ShellCuratorRunner(cr, args.report_file)
-    runner.run(runner.get_command())
+if __name__ == '__main__':
+    main__cedar_report()

--- a/src/python/genny/cedar_report.py
+++ b/src/python/genny/cedar_report.py
@@ -286,29 +286,29 @@ def main__cedar_report(argv=sys.argv[1:], env=None, cert_retriever_cls=CertRetri
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    # if not env:
-    #     with open(args.expansions_file, 'r') as f:
-    #         env = yaml.safe_load(f)
-    #
-    # if args.test_name:
-    #     env['test_name'] = args.test_name
-    # else:
-    #     env['test_name'] = env['task_name']
+    if not env:
+        with open(args.expansions_file, 'r') as f:
+            env = yaml.safe_load(f)
+
+    if args.test_name:
+        env['test_name'] = args.test_name
+    else:
+        env['test_name'] = env['task_name']
 
     metrics_file_names, test_run_time = cedar.run(args)
-    # config = _Config(env, metrics_file_names, test_run_time)
-    #
-    # report_dict = build_report(config)
-    #
-    # with open(args.report_file, 'w') as f:
-    #     json.dump(report_dict, f, cls=RFCDateTimeEncoder)
-    #
-    # jira_user = env['perf_jira_user']
-    # jira_pwd = env['perf_jira_pw']
-    #
-    # cr = cert_retriever_cls(jira_user, jira_pwd)
-    # runner = ShellCuratorRunner(cr, args.report_file)
-    # runner.run(runner.get_command())
+    config = _Config(env, metrics_file_names, test_run_time)
+
+    report_dict = build_report(config)
+
+    with open(args.report_file, 'w') as f:
+        json.dump(report_dict, f, cls=RFCDateTimeEncoder)
+
+    jira_user = env['perf_jira_user']
+    jira_pwd = env['perf_jira_pw']
+
+    cr = cert_retriever_cls(jira_user, jira_pwd)
+    runner = ShellCuratorRunner(cr, args.report_file)
+    runner.run(runner.get_command())
 
 
 if __name__ == '__main__':

--- a/src/python/genny/csv2.py
+++ b/src/python/genny/csv2.py
@@ -82,42 +82,43 @@ class _DataReader:
     def __next__(self):
         return self._parse_into_intermediate_csv(next(self.raw_reader))
 
-    def _parse_into_intermediate_csv(self, line):
-        for i in range(len(line)):
-
-            # Strip spaces from lines
-            line[i] = line[i].strip()
-
-            # Convert string digits to ints
-            if line[i].isdigit():
-                line[i] = int(line[i])
-
-        # Eagerly error if OUTCOME is > 1
-        if line[_OpColumns.OUTCOME] > 1:
-            raise CSV2ParsingError('Unexpected outcome on line %d: %s', self.raw_reader.line_num,
-                                   line)
-
-        op = line[_OpColumns.OPERATION]
-        actor = line[_OpColumns.ACTOR]
-        thread = line[_OpColumns.THREAD]
-        ts = line[_OpColumns.TIMESTAMP]
-        duration = line[_OpColumns.DURATION]
+    def _parse_into_intermediate_csv(self, csv_line):
+        op = csv_line[_OpColumns.OPERATION].rstrip()
+        actor = csv_line[_OpColumns.ACTOR].rstrip()
         # Convert timestamp from ns to ms and add offset.
-        unix_time = (ts + self.unix_time_offset) / (1000 * 1000)
+        unix_time = (int(csv_line[_OpColumns.TIMESTAMP]) + self.unix_time_offset) / (1000 * 1000)
 
         # Transform output into IntermediateCSV format.
-        out = [None for _ in range(len(IntermediateCSVColumns.default_columns()))]
-        out[IntermediateCSVColumns.UNIX_TIME] = unix_time
-        out[IntermediateCSVColumns.TS] = ts
-        out[IntermediateCSVColumns.THREAD] = thread
-        out[IntermediateCSVColumns.OPERATION] = op
-        out[IntermediateCSVColumns.DURATION] = duration
-        out[IntermediateCSVColumns.OUTCOME] = line[_OpColumns.OUTCOME]
-        out[IntermediateCSVColumns.N] = line[_OpColumns.N]
-        out[IntermediateCSVColumns.OPS] = line[_OpColumns.OPS]
-        out[IntermediateCSVColumns.ERRORS] = line[_OpColumns.ERRORS]
-        out[IntermediateCSVColumns.SIZE] = line[_OpColumns.SIZE]
-        out[IntermediateCSVColumns.WORKERS] = self.tc_map[(actor, op)]
+        # Python list assignment too slow so we construct the output array directly.
+        # out[IntermediateCSVColumns.UNIX_TIME] = unix_time
+        # out[IntermediateCSVColumns.TS] = ts
+        # out[IntermediateCSVColumns.THREAD] = thread
+        # out[IntermediateCSVColumns.OPERATION] = op
+        # out[IntermediateCSVColumns.DURATION] = duration
+        # out[IntermediateCSVColumns.OUTCOME] = int(csv_line[_OpColumns.OUTCOME])
+        # out[IntermediateCSVColumns.N] = int(csv_line[_OpColumns.N])
+        # out[IntermediateCSVColumns.OPS] = int(csv_line[_OpColumns.OPS])
+        # out[IntermediateCSVColumns.ERRORS] = int(csv_line[_OpColumns.ERRORS])
+        # out[IntermediateCSVColumns.SIZE] = int(csv_line[_OpColumns.SIZE])
+        # out[IntermediateCSVColumns.WORKERS] = self.tc_map[(actor, op)]
+
+        out = [
+            unix_time,
+            int(csv_line[_OpColumns.THREAD]),
+            op,
+            int(csv_line[_OpColumns.DURATION]),
+            int(csv_line[_OpColumns.OUTCOME]),
+            int(csv_line[_OpColumns.N]),
+            int(csv_line[_OpColumns.OPS]),
+            int(csv_line[_OpColumns.ERRORS]),
+            int(csv_line[_OpColumns.SIZE]),
+            self.tc_map[(actor, op)]
+        ]
+
+        # Eagerly error if OUTCOME is > 1
+        if out[IntermediateCSVColumns.OUTCOME] > 1:
+            raise CSV2ParsingError('Unexpected outcome on line %d: %s', self.raw_reader.line_num,
+                                   csv_line)
 
         return out, actor
 
@@ -269,6 +270,9 @@ class IntermediateCSVColumns(CSVColumns):
     ERRORS = 8
     SIZE = 9
     WORKERS = 10
+
+    # Manually compute the number of columns to speed up processing.
+    NUM_COLUMNS = 11
 
     @classmethod
     def default_columns(cls):

--- a/src/python/tests/fixtures/cedar/barebones.csv
+++ b/src/python/tests/fixtures/cedar/barebones.csv
@@ -8,5 +8,5 @@ actor,operation,workers
 MyActor,MyOperation,2
 
 Operations
-timestamp, actor  , thread, operation, duration, outcome, n, ops, errors, size
-12345000000    , MyActor, 0     , MyOperation   , 100     , 0      , 1, 6  , 2     , 40
+timestamp,actor,thread,operation,duration,outcome,n,ops,errors,size
+12345000000,MyActor,0,MyOperation,100,0,1,6,2,40

--- a/src/python/tests/fixtures/cedar/error_outcome.csv
+++ b/src/python/tests/fixtures/cedar/error_outcome.csv
@@ -8,7 +8,7 @@ actor,operation,workers
 MyActor,MyOperation,2
 
 Operations
-timestamp, actor  , thread, operation, duration, outcome, n, ops, errors, size
-12345000000    , MyActor, 0     , MyOperation   , 100     , 0      , 1, 6  , 2     , 40
-12345000000    , MyActor, 0     , MyOperation   , 100     , 2      , 1, 6  , 2     , 40
-12345000000    , MyActor, 0     , MyOperation   , 100     , 0      , 1, 6  , 2     , 40
+timestamp,actor,thread,operation,duration,outcome,n,ops,errors,size
+12345000000,MyActor,0,MyOperation,100,0,1,6,2,40
+12345000000,MyActor,0,MyOperation,100,2,1,6,2,40
+12345000000,MyActor,0,MyOperation,100,0,1,6,2,40

--- a/src/python/tests/fixtures/cedar/two_op.csv
+++ b/src/python/tests/fixtures/cedar/two_op.csv
@@ -9,22 +9,22 @@ InsertRemove,Insert,5
 InsertRemove,Remove,5
 
 Operations
-timestamp     , actor       , thread, operation, duration, outcome, n, ops, errors, size
-66632088, InsertRemove, 0     , Insert   , 100     , 0      , 1, 6  , 2     , 40
-66632403, InsertRemove, 0     , Insert   , 310     , 0      , 1, 9  , 3     , 60
-66632661, InsertRemove, 0     , Insert   , 180     , 0      , 1, 8  , 6     , 20
-66632088, InsertRemove, 1     , Insert   , 280     , 1      , 1, 3  , 1     , 20
-66632316, InsertRemove, 1     , Insert   , 190     , 1      , 1, 4  , 1     , 30
-66632088, InsertRemove, 2     , Insert   , 30      , 0      , 1, 4  , 1     , 30
-66632245, InsertRemove, 2     , Insert   , 80      , 1      , 1, 8  , 7     , 10
-66632088, InsertRemove, 3     , Insert   , 110     , 0      , 1, 7  , 2     , 50
-66632088, InsertRemove, 4     , Insert   , 40      , 0      , 1, 9  , 0     , 90
-66632088, InsertRemove, 0     , Remove   , 100     , 0      , 1, 6  , 2     , 40
-66632403, InsertRemove, 0     , Remove   , 410     , 0      , 1, 9  , 3     , 60
-66632661, InsertRemove, 0     , Remove   , 80      , 0      , 1, 8  , 6     , 21
-66632088, InsertRemove, 4     , Remove   , 280     , 1      , 1, 3  , 2     , 24
-66632316, InsertRemove, 1     , Remove   , 123     , 1      , 1, 4  , 2     , 35
-66632088, InsertRemove, 3     , Remove   , 130     , 0      , 1, 4  , 1     , 36
-66632245, InsertRemove, 2     , Remove   , 139     , 1      , 1, 8  , 7     , 10
-66632088, InsertRemove, 2     , Remove   , 110     , 0      , 1, 7  , 2     , 12
-66632088, InsertRemove, 1     , Remove   , 20      , 0      , 1, 9  , 0     , 19
+timestamp,actor,thread,operation,duration,outcome,n,ops,errors,size
+66632088,InsertRemove,0,Insert,100,0,1,6,2,40
+66632403,InsertRemove,0,Insert,310,0,1,9,3,60
+66632661,InsertRemove,0,Insert,180,0,1,8,6,20
+66632088,InsertRemove,1,Insert,280,1,1,3,1,20
+66632316,InsertRemove,1,Insert,190,1,1,4,1,30
+66632088,InsertRemove,2,Insert,30,0,1,4,1,30
+66632245,InsertRemove,2,Insert,80,1,1,8,7,10
+66632088,InsertRemove,3,Insert,110,0,1,7,2,50
+66632088,InsertRemove,4,Insert,40,0,1,9,0,90
+66632088,InsertRemove,0,Remove,100,0,1,6,2,40
+66632403,InsertRemove,0,Remove,410,0,1,9,3,60
+66632661,InsertRemove,0,Remove,80,0,1,8,6,21
+66632088,InsertRemove,4,Remove,280,1,1,3,2,24
+66632316,InsertRemove,1,Remove,123,1,1,4,2,35
+66632088,InsertRemove,3,Remove,130,0,1,4,1,36
+66632245,InsertRemove,2,Remove,139,1,1,8,7,10
+66632088,InsertRemove,2,Remove,110,0,1,7,2,12
+66632088,InsertRemove,1,Remove,20,0,1,9,0,19

--- a/src/python/third_party/csvsort.py
+++ b/src/python/third_party/csvsort.py
@@ -10,7 +10,6 @@ MongoDB Modifications:
 
 import csv
 import heapq
-import logging
 import os
 import sys
 import tempfile
@@ -63,7 +62,7 @@ def csvsort(input_filename,
 
         filenames = csvsplit(reader, max_size, quoting)
         if show_progress:
-            logging.info('Merging %d splits' % len(filenames))
+            print('Merging %d splits' % len(filenames))
         for filename in filenames:
             memorysort(filename, columns, quoting)
         sorted_filename = mergesort(filenames, columns, quoting)


### PR DESCRIPTION
I threw in some changes to improve the perf. We should see roughly double the throughput of the first half of csv parsing. (double `tottime` of `method 'writerow' of '_csv.writer' objects`).

I haven't benchmarked csvsort yet but I'm less confident about making large improvements there. If this PR doesn't visibly improve the overall performance of metrics parsing, we may have to do something else entirely for the longer term.

```
// python -m cProfile -s tottime -m genny.cedar_report
// BEFORE
         17957893 function calls (17954266 primitive calls) in 11.364 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   637040    5.467    0.000    7.051    0.000 csv2.py:85(_parse_into_intermediate_csv)
   637040    2.391    0.000    2.391    0.000 {method 'writerow' of '_csv.writer' objects}
637057/637041    0.978    0.000    0.999    0.000 {built-in method builtins.next}
  6370400    0.575    0.000    0.575    0.000 {method 'isdigit' of 'str' objects}
  6370419    0.525    0.000    0.525    0.000 {method 'strip' of 'str' objects}
        1    0.332    0.332   11.096   11.096 cedar.py:173(split_into_actor_csv_files)
   637040    0.321    0.000    8.372    0.000 csv2.py:82(__next__)
   637040    0.273    0.000    0.273    0.000 csv2.py:109(<listcomp>)
   637041    0.112    0.000    0.112    0.000 csv2.py:273(default_columns)
1280275/1279786    0.100    0.000    0.100    0.000 {built-in method builtins.len}

// AFTER
         7486149 function calls (7482522 primitive calls) in 11.639 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1226057    4.472    0.000    4.472    0.000 {method 'writerow' of '_csv.writer' objects}
  1226057    3.817    0.000    4.007    0.000 csv2.py:85(_parse_into_intermediate_csv)
1226074/1226058    1.739    0.000    1.774    0.000 {built-in method builtins.next}
  1226057    0.608    0.000    6.388    0.000 csv2.py:82(__next__)
        1    0.582    0.582   11.445   11.445 cedar.py:173(split_into_actor_csv_files)
  2457609    0.190    0.000    0.190    0.000 {method 'rstrip' of 'str' objects}
       17    0.029    0.002    0.030    0.002 {method 'get_filename' of 'zipimport.zipimporter' objects}
     17/1    0.029    0.002    0.075    0.075 {method 'load_module' of 'zipimport.zipimporter' objects}
     9399    0.019    0.000    0.019    0.000 {built-in method _codecs.utf_8_decode}
       25    0.016    0.001    0.017    0.001 {built-in method _imp.create_dynamic}
     9399    0.016    0.000    0.034    0.000 codecs.py:319(decode)
      180    0.016    0.000    0.016    0.000 {built-in method marshal.loads}
```