### PR TITLE
TIG-1098 Add standalone benchmark binary to measure genny perf impact

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_subdirectory(third_party)
 
 # keep in alpha order
+add_subdirectory(canaries)
 add_subdirectory(cast_core)
 add_subdirectory(driver)
 add_subdirectory(gennylib)

--- a/src/canaries/CMakeLists.txt
+++ b/src/canaries/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright 2019-present MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project(driver VERSION 0.0.1 LANGUAGES CXX)
+
+CreateGennyTargets(
+        NAME    canaries
+        TYPE    STATIC
+        DEPENDS
+        gennylib
+        metrics
+        Boost::program_options
+        EXECUTABLE    genny-canaries
+)

--- a/src/canaries/CMakeLists.txt
+++ b/src/canaries/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project(driver VERSION 0.0.1 LANGUAGES CXX)
+project(canaries VERSION 0.0.1 LANGUAGES CXX)
 
 CreateGennyTargets(
         NAME    canaries

--- a/src/canaries/include/canaries/Loops.hpp
+++ b/src/canaries/include/canaries/Loops.hpp
@@ -15,11 +15,8 @@
 #ifndef HEADER_C8D12C92_7C08_4B7F_9857_8B25F7258BB9_INCLUDED
 #define HEADER_C8D12C92_7C08_4B7F_9857_8B25F7258BB9_INCLUDED
 
-#include <iostream>
 
-#include <gennylib/PhaseLoop.hpp>
-#include <gennylib/context.hpp>
-
+#include <cstdint>
 
 namespace genny::canaries {
 

--- a/src/canaries/include/canaries/Loops.hpp
+++ b/src/canaries/include/canaries/Loops.hpp
@@ -1,0 +1,36 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include <gennylib/PhaseLoop.hpp>
+#include <gennylib/context.hpp>
+
+
+namespace genny::canaries {
+
+template <bool WithPing>
+class Loops {
+public:
+    Loops() = default;
+
+    int64_t simpleLoop(int64_t iterations);
+
+    int64_t phaseLoop(int64_t iterations);
+
+    int64_t metricsLoop(int64_t iterations);
+
+    int64_t metricsPhaseLoop(int64_t iterations);
+};
+}  // namespace genny::canaries

--- a/src/canaries/include/canaries/Loops.hpp
+++ b/src/canaries/include/canaries/Loops.hpp
@@ -61,4 +61,4 @@ private:
 };
 }  // namespace genny::canaries
 
-#endif    // HEADER_C8D12C92_7C08_4B7F_9857_8B25F7258BB9_INCLUDED
+#endif  // HEADER_C8D12C92_7C08_4B7F_9857_8B25F7258BB9_INCLUDED

--- a/src/canaries/include/canaries/Loops.hpp
+++ b/src/canaries/include/canaries/Loops.hpp
@@ -20,17 +20,41 @@
 
 namespace genny::canaries {
 
+/**
+ * Class for benchmarking Genny internals. It's recommended to run
+ * these benchmarks as canaries before running Genny workloads.
+ *
+ * @tparam WithPing whether to issue db.ping() to a mongo cluster or just
+ *                  do a simple increment. The former is useful for gauging
+ *                  the overhead of Genny and the latter is useful for seeing
+ *                  how this overhead changes over time.
+ */
 template <bool WithPing>
 class Loops {
 public:
-    Loops() = default;
+    explicit Loops(int64_t iterations) : _iterations(iterations){};
 
-    int64_t simpleLoop(int64_t iterations);
+    /**
+     * Run a basic for-loop, used as the baseline.
+     */
+    int64_t simpleLoop();
 
-    int64_t phaseLoop(int64_t iterations);
+    /**
+     * Run just the phase loop.
+     */
+    int64_t phaseLoop();
 
-    int64_t metricsLoop(int64_t iterations);
+    /**
+     * Run a basic for-loop and record one timer metric per loop.
+     */
+    int64_t metricsLoop();
 
-    int64_t metricsPhaseLoop(int64_t iterations);
+    /**
+     * Run the phase loop and record one timer metric per loop.
+     */
+    int64_t metricsPhaseLoop();
+
+private:
+    int64_t _iterations;
 };
 }  // namespace genny::canaries

