### PR TITLE
PERF-1748 Separate CommitLatency configurations into individual actors

### DIFF
--- a/src/workloads/networking/CommitLatency.yml
+++ b/src/workloads/networking/CommitLatency.yml
@@ -66,50 +66,26 @@ Actors:
 # All of the below is really just the same actor, but as Genny reports statistics using the actor
 # name, we need a different actor instance for each configuration. All of the below run in their
 # own slot, nothing is concurrent.
+# Since Drop+Reload is in phases 0,1,-,3,4,-... then the test itself must always be in a slot at
+# 2,5,8... = 3n-1 = 3n+2
 - Name: CommitLatency_w0_local
   Type: CommitLatency
   Threads: 1
   Repeat: 500
   Database: test
   Phases:
-  - *Nop # Load
-  - *Nop
+  - Phase: 0..1
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: 0
     ReadConcern:
       Level: local
     ReadPreference:
       ReadMode: primary
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 3..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_w1_local
   Type: CommitLatency
@@ -117,44 +93,18 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..4
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: 1
     ReadConcern:
       Level: local
     ReadPreference:
       ReadMode: primary
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 6..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_w1_local_sec
   Type: CommitLatency
@@ -162,44 +112,18 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..7
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: 1
     ReadConcern:
       Level: local
     ReadPreference:
       ReadMode: secondary
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 9..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_w1_jtrue_local_sec
   Type: CommitLatency
@@ -207,17 +131,9 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..10
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: 1
       Journal: true
@@ -225,27 +141,9 @@ Actors:
       Level: local
     ReadPreference:
       ReadMode: primary
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 12..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_wmajority_majority
   Type: CommitLatency
@@ -253,44 +151,18 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..13
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: majority
     ReadConcern:
       Level: majority
     ReadPreference:
       ReadMode: primary
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 15..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_wmajority_majority_sec
   Type: CommitLatency
@@ -298,44 +170,18 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..16
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: majority
     ReadConcern:
       Level: majority
     ReadPreference:
       ReadMode: secondary
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 18..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_wmajority_jtrue_majority
   Type: CommitLatency
@@ -343,26 +189,9 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..19
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: majority
       Journal: true
@@ -370,18 +199,9 @@ Actors:
       Level: majority
     ReadPreference:
       ReadMode: primary
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 21..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_wmajority_linearizable
   Type: CommitLatency
@@ -389,44 +209,18 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..22
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: majority
     ReadConcern:
       Level: linearizable
     ReadPreference:
       ReadMode: primary
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 24..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_wmajority_majority_session
   Type: CommitLatency
@@ -434,32 +228,9 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..25
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: majority
     ReadConcern:
@@ -467,12 +238,9 @@ Actors:
     ReadPreference:
       ReadMode: primary
     Session: True
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 27..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_wmajority_majority_sec_session
   Type: CommitLatency
@@ -480,35 +248,9 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..28
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: majority
     ReadConcern:
@@ -516,9 +258,9 @@ Actors:
     ReadPreference:
       ReadMode: secondary
     Session: True
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 30..32
+    Operation:
+      OperationName: Nop
 
 - Name: CommitLatency_wmajority_majority_trx
   Type: CommitLatency
@@ -526,38 +268,9 @@ Actors:
   Repeat: 500
   Database: test
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
+  - Phase: 0..31
+    Operation:
+      OperationName: Nop
   - WriteConcern:
       Level: majority
     ReadConcern:

--- a/src/workloads/networking/CommitLatency.yml
+++ b/src/workloads/networking/CommitLatency.yml
@@ -63,13 +63,16 @@ Actors:
 
 
 
-- Name: CommitLatency
+# All of the below is really just the same actor, but as Genny reports statistics using the actor
+# name, we need a different actor instance for each configuration. All of the below run in their
+# own slot, nothing is concurrent.
+- Name: CommitLatency_w0_local
   Type: CommitLatency
   Threads: 1
   Repeat: 500
   Database: test
   Phases:
-  - *Nop # Load phase is different actor
+  - *Nop # Load
   - *Nop
   - WriteConcern:
       Level: 0
@@ -79,6 +82,46 @@ Actors:
       ReadMode: primary
   - *Nop
   - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_w1_local
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - WriteConcern:
       Level: 1
     ReadConcern:
@@ -87,12 +130,92 @@ Actors:
       ReadMode: primary
   - *Nop
   - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_w1_local_sec
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - WriteConcern:
       Level: 1
     ReadConcern:
       Level: local
     ReadPreference:
       ReadMode: secondary
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_w1_jtrue_local_sec
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - *Nop
   - *Nop
   - WriteConcern:
@@ -104,12 +227,92 @@ Actors:
       ReadMode: primary
   - *Nop
   - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_wmajority_majority
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - WriteConcern:
       Level: majority
     ReadConcern:
       Level: majority
     ReadPreference:
       ReadMode: primary
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_wmajority_majority_sec
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - *Nop
   - *Nop
   - WriteConcern:
@@ -120,6 +323,46 @@ Actors:
       ReadMode: secondary
   - *Nop
   - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_wmajority_jtrue_majority
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - WriteConcern:
       Level: majority
       Journal: true
@@ -127,6 +370,46 @@ Actors:
       Level: majority
     ReadPreference:
       ReadMode: primary
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_wmajority_linearizable
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - *Nop
   - *Nop
   - WriteConcern:
@@ -137,6 +420,46 @@ Actors:
       ReadMode: primary
   - *Nop
   - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_wmajority_majority_session
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - WriteConcern:
       Level: majority
     ReadConcern:
@@ -146,6 +469,46 @@ Actors:
     Session: True
   - *Nop
   - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_wmajority_majority_sec_session
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - WriteConcern:
       Level: majority
     ReadConcern:
