### PR TITLE
TIG-2084 Fix 'Ended phase' log message off-by-one

### DIFF
--- a/src/gennylib/src/Orchestrator.cpp
+++ b/src/gennylib/src/Orchestrator.cpp
@@ -136,7 +136,7 @@ bool Orchestrator::awaitPhaseEnd(bool block, int removeTokens) {
 
     if (_currentTokens <= 0) {
         ++_current;
-        BOOST_LOG_TRIVIAL(debug) << "Ended phase " << this->_current;
+        BOOST_LOG_TRIVIAL(debug) << "Ended phase " << (this->_current - 1);
         _phaseChange.notify_all();
         state = State::PhaseEnded;
     } else {


### PR DESCRIPTION
Was logging

```
T0: Starting phase 0.
T1: Ending phase 1.
T2: Starting phase 1.
```

Now logs

```
T0: Starting phase 0.
T1: Ending phase 0.
T2: Starting phase 1.
```