### PR TITLE
TIG-2064: Add capabilities for collection scanner and rolling collections.

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/src/cast_core/include/cast_core/actors/CollectionScanner.hpp
+++ b/src/cast_core/include/cast_core/actors/CollectionScanner.hpp
@@ -59,8 +59,7 @@ private:
     /** @private */
     int _index;
     RunningActorCounter& _runningActorCounter;
-    std::string _databaseCommaList;
-    std::vector<std::string> _databaseNames;
+    std::string _databaseNames;
     PhaseLoop<PhaseConfig> _loop;
     bool _generateCollectionNames;
 };

--- a/src/cast_core/include/cast_core/actors/CollectionScanner.hpp
+++ b/src/cast_core/include/cast_core/actors/CollectionScanner.hpp
@@ -59,6 +59,8 @@ private:
     /** @private */
     int _index;
     RunningActorCounter& _runningActorCounter;
+    std::string _databaseCommaList;
+    std::vector<std::string> _databaseNames;
     PhaseLoop<PhaseConfig> _loop;
     bool _generateCollectionNames;
 };

--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -35,9 +35,14 @@
 namespace genny::actor {
 enum class ScanType { kCount, kSnapshot, kStandard };
 enum class SortOrderType { kSortNone, kSortForward, kSortReverse };
+// We don't need a metrics clock, as we're using this for measuring
+// the end of phase durations and scan durations.
 using SteadyClock = std::chrono::steady_clock;
 
 struct CollectionScanner::PhaseConfig {
+    // We keep collection names, not collections here, because the
+    // names make sense within the context of a database, and we may
+    // have multiple databases.
     std::vector<std::string> collectionNames;
     std::optional<DocumentGenerator> filterExpr;
     std::vector<mongocxx::database> databases;

--- a/src/cast_core/src/RollingCollections.cpp
+++ b/src/cast_core/src/RollingCollections.cpp
@@ -65,10 +65,12 @@ static std::string getRollingCollectionName() {
     timestamp[timestamp.size() - 1] = '.';
     std::stringstream ss;
     /*
-     * This will create a collection name looking something like: r134_2019-08-30-11:08:19.123,
+     * This will create a collection name looking something like: 2019-08-30-11:08:19.123_r134,
      * the setw and setfill pad 0's for the ms if its anything < 100 ms.
+     * Such a name should be unique, and the list of names in lexigraphic
+     * order will be ordered by time.
      */
-    ss << "r" << id << "_" << timestamp << std::setfill('0') << std::setw(3) << ms.count();
+    ss << timestamp << std::setfill('0') << std::setw(3) << ms.count() << "_r" << id;
     id++;
     return ss.str();
 }

--- a/src/cast_core/src/RollingCollections.cpp
+++ b/src/cast_core/src/RollingCollections.cpp
@@ -62,13 +62,8 @@ static std::string getRollingCollectionName() {
     // The id is tracked globally and increments for every collection created.
     static std::atomic_long id = 0;
     std::stringstream ss;
-    /*
-     * Create a collection name something like: 2019-08-30-11:08:19.123_r134.
-     * Such a name should be unique, and the list of such names in lexigraphic
-     * order will be conveniently ordered by time.
-     */
-    ss << timestamp << std::setfill('0') << std::setw(3) << ms.count()
-       << "_r" << id;
+    // Create a unique collection name that sorts lexographically by time.
+    ss << "r_" << getMillisecondsSinceEpoch() << "_" << id;
     id++;
     return ss.str();
 }
@@ -297,13 +292,13 @@ struct OplogTailer : public RunOperation {
                     auto collectionName = object["create"].get_utf8().value.to_string();
                     if (collectionName.length() > 2 && collectionName[0] == 'r' &&
                         collectionName[1] == '_') {
-                        // Get the time as soon as we know we its a collection we care about.
+                        // Get the time as soon as we know it's a collection we care about.
                         auto now = metrics::clock::now();
                         std::vector<std::string> timeSplit;
                         boost::algorithm::split(timeSplit, collectionName, boost::is_any_of("_"));
                         auto started = metrics::clock::time_point{
                             std::chrono::duration_cast<metrics::clock::time_point::duration>(
-                                std::chrono::milliseconds{std::stol(timeSplit[2])})};
+                                std::chrono::milliseconds{std::stol(timeSplit[1])})};
                         _oplogLagOperation.report(
                             now,
                             std::chrono::duration_cast<std::chrono::microseconds>(now - started),

--- a/src/cast_core/test/CollectionScanner_test.cpp
+++ b/src/cast_core/test/CollectionScanner_test.cpp
@@ -1,0 +1,179 @@
+// Copyright 2019-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <testlib/helpers.hpp>
+#include <yaml-cpp/yaml.h>
+
+#include <boost/exception/diagnostic_information.hpp>
+
+#include <bsoncxx/json.hpp>
+
+#include <testlib/ActorHelper.hpp>
+#include <testlib/MongoTestFixture.hpp>
+
+namespace {
+using namespace genny::testing;
+namespace BasicBson = bsoncxx::builder::basic;
+
+void populate(mongocxx::client& client) {
+    auto db0 = client.database("db0");
+    auto db1 = client.database("db1");
+    auto coll00 = db0.collection("Collection0-db0");
+    auto coll01 = db0.collection("Collection1-db0");
+    auto coll10 = db1.collection("Collection0-db1");
+    auto coll11 = db1.collection("Collection1-db1");
+    auto coll12 = db1.collection("Collection2-db1");
+    for (int i = 0; i < 100; i++) {
+        coll00.insert_one(BasicBson::make_document(BasicBson::kvp("a", i)));
+        coll01.insert_one(BasicBson::make_document(BasicBson::kvp("a", i)));
+        coll10.insert_one(BasicBson::make_document(BasicBson::kvp("a", i)));
+        coll11.insert_one(BasicBson::make_document(BasicBson::kvp("a", i)));
+        coll12.insert_one(BasicBson::make_document(BasicBson::kvp("a", i)));
+    }
+    auto count = coll00.count_documents(BasicBson::make_document());
+    REQUIRE(count == 100);
+    count = coll01.count_documents(BasicBson::make_document());
+    REQUIRE(count == 100);
+    count = coll10.count_documents(BasicBson::make_document());
+    REQUIRE(count == 100);
+    count = coll11.count_documents(BasicBson::make_document());
+    REQUIRE(count == 100);
+    count = coll12.count_documents(BasicBson::make_document());
+    REQUIRE(count == 100);
+}
+
+void testOneActor(genny::NodeSource& config,
+                  uint32_t requiredSeconds,
+                  const std::string& requiredEventStrings) {
+    auto events = ApmEvents{};
+    auto apmCallback = makeApmCallback(events);
+    genny::ActorHelper ah(
+        config.root(), 1, MongoTestFixture::connectionUri().to_string(), apmCallback);
+    auto start = std::chrono::steady_clock::now();
+    ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
+    auto seconds =
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - start);
+
+    // Make sure that we ran for the required time period, and
+    // got expected events.
+    REQUIRE(seconds.count() >= requiredSeconds);
+    std::string eventStrings;
+    for (auto&& event : events) {
+        eventStrings += event.command_name + ":";
+    }
+    REQUIRE(eventStrings == requiredEventStrings);
+}
+
+
+TEST_CASE_METHOD(MongoTestFixture, "CollectionScanner", "[standalone][CollectionScanner]") {
+
+    SECTION("Scan documents in all collections of a database") {
+        genny::NodeSource config(R"(
+      SchemaVersion: 2018-07-01
+      Actors:
+      - Name: SnapshotScanner
+        Type: CollectionScanner
+        Threads: 1
+        Database: db0
+        Phases:
+        - Duration: 5 seconds
+          ScanType: snapshot
+          CollectionSortOrder: forward
+          GlobalRate: 1 per 3 seconds
+        - Duration: 5 seconds
+          ScanType: snapshot
+          GlobalRate: 1 per 3 seconds
+          Documents: 20
+      )",
+                                 "");
+
+        try {
+            dropAllDatabases();
+            populate(client);
+
+            // In each phase, there is time to call the actor twice.
+            // In the first phase, expected events for each invocation of
+            // the actor are:
+            //  listCollections  (for db0, yielding two collections).
+            //  find (for first collection)
+            //  find (for second collection).
+            // In the second phase, we limited to 20 documents, so we
+            // only do a find on the first collection.
+            testOneActor(config,
+                         10,
+                         "listCollections:find:find:"  // 1st phase, 1st call
+                         "listCollections:find:find:"  // 1st phase, 2nd call
+                         "listCollections:find:"       // 2nd phase, 1st call
+                         "listCollections:find:");     // 2nd phase, 2nd call
+        } catch (const std::exception& e) {
+            auto diagInfo = boost::diagnostic_information(e);
+            INFO("CAUGHT " << diagInfo);
+            FAIL(diagInfo);
+        }
+    }
+}
+
+TEST_CASE_METHOD(MongoTestFixture, "CollectionScannerAll", "[standalone][CollectionScanner]") {
+
+    SECTION("Scan documents in all collections of multiple databases") {
+        genny::NodeSource config2(R"(
+      SchemaVersion: 2018-07-01
+      Actors:
+      - Name: SnapshotScannerAll
+        Type: CollectionScanner
+        Threads: 1
+        Database: db0,db1
+        Phases:
+        - Duration: 5 seconds
+          ScanType: snapshot
+          CollectionSortOrder: forward
+          GlobalRate: 1 per 3 seconds
+        - Duration: 5 seconds
+          ScanType: snapshot
+          CollectionSortOrder: forward
+          GlobalRate: 1 per 3 seconds
+          Documents: 350
+      )",
+                                  "");
+
+        try {
+            dropAllDatabases();
+            populate(client);
+
+            // In the first phase, there is time to call the actor twice.
+            // Expected events for each invocation of the actor are:
+            //  listCollections  (for db0, yielding two collections).
+            //  listCollections  (for db1, yielding two collections).
+            //  2 finds for db0's collections, 3 finds for db1's collections.
+            // In the second phase, we are limiting to 350 documents, so
+            // we'll satisfy that in the middle of the 4th collection scan.
+            testOneActor(config2,
+                         5,
+                         "listCollections:listCollections:"  // 1st phase, 1st call
+                         "find:find:find:find:find:"
+                         "listCollections:listCollections:"  // 1st phase, 2nd call
+                         "find:find:find:find:find:"
+                         "listCollections:listCollections:"  // 2nd phase, 1st call
+                         "find:find:find:find:"
+                         "listCollections:listCollections:"  // 2nd phase, 2nd call
+                         "find:find:find:find:");
+
+        } catch (const std::exception& e) {
+            auto diagInfo = boost::diagnostic_information(e);
+            INFO("CAUGHT " << diagInfo);
+            FAIL(diagInfo);
+        }
+    }
+}
+}  // namespace

