### PR TITLE
TIG-1566 improve metrics parsing perf

### DIFF
--- a/src/canaries/src/main.cpp
+++ b/src/canaries/src/main.cpp
@@ -94,7 +94,7 @@ struct ProgramOptions {
         ("metrics-output-file,o",
                 po::value<std::string>(),
                 "Write output to file in addition to stdout. The format ouf the output"
-                "file is [task-name],[loop-type],[average_duration_in_picoseconds]");
+                "file is [task-name]_[loop-type],[average_duration_in_picoseconds]");
         //clang-format on
 
         positional.add("task", 1);

--- a/src/python/third_party/csvsort.py
+++ b/src/python/third_party/csvsort.py
@@ -153,8 +153,11 @@ def decorated_csv(filename, columns, quoting):
             yield get_key(row, columns), row
 
 
-def mergesort(sorted_filenames, columns, quoting, nway=2):
+def mergesort(sorted_filenames, columns, quoting, nway=100):
     """Merge these 2 sorted csv files into a single output file
+
+    `nway` defaults to 100 to allow for 100MB * 100 = 10GB of files
+    to be read in at once with the default file size of 100MB.
     """
     merge_n = 0
     while len(sorted_filenames) > 1:


### PR DESCRIPTION
I [left a comment on the ticket](https://jira.mongodb.org/browse/TIG-1566) with a patch build showing a roughly 40% perf improvement from sorting 10GB of csv in memory at once. Is that sufficient or do we want to pursue more aggressive optimizations?