### PR TITLE
TIG-1397: Move some YAML-Based Testing Infrastructure to testlib

### DIFF
--- a/src/testlib/include/testlib/helpers.hpp
+++ b/src/testlib/include/testlib/helpers.hpp
@@ -17,4 +17,30 @@
 
 #include <catch2/catch.hpp>
 
+#include <string>
+
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/document/view_or_value.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+namespace genny {
+
+inline std::string toString(const std::string& str) {
+    return str;
+}
+
+inline std::string toString(const bsoncxx::document::view_or_value& t) {
+    return bsoncxx::to_json(t, bsoncxx::ExtendedJsonMode::k_canonical);
+}
+
+inline std::string toString(const YAML::Node& node) {
+    YAML::Emitter out;
+    out << node;
+    return std::string{out.c_str()};
+}
+
+
+}
+
 #endif  // HEADER_E501BBB0_810A_4185_96B2_60CE322C4B78_INCLUDED

--- a/src/testlib/include/testlib/helpers.hpp
+++ b/src/testlib/include/testlib/helpers.hpp
@@ -19,8 +19,8 @@
 
 #include <string>
 
-#include <bsoncxx/json.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
+#include <bsoncxx/json.hpp>
 
 #include <yaml-cpp/yaml.h>
 
@@ -41,6 +41,6 @@ inline std::string toString(const YAML::Node& node) {
 }
 
 
-}
+}  // namespace genny
 
 #endif  // HEADER_E501BBB0_810A_4185_96B2_60CE322C4B78_INCLUDED

--- a/src/testlib/include/testlib/yamlTest.hpp
+++ b/src/testlib/include/testlib/yamlTest.hpp
@@ -20,16 +20,10 @@
 
 #include <yaml-cpp/yaml.h>
 
