### PR TITLE
PERF-1933: Run parallel_insert workload with slow network

### DIFF
--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -187,3 +187,7 @@ AutoRun:
         - replica
         - single-replica
         - replica-noflowcontrol
+  PrepareEnvironmentWith:
+    setup:
+    - replica-delay-mixed
+    - replica


### PR DESCRIPTION
This is for the project "Use Exhaust Cusor for Oplog Fetching".