### PR TITLE
TIG-1720 Option to Skip Cedar Reporting

### DIFF
--- a/src/python/genny/cedar_report.py
+++ b/src/python/genny/cedar_report.py
@@ -303,6 +303,9 @@ def main__cedar_report(argv=sys.argv[1:], env=None, cert_retriever_cls=CertRetri
         with open(args.expansions_file, 'r') as f:
             env = yaml.safe_load(f)
 
+    if env.get('cedar_mode', '') == 'skip':
+        return
+
     if args.test_name:
         env['test_name'] = args.test_name
     else:

--- a/src/python/tests/cedar_report_test.py
+++ b/src/python/tests/cedar_report_test.py
@@ -162,3 +162,16 @@ class CedarReportTest(unittest.TestCase):
             self.assertDictEqual(expected_json, report_json)
 
         mock_uploader_run.assert_called_with(expected_uploader_run_args)
+
+    @patch('genny.cedar_report.ShellCuratorRunner.run')
+    def test_cedar_mode_skip(self, mock_uploader_run):
+        mock_env = {
+            'cedar_mode': 'skip',
+        }
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            argv = [get_fixture('cedar', 'shared_with_cxx_metrics_test.csv'), output_dir]
+            main__cedar_report(argv, mock_env, _NoopCertRetriever)
+
+        mock_uploader_run.assert_not_called()
+


### PR DESCRIPTION
This lets you skip cedar reporting when running DSI locally.