--- a/src/canaries/include/canaries/Loops.hpp
+++ b/src/canaries/include/canaries/Loops.hpp
@@ -20,6 +20,8 @@
 
 namespace genny::canaries {
 
+using Nanosecond = int64_t;
+
 /**
  * Class for benchmarking Genny internals. It's recommended to run
  * these benchmarks as canaries before running Genny workloads.
@@ -37,22 +39,22 @@ public:
     /**
      * Run a basic for-loop, used as the baseline.
      */
-    int64_t simpleLoop();
+    Nanosecond simpleLoop();
 
     /**
      * Run just the phase loop.
      */
-    int64_t phaseLoop();
+    Nanosecond phaseLoop();
 
     /**
      * Run a basic for-loop and record one timer metric per loop.
      */
-    int64_t metricsLoop();
+    Nanosecond metricsLoop();
 
     /**
      * Run the phase loop and record one timer metric per loop.
      */
-    int64_t metricsPhaseLoop();
+    Nanosecond metricsPhaseLoop();
 
 private:
     int64_t _iterations;

--- a/src/canaries/include/canaries/Loops.hpp
+++ b/src/canaries/include/canaries/Loops.hpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef HEADER_C8D12C92_7C08_4B7F_9857_8B25F7258BB9_INCLUDED
+#define HEADER_C8D12C92_7C08_4B7F_9857_8B25F7258BB9_INCLUDED
+
 #include <iostream>
 
 #include <gennylib/PhaseLoop.hpp>
@@ -58,3 +61,5 @@ private:
     int64_t _iterations;
 };
 }  // namespace genny::canaries
+
+#endif    // HEADER_C8D12C92_7C08_4B7F_9857_8B25F7258BB9_INCLUDED

--- a/src/canaries/src/Loops.cpp
+++ b/src/canaries/src/Loops.cpp
@@ -58,6 +58,8 @@ inline void doPingIfNeeded() {
         std::cout << "PING!" << std::endl;
     } else {
         int x = 0;
+        // Ensure memory is flushed and instruct the compiler
+        // to not optimize this line out.
         asm volatile("" : : "r,m"(x++) : "memory");
     }
 }

--- a/src/canaries/src/Loops.cpp
+++ b/src/canaries/src/Loops.cpp
@@ -1,0 +1,157 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <canaries/Loops.hpp>
+
+#include <chrono>
+#include <optional>
+
+#include <gennylib/Orchestrator.hpp>
+#include <gennylib/PhaseLoop.hpp>
+
+#include <metrics/MetricsReporter.hpp>
+#include <metrics/metrics.hpp>
+
+#if defined(__APPLE__)
+
+#include "../../testlib/include/testlib/clocks.hpp"
+#include <mach/mach_time.h>
+
+#endif
+
+// Adapted from Google Benchmark
+// https://github.com/google/benchmark/blob/439d6b1c2a6da5cb6adc4c4dfc555af235722396/src/cycleclock.h#L61
+inline int64_t now() {
+#if defined(__APPLE__)
+    return mach_absolute_time();
+#elif defined(__x86_64__) || defined(__amd64__)
+    uint64_t low, high;
+    __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
+    return (high << 32) | low;
+#endif
+}
+
+template <bool WithPing>
+inline void doPingIfNeeded() {
+    if constexpr (WithPing) {
+        std::cout << "PING!" << std::endl;
+    } else {
+        int x = 0;
+        asm volatile("" : : "r,m"(x++) : "memory");
+    }
+}
+
+genny::TimeSpec operator""_ts(unsigned long long v) {
+    return genny::TimeSpec(std::chrono::milliseconds{v});
+}
+
+namespace genny::canaries {
+
+template <bool WithPing>
+int64_t Loops<WithPing>::simpleLoop(int64_t iterations) {
+    // Warm up.
+    for (int i = 0; i < iterations; i++) {
+        doPingIfNeeded<WithPing>();
+    }
+
+    int64_t before = now();
+    for (int i = 0; i < iterations; i++) {
+        doPingIfNeeded<WithPing>();
+    }
+    int64_t after = now();
+
+    return after - before;
+}
+
+template <bool WithPing>
+int64_t Loops<WithPing>::phaseLoop(int64_t iterations) {
+
+    Orchestrator o{};
+    v1::ActorPhase<int> loop{
+        o,
+        std::make_unique<v1::IterationChecker>(std::nullopt,
+                                               std::make_optional(IntegerSpec(iterations)),
+                                               false,
+                                               0_ts,
+                                               0_ts,
+                                               std::nullopt),
+        1};
+
+    int64_t before = now();
+    for (auto _ : loop)
+        doPingIfNeeded<WithPing>();
+    int64_t after = now();
+
+    return after - before;
+}
+
+template <bool WithPing>
+int64_t Loops<WithPing>::metricsLoop(int64_t iterations) {
+
+    auto metrics = genny::metrics::Registry{};
+    metrics::Reporter{metrics};
+
+    // dummyOp to measure the performance overhead of having metrics. The results are unused.
+    auto dummyOp = metrics.operation("metricsLoop", WithPing ? "db.ping()" : "Nop", 0u);
+
+    int64_t before = now();
+    for (int i = 0; i < iterations; i++) {
+        auto ctx = dummyOp.start();
+        doPingIfNeeded<WithPing>();
+        ctx.success();
+    }
+    int64_t after = now();
+
+    return after - before;
+}
+
+template <bool WithPing>
+int64_t Loops<WithPing>::metricsPhaseLoop(int64_t iterations) {
+
+    // Copy/pasted from phaseLoop() and metricsLoop()
+    Orchestrator o{};
+    v1::ActorPhase<int> loop{
+            o,
+            std::make_unique<v1::IterationChecker>(std::nullopt,
+                                                   std::make_optional(IntegerSpec(iterations)),
+                                                   false,
+                                                   0_ts,
+                                                   0_ts,
+                                                   std::nullopt),
+            1};
+
+    auto metrics = genny::metrics::Registry{};
+    metrics::Reporter{metrics};
+
+    // dummyOp to measure the performance overhead of having metrics. The results are unused.
+    auto dummyOp = metrics.operation("metricsLoop", WithPing ? "db.ping()" : "Nop", 0u);
+
+    int64_t before = now();
+    for (auto _ : loop) {
+        auto ctx = dummyOp.start();
+        doPingIfNeeded<WithPing>();
+        ctx.success();
+    }
+    int64_t after = now();
+
+    return after - before;
+}
+
+// "The definition of ... a non-exported member function or static data member
+// of a class template shall be present in every translation unit in which it
+// is explicitly instantiated."
+template class Loops<true>;
+
+template class Loops<false>;
+}  // namespace genny::canaries

