### PR TITLE
TIG-1964 support collecting overlapping metrics

### DIFF
--- a/src/python/genny/parsers/cedar.py
+++ b/src/python/genny/parsers/cedar.py
@@ -82,8 +82,8 @@ class IntermediateCSVReader:
         # dict(operation -> total_duration)
         self.total_for_op = defaultdict(int)
 
-        # dict(thread -> prev_op_ts))
-        self.prev_ts_for_thread = {}
+        # dict(thread -> op -> prev_op_ts))
+        self.prev_ts_of_op_thread = defaultdict(lambda: {})
 
     def __iter__(self):
         return self
@@ -107,13 +107,13 @@ class IntermediateCSVReader:
 
         # total_duration is duration for the first operation on each thread
         # because we don't track when each thread starts.
-        if thread in self.prev_ts_for_thread:
-            cur_total = line[ts_col] - self.prev_ts_for_thread[thread]
+        if thread in self.prev_ts_of_op_thread and op in self.prev_ts_of_op_thread[thread]:
+            cur_total = line[ts_col] - self.prev_ts_of_op_thread[thread][op]
         else:
             cur_total = line[dur]
 
         self.total_for_op[op] += cur_total
-        self.prev_ts_for_thread[thread] = line[ts_col]
+        self.prev_ts_of_op_thread[thread][op] = line[ts_col]
 
     def _parse_into_cedar_format(self, line):
         # Compute all cumulative values for simplicity; Not all values are used.

--- a/src/python/tests/cedar_test.py
+++ b/src/python/tests/cedar_test.py
@@ -111,7 +111,7 @@ class CedarIntegrationTest(unittest.TestCase):
             ])),
             ('timers', OrderedDict([
                 ('duration', 1392),
-                ('total', 0)
+                ('total', 1598)
             ])),
             ('gauges', OrderedDict([('workers', 5)]))
         ])
@@ -199,7 +199,7 @@ class CedarIntegrationTest(unittest.TestCase):
                 ])),
                 ('timers', OrderedDict([
                     ('duration', 10),
-                    ('total', 12)
+                    ('total', 10)
                 ])),
                 ('gauges', OrderedDict([('workers', 2)]))
             ]),
@@ -214,7 +214,7 @@ class CedarIntegrationTest(unittest.TestCase):
                 ])),
                 ('timers', OrderedDict([
                     ('duration', 27),
-                    ('total', 29)
+                    ('total', 27)
                 ])),
                 ('gauges', OrderedDict([('workers', 2)]))
             ]),


### PR DESCRIPTION
The metrics parsing code assumes each thread runs one op at a time. This is not always the case as we collect "nested" metrics. E.g. metrics for a single op in a bulk op, as well as the total for the entire bulk op.

There's a side effect of this change: since we don't know which metrics are nested, every time genny encounters a new metric, it needs to assume the duration equals the total, instead of using the latest timestamp on that thread from some previous operation

Will run a sys-perf patch once PR is approved.