### PR TITLE
PERF-1948 Add performance workload for creating an index on a sharded collection

### DIFF
--- a/src/phases/execution/CreateIndexPhase.yml
+++ b/src/phases/execution/CreateIndexPhase.yml
@@ -5,7 +5,7 @@ Owner: "@mongodb/server-execution"
 
 InsertData:
   Repeat: 1
-  Database: &db test
+  Database: &db {^Parameter: {Name: "db", Default: test}}
   Threads: 1
   CollectionCount: 1
   DocumentCount: 150000

--- a/src/phases/execution/CreateIndexPhase.yml
+++ b/src/phases/execution/CreateIndexPhase.yml
@@ -1,0 +1,176 @@
+# This Phase has 2 actors, InsertData and IndexCollection. InsertData inserts documents containing all types of indexes, and IndexCollection creates indexes for each of them, one at a time.
+
+PhaseSchemaVersion: 2018-07-01
+Owner: "@mongodb/server-execution"
+
+InsertData:
+  Repeat: 1
+  Database: &db test
+  Threads: 1
+  CollectionCount: 1
+  DocumentCount: 150000
+  BatchSize: 10000
+  Document:
+    loc2d: &loc2d [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -180, max: 180}}]
+    loc2dSphere: &loc2dSphere [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -90, max: 90}}]
+    point: &point { type: Point, coordinates: [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -90, max: 90}}] }
+    randomString: &randomString {^RandomString: {length: 20}}
+    randomInt: &randomInt {^RandomInt: {min: -10000000, max: 10000000}}
+    attributes: &attributes { color: *randomString, size: *randomString, inside: { bookmark: *randomInt, postitnote: *randomInt }, outside: { dustcover: *randomString }}
+
+Create2dIndexesCmd:
+  Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+  Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}
+  Database: *db
+  Operations:
+  - OperationMetricsName: Create2dIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      createIndexes: Collection0
+      indexes:
+      - key:
+          loc2d: "2d"
+        min: -180
+        max: 180
+        bits: 32
+        name: 2dIndex
+  - OperationMetricsName: DropCreated2dIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      dropIndexes: Collection0
+      index: 2dIndex
+
+Create2dSphereIndexesCoordCmd:
+  Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+  Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}
+  Database: *db
+  Operations:
+  - OperationMetricsName: Create2dSphereIndexesCoordCmd
+    OperationName: RunCommand
+    OperationCommand:
+      createIndexes: Collection0
+      indexes:
+      - key:
+          loc2dSphere: "2dsphere"
+        name: 2dsphereCoordIndex
+  - OperationMetricsName: DropCreated2dSpCreate2dSphereIndexesCoordCmdhereIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      dropIndexes: Collection0
+      index: 2dsphereCoordIndex
+
+Create2dSphereGeoJsonIndexesCmd:
+  Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+  Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}
+  Database: *db
+  Operations:
+  - OperationMetricsName: Create2dSphereGeoJsonIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      createIndexes: Collection0
+      indexes:
+      - key:
+          point: "2dsphere"
+        name: 2dsphereGeoJsonIndex
+  - OperationMetricsName: Create2dSphereGeoJsonIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      dropIndexes: Collection0
+      index: 2dsphereGeoJsonIndex
+
+CreateGeoHaystackIndexesCmd:
+  Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+  Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}
+  Database: *db
+  Operations:
+  - OperationMetricsName: CreateGeoHaystackIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      createIndexes: Collection0
+      indexes:
+      - key:
+          loc2d: "geoHaystack"
+          randomString: 1
+        bucketSize: 5
+        name: geoHaystackIndex
+  - OperationMetricsName: DropCreatedGeoHaystackIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      dropIndexes: Collection0
+      index: geoHaystackIndex
+
+CreateHashedIndexesCmd:
+  Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+  Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}
+  Database: *db
+  Operations:
+  - OperationMetricsName: CreateHashedIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      createIndexes: Collection0
+      indexes:
+      - key:
+          randomString: "hashed"
+        name: hashedIndex
+  - OperationMetricsName: DropCreatedHashedIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      dropIndexes: Collection0
+      index: hashedIndex
+
+CreateTextIndexesCmd:
+  Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+  Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}
+  Database: *db
+  Operations:
+  - OperationMetricsName: CreateTextIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      createIndexes: Collection0
+      indexes:
+      - key:
+          randomString: "text"
+        name: textIndex
+  - OperationMetricsName: DropCreatedTextIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      dropIndexes: Collection0
+      index: textIndex
+
+CreateUniqueIndexesCmd:
+  Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+  Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}
+  Database: *db
+  Operations:
+  - OperationMetricsName: CreateUniqueIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      createIndexes: Collection0
+      indexes:
+      - key:
+          randomString: 1
+        name: uniqueIndex
+        unique: true
+  - OperationMetricsName: DropCreatedUniqueIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      dropIndexes: Collection0
+      index: uniqueIndex
+
+CreateWildCardIndexesCmd:
+  Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+  Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}
+  Database: *db
+  Operations:
+  - OperationMetricsName: CreateWildCardIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      createIndexes: Collection0
+      indexes:
+      - key: { "attributes.$**": 1 }
+        name: wildCardIndex
+  - OperationMetricsName: DropCreatedWildCardIndexesCmd
+    OperationName: RunCommand
+    OperationCommand:
+      dropIndexes: Collection0
+      index: wildCardIndex

