### PR TITLE
TIG-1657: Updating code to report on ops/sec instead of mean

### DIFF
--- a/src/python/genny/legacy_report.py
+++ b/src/python/genny/legacy_report.py
@@ -24,10 +24,9 @@ class _LegacyReportIntermediateFormat(object):
         self.threads = set()
         self.started = sys.maxsize
         self.ended = 0
-        self.mean = 0
 
     def finalize(self):
-        self.mean = self.duration_sum / self.n
+        self.ops_per_ns = self.n / (self.ended - self.started)
         return self
 
     def _asdict(self):
@@ -35,7 +34,7 @@ class _LegacyReportIntermediateFormat(object):
         return {
             'started': self.started,
             'ended': self.ended,
-            'mean': self.mean,
+            'ops_per_ns': self.ops_per_ns,
             'threads': self.threads
         }
 
@@ -50,8 +49,8 @@ def _translate_to_perf_json(timers):
             'end': timer['ended'] / 100000,
             'results': {
                 len(timer['threads']): {
-                    'ops_per_sec': timer['mean'],
-                    'ops_per_sec_values': [timer['mean']]
+                    'ops_per_sec': timer['ops_per_ns'] * 1e9,
+                    'ops_per_sec_values': [timer['ops_per_ns'] * 1e9]
                 }
             }
         })

--- a/src/python/tests/legacy_report_test.py
+++ b/src/python/tests/legacy_report_test.py
@@ -21,8 +21,8 @@ class LegacyReportTest(unittest.TestCase):
                 'end': 419.99981,
                 'results': {
                     '1': {
-                        'ops_per_sec': 13.0,
-                        'ops_per_sec_values': [13.0]
+                        'ops_per_sec': 76923076.92307693,
+                        'ops_per_sec_values': [76923076.92307693]
                     }
                 }
             }, {
@@ -32,8 +32,8 @@ class LegacyReportTest(unittest.TestCase):
                 'end': 420.0,
                 'results': {
                     '2': {
-                        'ops_per_sec': 13.5,
-                        'ops_per_sec_values': [13.5]
+                        'ops_per_sec': 117647058.8235294,
+                        'ops_per_sec_values': [117647058.8235294]
                     }
                 }
             }, {
@@ -43,8 +43,8 @@ class LegacyReportTest(unittest.TestCase):
                 'end': 419.99985,
                 'results': {
                     '2': {
-                        'ops_per_sec': 21.5,
-                        'ops_per_sec_values': [21.5]
+                        'ops_per_sec': 80000000.0,
+                        'ops_per_sec_values': [80000000.0]
                     }
                 }
             }]


### PR DESCRIPTION
I noticed that we were reporting on mean latency instead of ops_per_second. 