### PR TITLE
TIG-1683 enforce min macOS version of 10.14

### DIFF
--- a/src/lamplib/__main__.py
+++ b/src/lamplib/__main__.py
@@ -19,11 +19,27 @@ def run_self_test():
     sys.exit(0)
 
 
-def main():
+def validate_environment():
     # Check Python version
     if not sys.version_info >= (3, 7):
         logging.error('Please run this script with Python 3.7 or newer')
         sys.exit(1)
+
+    # Check the macOS version. Non-mac platforms return a tuple of empty strings
+    # for platform.mac_ver().
+    if platform.mac_ver()[0]:
+        release_triplet = platform.mac_ver()[0].split('.')
+        if int(release_triplet[1]) < 15:
+            # You could technically compile clang or gcc yourself on an older version
+            # of macOS, but it's untested so we might as well just enforce
+            # a blanket minimum macOS version for simplicity.
+            logging.error('Genny requires macOS 10.14 Mojave or newer')
+            sys.exit(1)
+    return
+
+
+def main():
+    validate_environment()
 
     # Initialize the global context.
     os_family = platform.system()

--- a/src/lamplib/__main__.py
+++ b/src/lamplib/__main__.py
@@ -29,7 +29,7 @@ def validate_environment():
     # for platform.mac_ver().
     if platform.mac_ver()[0]:
         release_triplet = platform.mac_ver()[0].split('.')
-        if int(release_triplet[1]) < 15:
+        if int(release_triplet[1]) < 14:
             # You could technically compile clang or gcc yourself on an older version
             # of macOS, but it's untested so we might as well just enforce
             # a blanket minimum macOS version for simplicity.


### PR DESCRIPTION
I tested this manually by changing 14 to 15 and verifying that `./scripts/lamp` fails locally with the expected error message.