--- a/src/workloads/execution/CreateIndex.yml
+++ b/src/workloads/execution/CreateIndex.yml
@@ -1,5 +1,3 @@
-# This workload has 2 actors, InsertData and IndexCollection. InsertData inserts documents containing all types of indexes, and IndexCollection creates indexes for each of them, one at a time.
-
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/server-execution"
 
@@ -8,19 +6,9 @@ Actors:
   Type: Loader
   Threads: 1
   Phases:
-  - Repeat: 1
-    Database: &db test
-    Threads: 1
-    CollectionCount: 1
-    DocumentCount: 150000
-    BatchSize: 10000
-    Document:
-      loc2d: &loc2d [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -180, max: 180}}]
-      loc2dSphere: &loc2dSphere [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -90, max: 90}}]
-      point: &point { type: Point, coordinates: [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -90, max: 90}}] }
-      randomString: &randomString {^RandomString: {length: 20}}
-      randomInt: &randomInt {^RandomInt: {min: -10000000, max: 10000000}}
-      attributes: &attributes { color: *randomString, size: *randomString, inside: { bookmark: *randomInt, postitnote: *randomInt }, outside: { dustcover: *randomString }}
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: InsertData
   - &Nop {Nop: true}
   - *Nop
   - *Nop
@@ -35,139 +23,46 @@ Actors:
   Threads: 1
   Phases:
   - *Nop
-  - Repeat: 5
-    Database: *db
-    Operations:
-    - OperationMetricsName: Create2dIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key: 
-            loc2d: "2d"
-          min: -180
-          max: 180
-          bits: 32
-          name: 2dIndex
-    - OperationMetricsName: DropCreated2dIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: 2dIndex
-  - Repeat: 5
-    Database: *db
-    Operations:
-    - OperationMetricsName: Create2dSphereIndexesCoordCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key:
-            loc2dSphere: "2dsphere"
-          name: 2dsphereCoordIndex
-    - OperationMetricsName: DropCreated2dSpCreate2dSphereIndexesCoordCmdhereIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: 2dsphereCoordIndex
-  - Repeat: 5
-    Database: *db
-    Operations:
-    - OperationMetricsName: Create2dSphereGeoJsonIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key:
-            point: "2dsphere"
-          name: 2dsphereGeoJsonIndex
-    - OperationMetricsName: Create2dSphereGeoJsonIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: 2dsphereGeoJsonIndex
-  - Repeat: 5
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateGeoHaystackIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key: 
-            loc2d: "geoHaystack"
-            randomString: 1
-          bucketSize: 5
-          name: geoHaystackIndex
-    - OperationMetricsName: DropCreatedGeoHaystackIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: geoHaystackIndex
-  - Repeat: 5
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateHashedIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key: 
-            randomString: "hashed"
-          name: hashedIndex
-    - OperationMetricsName: DropCreatedHashedIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: hashedIndex
-  - Repeat: 5
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateTextIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key: 
-            randomString: "text"
-          name: textIndex
-    - OperationMetricsName: DropCreatedTextIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: textIndex
-  - Repeat: 5
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateUniqueIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key: 
-            randomString: 1
-          name: uniqueIndex
-          unique: true
-    - OperationMetricsName: DropCreatedUniqueIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: uniqueIndex
-  - Repeat: 5
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateWildCardIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key: { "attributes.$**": 1 }
-          name: wildCardIndex
-    - OperationMetricsName: DropCreatedWildCardIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: wildCardIndex
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: Create2dIndexesCmd
+      Parameters:
+        Repeat: 5
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: Create2dSphereIndexesCoordCmd
+      Parameters:
+        Repeat: 5
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: Create2dSphereGeoJsonIndexesCmd
+      Parameters:
+        Repeat: 5
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateGeoHaystackIndexesCmd
+      Parameters:
+        Repeat: 5
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateHashedIndexesCmd
+      Parameters:
+        Repeat: 5
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateTextIndexesCmd
+      Parameters:
+        Repeat: 5
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateUniqueIndexesCmd
+      Parameters:
+        Repeat: 5
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateWildCardIndexesCmd
+      Parameters:
+        Repeat: 5
 
 AutoRun:
   Requires:

