### PR TITLE
TIG-1888 TIG-1889 TIG-1890 Implement LongLived Actors using existing Actor types

### DIFF
--- a/src/workloads/docs/LongLivedCreator.yml
+++ b/src/workloads/docs/LongLivedCreator.yml
@@ -1,0 +1,43 @@
+SchemaVersion: 2018-07-01
+Owner: Storage Engines
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 400
+
+Actors:
+- Name: LongLivedCreator
+  Type: Loader
+  Threads: 10
+  Phases:
+  - Repeat: 1
+    Database: &DB longlived
+    CollectionCount: &CollectionCount 1000
+    Threads: 10
+    DocumentCount: &DocumentCount 1000
+    BatchSize: 1000
+    Document:
+      # Each document ranges in size from about 90 to 150 bytes (average 120)
+      x0: &rand_10k_int {^RandomInt: {min: 0, max: 10000}}
+      x1: &rand4int {^RandomInt: {min: 0, max: 2147483647}}
+      x2: *rand4int
+      x3: *rand4int
+      x4: *rand4int
+      x5: *rand4int
+      x6: *rand4int
+      x7: *rand4int
+      x8: *rand4int
+      s0: {^RandomString: {length: {^RandomInt: {min: 20, max: 80}}}}
+    Indexes:
+    - keys: {x0: 1}
+    - keys: {x1: 1}
+    - keys: {x2: 1}
+    - keys: {x3: 1}
+    - keys: {x4: 1}
+    - keys: {x5: 1}
+    - keys: {x6: 1}
+    - keys: {x7: 1}
+    - keys: {x8: 1}
+  - {Nop: true}
+      

--- a/src/workloads/docs/LongLivedReader.yml
+++ b/src/workloads/docs/LongLivedReader.yml
@@ -1,0 +1,68 @@
+SchemaVersion: 2018-07-01
+Owner: Storage Engines
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 400
+
+Actors:
+- Name: LongLivedCreator
+  Type: Loader
+  Threads: 10
+  Phases:
+  - Repeat: 1
+    Database: &DB longlived
+    CollectionCount: &CollectionCount 1000
+    Threads: 10
+    DocumentCount: &DocumentCount 1000
+    BatchSize: 1000
+    Document:
+      # Each document ranges in size from about 90 to 150 bytes (average 120)
+      x0: &rand_10k_int {^RandomInt: {min: 0, max: 10000}}
+      x1: &rand4int {^RandomInt: {min: 0, max: 2147483647}}
+      x2: *rand4int
+      x3: *rand4int
+      x4: *rand4int
+      x5: *rand4int
+      x6: *rand4int
+      x7: *rand4int
+      x8: *rand4int
+      s0: {^RandomString: {length: {^RandomInt: {min: 20, max: 80}}}}
+    Indexes:
+    - keys: {x0: 1}
+    - keys: {x1: 1}
+    - keys: {x2: 1}
+    - keys: {x3: 1}
+    - keys: {x4: 1}
+    - keys: {x5: 1}
+    - keys: {x6: 1}
+    - keys: {x7: 1}
+    - keys: {x8: 1}
+  - {Nop: true}
+      
+- Name: LongLivedIndexReader
+  Type: MultiCollectionQuery
+  Threads: 100
+  GlobalRate: 10 per 1 second
+  Phases:
+  - {Nop: true}
+  - Duration: 3 minutes
+    Database: *DB
+    CollectionCount: *CollectionCount
+    DocumentCount: *DocumentCount
+    Threads: 10
+    Filter: {x0: *rand_10k_int}
+
+- Name: LongLivedReader
+  Type: MultiCollectionQuery
+  Threads: 100
+  GlobalRate: 10 per 1 second
+  Phases:
+  - {Nop: true}
+  - Duration: 3 minutes
+    Database: *DB
+    CollectionCount: *CollectionCount
+    DocumentCount: *DocumentCount
+    Threads: 10
+    Filter: {_id: *rand_10k_int}

--- a/src/workloads/docs/LongLivedWriter.yml
+++ b/src/workloads/docs/LongLivedWriter.yml
@@ -1,0 +1,56 @@
+SchemaVersion: 2018-07-01
+Owner: Storage Engines
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 400
+
+Actors:
+- Name: LongLivedCreator
+  Type: Loader
+  Threads: 10
+  Phases:
+  - Repeat: 1
+    Database: &DB longlived
+    CollectionCount: &CollectionCount 1000
+    Threads: 10
+    DocumentCount: &DocumentCount 1000
+    BatchSize: 1000
+    Document:
+      # Each document ranges in size from about 90 to 150 bytes (average 120)
+      x0: &rand_10k_int {^RandomInt: {min: 0, max: 10000}}
+      x1: &rand4int {^RandomInt: {min: 0, max: 2147483647}}
+      x2: *rand4int
+      x3: *rand4int
+      x4: *rand4int
+      x5: *rand4int
+      x6: *rand4int
+      x7: *rand4int
+      x8: *rand4int
+      s0: {^RandomString: {length: {^RandomInt: {min: 20, max: 80}}}}
+    Indexes:
+    - keys: {x0: 1}
+    - keys: {x1: 1}
+    - keys: {x2: 1}
+    - keys: {x3: 1}
+    - keys: {x4: 1}
+    - keys: {x5: 1}
+    - keys: {x6: 1}
+    - keys: {x7: 1}
+    - keys: {x8: 1}
+  - {Nop: true}
+      
+- Name: LongLivedWriter
+  Type: MultiCollectionUpdate
+  Threads: 100
+  GlobalRate: 100 in 1 second
+  Phases:
+  - {Nop: true}
+  - Duration: 3 minutes
+    Database: *DB
+    CollectionCount: *CollectionCount
+    DocumentCount: *DocumentCount
+    Threads: 10
+    UpdateFilter: {_id: *rand_10k_int}
+    Update: {$inc: {x1: 1}}


### PR DESCRIPTION
I started to write my own Creator class (which was a good exercise), but ultimately decided that the standard classes probably suffice.

None of these implement "Prefix" from the design document - which was a way to prefix collection names so that multiple copies of these can run simultaneously and not overlap, but it looks like the same intention can be achieved by using different database names.

And the design document lists an "Index" parameter to specify that the Reader uses an index.  I just created different actors that query based on an index name vs. an _id.

These seemed like reasonable simplifications given the benefits of using existing actors.

Note that LongLivedCreator is identical between the three files, I don't know if there is a way to "include" or otherwise share that code.
