### PR TITLE
BF-15755 Remove single-replica from ParallelInsert.yml

### DIFF
--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -185,7 +185,6 @@ AutoRun:
     bootstrap:
       mongodb_setup:
         - replica
-        - single-replica
         - replica-noflowcontrol
   PrepareEnvironmentWith:
     setup:


### PR DESCRIPTION
The current autorun section of this workload generates a task that tries to have the following in bootstrap.yml:

```yaml
infrastructure_provisioning: single
mongodb_setup: replica
```

This [fails](https://evergreen.mongodb.com/task/sys_perf_linux_1_node_replSet_parallel_insert_replica_8ea803b42abc5b9b653fe7931e90f00f0e8c8043_19_12_18_21_48_52/1) because `mongodb_setup.replica.yml` assumes an `infrastructure_provisioning` of at least 3 nodes.

I suspect this was introduced by TIG-2077 and we accidentally added this line.

This is theoretically possible to catch prior to committing, so I added to GI-075 the [Genny Ideas Doc](https://docs.google.com/document/d/1K0SlHoKkIACIXhkNP_KPHvb3IV6r53ReqsHqEYTnXDA/edit#) to consider adding code to prevent something like this from happening in the future.

(fyi @ldennis - nothing you need to do just a heads-up.)