--- a/src/workloads/execution/CreateIndexSharded.yml
+++ b/src/workloads/execution/CreateIndexSharded.yml
@@ -2,65 +2,18 @@ SchemaVersion: 2018-07-01
 Owner: "@mongodb/sharding"
 
 Actors:
-- Name: InsertData
-  Type: Loader
-  Threads: 1
-  Phases:
-  - ExternalPhaseConfig:
-      Path: ../../phases/execution/CreateIndexPhase.yml
-      Key: InsertData
-      Parameters:
-        db: &db test
-  - &Nop {Nop: true}
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-
 - Name: EnableSharding
   Type: AdminCommand
   Threads: 1
   Phases:
-  - *Nop
   - Repeat: 1
     Database: admin
     Operations:
     - OperationMetricsName: EnableSharding
       OperationName: AdminCommand
       OperationCommand:
-        enableSharding: *db
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-
-- Name: CreateShardKeyIndex
-  Type: RunCommand
-  Threads: 1
-  Phases:
-  - *Nop
-  - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateShardKeyIndex
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0 # This is the default collection populated by the Loader.
-        indexes:
-        - key:
-            _id: hashed
-          name: _id_1
+        enableSharding: &db test
+  - &Nop {Nop: true}
   - *Nop
   - *Nop
   - *Nop
@@ -75,17 +28,35 @@ Actors:
   Threads: 1
   Phases:
   - *Nop
-  - *Nop
-  - *Nop
   - Repeat: 1
     Database: admin
     Operations:
     - OperationMetricsName: ShardCollection
       OperationName: AdminCommand
       OperationCommand:
-        shardCollection: test.Collection0
+        shardCollection: test.Collection0 # Collection0 is the default collection populated by the Loader.
         key:
           _id: hashed
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: InsertData
+      Parameters:
+        db: *db
   - *Nop
   - *Nop
   - *Nop
@@ -98,7 +69,6 @@ Actors:
   Type: RunCommand
   Threads: 1
   Phases:
-  - *Nop
   - *Nop
   - *Nop
   - *Nop

--- a/src/workloads/execution/CreateIndexSharded.yml
+++ b/src/workloads/execution/CreateIndexSharded.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/server-execution"
+Owner: "@mongodb/sharding"
 
 Actors:
 - Name: InsertData
@@ -9,7 +9,83 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/execution/CreateIndexPhase.yml
       Key: InsertData
+      Parameters:
+        db: &db test
   - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: EnableSharding
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationMetricsName: EnableSharding
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: *db
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: CreateShardKeyIndex
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateShardKeyIndex
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0 # This is the default collection populated by the Loader.
+        indexes:
+        - key:
+            _id: hashed
+          name: _id_1
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: ShardCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationMetricsName: ShardCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: test.Collection0
+        key:
+          _id: hashed
   - *Nop
   - *Nop
   - *Nop
@@ -22,6 +98,9 @@ Actors:
   Type: RunCommand
   Threads: 1
   Phases:
+  - *Nop
+  - *Nop
+  - *Nop
   - *Nop
   - ExternalPhaseConfig:
       Path: ../../phases/execution/CreateIndexPhase.yml
@@ -51,11 +130,6 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/execution/CreateIndexPhase.yml
       Key: CreateTextIndexesCmd
