### PR TITLE
TIG 2096: Add --workloads option to genny_auto_tasks

### DIFF
--- a/src/python/README.md
+++ b/src/python/README.md
@@ -49,6 +49,21 @@ Make you run the script from the root of the Genny repository
 (so it can pick up on the `.yamllint` linter config file)
 
 
+Script: `genny-auto-tasks`
+---------------------------------
+
+Generates JSON that can be used as input to evergreen's generate.tasks,
+representing genny workloads to be run.
+
+For example, if one wanted to write JSON to `build/tasks.json` that would run the big_update and insert_remove workloads on the `linux-1-node-replSet` buildvariant, the following command could be used:
+
+```sh
+genny-auto-tasks --workloads scale/BigUpdate.yml scale/InsertRemove.yml --variants linux-1-node-replSet --output build/tasks.json
+```
+
+If the `--workloads` flag is not set, the script will instead generate JSON for all workloads that have been added or modified locally (relative to origin/master).
+
+
 Script: `genny-metrics-legacy-report`
 ---------------------------------
 

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -55,13 +55,13 @@ Script: `genny-auto-tasks`
 Generates JSON that can be used as input to evergreen's generate.tasks,
 representing genny workloads to be run.
 
-For example, if one wanted to write JSON to `build/tasks.json` that would run the big_update and insert_remove workloads on the `linux-1-node-replSet` buildvariant, the following command could be used:
+For example, if one wanted to write JSON tasks to `build/tasks.json` that would run the big_update and insert_remove workloads on the `linux-1-node-replSet` buildvariant, the following command could be used:
 
 ```sh
 genny-auto-tasks --workloads scale/BigUpdate.yml scale/InsertRemove.yml --variants linux-1-node-replSet --output build/tasks.json
 ```
 
-If the `--workloads` flag is not set, the script will instead generate JSON for all workloads that have been added or modified locally (relative to origin/master).
+If the `--workloads` flag is not set, the script will instead generate JSON for all workloads that have been added or modified locally (relative to origin/master). Run with the `-h` flag for more information.
 
 
 Script: `genny-metrics-legacy-report`

--- a/src/python/genny/genny_auto_tasks.py
+++ b/src/python/genny/genny_auto_tasks.py
@@ -60,7 +60,7 @@ def get_project_root():
 
 def validate_user_workloads(workloads):
     if len(workloads) == 0:
-        return 'No workloads specified'
+        return ['No workloads specified']
 
     errors = []
     genny_root = get_project_root()

--- a/src/python/genny/genny_auto_tasks.py
+++ b/src/python/genny/genny_auto_tasks.py
@@ -33,7 +33,7 @@ def modified_workload_files():
         out = subprocess.check_output(
             'git diff --name-only --diff-filter=AMR $(git merge-base HEAD origin/master) -- ../workloads/', shell=True)
     except subprocess.CalledProcessError as e:
-        print(e.output)
+        print(e.output, file=sys.stderr)
         raise e
 
     if out.decode() == '':
@@ -52,7 +52,7 @@ def get_project_root():
     try:
         out = subprocess.check_output('git rev-parse --show-toplevel', shell=True)
     except subprocess.CalledProcessError as e:
-        print(e.output)
+        print(e.output, file=sys.stderr)
         raise e
 
     return out.decode().strip()
@@ -125,7 +125,7 @@ def main():
     if args.workloads is not None:
         err = validate_user_workloads(args.workloads)
         if err is not None:
-            print(err)  # TODO stderr
+            print('invalid workload: {}'.format(err), file=sys.stderr)
             return
         workloads = args.workloads
     else:

--- a/src/python/tests/auto_tasks_test.py
+++ b/src/python/tests/auto_tasks_test.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from unittest.mock import Mock
 from genny.genny_auto_tasks import construct_task_json
 from genny.genny_auto_tasks import modified_workload_files
+from genny.genny_auto_tasks import validate_user_workloads
 
 
 class AutoTasksTest(unittest.TestCase):
@@ -117,3 +118,37 @@ class AutoTasksTest(unittest.TestCase):
         mock_check_output.side_effect = CalledProcessError(127, 'cmd')
         with self.assertRaises(CalledProcessError) as cm:
             modified_workload_files()
+
+    def test_validate_user_workloads(self):
+        cases = [
+            (
+                ['scale/BigUpdate.yml'],
+                None
+            ),
+            (
+                ['scale/InsertBigDocs.yml', 'selftests/GennyOverhead.yml'],
+                None
+            ),
+            (
+                ['networking/NonExistent.yml'],
+                'no file'
+            ),
+            (
+                ['scale/BigUpdate.yml', 'docs'],
+                'no file'
+            ),
+            (
+                ['CMakeLists.txt'],
+                'not a .yml'
+            ),
+        ]
+
+        for tc in cases:
+            expected = tc[1]
+            actual = validate_user_workloads(tc[0])
+
+            # expected is either None (no validation error), or a required substring of the validation error.
+            if expected is not None and actual is not None:
+                self.assertTrue(expected in actual)
+            else:
+                self.assertEqual(expected, actual)

--- a/src/python/tests/auto_tasks_test.py
+++ b/src/python/tests/auto_tasks_test.py
@@ -123,23 +123,23 @@ class AutoTasksTest(unittest.TestCase):
         cases = [
             (
                 ['scale/BigUpdate.yml'],
-                None
+                []
             ),
             (
                 ['scale/InsertBigDocs.yml', 'selftests/GennyOverhead.yml'],
-                None
+                []
             ),
             (
                 ['networking/NonExistent.yml'],
-                'no file'
+                ['no file']
             ),
             (
                 ['scale/BigUpdate.yml', 'docs'],
-                'no file'
+                ['no file']
             ),
             (
                 ['CMakeLists.txt'],
-                'not a .yml'
+                ['not a .yml']
             ),
         ]
 
@@ -147,8 +147,7 @@ class AutoTasksTest(unittest.TestCase):
             expected = tc[1]
             actual = validate_user_workloads(tc[0])
 
-            # expected is either None (no validation error), or a required substring of the validation error.
-            if expected is not None and actual is not None:
-                self.assertTrue(expected in actual)
-            else:
-                self.assertEqual(expected, actual)
+            # expected is either an empty list (no validation errors), or an ordered list of required substrings of the validation errors.
+            self.assertEqual(len(expected), len(actual))
+            for idx, expected_err in enumerate(expected):
+                self.assertTrue(expected_err in actual[idx])


### PR DESCRIPTION
- Add --workloads as an option in the ArgumentParser
- Branch logic in main to use --workloads specified if present, else use the result of `modified_workload_files`
- Add function `validate_user_workloads` to validate the user input
- Add a test for the above
- Update the README with info on `genny_auto_tasks`