--- a/src/canaries/src/Loops.cpp
+++ b/src/canaries/src/Loops.cpp
@@ -19,6 +19,7 @@
 
 #include <gennylib/Orchestrator.hpp>
 #include <gennylib/PhaseLoop.hpp>
+#include <gennylib/context.hpp>
 
 #include <metrics/MetricsReporter.hpp>
 #include <metrics/metrics.hpp>
@@ -55,7 +56,7 @@ inline int64_t now() {
 template <bool WithPing>
 inline void doPingIfNeeded() {
     if constexpr (WithPing) {
-        std::cout << "PING!" << std::endl;
+        // TODO: call db.ping();
     } else {
         int x = 0;
         // Ensure memory is flushed and instruct the compiler

--- a/src/canaries/src/main.cpp
+++ b/src/canaries/src/main.cpp
@@ -88,18 +88,24 @@ struct ProgramOptions {
 
 template<bool WithPing>
 void runTest(std::vector<std::string>& testNames, int64_t iterations) {
-    canaries::Loops<WithPing> loops;
+    canaries::Loops<WithPing> loops(iterations);
     for (const auto& testName : testNames) {
         int64_t time;
-        if (testName == "simple-loop")
-            time = loops.simpleLoop(iterations);
-        else if (testName == "phase-loop")
-            time = loops.phaseLoop(iterations);
-        else if (testName == "metrics-loop")
-            time = loops.metricsLoop(iterations);
-        else if (testName == "real-loop")
-            time = loops.metricsPhaseLoop(iterations);
-        else {
+
+        // Run each test twice, the first time is warm up and the results are discarded.
+        if (testName == "simple-loop") {
+            loops.simpleLoop();
+            time = loops.simpleLoop();
+        } else if (testName == "phase-loop") {
+            loops.simpleLoop();
+            time = loops.phaseLoop();
+        } else if (testName == "metrics-loop") {
+            loops.simpleLoop();
+            time = loops.metricsLoop();
+        } else if (testName == "real-loop") {
+            loops.simpleLoop();
+            time = loops.metricsPhaseLoop();
+        } else {
             std::ostringstream stm;
             stm << "Unknown test name: " << testName;
             throw InvalidConfigurationException(stm.str());

--- a/src/canaries/src/main.cpp
+++ b/src/canaries/src/main.cpp
@@ -1,0 +1,125 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <boost/program_options.hpp>
+
+#include <canaries/Loops.hpp>
+#include <gennylib/InvalidConfigurationException.hpp>
+
+using namespace genny;
+
+struct ProgramOptions {
+    std::vector<std::string> _testNames;
+    std::string _description;
+    bool _isHelp = false;
+    bool _withPing = false;
+    int64_t _iterations = 0;
+
+    explicit ProgramOptions() = default;
+
+    ProgramOptions(int argc, char** argv) {
+        namespace po = boost::program_options;
+
+        std::ostringstream progDesc;
+        progDesc << "Genny Canaries - Microbenchmarks for measuring overhead of various Genny "
+                    "functionality\n\n";
+        progDesc << "Usage:\n";
+        progDesc << "    " << argv[0] << " <test-name [test-name] ...>\n";
+
+        progDesc << "Options:";
+        po::options_description optDesc(progDesc.str());
+        po::positional_options_description positional;
+
+        // clang-format off
+        optDesc.add_options()
+        ("help,h",
+                "Show this help message")
+        ("test-name",
+                po::value<std::vector<std::string>>()->multitoken(),
+                "One or more names of tests to run")
+        ("run-ping,p",
+                po::value<bool>()->default_value(true),
+                "Whether to run a db.ping() in each iteration of the canary or do nothing."
+                "Running db.ping() will simulate real-world performance more closely while"
+                "running nothing may help profile genny code with less noise")
+        ("iterations,i",
+                po::value<int64_t>()->default_value(1e6),
+                "number of iterations to run the tests");
+        //clang-format on
+
+        positional.add("test-name", -1);
+
+        auto run =
+            po::command_line_parser(argc, argv).options(optDesc).positional(positional).run();
+
+        std::ostringstream stm;
+        stm << optDesc;
+        _description = stm.str();
+
+        po::variables_map vm;
+        po::store(run, vm);
+        po::notify(vm);
+
+        if (vm.count("help") >= 1)
+            _isHelp = true;
+
+        _withPing = vm["run-ping"].as<bool>();
+        _iterations = vm["iterations"].as<int64_t>();
+
+        if (vm.count("test-name") >= 1)
+            _testNames = vm["test-name"].as<std::vector<std::string>>();
+    }
+};
+
+template<bool WithPing>
+void runTest(std::vector<std::string>& testNames, int64_t iterations) {
+    canaries::Loops<WithPing> loops;
+    for (const auto& testName : testNames) {
+        int64_t time;
+        if (testName == "simple-loop")
+            time = loops.simpleLoop(iterations);
+        else if (testName == "phase-loop")
+            time = loops.phaseLoop(iterations);
+        else if (testName == "metrics-loop")
+            time = loops.metricsLoop(iterations);
+        else if (testName == "real-loop")
+            time = loops.metricsPhaseLoop(iterations);
+        else {
+            std::ostringstream stm;
+            stm << "Unknown test name: " << testName;
+            throw InvalidConfigurationException(stm.str());
+        }
+        std::cout << testName << ":\t" << time << "ns" << std::endl;
+    }
+
+}
+
+int main(int argc, char** argv) {
+    auto opts = ProgramOptions(argc, argv);
+    if (opts._isHelp || opts._testNames.empty()) {
+        std::cout << opts._description << std::endl;
+        return 0;
+    }
+
+    if (opts._withPing)
+        runTest<true>(opts._testNames, opts._iterations);
+    else
+        runTest<false>(opts._testNames, opts._iterations);
+
+    return 0;
+}


### PR DESCRIPTION
Most of what's described in TIG-1098 is covered. `db.ping()` is missing, but I'm planning to do it as part of TIG-1337 now that the ticket has been reopened. I'll probably also file a ticket to integrate the canaries with DSI. 

Right now the output is in a human readable format:

```bash
➜  genny git:(tig1098) ./dist/bin/genny-canaries "simple-loop" "phase-loop" "metrics-loop" "real-loop" -p false
simple-loop:	2143012ns
phase-loop:	50859249ns
metrics-loop:	192317833ns
real-loop:	219668218ns
➜  genny git:(tig1098) ./dist/bin/genny-canaries "simple-loop" "phase-loop" "metrics-loop" "real-loop" -p false
simple-loop:	2108709ns
phase-loop:	51095903ns
metrics-loop:	194208899ns
real-loop:	220928299ns
➜  genny git:(tig1098) ./dist/bin/genny-canaries "simple-loop" "phase-loop" "metrics-loop" "real-loop" -p false
simple-loop:	2282825ns
phase-loop:	51424344ns
metrics-loop:	192888125ns
real-loop:	219086235ns
```