### PR TITLE
Don't raise exception for no modified workloads if there are --forced-workloads

### DIFF
--- a/src/python/genny/genny_auto_tasks.py
+++ b/src/python/genny/genny_auto_tasks.py
@@ -329,10 +329,13 @@ def main():
         elif args.modified:
             workloads = modified_workload_files()
             if len(workloads) == 0:
-                raise Exception(
-                    'No modified workloads found, generating no tasks.\n\
+                err_msg = 'No modified workloads found.\n\
                     No results from command: git diff --name-only --diff-filter=AMR $(git merge-base HEAD origin/master) -- ../workloads/\n\
-                    Ensure that any added/modified workloads have been committed locally.')
+                    Ensure that any added/modified workloads have been committed locally.'
+                if args.forced_workloads is None:
+                    raise Exception(err_msg)
+                else:
+                    print(err_msg, file=sys.stderr)
 
         if args.forced_workloads is not None:
             errs = validate_user_workloads(args.forced_workloads)

--- a/src/python/genny/genny_auto_tasks.py
+++ b/src/python/genny/genny_auto_tasks.py
@@ -328,14 +328,10 @@ def main():
                 print('No AutoRun workloads found matching environment, generating no tasks.')
         elif args.modified:
             workloads = modified_workload_files()
-            if len(workloads) == 0:
-                err_msg = 'No modified workloads found.\n\
+            if len(workloads) == 0 and args.forced_workloads is None:
+                raise Exception('No modified workloads found.\n\
                     No results from command: git diff --name-only --diff-filter=AMR $(git merge-base HEAD origin/master) -- ../workloads/\n\
-                    Ensure that any added/modified workloads have been committed locally.'
-                if args.forced_workloads is None:
-                    raise Exception(err_msg)
-                else:
-                    print(err_msg, file=sys.stderr)
+                    Ensure that any added/modified workloads have been committed locally.')
 
         if args.forced_workloads is not None:
             errs = validate_user_workloads(args.forced_workloads)


### PR DESCRIPTION
Small fix to increase the usability of genny_patch_tasks: currently we always raise an exception if there are no locally modified tasks. This PR would stop throwing an exception if the user also supplies workloads to run via the `--forced-workloads` flag. This way, genny_patch_tasks can be used to just run a one-off task via `--forced-workloads`, even if there are no locally modified tasks.