-namespace genny::testing {
+namespace genny::testing::v1 {
 
-namespace v1 {
-
-
-template <typename TC>
-class ResultT {
+class Result {
 public:
-    explicit ResultT(const TC& testCase) : _testCase{testCase} {}
-
     bool pass() const {
         return _expectedVsActual.empty() && !_expectedExceptionButNotThrown;
     }
@@ -49,12 +43,7 @@ public:
         return _expectedVsActual;
     }
 
-    const TC& testCase() const {
-        return _testCase;
-    }
-
 private:
-    const TC& _testCase;
     std::vector<std::pair<std::string, std::string>> _expectedVsActual;
     bool _expectedExceptionButNotThrown = false;
 };
@@ -89,12 +78,7 @@ private:
     std::vector<TC> _cases;
 };
 
-}  // namespace v1
-
-template <typename TC>
-using Result = v1::ResultT<TC>;
-
-}  // namespace genny::testing
+}  // namespace genny::testing::v1
 
 namespace YAML {
 
@@ -112,6 +96,8 @@ struct convert<genny::testing::v1::YamlTests<TC>> {
 }  // namespace YAML
 
 namespace genny::testing {
+
+using Result = v1::Result;
 
 template <typename TC>
 void runTestCaseYaml(const std::string& repoRelativePathToYaml) {

--- a/src/testlib/include/testlib/yamltest.hpp
+++ b/src/testlib/include/testlib/yamltest.hpp
@@ -17,9 +17,24 @@
 
 #include <vector>
 #include <string>
-#include <util>
 
 namespace genny::testing {
+
+inline std::string toString(const std::string& str) {
+    return str;
+}
+
+inline std::string toString(const bsoncxx::document::view_or_value& t) {
+    return bsoncxx::to_json(t, bsoncxx::ExtendedJsonMode::k_canonical);
+}
+
+inline std::string toString(const YAML::Node& node) {
+    YAML::Emitter out;
+    out << node;
+    return std::string{out.c_str()};
+}
+
+
 
 template<typename TC>
 class ResultT {

--- a/src/testlib/include/testlib/yamltest.hpp
+++ b/src/testlib/include/testlib/yamltest.hpp
@@ -97,7 +97,7 @@ public:
     }
 
 private:
-    std::vector<Result> _cases;
+    std::vector<TC> _cases;
 };
 
 

--- a/src/testlib/include/testlib/yamltest.hpp
+++ b/src/testlib/include/testlib/yamltest.hpp
@@ -101,7 +101,25 @@ private:
 };
 
 
-
+template<typename TC>
+void runTestCaseYaml(const std::string& repoRelativePathToYaml) {
+    try {
+        const auto file =
+                genny::findRepoRoot() + repoRelativePathToYaml;
+        const auto yaml = YAML::LoadFile(file);
+        auto tests = yaml.as<genny::testing::YamlTests<TC>>();
+        auto results = tests.run();
+        if (!results.empty()) {
+            std::stringstream msg;
+            msg << results;
+            WARN(msg.str());
+        }
+        REQUIRE(results.empty());
+    } catch (const std::exception& ex) {
+        WARN(ex.what());
+        throw;
+    }
+}
 
 }  // namespae genny::testing
 

--- a/src/testlib/include/testlib/yamltest.hpp
+++ b/src/testlib/include/testlib/yamltest.hpp
@@ -1,0 +1,94 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HEADER_8A80B79E_1A24_4745_BB59_B1FCD1439C6D_INCLUDED
+#define HEADER_8A80B79E_1A24_4745_BB59_B1FCD1439C6D_INCLUDED
+
+#include <vector>
+#include <string>
+#include <util>
+
+namespace genny::testing {
+
+template<typename TC>
+class ResultT {
+public:
+    explicit ResultT(const TC& testCase) : _testCase{testCase} {}
+
+    bool pass() const {
+        return _expectedVsActual.empty() && !_expectedExceptionButNotThrown;
+    }
+
+    template <typename E, typename A>
+    void expectEqual(E expect, A actual) {
+        if (expect != actual) {
+            _expectedVsActual.emplace_back(toString(expect), toString(actual));
+        }
+    }
+
+    void expectedExceptionButNotThrown() {
+        _expectedExceptionButNotThrown = true;
+    }
+
+    const std::vector<std::pair<std::string, std::string>>& expectedVsActual() const {
+        return _expectedVsActual;
+    }
+
+    const TC& testCase() const {
+        return _testCase;
+    }
+
+private:
+    const TC& _testCase;
+    std::vector<std::pair<std::string, std::string>> _expectedVsActual;
+    bool _expectedExceptionButNotThrown = false;
+};
+
+
+template<typename TC>
+class YamlTests {
+public:
+    using Result = typename TC::Result;
+
+    explicit YamlTests() = default;
+    YamlTests(const YamlTests&) = default;
+
+    explicit YamlTests(const YAML::Node& node) {
+        for (auto&& n : node["Cases"]) {
+            _cases.push_back(std::move(n.as<TC>()));
+        }
+    }
+
+    std::vector<Result> run() const {
+        std::vector<Result> out{};
+        for (auto& tcase : _cases) {
+            auto result = tcase.run();
+            if (!result.pass()) {
+                out.push_back(std::move(result));
+            }
+        }
+        return out;
+    }
+
+private:
+    std::vector<Result> _cases;
+};
+
+
+
+
+}  // namespae genny::testing
+
+
+#endif  // HEADER_8A80B79E_1A24_4745_BB59_B1FCD1439C6D_INCLUDED

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -29,16 +29,16 @@ genny::DefaultRandom rng;
 
 }  // namespace
 
-struct YamlTestCase;
+struct ValGenTestCase;
 
-using Result = genny::testing::ResultT<YamlTestCase>;
+using ValGenResult = genny::testing::ResultT<ValGenTestCase>;
 
-class YamlTestCase {
+class ValGenTestCase {
 public:
-    using Result = Result;
-    explicit YamlTestCase() = default;
+    using Result = ValGenResult;
+    explicit ValGenTestCase() = default;
 
-    explicit YamlTestCase(YAML::Node node)
+    explicit ValGenTestCase(YAML::Node node)
         : _wholeTest{node},
           _name{node["Name"].as<std::string>("No Name")},
           _givenTemplate{node["GivenTemplate"]},
@@ -71,8 +71,8 @@ public:
         }
     }
 
