### PR TITLE
TIG-2094 Fix: Genny Workloads Timeout After 6 Hours

### DIFF
--- a/src/python/genny/genny_auto_tasks.py
+++ b/src/python/genny/genny_auto_tasks.py
@@ -209,6 +209,7 @@ def construct_all_tasks_json():
     :return: json representation of tasks for all workloads in the /src/workloads directory relative to the genny root.
     """
     c = Configuration()
+    c.exec_timeout(64800)  # 18 hours
 
     workload_dir = '{}/src/workloads'.format(get_project_root())
     all_workloads = glob.glob('{}/**/*.yml'.format(workload_dir), recursive=True)

--- a/src/python/genny/parsers/cedar.py
+++ b/src/python/genny/parsers/cedar.py
@@ -207,7 +207,8 @@ def split_into_actor_csv_files(data_reader, out_dir):
         if counter % 1e6 == 0:
             print('Parsed {} metrics'.format(counter))
 
-    cur_out_fh.close()
+    if cur_out_fh is not None:
+        cur_out_fh.close()
 
     return output_files
 

--- a/src/python/tests/auto_tasks_test.py
+++ b/src/python/tests/auto_tasks_test.py
@@ -79,6 +79,7 @@ class AutoTasksTest(unittest.TestCase):
                     'priority': 5
                 },
             ],
+            'timeout': 64800,
         }
 
         actual_json_str = construct_all_tasks_json()


### PR DESCRIPTION
(and don't capture WT diagnostic.data/FTDC as a result)

1. Allow Genny Workloads to run for 18 hours
2. Another minor bug-fix in genny metrics-parsing.

Patch-build [here](https://evergreen.mongodb.com/version/5de81e7e850e612617719bf5).
The task is still red because we ran out of disk-space when processing metrics, but importantly the WT diagnostic data is in the artifact tarball