-      Parameters:
-        Duration: 5 minutes
-  - ExternalPhaseConfig:
-      Path: ../../phases/execution/CreateIndexPhase.yml
-      Key: CreateUniqueIndexesCmd
       Parameters:
         Duration: 5 minutes
   - ExternalPhaseConfig:

--- a/src/workloads/execution/CreateIndexSharded.yml
+++ b/src/workloads/execution/CreateIndexSharded.yml
@@ -1,5 +1,3 @@
-# This workload has 2 actors, InsertData and IndexCollection. InsertData inserts documents containing all types of indexes, and IndexCollection creates indexes for each of them, one at a time.
-
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/server-execution"
 
@@ -8,19 +6,9 @@ Actors:
   Type: Loader
   Threads: 1
   Phases:
-  - Repeat: 1
-    Database: &db test
-    Threads: 1
-    CollectionCount: 1
-    DocumentCount: 150000
-    BatchSize: 10000
-    Document:
-      loc2d: &loc2d [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -180, max: 180}}]
-      loc2dSphere: &loc2dSphere [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -90, max: 90}}]
-      point: &point { type: Point, coordinates: [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -90, max: 90}}] }
-      randomString: &randomString {^RandomString: {length: 20}}
-      randomInt: &randomInt {^RandomInt: {min: -10000000, max: 10000000}}
-      attributes: &attributes { color: *randomString, size: *randomString, inside: { bookmark: *randomInt, postitnote: *randomInt }, outside: { dustcover: *randomString }}
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: InsertData
   - &Nop {Nop: true}
   - *Nop
   - *Nop
@@ -35,136 +23,50 @@ Actors:
   Threads: 1
   Phases:
   - *Nop
-  - Duration: 10 minutes
-    Database: *db
-    Operations:
-    - OperationMetricsName: Create2dIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key:
-            loc2d: "2d"
-          min: -180
-          max: 180
-          bits: 32
-          name: 2dIndex
-    - OperationMetricsName: DropCreated2dIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: 2dIndex
-  - Duration: 10 minutes
-    Database: *db
-    Operations:
-    - OperationMetricsName: Create2dSphereIndexesCoordCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key:
-            loc2dSphere: "2dsphere"
-          name: 2dsphereCoordIndex
-    - OperationMetricsName: DropCreated2dSpCreate2dSphereIndexesCoordCmdhereIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: 2dsphereCoordIndex
-  - Duration: 10 minutes
-    Database: *db
-    Operations:
-    - OperationMetricsName: Create2dSphereGeoJsonIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key:
-            point: "2dsphere"
-          name: 2dsphereGeoJsonIndex
-    - OperationMetricsName: Create2dSphereGeoJsonIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: 2dsphereGeoJsonIndex
-  - Duration: 10 minutes
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateGeoHaystackIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key:
-            loc2d: "geoHaystack"
-            randomString: 1
-          bucketSize: 5
-          name: geoHaystackIndex
-    - OperationMetricsName: DropCreatedGeoHaystackIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: geoHaystackIndex
-  - Duration: 10 minutes
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateHashedIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key:
-            randomString: "hashed"
-          name: hashedIndex
-    - OperationMetricsName: DropCreatedHashedIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: hashedIndex
-  - Duration: 10 minutes
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateTextIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key:
-            randomString: "text"
-          name: textIndex
-    - OperationMetricsName: DropCreatedTextIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: textIndex
-  - Duration: 10 minutes
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateUniqueIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key:
-            randomString: 1
-          name: uniqueIndex
-          unique: true
-    - OperationMetricsName: DropCreatedUniqueIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: uniqueIndex
-  - Duration: 10 minutes
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateWildCardIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: Collection0
-        indexes:
-        - key: { "attributes.$**": 1 }
-          name: wildCardIndex
-    - OperationMetricsName: DropCreatedWildCardIndexesCmd
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes: Collection0
-        index: wildCardIndex
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: Create2dIndexesCmd
+      Parameters:
+        Duration: 5 minutes
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: Create2dSphereIndexesCoordCmd
+      Parameters:
+        Duration: 5 minutes
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: Create2dSphereGeoJsonIndexesCmd
+      Parameters:
+        Duration: 5 minutes
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateGeoHaystackIndexesCmd
+      Parameters:
+        Duration: 5 minutes
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateHashedIndexesCmd
+      Parameters:
+        Duration: 5 minutes
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateTextIndexesCmd
+      Parameters:
+        Duration: 5 minutes
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateUniqueIndexesCmd
+      Parameters:
+        Duration: 5 minutes
+  - ExternalPhaseConfig:
+      Path: ../../phases/execution/CreateIndexPhase.yml
+      Key: CreateWildCardIndexesCmd
+      Parameters:
+        Duration: 5 minutes
+
+AutoRun:
+  Requires:
+    bootstrap:
+      mongodb_setup:
+        - shard
+        - shard-lite

