### PR TITLE
Unique indexes

### DIFF
--- a/src/workloads/scale/UniqueIndexStress.yml
+++ b/src/workloads/scale/UniqueIndexStress.yml
@@ -1,9 +1,14 @@
 # This workload is developed as ... FILL ME IN
+# This workload tests insert performance with unique indexes. Each pair of phases first, drops the
+# database, then creates 7 indexes, before inserting documents as fast as it can. The difference
+# between the different phases is how many of the indexes are unique. It first does 0 unique
+# secondary indexes, then 1, 2, up to 7.
 
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 
 string_length: &string_length 10
+insert_threads: &insert_threads 1
 
 Actors:
 - Name: Setup
@@ -22,7 +27,18 @@ Actors:
         indexes:
         - key: {a: 1}
           name: a
-          unique: true
+        - key: {b: 1}
+          name: b
+        - key: {c: 1}
+          name: c
+        - key: {d: 1}
+          name: d
+        - key: {e: 1}
+          name: e
+        - key: {f: 1}
+          name: f
+        - key: {g: 1}
+          name: g
   - &Nop {Nop: true}
   - Repeat: 1
     Database: &db test
@@ -39,20 +55,208 @@ Actors:
           unique: true
         - key: {b: 1}
           name: b
+        - key: {c: 1}
+          name: c
+        - key: {d: 1}
+          name: d
+        - key: {e: 1}
+          name: e
+        - key: {f: 1}
+          name: f
+        - key: {g: 1}
+          name: g
+  - *Nop
+  - Repeat: 1
+    Database: &db test
+    Collection: &coll test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key: {a: 1}
+          name: a
+          unique: true
+        - key: {b: 1}
+          name: b
+          unique: true
+        - key: {c: 1}
+          name: c
+        - key: {d: 1}
+          name: d
+        - key: {e: 1}
+          name: e
+        - key: {f: 1}
+          name: f
+        - key: {g: 1}
+          name: g
+  - *Nop
+  - Repeat: 1
+    Database: &db test
+    Collection: &coll test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key: {a: 1}
+          name: a
+          unique: true
+        - key: {b: 1}
+          name: b
+          unique: true
+        - key: {c: 1}
+          name: c
+          unique: true
+        - key: {d: 1}
+          name: d
+        - key: {e: 1}
+          name: e
+        - key: {f: 1}
+          name: f
+        - key: {g: 1}
+          name: g
+  - *Nop
+  - Repeat: 1
+    Database: &db test
+    Collection: &coll test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key: {a: 1}
+          name: a
+          unique: true
+        - key: {b: 1}
+          name: b
+          unique: true
+        - key: {c: 1}
+          name: c
+          unique: true
+        - key: {d: 1}
+          name: d
+          unique: true
+        - key: {e: 1}
+          name: e
+        - key: {f: 1}
+          name: f
+        - key: {g: 1}
+          name: g
+  - *Nop
+  - Repeat: 1
+    Database: &db test
+    Collection: &coll test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key: {a: 1}
+          name: a
+          unique: true
+        - key: {b: 1}
+          name: b
+          unique: true
+        - key: {c: 1}
+          name: c
+          unique: true
+        - key: {d: 1}
+          name: d
+          unique: true
+        - key: {e: 1}
+          name: e
+          unique: true
+        - key: {f: 1}
+          name: f
+        - key: {g: 1}
+          name: g
+  - *Nop
+  - Repeat: 1
+    Database: &db test
+    Collection: &coll test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key: {a: 1}
+          name: a
+          unique: true
+        - key: {b: 1}
+          name: b
+          unique: true
+        - key: {c: 1}
+          name: c
+          unique: true
+        - key: {d: 1}
+          name: d
+          unique: true
+        - key: {e: 1}
+          name: e
+          unique: true
+        - key: {f: 1}
+          name: f
+          unique: true
+        - key: {g: 1}
+          name: g
+  - *Nop
+  - Repeat: 1
+    Database: &db test
+    Collection: &coll test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key: {a: 1}
+          name: a
+          unique: true
+        - key: {b: 1}
+          name: b
+          unique: true
+        - key: {c: 1}
+          name: c
+          unique: true
+        - key: {d: 1}
+          name: d
+          unique: true
+        - key: {e: 1}
+          name: e
+          unique: true
+        - key: {f: 1}
+          name: f
+          unique: true
+        - key: {g: 1}
+          name: g
           unique: true
   - *Nop
 
-- Name: InsertData
+- &InsertActor
+  Name: UniqueIndexes0
   Type: CrudActor
   Database: *db