@@ -153,6 +516,46 @@ Actors:
     ReadPreference:
       ReadMode: secondary
     Session: True
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CommitLatency_wmajority_majority_trx
+  Type: CommitLatency
+  Threads: 1
+  Repeat: 500
+  Database: test
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - *Nop
   - *Nop
   - WriteConcern:

--- a/src/workloads/networking/CommitLatencySingleUpdate.yml
+++ b/src/workloads/networking/CommitLatencySingleUpdate.yml
@@ -26,15 +26,9 @@ Actors:
             OperationCommand:
                 insert: *Collection
                 documents: [{_id: 1, n: 0}]
-      - &Nop
+      - Phase: 2..9
         Operation:
           OperationName: Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
 
 
   - Name: SingleThreadUpdate_w0
@@ -42,154 +36,135 @@ Actors:
     Threads: 1
     Database: test
     Phases:
-      - *Nop
-      - *Nop
+      - Phase: 0..1
+        Operation:
+          OperationName: Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern: { w: 0 }
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 3..9
+        Operation:
+          OperationName: Nop
 
   - Name: SingleThreadUpdate_w1
     Type: RunCommand
     Threads: 1
     Database: test
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 0..2
+        Operation:
+          OperationName: Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: 1 }
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 4..9
+        Operation:
+          OperationName: Nop
 
   - Name: SingleThreadUpdate_w2
     Type: RunCommand
     Threads: 1
     Database: test
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 0..3
+        Operation:
+          OperationName: Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: 2 }
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 5..9
+        Operation:
+          OperationName: Nop
 
   - Name: SingleThreadUpdate_w3
     Type: RunCommand
     Threads: 1
     Database: test
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 0..4
+        Operation:
+          OperationName: Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: 3 }
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 6..9
+        Operation:
+          OperationName: Nop
 
   - Name: SingleThreadUpdate_jtrue
     Type: RunCommand
     Threads: 1
     Database: test
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 0..5
+        Operation:
+          OperationName: Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { j: true }
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 7..9
+        Operation:
+          OperationName: Nop
 
   - Name: SingleThreadUpdate_w2_jtrue
     Type: RunCommand
     Threads: 1
     Database: test
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 0..6
+        Operation:
+          OperationName: Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: 2, j: true }
-      - *Nop
-      - *Nop
+      - Phase: 8..9
+        Operation:
+          OperationName: Nop
 
   - Name: SingleThreadUpdate_wmajority
     Type: RunCommand
     Threads: 1
     Database: test
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 0..7
+        Operation:
+          OperationName: Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: majority, j: false }
-      - *Nop
+      - Phase: 9
+        Operation:
+          OperationName: Nop
 
   - Name: SingleThreadUpdate_wmajority_jtrue
     Type: RunCommand
     Threads: 1
     Database: test
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      - Phase: 0..8
+        Operation:
+          OperationName: Nop
       - Repeat: 500
         Operations:
         - OperationCommand:

--- a/src/workloads/networking/CommitLatencySingleUpdate.yml
+++ b/src/workloads/networking/CommitLatencySingleUpdate.yml
@@ -4,8 +4,11 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 
+# All of the below is really just the same actor, but as Genny reports statistics using the actor
+# name, we need a different actor instance for each configuration. All of the below run in their
+# own slot, nothing is concurrent.
 Actors:
-  - Name: SingleThreadUpdate
+  - Name: Load
     Type: RunCommand
     Threads: 1
     Database: test
@@ -23,49 +26,170 @@ Actors:
             OperationCommand:
                 insert: *Collection
                 documents: [{_id: 1, n: 0}]
-        # Tests
+      - &Nop
+        Operation:
+          OperationName: Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+
+
+  - Name: SingleThreadUpdate_w0
+    Type: RunCommand
+    Threads: 1
+    Database: test
+    Phases:
+      - *Nop
+      - *Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern: { w: 0 }
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+
+  - Name: SingleThreadUpdate_w1
+    Type: RunCommand
+    Threads: 1
+    Database: test
+    Phases:
+      - *Nop
+      - *Nop
+      - *Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: 1 }
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+
+  - Name: SingleThreadUpdate_w2
+    Type: RunCommand
+    Threads: 1
+    Database: test
+    Phases:
+      - *Nop
+      - *Nop
+      - *Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: 2 }
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+
+  - Name: SingleThreadUpdate_w3
+    Type: RunCommand
+    Threads: 1
+    Database: test
+    Phases:
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: 3 }
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+
+  - Name: SingleThreadUpdate_jtrue
+    Type: RunCommand
+    Threads: 1
+    Database: test
+    Phases:
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { j: true }
+      - *Nop
+      - *Nop
+      - *Nop
+
+  - Name: SingleThreadUpdate_w2_jtrue
+    Type: RunCommand
+    Threads: 1
+    Database: test
+    Phases:
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: 2, j: true }
+      - *Nop
+      - *Nop
+
+  - Name: SingleThreadUpdate_wmajority
+    Type: RunCommand
+    Threads: 1
+    Database: test
+    Phases:
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
       - Repeat: 500
         Operations:
         - OperationCommand:
             update: *Collection
             updates: [ { q: { _id: 1 }, u: { $inc: { n: 1 } } } ]
             writeConcern:  { w: majority, j: false }
+      - *Nop
+
+  - Name: SingleThreadUpdate_wmajority_jtrue
+    Type: RunCommand
+    Threads: 1
+    Database: test
+    Phases:
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
+      - *Nop
       - Repeat: 500
         Operations:
         - OperationCommand:


### PR DESCRIPTION
Genny reports metrics per Actor (multiple phases aggregate together), so each configuration needs to be its own actor instance.