### PR TITLE
Fix use of shared state in CollectionScanner and RandomSampler

### DIFF
--- a/src/cast_core/include/cast_core/actors/CollectionScanner.hpp
+++ b/src/cast_core/include/cast_core/actors/CollectionScanner.hpp
@@ -35,7 +35,7 @@ namespace genny::actor {
  * Owner: Storage Engines
  */
 class CollectionScanner : public Actor {
-    // Used to assign each RandomSampler instance an id starting at 0.
+    // Used to assign each CollectionScanner instance an id starting at 0.
     // The genny::Acttor::id() field is monotonically increasing across all Actors
     // of all types.
     struct ActorCounter : genny::WorkloadContext::ShareableState<std::atomic_int> {};
@@ -57,7 +57,7 @@ private:
 
     /** @private */
     struct PhaseConfig;
-    ActorCounter& _actorCounter;
+    int _index;
     RunningActorCounter& _runningActorCounter;
     PhaseLoop<PhaseConfig> _loop;
 };

--- a/src/cast_core/include/cast_core/actors/RandomSampler.hpp
+++ b/src/cast_core/include/cast_core/actors/RandomSampler.hpp
@@ -54,7 +54,7 @@ private:
     /** @private */
     struct PhaseConfig;
     DefaultRandom& _random;
-    ActorCounter& _actorCounter;
+    int _index;
     PhaseLoop<PhaseConfig> _loop;
     CollectionScanner::RunningActorCounter& _activeCollectionScannerInstances;
 };

--- a/src/cast_core/src/RandomSampler.cpp
+++ b/src/cast_core/src/RandomSampler.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cast_core/actors/RandomSampler.hpp>
 #include <cast_core/actors/CollectionScanner.hpp>
+#include <cast_core/actors/RandomSampler.hpp>
 
 #include <memory>
 

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -258,8 +258,7 @@ public:
     bool operator==(const ActorPhaseIterator& rhs) const {
         if (_iterationCheck) {
             _iterationCheck->sleepBefore(*_orchestrator, _inPhase);
-            _iterationCheck->limitRate(
-                _referenceStartingPoint, _currentIteration, _inPhase);
+            _iterationCheck->limitRate(_referenceStartingPoint, _currentIteration, _inPhase);
         }
         // clang-format off
         return

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -114,7 +114,8 @@ public:
 
         // Use the "weak" version for performance at the expense of false negatives (i.e.
         // `compare_exchange` not comparing equal when it should).
-        const auto success = _lastEmptiedTimeNS.compare_exchange_weak(curEmptiedTime, newEmptiedTime);
+        const auto success =
+            _lastEmptiedTimeNS.compare_exchange_weak(curEmptiedTime, newEmptiedTime);
 
         // Note that incrementing _burstCount is *not* atomic with incrementing _lastEmptiedTimeNS.
         // This may cause some threads to see an outdated _burstCount, causing unnecessary waiting
@@ -124,7 +125,6 @@ public:
             _burstCount++;
         }
         return success;
-
     }
 
     constexpr int64_t getRate() const {

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -95,7 +95,7 @@ public:
     void run() override {
         for (auto&& config : _loop) {
             for (auto _ : config) {
-//                BOOST_LOG_TRIVIAL(info) << "Incrementing";
+                //                BOOST_LOG_TRIVIAL(info) << "Incrementing";
                 ++_counter;
             }
         }

--- a/src/workloads/scale/OutOfCacheScanner.yml
+++ b/src/workloads/scale/OutOfCacheScanner.yml
@@ -41,73 +41,12 @@ Actors:
 
 - Name: ColdScanner
   Type: CollectionScanner
-  Threads: 1
+  Threads: 6
   Database: cold
-  CollectionCount: 10
+  CollectionCount: 60
   Phases:
   - {Nop: true}
   - {Nop: true}
   - Duration: 30 minutes
     SkipFirstLoop: true
-    GlobalRate: 1 per 4 minutes
-
-- Name: ColdScanner2
-  Type: CollectionScanner
-  Threads: 1
-  Database: cold
-  CollectionCount: 10
-  Phases:
-  - {Nop: true}
-  - {Nop: true}
-  - Duration: 30 minutes
-    SkipFirstLoop: true
-    GlobalRate: 1 per 4 minutes
-
-- Name: ColdScanner3
-  Type: CollectionScanner
-  Threads: 1
-  Database: cold
-  CollectionCount: 10
-  Phases:
-  - {Nop: true}
-  - {Nop: true}
-  - Duration: 30 minutes
-    SkipFirstLoop: true
-    GlobalRate: 1 per 4 minutes
-
-- Name: ColdScanner4
-  Type: CollectionScanner
-  Threads: 1
-  Database: cold
-  CollectionCount: 10
-  Phases:
-  - {Nop: true}
-  - {Nop: true}
-  - Duration: 30 minutes
-    SkipFirstLoop: true
-    GlobalRate: 1 per 4 minutes
-
-- Name: ColdScanner5
-  Type: CollectionScanner
-  Threads: 1
-  Database: cold
-  CollectionCount: 10
-  Phases:
-  - {Nop: true}
-  - {Nop: true}
-  - Duration: 30 minutes
-    SkipFirstLoop: true
-    GlobalRate: 1 per 4 minutes
-
-- Name: ColdScanner6
-  Type: CollectionScanner
-  Threads: 1
-  Database: cold
-  CollectionCount: 10
-  Phases:
-  - {Nop: true}
-  - {Nop: true}
-  - Duration: 30 minutes
-    SkipFirstLoop: true
-    GlobalRate: 1 per 4 minutes
-
+    GlobalRate: 6 per 4 minutes


### PR DESCRIPTION
The shared-state counter was being incremented for each PhaseConfig constructor call not for each Actor ctor call. I think this fix also resolves the weird `.2` suffix thing.