--- a/src/workloads/docs/CollectionScanner.yml
+++ b/src/workloads/docs/CollectionScanner.yml
@@ -80,8 +80,26 @@ Actors:
   - {Nop: true}
   - Duration: 2 minutes
     ScanType: snapshot
+    CollectionSkip: 2
+    CollectionSortOrder: forward
     GlobalRate: 1 per 1 minute
   - Duration: 1 minute
     ScanType: snapshot
     GlobalRate: 10 per 20 seconds
     Documents: 200
+
+# Each time this snapshot scanner runs, two databases are fully scanned.
+# This is done within a snapshot transaction, which is specified to be
+# held open for a full 2 minutes if it completes before then.
+- Name: AllScanner
+  Type: CollectionScanner
+  Threads: 10
+  Database: hot, cold          # multiple databases can be specified
+  Phases:
+  - {Nop: true}
+  - {Nop: true}
+  - {Nop: true}
+  - Duration: 10 minutes       # the duration of this phase
+    ScanType: snapshot
+    ScanDuration: 2 minutes    # the duration of each scan, transactions held open this long.
+    GlobalRate: 1 per 4 minutes


### PR DESCRIPTION
New options: CollectionSkip (skip a number of collections when scanning), CollectionSortOrder (sort the collection names forward or backward before scanning), ScanDuration (hold a snapshot scan transaction open until a duration has elapsed).

Modified option: Allow Database to be a single database name or a comma separated list of databases to scan.

Rolling Collections now are named in a manner that gives a time based ordering when sorted by name. This is needed by the large scale workload so collections can be traversed "ahead" of when they are expiring.