-    genny::Result run() const {
-        genny::Result out{*this};
+    genny::ValGenResult run() const {
+        genny::ValGenResult out{*this};
         if (_runMode == RunMode::kExpectException) {
             try {
                 genny::DocumentGenerator(this->_givenTemplate, rng);
@@ -118,7 +118,7 @@ private:
 };
 
 
-std::ostream& operator<<(std::ostream& out, const std::vector<Result>& results) {
+std::ostream& operator<<(std::ostream& out, const std::vector<ValGenResult>& results) {
     out << std::endl;
     for (auto&& result : results) {
         out << "- Name: " << result.testCase().name() << std::endl;
@@ -137,25 +137,25 @@ std::ostream& operator<<(std::ostream& out, const std::vector<Result>& results) 
 namespace YAML {
 
 template <>
-struct convert<genny::testing::YamlTests<genny::YamlTestCase>> {
-    static Node encode(const genny::testing::YamlTests<genny::YamlTestCase>& rhs) {
+struct convert<genny::testing::YamlTests<genny::ValGenTestCase>> {
+    static Node encode(const genny::testing::YamlTests<genny::ValGenTestCase>& rhs) {
         return {};
     }
 
-    static bool decode(const Node& node, genny::testing::YamlTests<genny::YamlTestCase>& rhs) {
-        rhs = genny::testing::YamlTests<genny::YamlTestCase>(node);
+    static bool decode(const Node& node, genny::testing::YamlTests<genny::ValGenTestCase>& rhs) {
+        rhs = genny::testing::YamlTests<genny::ValGenTestCase>(node);
         return true;
     }
 };
 
 template <>
-struct convert<genny::YamlTestCase> {
-    static Node encode(const genny::YamlTestCase& rhs) {
+struct convert<genny::ValGenTestCase> {
+    static Node encode(const genny::ValGenTestCase& rhs) {
         return {};
     }
 
-    static bool decode(const Node& node, genny::YamlTestCase& rhs) {
-        rhs = genny::YamlTestCase(node);
+    static bool decode(const Node& node, genny::ValGenTestCase& rhs) {
+        rhs = genny::ValGenTestCase(node);
         return true;
     }
 };
@@ -170,8 +170,8 @@ TEST_CASE("YAML Tests") {
         const auto file =
             genny::findRepoRoot() + "/src/value_generators/test/DocumentGeneratorTestCases.yml";
         const auto yaml = YAML::LoadFile(file);
-        auto tests = yaml.as<genny::testing::YamlTests<genny::YamlTestCase>>();
-        std::vector<genny::Result> results = tests.run();
+        auto tests = yaml.as<genny::testing::YamlTests<genny::ValGenTestCase>>();
+        std::vector<genny::ValGenResult> results = tests.run();
         if (!results.empty()) {
             std::stringstream msg;
             msg << results;

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -15,6 +15,7 @@
 #include <testlib/findRepoRoot.hpp>
 #include <testlib/helpers.hpp>
 #include <testlib/yamlToBson.hpp>
+#include <testlib/yamltest.hpp>
 
 #include <value_generators/DefaultRandom.hpp>
 #include <value_generators/DocumentGenerator.hpp>
@@ -46,39 +47,7 @@ class YamlTests;
 struct YamlTestCase;
 
 
-class Result {
-public:
-    explicit Result(const YamlTestCase& testCase) : _testCase{testCase} {}
-
-    bool pass() const {
-        return _expectedVsActual.empty() && !_expectedExceptionButNotThrown;
-    }
-
-    template <typename E, typename A>
-    void expectEqual(E expect, A actual) {
-        if (expect != actual) {
-            _expectedVsActual.emplace_back(toString(expect), toString(actual));
-        }
-    }
-
-    void expectedExceptionButNotThrown() {
-        _expectedExceptionButNotThrown = true;
-    }
-
-    const std::vector<std::pair<std::string, std::string>>& expectedVsActual() const {
-        return _expectedVsActual;
-    }
-
-    const YamlTestCase& testCase() const {
-        return _testCase;
-    }
-
-private:
-    const YamlTestCase& _testCase;
-    std::vector<std::pair<std::string, std::string>> _expectedVsActual;
-    bool _expectedExceptionButNotThrown = false;
-};
-
+using Result = genny::testing::ResultT<YamlTestCase>;
 
 class YamlTestCase {
 public:
@@ -163,32 +132,6 @@ private:
     YAML::Node _expectedExceptionMessage;
 };
 
-
-class YamlTests {
-public:
-    explicit YamlTests() = default;
-    YamlTests(const YamlTests&) = default;
-
-    explicit YamlTests(const YAML::Node& node) {
-        for (auto&& n : node["Cases"]) {
-            _cases.push_back(std::move(n.as<genny::YamlTestCase>()));
-        }
-    }
-
-    std::vector<Result> run() const {
-        std::vector<Result> out{};
-        for (auto& tcase : _cases) {
-            auto result = tcase.run();
-            if (!result.pass()) {
-                out.push_back(std::move(result));
-            }
-        }
-        return out;
-    }
-
-private:
-    std::vector<YamlTestCase> _cases;
-};
 
 std::ostream& operator<<(std::ostream& out, const std::vector<Result>& results) {
     out << std::endl;

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -162,26 +162,6 @@ struct convert<genny::ValGenTestCase> {
 
 }  // namespace YAML
 
-
-namespace {
-
 TEST_CASE("YAML Tests") {
-    try {
-        const auto file =
-            genny::findRepoRoot() + "/src/value_generators/test/DocumentGeneratorTestCases.yml";
-        const auto yaml = YAML::LoadFile(file);
-        auto tests = yaml.as<genny::testing::YamlTests<genny::ValGenTestCase>>();
-        std::vector<genny::ValGenResult> results = tests.run();
-        if (!results.empty()) {
-            std::stringstream msg;
-            msg << results;
-            WARN(msg.str());
-        }
-        REQUIRE(results.empty());
-    } catch (const std::exception& ex) {
-        WARN(ex.what());
-        throw;
-    }
+    genny::testing::runTestCaseYaml<genny::ValGenTestCase>("/src/value_generators/test/DocumentGeneratorTestCases.yml");
 }
-
-}  // namespace

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -154,7 +154,7 @@ struct convert<genny::ValGenTestCase> {
 
 }  // namespace YAML
 
-TEST_CASE("YAML Tests") {
-    genny::testing::runTestCaseYaml<genny::ValGenTestCase>(
+TEMPLATE_TEST_CASE("YAML Tests", "", genny::ValGenTestCase) {
+    genny::testing::runTestCaseYaml<TestType>(
         "/src/value_generators/test/DocumentGeneratorTestCases.yml");
 }

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -23,19 +23,12 @@
 namespace genny {
 
 namespace {
-
 genny::DefaultRandom rng;
-
-
 }  // namespace
-
-struct ValGenTestCase;
-
-using ValGenResult = genny::testing::ResultT<ValGenTestCase>;
 
 class ValGenTestCase {
 public:
-    using Result = ValGenResult;
+    using Result = typename genny::testing::ResultT<ValGenTestCase>;
     explicit ValGenTestCase() = default;
 
     explicit ValGenTestCase(YAML::Node node)
@@ -71,8 +64,8 @@ public:
         }
     }
 
-    genny::ValGenResult run() const {
-        genny::ValGenResult out{*this};
+    Result run() const {
+        Result out{*this};
         if (_runMode == RunMode::kExpectException) {
             try {
                 genny::DocumentGenerator(this->_givenTemplate, rng);
@@ -118,7 +111,7 @@ private:
 };
 
 
-std::ostream& operator<<(std::ostream& out, const std::vector<ValGenResult>& results) {
+std::ostream& operator<<(std::ostream& out, const std::vector<ValGenTestCase::Result>& results) {
     out << std::endl;
     for (auto&& result : results) {
         out << "- Name: " << result.testCase().name() << std::endl;

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -15,7 +15,7 @@
 #include <testlib/findRepoRoot.hpp>
 #include <testlib/helpers.hpp>
 #include <testlib/yamlToBson.hpp>
-#include <testlib/yamltest.hpp>
+#include <testlib/yamlTest.hpp>
 
 #include <value_generators/DefaultRandom.hpp>
 #include <value_generators/DocumentGenerator.hpp>
@@ -28,7 +28,7 @@ genny::DefaultRandom rng;
 
 class ValGenTestCase {
 public:
-    using Result = typename genny::testing::ResultT<ValGenTestCase>;
+    using Result = typename genny::testing::Result<ValGenTestCase>;
     explicit ValGenTestCase() = default;
 
     explicit ValGenTestCase(YAML::Node node)
@@ -39,25 +39,25 @@ public:
           _expectedExceptionMessage{node["ThenThrows"]} {
         if (!_givenTemplate) {
             std::stringstream msg;
-            msg << "Need GivenTemplate in '" << testing::toString(node) << "'";
+            msg << "Need GivenTemplate in '" << toString(node) << "'";
             throw std::invalid_argument(msg.str());
         }
         if (_thenReturns && _expectedExceptionMessage) {
             std::stringstream msg;
-            msg << "Can't have ThenReturns and ThenThrows in '" << testing::toString(node) << "'";
+            msg << "Can't have ThenReturns and ThenThrows in '" << toString(node) << "'";
             throw std::invalid_argument(msg.str());
         }
         if (_thenReturns) {
             if (!_thenReturns.IsSequence()) {
                 std::stringstream msg;
-                msg << "ThenReturns must be list in '" << testing::toString(node) << "'";
+                msg << "ThenReturns must be list in '" << toString(node) << "'";
                 throw std::invalid_argument(msg.str());
             }
             _runMode = RunMode::kExpectReturn;
         } else {
             if (!_expectedExceptionMessage) {
                 std::stringstream msg;
-                msg << "Need ThenThrows if no ThenReturns in '" << testing::toString(node) << "'";
+                msg << "Need ThenThrows if no ThenReturns in '" << toString(node) << "'";
                 throw std::invalid_argument(msg.str());
             }
             _runMode = RunMode::kExpectException;
@@ -115,7 +115,7 @@ std::ostream& operator<<(std::ostream& out, const std::vector<ValGenTestCase::Re
     out << std::endl;
     for (auto&& result : results) {
         out << "- Name: " << result.testCase().name() << std::endl;
-        out << "  GivenTemplate: " << testing::toString(result.testCase().givenTemplate()) << std::endl;
+        out << "  GivenTemplate: " << toString(result.testCase().givenTemplate()) << std::endl;
         out << "  ThenReturns: " << std::endl;
         for (auto&& [expect, actual] : result.expectedVsActual()) {
             out << "    - " << actual << std::endl;
@@ -130,20 +130,8 @@ std::ostream& operator<<(std::ostream& out, const std::vector<ValGenTestCase::Re
 namespace YAML {
 
 template <>
-struct convert<genny::testing::YamlTests<genny::ValGenTestCase>> {
-    static Node encode(const genny::testing::YamlTests<genny::ValGenTestCase>& rhs) {
-        return {};
-    }
-
-    static bool decode(const Node& node, genny::testing::YamlTests<genny::ValGenTestCase>& rhs) {
-        rhs = genny::testing::YamlTests<genny::ValGenTestCase>(node);
-        return true;
-    }
-};
-
-template <>
 struct convert<genny::ValGenTestCase> {
-    static Node encode(const genny::ValGenTestCase& rhs) {
+    static Node encode(genny::ValGenTestCase& rhs) {
         return {};
     }
 

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -1,6 +1,6 @@
 ---
 
-Cases:
+Tests:
 
   # These tests use large numbers for number parameters
   # because short numbers get automatically narrowed to


### PR DESCRIPTION
I want to re-use some of the yaml-based-testing code for CrudActor testing. Refactoring to testlib makes the most sense. I'm holding off on adding too much documentation or self-testing to this for now since I anticipate needing to make a few tweaks once the code is used in more than just one place. I'll add that once CrudActor testing is using it as well.

There's almost no new code here just adding `template<...>` in a few places.