### PR TITLE
Make CrudActor respect MetricsName in Phase: YAML Blocks

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -351,7 +351,7 @@ struct InsertOneOperation : public WriteOperation {
           _collection{std::move(collection)},
           _operation{operation},
           _options{opNode["OperationOptions"].maybe<mongocxx::options::insert>().value_or(
-                  mongocxx::options::insert{})},
+              mongocxx::options::insert{})},
           _docExpr{createDocumentGenerator(opNode, "insertOne", "Document", context, id)} {}
 
     mongocxx::model::write getModel() override {

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -350,7 +350,8 @@ struct InsertOneOperation : public WriteOperation {
           _onSession{onSession},
           _collection{std::move(collection)},
           _operation{operation},
-          _options{opNode["OperationOptions"].to<mongocxx::options::insert>()},
+          _options{opNode["OperationOptions"].maybe<mongocxx::options::insert>().value_or(
+                  mongocxx::options::insert{})},
           _docExpr{createDocumentGenerator(opNode, "insertOne", "Document", context, id)} {}
 
     mongocxx::model::write getModel() override {

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -539,7 +539,7 @@ Tests:
 
   - Description: set WriteConcern 1 on an InsertOne
     Operations:
-      - OperatioName: insertOne
+      - OperationName: insertOne
         OperationCommand:
           Document: {a: 1}
         OperationOptions:

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -536,3 +536,15 @@ Tests:
     OutcomeCounts:
       - Filter: {a: 1}
         Count: 1
+
+  - Description: set WriteConcern 1 on an InsertOne
+    Operations:
+      - OperatioName: insertOne
+        OperationCommand:
+          Document: {a: 1}
+        OperationOptions:
+          WriteConcern: { Level: 1 }
+          Timeout: 6000 milliseconds
+    OutcomeCounts:
+      - Filter: {a: 1}
+        Count: 1


### PR DESCRIPTION
1. We were previously recording all data on one `metrics::Operation` per `Operation` name, so e.g. all `bulkWrite` operations would be recorded together even if they were on different phases or had very different semantics.

    After this Actor was written we introduced the `MetricsName:` concept in a `Phase` block, but we never brought it in.

2. Fixed a bug where we could not specify insert-options and added a test

3. Also did some drive-by 💅.