### PR TITLE
TIG-1779 Let mongocxx::database be a value in the generated PhaseConfig

### DIFF
--- a/scripts/create-new-actor.sh
+++ b/scripts/create-new-actor.sh
@@ -280,6 +280,8 @@ namespace genny::actor {
 //
 
 struct ${actor_name}::PhaseConfig {
+    mongocxx::database database;
+
     mongocxx::collection collection;
 
     //
@@ -316,8 +318,9 @@ struct ${actor_name}::PhaseConfig {
     // documentation in ${q}context.hpp${q}.
     //
 
-    PhaseConfig(PhaseContext& phaseContext, const mongocxx::database& db, ActorId id)
-        : collection{db[phaseContext["Collection"].to<std::string>()]},
+    PhaseConfig(PhaseContext& phaseContext, mongocxx::database db, ActorId id)
+        : database{std::move(db)},
+          collection{database[phaseContext["Collection"].to<std::string>()]},
           documentExpr{phaseContext["Document"].to<DocumentGenerator>(phaseContext, id)} {}
 };
 

--- a/scripts/create-new-actor.sh
+++ b/scripts/create-new-actor.sh
@@ -318,8 +318,8 @@ struct ${actor_name}::PhaseConfig {
     // documentation in ${q}context.hpp${q}.
     //
 
-    PhaseConfig(PhaseContext& phaseContext, mongocxx::database db, ActorId id)
-        : database{std::move(db)},
+    PhaseConfig(PhaseContext& phaseContext, mongocxx::database&& db, ActorId id)
+        : database{db},
           collection{database[phaseContext["Collection"].to<std::string>()]},
           documentExpr{phaseContext["Document"].to<DocumentGenerator>(phaseContext, id)} {}
 };


### PR DESCRIPTION
It's currently passed in as const mongocxx::database& but at the call-site it's a value. Treating it as a const allows the PhaseConfig to implicitly copy it as a ref and it prohibits the PhaseConfig from calling non-const methods.
