### PR TITLE
Don't reference PhaseConfig through v1::ActorPhase

### DIFF
--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -175,14 +175,14 @@ void CollectionScanner::run() {
 
             // Do each kind of scan.
             if (config->scanType == Count) {
-                countScan(&*config, collections);
+                countScan(config, collections);
             } else if (config->scanType == Snapshot) {
                 mongocxx::client_session session = _client->start_session({});
                 session.start_transaction(*config->transactionOptions);
-                collectionScan(&*config, collections);
+                collectionScan(config, collections);
                 session.commit_transaction();
             } else {
-                collectionScan(&*config, collections);
+                collectionScan(config, collections);
             }
             _runningActorCounter--;
             BOOST_LOG_TRIVIAL(info) << "Finished collection scanner id: " << this->_index;

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -329,6 +329,9 @@ public:
  * if the Phase is non-blocking for the Actor, as long as the
  * Phase is held open by other Actors.
  *
+ * This type can be used as a `T*` through its implicit conversion
+ * and by its operator-overloads.
+ *
  * This is intended to be used via `PhaseLoop` below.
  */
 template <class T>
@@ -417,6 +420,16 @@ public:
         }
 #endif
         return _value.operator*();
+    }
+
+    // Allow ActorPhase<T> to be used as a T* through implicit conversion.
+    operator std::add_pointer_t<std::remove_reference_t<T>>() {
+#ifndef NDEBUG
+        if (!_value) {
+            BOOST_THROW_EXCEPTION(std::logic_error("Trying to dereference via * in a Nop phase."));
+        }
+#endif
+        return _value.operator->();
     }
 
     PhaseNumber phaseNumber() const {


### PR DESCRIPTION
Fast follow from #273 - the `&*` syntax is a bit icky but it's "correct" 😄 