### PR TITLE
TIG-1834 Don't allow accidental empty phases

### DIFF
--- a/src/HitchhikersGuide.md
+++ b/src/HitchhikersGuide.md
@@ -89,11 +89,26 @@ calls run), the actor iterates over its `PhaseLoop` using the
 into an `ActorPhase` (it actually creates an entry into `the` `_loop`
 object for each thread that the YAML file specifies). The inner loop
 iterates over the config and runs the specified operation for the actor
-for as many times as `Repeat` or `Duration` specify it to run. If both
-the `Repeat` and `Duration` keywords are specified, then it will run for
+for as many times as `Repeat` or `Duration` specify it to run.
+
+**Notes on Repeat, Duration, and Blocking**
+
+If both the `Repeat` and `Duration` keywords are specified, then it will run for
 the longer of the two (e.g. `{ Duration: 2 seconds, Repeat: 1 }` the
 Duration will win unless the single iteration takes longer than 2
 seconds).
+
+If neither `Duration` nor `Repeat` is given for a `Phase` block,
+the YAML must specify `Blocking: None` to prevent accidentally
+causing an Actor to not run at all during a Phase. It is still possible
+for all Actors to specify `Blocking:None` for a given Phase in which
+case the number of iterations that all Actors will take in that Phase
+is undefined (but in practice is either 0 or 1 depending on how fast
+all the Actors call into the `Orchestrator` to say they're done blocking
+in the current Phase.)
+
+See extended discussion of how `Blocking` works in
+`src/workloads/docs/HelloWorld-MultiplePhases.yml`.
 
 ### Casts
 

--- a/src/cast_core/test/RunCommandActor_test.cpp
+++ b/src/cast_core/test/RunCommandActor_test.cpp
@@ -84,7 +84,7 @@ TEST_CASE_METHOD(MongoTestFixture,
 
             REQUIRE(diagInfo.find("no such command") != std::string::npos);
             REQUIRE(diagInfo.find("ServerResponse") != std::string::npos);
-        } catch(const std::exception& x) {
+        } catch (const std::exception& x) {
             FAIL(x.what());
         }
 

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -107,13 +107,14 @@ public:
             phaseContext["Blocking"].maybe<std::string>() != "None") {
             std::stringstream msg;
             msg << "Must specify 'Blocking: None' for Actors in Phases that don't block "
-                   "completion with a Repeat or Duration value. In Phase " << phaseContext.path() << ". Gave";
+                   "completion with a Repeat or Duration value. In Phase "
+                << phaseContext.path() << ". Gave";
             msg << " Duration:"
                 << phaseContext["Duration"].maybe<std::string>().value_or("undefined");
             msg << " Repeat:" << phaseContext["Repeat"].maybe<std::string>().value_or("undefined");
             msg << " Blocking:"
                 << phaseContext["Blocking"].maybe<std::string>().value_or("undefined");
-                throw InvalidConfigurationException(msg.str());
+            throw InvalidConfigurationException(msg.str());
         }
 
         const auto rateSpec = phaseContext["GlobalRate"].maybe<RateSpec>();

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -103,8 +103,20 @@ public:
                            phaseContext["SleepBefore"].maybe<TimeSpec>().value_or(TimeSpec{}),
                            phaseContext["SleepAfter"].maybe<TimeSpec>().value_or(TimeSpec{}),
                            phaseContext["GlobalRate"].maybe<RateSpec>()) {
-        const auto rateSpec = phaseContext["GlobalRate"].maybe<RateSpec>();
+        if (!phaseContext.isNop() && !phaseContext["Duration"] && !phaseContext["Repeat"] &&
+            phaseContext["Blocking"].maybe<std::string>() != "None") {
+            std::stringstream msg;
+            msg << "Must specify 'Blocking: None' for Actors in Phases that don't block "
+                   "completion with a Repeat or Duration value. In Phase " << phaseContext.path() << ". Gave";
+            msg << " Duration:"
+                << phaseContext["Duration"].maybe<std::string>().value_or("undefined");
+            msg << " Repeat:" << phaseContext["Repeat"].maybe<std::string>().value_or("undefined");
+            msg << " Blocking:"
+                << phaseContext["Blocking"].maybe<std::string>().value_or("undefined");
+                throw InvalidConfigurationException(msg.str());
+        }
 
+        const auto rateSpec = phaseContext["GlobalRate"].maybe<RateSpec>();
         const auto rateLimiterName =
             phaseContext["RateLimiterName"].maybe<std::string>().value_or("defaultRateLimiter");
 
@@ -148,7 +160,7 @@ public:
                 if (!success && (o.currentPhase() == inPhase)) {
                     // Add some jitter to avoid threads waking up at once.
                     std::this_thread::sleep_for(std::chrono::nanoseconds(
-                            (_rateLimiter->getRate() * int64_t(0.95 + double(std::rand() % 10) / 10))));
+                        (_rateLimiter->getRate() * int64_t(0.95 + double(std::rand() % 10) / 10))));
                     continue;
                 }
                 break;
