### PR TITLE
TIG-1940 tune workload

### DIFF
--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -157,11 +157,11 @@ void CollectionScanner::run() {
         for (const auto&& _ : config) {
             if (config->skipFirstLoop) {
                 config->skipFirstLoop = false;
+                std::this_thread::sleep_for(std::chrono::seconds{1});
                 continue;
             }
             _runningActorCounter++;
             BOOST_LOG_TRIVIAL(info) << "Starting collection scanner id: " << this->_index;
-            std::this_thread::sleep_for(std::chrono::seconds{1});
 
             // Populate collections if need be.
             std::vector<mongocxx::collection>& collections = config->collections;

--- a/src/workloads/scale/OutOfCacheScanner.yml
+++ b/src/workloads/scale/OutOfCacheScanner.yml
@@ -31,13 +31,13 @@ Actors:
 
 - Name: HotSampler
   Type: RandomSampler
-  Threads: 50
+  Threads: 10
   CollectionCount: 50
   Database: hot
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: 45 minutes
+  - Duration: 59 minutes
     GlobalRate: 10 per 10 milliseconds
 
 - Name: ColdScanner
@@ -48,7 +48,7 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: 45 minutes
+  - Duration: 59 minutes
     SkipFirstLoop: true
-    GlobalRate: 6 per 6 minutes
+    GlobalRate: 6 per 10 minutes
     ScanType: Standard

--- a/src/workloads/scale/OutOfCacheScanner.yml
+++ b/src/workloads/scale/OutOfCacheScanner.yml
@@ -15,7 +15,7 @@ Actors:
     Database: cold
     CollectionCount: 6
     Threads: 1
-    DocumentCount: 2000000
+    DocumentCount: 1800000
     BatchSize: 100000
     Document:
       a: {^RandomString: { length: 100 }}
@@ -23,7 +23,7 @@ Actors:
     Database: hot
     CollectionCount: 5
     Threads: 1
-    DocumentCount: 2000000
+    DocumentCount: 1500000
     BatchSize: 100000
     Document:
       a: {^RandomString: {length: 100 }}
@@ -37,7 +37,8 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: 30 minutes
+  - Duration: 45 minutes
+    GlobalRate: 10 per 10 milliseconds
 
 - Name: ColdScanner
   Type: CollectionScanner
@@ -47,7 +48,7 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: 30 minutes
+  - Duration: 45 minutes
     SkipFirstLoop: true
-    GlobalRate: 6 per 4 minutes
+    GlobalRate: 6 per 6 minutes
     ScanType: Standard


### PR DESCRIPTION
I've had a look at the perf.jsons in the relevant patch builds and they're looking good. As such I think this PR is good to merge pretty much straight away. 

The original workload was not performing as expected in prod causing it to have extremely varied throughputs.

This also fixes a bug where a sleep was in an incorrect location causing the out of cache scanner threads to act out of order.