-  Threads: 1
+  Threads: *insert_threads
   Phases:
   - *Nop
   - &InsertMany
     Collection: *coll
-    Repeat: 1000
+    Repeat: 10000
     Operations:
-    - OperationName: insertMany
+    - &InsertOp
+      OperationName: insertMany
       OperationCommand:
         Documents:
         - &doc
@@ -76,4 +280,171 @@ Actors:
         - *doc
         - *doc
   - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: UniqueIndexes1
+  Type: CrudActor
+  Database: *db
+  Threads: *insert_threads
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
   - *InsertMany
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: UniqueIndexes2
+  Type: CrudActor
+  Database: *db
+  Threads: *insert_threads
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *InsertMany
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: UniqueIndexes3
+  Type: CrudActor
+  Database: *db
+  Threads: *insert_threads
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *InsertMany
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: UniqueIndexes4
+  Type: CrudActor
+  Database: *db
+  Threads: *insert_threads
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *InsertMany
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: UniqueIndexes5
+  Type: CrudActor
+  Database: *db
+  Threads: *insert_threads
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *InsertMany
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: UniqueIndexes6
+  Type: CrudActor
+  Database: *db
+  Threads: *insert_threads
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *InsertMany
+  - *Nop
+  - *Nop
+
+- Name: UniqueIndexes2
+  Type: CrudActor
+  Database: *db
+  Threads: *insert_threads
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *InsertMany
+

--- a/src/workloads/scale/UniqueIndexStress.yml
+++ b/src/workloads/scale/UniqueIndexStress.yml
@@ -10,6 +10,12 @@ Owner: "@mongodb/product-perf"
 string_length: &string_length 10
 insert_threads: &insert_threads 1
 
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 1000
+
+
 Actors:
 - Name: Setup
   Type: RunCommand

--- a/src/workloads/scale/UniqueIndexStress.yml
+++ b/src/workloads/scale/UniqueIndexStress.yml
@@ -1,4 +1,3 @@
-# This workload is developed as ... FILL ME IN
 # This workload tests insert performance with unique indexes. Each pair of phases first, drops the
 # database, then creates 7 indexes, before inserting documents as fast as it can. The difference
 # between the different phases is how many of the indexes are unique. It first does 0 unique

--- a/src/workloads/scale/UniqueIndexStress.yml
+++ b/src/workloads/scale/UniqueIndexStress.yml
@@ -1,0 +1,79 @@
+# This workload is developed as ... FILL ME IN
+
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+
+string_length: &string_length 10
+
+Actors:
+- Name: Setup
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: &db test
+    Collection: &coll test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key: {a: 1}
+          name: a
+          unique: true
+  - &Nop {Nop: true}
+  - Repeat: 1
+    Database: &db test
+    Collection: &coll test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key: {a: 1}
+          name: a
+          unique: true
+        - key: {b: 1}
+          name: b
+          unique: true
+  - *Nop
+
+- Name: InsertData
+  Type: CrudActor
+  Database: *db
+  Threads: 1
+  Phases:
+  - *Nop
+  - &InsertMany
+    Collection: *coll
+    Repeat: 1000
+    Operations:
+    - OperationName: insertMany
+      OperationCommand:
+        Documents:
+        - &doc
+          a: &rs {^RandomString: {length: *string_length}}
+          b: *rs
+          c: *rs
+          d: *rs
+          e: *rs
+          f: *rs
+          g: *rs
+          h: *rs
+          i: *rs
+          j: *rs
+        - *doc
+        - *doc
+        - *doc
+        - *doc
+        - *doc
+        - *doc
+        - *doc
+        - *doc
+        - *doc
+  - *Nop
+  - *InsertMany

--- a/src/workloads/scale/UniqueIndexStress.yml
+++ b/src/workloads/scale/UniqueIndexStress.yml
@@ -432,7 +432,7 @@ Actors:
   - *Nop
   - *Nop
 
-- Name: UniqueIndexes2
+- Name: UniqueIndexes7
   Type: CrudActor
   Database: *db
   Threads: *insert_threads


### PR DESCRIPTION
I made this workload for https://jira.mongodb.org/browse/BF-10848. We will probably add a microbenchmark instead of a sys-perf benchmark for it ultimately, so this probably doesn't get used in production (unless we use this instead of a mongo-perf in there). 

That said, do you guys want to accumulate workloads like this in the workloads directory, or only mainly get the ones that go into production? Let me know. For now I'm putting it up here for discussion. 

Also, it was interesting to make -- I have a lot of actors to keep the results straight. I would have preferred to have 2 actors total, and differentiate the results by phase. I suspect that are things that could make this workload a lot more concise. 