### PR TITLE
TIG-2077 Don't throw exception if no autorun tasks are generated, fix small bug

### DIFF
--- a/src/python/genny/genny_auto_tasks.py
+++ b/src/python/genny/genny_auto_tasks.py
@@ -170,6 +170,8 @@ def make_env_dict(dirname):
             return None
         with open(fname, 'r') as handle:
             config = yaml.safe_load(handle)
+            if config is None:
+                return None
             module = os.path.basename(fname).split('.yml')[0]
             env_dict[module] = config
     return env_dict
@@ -300,7 +302,7 @@ def main():
 
             workloads = autorun_workload_files(env_dict)
             if len(workloads) == 0:
-                raise Exception('No AutoRun workloads found matching environment, generating no tasks.')
+                print('No AutoRun workloads found matching environment, generating no tasks.')
         elif args.modified:
             workloads = modified_workload_files()
             if len(workloads) == 0:


### PR DESCRIPTION
As I discussed with @guoyr offline, this change would make it **not** an error if there are no tasks that should be autorun. 

There are some buildvariants on Evergreen that do not have any associated genny workloads. We could get rid of `genny_auto_tasks` for these variants, but then, if someone added a new genny workload that should run on one of these variants, they would have to edit `system_perf.yml` which defeats the purpose of this ticket.

This PR also fixes an unexpected issue that would occur if `bootstrap.yml` or `runtime.yml` is empty.