### PR TITLE
Add logging and make log-level configurable by command-line opts

### DIFF
--- a/src/driver/include/driver/v1/DefaultDriver.hpp
+++ b/src/driver/include/driver/v1/DefaultDriver.hpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/log/trivial.hpp>
+
 #include <gennylib/ActorProducer.hpp>
 #include <gennylib/ActorVector.hpp>
 
@@ -36,7 +38,6 @@ public:
         kListActors,
         kHelp,
     };
-
 
     enum class OutcomeCode {
         kSuccess = 0,
@@ -66,6 +67,7 @@ public:
         std::string description;
         bool isSmokeTest;
         DefaultDriver::RunMode runMode = RunMode::kNormal;
+        boost::log::trivial::severity_level logVerbosity;
     };
 
     /**

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <fstream>
 #include <sstream>
 #include <thread>
 #include <vector>

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <cassert>
-#include <cstdlib>
 #include <fstream>
-#include <map>
 #include <sstream>
 #include <thread>
 #include <vector>
@@ -24,6 +21,8 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/exception/exception.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/log/core.hpp>
+#include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/program_options.hpp>
 
@@ -68,7 +67,11 @@ void runActor(Actor&& actor,
 }
 
 DefaultDriver::OutcomeCode doRunLogic(const DefaultDriver::ProgramOptions& options) {
+    // setup logging as the first thing we do.
+    boost::log::core::get()->set_filter(boost::log::trivial::severity >= options.logVerbosity);
+
     genny::metrics::Registry metrics;
+
     const auto workloadName = fs::path(options.workloadSource).stem().string();
     auto actorSetup = metrics.operation(workloadName, "Setup", 0u);
     auto setupCtx = actorSetup.start();
@@ -178,10 +181,7 @@ DefaultDriver::OutcomeCode doRunLogic(const DefaultDriver::ProgramOptions& optio
         std::ofstream metricsOutput;
         metricsOutput.open(options.metricsOutputFileName,
                            std::ofstream::out | std::ofstream::trunc);
-        auto logMode = options.metricsOutputFileName == "/dev/stdout"
-            ? genny::metrics::LogMode::kNone
-            : genny::metrics::LogMode::kCI;
-        reporter.report(metricsOutput, options.metricsFormat, logMode);
+        reporter.report(metricsOutput, options.metricsFormat);
     }
 
     return outcomeCode;
@@ -221,6 +221,31 @@ std::string normalizeOutputFile(const std::string& str) {
         return std::string("/dev/stdout");
     }
     return str;
+}
+
+boost::log::trivial::severity_level parseVerbosity(const std::string& level) {
+
+    if (level == "trace") {
+        return boost::log::trivial::trace;
+    }
+    if (level == "debug") {
+        return boost::log::trivial::debug;
+    }
+    if (level == "info") {
+        return boost::log::trivial::info;
+    }
+    if (level == "warning") {
+        return boost::log::trivial::warning;
+    }
+    if (level == "error") {
+        return boost::log::trivial::error;
+    }
+    if (level == "fatal") {
+        return boost::log::trivial::fatal;
+    }
+
+    throw std::invalid_argument("Invalid verbosity level '" + level +
+                                "'. Need one of trace/debug/info/warning/error/fatal");
 }
 
 }  // namespace
@@ -265,6 +290,9 @@ DefaultDriver::ProgramOptions::ProgramOptions(int argc, char** argv) {
             ("mongo-uri,u",
              po::value<std::string>()->default_value("mongodb://localhost:27017"),
              "Mongo URI to use for the default connection-pool.")
+            ("verbosity,v",
+              po::value<std::string>()->default_value("info"),
+              "Log severity for boost logging. Valid values are trace/debug/info/warning/error/fatal.")
             ("smoke-test,s",
              po::value<bool>()->default_value(false),
              "Run a workload in smoke test mode where all phases are set to Repeat=1");
@@ -313,6 +341,8 @@ DefaultDriver::ProgramOptions::ProgramOptions(int argc, char** argv) {
 
     if (vm.count("help") >= 1)
         this->runMode = RunMode::kHelp;
+
+    this->logVerbosity = parseVerbosity(vm["verbosity"].as<std::string>());
     this->metricsFormat = vm["metrics-format"].as<std::string>();
     this->isSmokeTest = vm["smoke-test"].as<bool>();
     this->metricsOutputFileName = normalizeOutputFile(vm["metrics-output-file"].as<std::string>());

--- a/src/driver/src/main.cpp
+++ b/src/driver/src/main.cpp
@@ -12,16 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <optional>
-
-#include <boost/log/core.hpp>
-#include <boost/log/expressions.hpp>
-#include <boost/log/trivial.hpp>
-
-#include <yaml-cpp/yaml.h>
 
 #include <gennylib/version.hpp>
 
@@ -37,9 +30,6 @@ int main(int argc, char** argv) {
         std::cout << opts.description << std::endl;
         return 0;
     }
-
-    // do this based on -v flag or something
-    boost::log::core::get()->set_filter(boost::log::trivial::severity >= boost::log::trivial::info);
 
     genny::driver::DefaultDriver d;
 

--- a/src/gennylib/src/Orchestrator.cpp
+++ b/src/gennylib/src/Orchestrator.cpp
@@ -14,9 +14,10 @@
 
 #include <gennylib/Orchestrator.hpp>
 
+#include <boost/log/trivial.hpp>
+
 #include <algorithm>  // std::max
 #include <cassert>
-#include <iostream>
 
 namespace {
 
@@ -79,11 +80,12 @@ PhaseNumber Orchestrator::awaitPhaseStart(bool block, int addTokens) {
 
     _currentTokens += addTokens;
 
-    auto currentPhase = this->_current;
+    const auto currentPhase = this->_current;
     if (_currentTokens >= _requireTokens) {
         for (auto&& cb : _prePhaseHooks) {
             cb(this);
         }
+        BOOST_LOG_TRIVIAL(debug) << "Beginning phase " << currentPhase;
         _phaseChange.notify_all();
         state = State::PhaseStarted;
     } else {
@@ -134,6 +136,7 @@ bool Orchestrator::awaitPhaseEnd(bool block, int removeTokens) {
 
     if (_currentTokens <= 0) {
         ++_current;
+        BOOST_LOG_TRIVIAL(debug) << "Ended phase " << this->_current;
         _phaseChange.notify_all();
         state = State::PhaseEnded;
     } else {

--- a/src/metrics/include/metrics/MetricsReporter.hpp
+++ b/src/metrics/include/metrics/MetricsReporter.hpp
@@ -31,6 +31,16 @@ namespace genny::metrics {
  */
 namespace v1 {
 
+void logMaybe(unsigned long long iteration,
+              const std::string& actorName,
+              const std::string& opName) {
+    // Log progress every 100e6 iterations
+    if (iteration % (100 * 1000 * 1000)) {
+        BOOST_LOG_TRIVIAL(info) << "Processed " << iteration << " metrics. Processing " << actorName
+                                << "." << opName;
+    }
+}
+
 /**
  * A ReporterT is the only object in the system that
  * has read access to metrics data-points. It is not
@@ -167,12 +177,7 @@ private:
                         out << getter(event.second);
                         out << std::endl;
 
-                        // Log progress every 100e6 iterations
-                        if (++iter % (100 * 1000 * 1000) == 0) {
-                            BOOST_LOG_TRIVIAL(info)
-                                << "Processed " << iter << " metrics. Processing " << actorName
-                                << "." << opName;
-                        }
+                        logMaybe(++iter, actorName, opName);
                     }
                 }
             }
@@ -314,12 +319,7 @@ private:
                         out << event.second.errors << ",";
                         out << event.second.size << std::endl;
 
-                        // Log progress every 100e6 iterations
-                        if (++iter % (100 * 1000 * 1000)) {
-                            BOOST_LOG_TRIVIAL(info)
-                                << "Processed " << iter << " metrics. Processing " << actorName
-                                << "." << opName;
-                        }
+                        logMaybe(++iter, actorName, opName);
                     }
                 }
             }

--- a/src/metrics/include/metrics/MetricsReporter.hpp
+++ b/src/metrics/include/metrics/MetricsReporter.hpp
@@ -31,9 +31,17 @@ namespace genny::metrics {
  */
 namespace v1 {
 
-void logMaybe(unsigned long long iteration,
-              const std::string& actorName,
-              const std::string& opName) {
+// Used in the implementation of outputting metrics. Only at the top of the file
+// because C++ is a delight.
+//
+// This has to be inline because it'll be included in multiple translation-units.
+// We could just have the decl here and make a separate impl .cpp file, but the
+// rest of the "metrics" module is header-only and it seems silly to kill that
+// just for a single function. If additional 'inline' functions abound in the
+// future, please move to a .cpp file to decrease compile- and link-times.
+inline void logMaybe(unsigned long long iteration,
+                     const std::string& actorName,
+                     const std::string& opName) {
     // Log progress every 100e6 iterations
     if (iteration % (100 * 1000 * 1000)) {
         BOOST_LOG_TRIVIAL(info) << "Processed " << iteration << " metrics. Processing " << actorName

--- a/src/metrics/test/metrics_test.cpp
+++ b/src/metrics/test/metrics_test.cpp
@@ -13,11 +13,7 @@
 // limitations under the License.
 
 #include <iomanip>
-#include <iostream>
 #include <optional>
-#include <sstream>
-
-#include <gennylib/context.hpp>
 
 #include <metrics/MetricsReporter.hpp>
 #include <metrics/metrics.hpp>
@@ -210,7 +206,7 @@ TEST_CASE("metrics output format") {
             "\n";
 
         std::ostringstream out;
-        reporter.report<ReporterClockSourceStub>(out, "csv", genny::metrics::LogMode::kNone);
+        reporter.report<ReporterClockSourceStub>(out, "csv");
         REQUIRE(out.str() == expected);
     }
 
@@ -236,7 +232,7 @@ TEST_CASE("metrics output format") {
             "28,InsertRemove,1,Insert,23,0,1,9,0,300\n";
 
         std::ostringstream out;
-        reporter.report<ReporterClockSourceStub>(out, "cedar-csv", genny::metrics::LogMode::kNone);
+        reporter.report<ReporterClockSourceStub>(out, "cedar-csv");
         REQUIRE(out.str() == expected);
     }
 }
@@ -270,7 +266,7 @@ TEST_CASE("Genny.Setup metric") {
             "\n";
 
         std::ostringstream out;
-        reporter.report<ReporterClockSourceStub>(out, "csv", genny::metrics::LogMode::kNone);
+        reporter.report<ReporterClockSourceStub>(out, "csv");
         REQUIRE(out.str() == expected);
     }
 
@@ -290,7 +286,7 @@ TEST_CASE("Genny.Setup metric") {
             "15,Genny,0,Setup,10,0,1,0,0,0\n";
 
         std::ostringstream out;
-        reporter.report<ReporterClockSourceStub>(out, "cedar-csv", genny::metrics::LogMode::kNone);
+        reporter.report<ReporterClockSourceStub>(out, "cedar-csv");
         REQUIRE(out.str() == expected);
     }
 }
@@ -350,7 +346,7 @@ TEST_CASE("Genny.ActiveActors metric") {
             "\n";
 
         std::ostringstream out;
-        reporter.report<ReporterClockSourceStub>(out, "csv", genny::metrics::LogMode::kNone);
+        reporter.report<ReporterClockSourceStub>(out, "csv");
         REQUIRE(out.str() == expected);
     }
 
@@ -368,7 +364,7 @@ TEST_CASE("Genny.ActiveActors metric") {
             "timestamp,actor,thread,operation,duration,outcome,n,ops,errors,size\n";
 
         std::ostringstream out;
-        reporter.report<ReporterClockSourceStub>(out, "cedar-csv", genny::metrics::LogMode::kNone);
+        reporter.report<ReporterClockSourceStub>(out, "cedar-csv");
         REQUIRE(out.str() == expected);
     }
 }

--- a/src/testlib/src/ActorHelper.cpp
+++ b/src/testlib/src/ActorHelper.cpp
@@ -108,6 +108,6 @@ void ActorHelper::doRunThreaded(const WorkloadContext& wl) {
 
     auto reporter = genny::metrics::Reporter{*_registry};
 
-    reporter.report(_metricsOutput, "csv", genny::metrics::LogMode::kNone);
+    reporter.report(_metricsOutput, "csv");
 }
 }  // namespace genny


### PR DESCRIPTION
Spent a fair amount of time debugging a thing with @luke-pearson that could have been avoided if genny were more verbose with its logging at key lifecycle points.

- add begin/end logging around MetricsReporter::report
- do the same periodic output-logging when reporting `--metrics-format=csv` as in `--metrics-format=cedar-csv`
- add begin/end logging for each Phase
- make log level configurable by passing in the `-v $level` flag