### PR TITLE
PERF-1909 Create workload to build an index on a large collection

### DIFF
--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -33,6 +33,11 @@ Actors:
   - Repeat: 1
     Database: admin
     Operations:
+    # Fsync to force a checkpoint and quiesce the system.
+    - OperationMetricsName: FsyncCommand
+      OperationName: AdminCommand
+      OperationCommand:
+        fsync: 1
     - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
       OperationName: RunCommand
       OperationCommand:
@@ -52,11 +57,6 @@ Actors:
   - Repeat: 5
     Database: *db
     Operations:
-    # Fsync before each index build to force a checkpoint and quiesce the system.
-    - OperationMetricsName: FsyncCommand
-      OperationName: AdminCommand
-      OperationCommand:
-        fsync: 1
     - OperationMetricsName: CreateIndexInt
       OperationName: RunCommand
       OperationCommand:
@@ -74,11 +74,6 @@ Actors:
   - Repeat: 5
     Database: *db
     Operations:
-    # Fsync before each index build to force a checkpoint and quiesce the system.
-    - OperationMetricsName: FsyncCommand
-      OperationName: AdminCommand
-      OperationCommand:
-        fsync: 1
     - OperationMetricsName: CreateIndexString
       OperationName: RunCommand
       OperationCommand:


### PR DESCRIPTION
The goal of this workload is to force the external sorter to spill to disk, with just a few simple workloads since it takes so long. I can't run Genny locally because it requires Mojave, so waiting for the results of this patch build to verify that it behaves correctly:  https://evergreen.mongodb.com/version/5d6417d1d1fe07461234396d