--- a/src/workloads/execution/CreateIndexSharded.yml
+++ b/src/workloads/execution/CreateIndexSharded.yml
@@ -1,0 +1,170 @@
+# This workload has 2 actors, InsertData and IndexCollection. InsertData inserts documents containing all types of indexes, and IndexCollection creates indexes for each of them, one at a time.
+
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/server-execution"
+
+Actors:
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: &db test
+    Threads: 1
+    CollectionCount: 1
+    DocumentCount: 150000
+    BatchSize: 10000
+    Document:
+      loc2d: &loc2d [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -180, max: 180}}]
+      loc2dSphere: &loc2dSphere [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -90, max: 90}}]
+      point: &point { type: Point, coordinates: [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -90, max: 90}}] }
+      randomString: &randomString {^RandomString: {length: 20}}
+      randomInt: &randomInt {^RandomInt: {min: -10000000, max: 10000000}}
+      attributes: &attributes { color: *randomString, size: *randomString, inside: { bookmark: *randomInt, postitnote: *randomInt }, outside: { dustcover: *randomString }}
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: IndexCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Duration: 10 minutes
+    Database: *db
+    Operations:
+    - OperationMetricsName: Create2dIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0
+        indexes:
+        - key:
+            loc2d: "2d"
+          min: -180
+          max: 180
+          bits: 32
+          name: 2dIndex
+    - OperationMetricsName: DropCreated2dIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: Collection0
+        index: 2dIndex
+  - Duration: 10 minutes
+    Database: *db
+    Operations:
+    - OperationMetricsName: Create2dSphereIndexesCoordCmd
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0
+        indexes:
+        - key:
+            loc2dSphere: "2dsphere"
+          name: 2dsphereCoordIndex
+    - OperationMetricsName: DropCreated2dSpCreate2dSphereIndexesCoordCmdhereIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: Collection0
+        index: 2dsphereCoordIndex
+  - Duration: 10 minutes
+    Database: *db
+    Operations:
+    - OperationMetricsName: Create2dSphereGeoJsonIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0
+        indexes:
+        - key:
+            point: "2dsphere"
+          name: 2dsphereGeoJsonIndex
+    - OperationMetricsName: Create2dSphereGeoJsonIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: Collection0
+        index: 2dsphereGeoJsonIndex
+  - Duration: 10 minutes
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateGeoHaystackIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0
+        indexes:
+        - key:
+            loc2d: "geoHaystack"
+            randomString: 1
+          bucketSize: 5
+          name: geoHaystackIndex
+    - OperationMetricsName: DropCreatedGeoHaystackIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: Collection0
+        index: geoHaystackIndex
+  - Duration: 10 minutes
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateHashedIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0
+        indexes:
+        - key:
+            randomString: "hashed"
+          name: hashedIndex
+    - OperationMetricsName: DropCreatedHashedIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: Collection0
+        index: hashedIndex
+  - Duration: 10 minutes
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateTextIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0
+        indexes:
+        - key:
+            randomString: "text"
+          name: textIndex
+    - OperationMetricsName: DropCreatedTextIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: Collection0
+        index: textIndex
+  - Duration: 10 minutes
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateUniqueIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0
+        indexes:
+        - key:
+            randomString: 1
+          name: uniqueIndex
+          unique: true
+    - OperationMetricsName: DropCreatedUniqueIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: Collection0
+        index: uniqueIndex
+  - Duration: 10 minutes
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateWildCardIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0
+        indexes:
+        - key: { "attributes.$**": 1 }
+          name: wildCardIndex
+    - OperationMetricsName: DropCreatedWildCardIndexesCmd
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: Collection0
+        index: wildCardIndex


### PR DESCRIPTION
Added a workload similar to CreateIndex.yml for running against a sharded collection. The only difference is that I got rid of `mongodb_setup: single-replica` and used `Duration` instead of `Repeat` to make it run more operations. 