@@ -200,7 +212,7 @@ private:
 
 
 /**
- * The iterator used in `for(auto _ : phase)` and returned from
+ * The iterator used in `for(auto _ : cfg)` and returned from
  * `ActorPhase::begin()` and `ActorPhase::end()`.
  *
  * Configured with {@link IterationCompletionCheck} and will continue

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -74,6 +74,10 @@ public:
         return std::move(this->_node.getPlural<T, F>(singular, plural, std::forward<F>(f)));
     }
 
+    auto path() const {
+        return _node.path();
+    }
+
 protected:
     const Node& _node;
 };

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -64,8 +64,7 @@ public:
 
 public:
     explicit BaseGlobalRateLimiter(const RateSpec& rs)
-        : _burstSize(rs.operations),
-          _rateNS(rs.per.count()) {};
+        : _burstSize(rs.operations), _rateNS(rs.per.count()){};
 
     // No copies or moves.
     BaseGlobalRateLimiter(const BaseGlobalRateLimiter& other) = delete;

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -119,6 +119,7 @@ Actors:
   Threads: 1
   Phases:
     - GlobalRate: 5 per 4 seconds
+      Blocking: None
 )",
                       "");
         auto& config = ns.root();

--- a/src/gennylib/test/PhaseLoop_test.cpp
+++ b/src/gennylib/test/PhaseLoop_test.cpp
@@ -498,11 +498,10 @@ TEST_CASE("Actual Actor Example") {
 
         auto imvProducer = std::make_shared<CounterProducer<IncrementsMapValues>>("Inc");
 
-        REQUIRE_THROWS_WITH(
-                ([&]() {
-                    ActorHelper ah(config.root(), 1, {{"Inc", imvProducer}});
-                    ah.run();
-                }()),
-                Catch::Matches(".*Must specify 'Blocking: None'.*"));
+        REQUIRE_THROWS_WITH(([&]() {
+                                ActorHelper ah(config.root(), 1, {{"Inc", imvProducer}});
+                                ah.run();
+                            }()),
+                            Catch::Matches(".*Must specify 'Blocking: None'.*"));
     }
 }

--- a/src/gennylib/test/PhaseLoop_test.cpp
+++ b/src/gennylib/test/PhaseLoop_test.cpp
@@ -483,4 +483,26 @@ TEST_CASE("Actual Actor Example") {
         REQUIRE(duration > 0ms);
         REQUIRE(duration < 350ms);
     }
+
+    SECTION("Missing explicit Blocking = None") {
+        using namespace std::literals::chrono_literals;
+        NodeSource config(R"(
+            SchemaVersion: 2018-07-01
+            Actors:
+            - Type: Inc
+              Name: Inc
+              Phases:
+              - Key: 72
+        )",
+                          "");
+
+        auto imvProducer = std::make_shared<CounterProducer<IncrementsMapValues>>("Inc");
+
+        REQUIRE_THROWS_WITH(
+                ([&]() {
+                    ActorHelper ah(config.root(), 1, {{"Inc", imvProducer}});
+                    ah.run();
+                }()),
+                Catch::Matches(".*Must specify 'Blocking: None'.*"));
+    }
 }

--- a/src/workloads/docs/HelloWorld-MultiplePhases.yml
+++ b/src/workloads/docs/HelloWorld-MultiplePhases.yml
@@ -29,7 +29,7 @@ Description: |
           Duration: 2 seconds            Repeat: 10
 
         - Message: A.1                 - Message: B.1
-                                         Repeat: 1e3
+          Blocking: None                 Repeat: 1e3
 
   The HelloWorld Actor echoes its "Message" parameter in a
   loop.
@@ -67,11 +67,13 @@ Description: |
 
           A                  B
       Message: A.1      Message: B.1
-                        Repeat: 1e3
+      Blocking: None    Repeat: 1e3
 
   Notice how Actor A does not specify either a Repeat nor a
   Duration. This means A is considered a "background" Actor
-  for this Phase. It will run as long as it can while other
+  for this Phase. Since it doesn't specify Repeat or Duration
+  it must specify Blocking: None as a precaution against
+  footgunning. It will run as long as it can while other
   Actors are doing their work. This is useful if you want to
   have some "background" operation such as doing a db.ping()
   or a collection.drop() etc.
@@ -106,6 +108,7 @@ Actors:
   - Message: A.0
     Duration: 2 seconds
   - Message: A.1
+    Blocking: None
 
 - Type: HelloWorld
   Name: B

--- a/src/workloads/docs/InsertWithNop.yml
+++ b/src/workloads/docs/InsertWithNop.yml
@@ -14,13 +14,17 @@ Actors:
   - {Nop: true}
   - Collection: "inserts"
     Document: {"a": {^RandomInt: {min: 50, max: 60}}}
+    Repeat: 1
   - {Nop: true}
   - {Nop: true}
   - Collection: "inserts"
     Document: {"b": {^RandomString: {length: {^RandomInt: {min: 5, max: 15}}, alphabet: abcde}}}
+    Repeat: 1
   - Collection: "inserts"
     Document: {"a": {^RandomInt: {min: 63, max: 70}}}
+    Repeat: 1
   - {Nop: true}
   - Collection: "inserts"
     Document: {"b": {^RandomString: {length: {^RandomInt: {min: 15, max: 25}}, alphabet: abcde}}}
+    Repeat: 1
   - {Nop: true}

--- a/src/workloads/docs/RunCommand.yml
+++ b/src/workloads/docs/RunCommand.yml
@@ -40,6 +40,7 @@ Actors:
   Threads: 1
   Phases:
   - Phase: 0
+    Repeat: 1
     Operation:
       OperationMetricsName: Stepdown
       OperationName: RunCommand

--- a/src/workloads/networking/PrimaryRequiredReads.yml
+++ b/src/workloads/networking/PrimaryRequiredReads.yml
@@ -65,6 +65,6 @@ Actors:
       t: {^RandomInt: {min: 0, max: 10}}
     Indexes:
     - keys: {t: 1}
-
+    Repeat: 1
   - Phase: 1  # Run
     Nop: true

--- a/src/workloads/networking/SecondaryAllowed.yml
+++ b/src/workloads/networking/SecondaryAllowed.yml
@@ -54,6 +54,7 @@ Actors:
   Phases:
   - Phase: 0
     Threads: 1
+    Repeat: 1
     Database: test
     CollectionCount: 1
     DocumentCount: 100


### PR DESCRIPTION
It's too easy for workload YAML to not specify a `Repeat` or `Duration` value for a Phase and unintentionally make that Phase a "background" phase. This can create hard-to-debug scenarios if no Actor specifies a Repeat/Duration for a given Phase (which is always a mis-configuration).

Require an extra configuration for Phases without Repeat or Duration that makes it obvious the yaml author intended for the Actor to operate in the background for the given Phase.

Fortunately (or unfortunately depending on how much victim you wanna play) this caught a few workloads already in production....

cc @dalyd this woulda saved both of us a couple hours the other day 😸 