### PR TITLE
TIG-2260 Make metrics::Registry Aware of Actor-counts and Phase-Numbers

### DIFF
--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -24,6 +24,7 @@
 #include <typeinfo>
 #include <unordered_map>
 #include <vector>
+#include <optional>
 
 #include <boost/noncopyable.hpp>
 #include <boost/throw_exception.hpp>
@@ -477,7 +478,7 @@ public:
         }
 
         return this->workload()._registry->operation(
-            this->_actor->operator[]("Name").to<std::string>(), stm.str(), id);
+            this->_actor->operator[]("Name").to<std::string>(), stm.str(), id, _phaseNumber);
     }
 
     const auto getPhaseNumber() const {

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -24,7 +24,6 @@
 #include <typeinfo>
 #include <unordered_map>
 #include <vector>
-#include <optional>
 
 #include <boost/noncopyable.hpp>
 #include <boost/throw_exception.hpp>

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -127,8 +127,8 @@ public:
         return ClockSource::now();
     }
 
-    std::size_t threadCount(const std::string& actorName, const std::string& opName) const {
-        return _ops[actorName][opName].size();
+    std::size_t getWorkerCount(const std::string& actorName, const std::string& opName) const {
+        return (_ops.at(actorName).at(opName)).size();
     }
 
 private:

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -127,6 +127,10 @@ public:
         return ClockSource::now();
     }
 
+    std::size_t threadCount(const std::string& actorName, const std::string& opName) const {
+        return _ops[actorName][opName].size();
+    }
+
 private:
     OperationsMap _ops;
 };

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -34,6 +34,9 @@ namespace genny::metrics {
  */
 namespace v1 {
 
+template <typename Clocksource>
+class OperationImpl;
+
 class MetricsClockSource {
 private:
     using clock_type = std::chrono::steady_clock;
@@ -89,7 +92,7 @@ public:
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];
         auto opIt = opsByThread.try_emplace(actorId,  std::move(actorName), std::move(opsByThread.size()),
-                std::move(opName), std::move(phase)).first;
+                *this, std::move(opName), std::move(phase)).first;
         return OperationT{opIt->second};
     }
 
@@ -108,6 +111,7 @@ public:
                     actorId,
                     std::move(actorName),
                     std::move(opsByThread.size()),
+                    *this,
                     std::move(opName),
                     std::move(phase),
                     std::make_optional<typename OperationImpl<ClockSource>::OperationThreshold>(

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -85,10 +85,11 @@ public:
 
     explicit RegistryT() = default;
 
-    OperationT<ClockSource> operation(std::string actorName, std::string opName, ActorId actorId) {
+    OperationT<ClockSource> operation(std::string actorName, std::string opName, ActorId actorId, std::optional<genny::PhaseNumber> phase = std::nullopt) {
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];
-        auto opIt = opsByThread.try_emplace(actorId, std::move(actorName), std::move(opName)).first;
+        auto opIt = opsByThread.try_emplace(actorId, std::move(actorName), std::move(opName), 
+                std::move(phase)).first;
         return OperationT{opIt->second};
     }
 
@@ -96,7 +97,9 @@ public:
                                       std::string opName,
                                       ActorId actorId,
                                       genny::TimeSpec threshold,
-                                      double_t percentage) {
+                                      double_t percentage,
+                                      std::optional<genny::PhaseNumber> phase = std::nullopt 
+                                      ) {
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];
         auto opIt =
@@ -105,6 +108,7 @@ public:
                     actorId,
                     std::move(actorName),
                     std::move(opName),
+                    std::move(phase),
                     std::make_optional<typename OperationImpl<ClockSource>::OperationThreshold>(
                         threshold, percentage))
                 .first;

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -91,7 +91,7 @@ public:
     OperationT<ClockSource> operation(std::string actorName, std::string opName, ActorId actorId, std::optional<genny::PhaseNumber> phase = std::nullopt) {
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];
-        auto opIt = opsByThread.try_emplace(actorId,  std::move(actorName), *this, 
+        auto opIt = opsByThread.try_emplace(actorId,  std::move(actorName), *this,
                 std::move(opName), std::move(phase)).first;
         return OperationT{opIt->second};
     }

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -98,7 +98,7 @@ public:
                                       ActorId actorId,
                                       genny::TimeSpec threshold,
                                       double_t percentage,
-                                      std::optional<genny::PhaseNumber> phase = std::nullopt 
+                                      std::optional<genny::PhaseNumber> phase = std::nullopt
                                       ) {
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -88,8 +88,8 @@ public:
     OperationT<ClockSource> operation(std::string actorName, std::string opName, ActorId actorId, std::optional<genny::PhaseNumber> phase = std::nullopt) {
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];
-        auto opIt = opsByThread.try_emplace(actorId, std::move(actorName), std::move(opName), 
-                std::move(phase)).first;
+        auto opIt = opsByThread.try_emplace(actorId,  std::move(actorName), std::move(opsByThread.size()),
+                std::move(opName), std::move(phase)).first;
         return OperationT{opIt->second};
     }
 
@@ -107,6 +107,7 @@ public:
                 .try_emplace(
                     actorId,
                     std::move(actorName),
+                    std::move(opsByThread.size()),
                     std::move(opName),
                     std::move(phase),
                     std::make_optional<typename OperationImpl<ClockSource>::OperationThreshold>(

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -88,11 +88,17 @@ public:
 
     explicit RegistryT() = default;
 
-    OperationT<ClockSource> operation(std::string actorName, std::string opName, ActorId actorId, std::optional<genny::PhaseNumber> phase = std::nullopt) {
+    OperationT<ClockSource> operation(std::string actorName,
+                                      std::string opName,
+                                      ActorId actorId,
+                                      std::optional<genny::PhaseNumber> phase = std::nullopt) {
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];
-        auto opIt = opsByThread.try_emplace(actorId,  std::move(actorName), *this,
-                std::move(opName), std::move(phase)).first;
+        auto opIt =
+            opsByThread
+                .try_emplace(
+                    actorId, std::move(actorName), *this, std::move(opName), std::move(phase))
+                .first;
         return OperationT{opIt->second};
     }
 
@@ -101,8 +107,7 @@ public:
                                       ActorId actorId,
                                       genny::TimeSpec threshold,
                                       double_t percentage,
-                                      std::optional<genny::PhaseNumber> phase = std::nullopt
-                                      ) {
+                                      std::optional<genny::PhaseNumber> phase = std::nullopt) {
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];
         auto opIt =
@@ -127,6 +132,10 @@ public:
         return ClockSource::now();
     }
 
+    /**
+     * Returns the number of workers performing a given operation.
+     * Assumes the count is constant across phases for a given (actor, operation).
+     */
     std::size_t getWorkerCount(const std::string& actorName, const std::string& opName) const {
         return (_ops.at(actorName).at(opName)).size();
     }

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -91,8 +91,8 @@ public:
     OperationT<ClockSource> operation(std::string actorName, std::string opName, ActorId actorId, std::optional<genny::PhaseNumber> phase = std::nullopt) {
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];
-        auto opIt = opsByThread.try_emplace(actorId,  std::move(actorName), std::move(opsByThread.size()),
-                *this, std::move(opName), std::move(phase)).first;
+        auto opIt = opsByThread.try_emplace(actorId,  std::move(actorName), *this, 
+                std::move(opName), std::move(phase)).first;
         return OperationT{opIt->second};
     }
 
@@ -110,7 +110,6 @@ public:
                 .try_emplace(
                     actorId,
                     std::move(actorName),
-                    std::move(opsByThread.size()),
                     *this,
                     std::move(opName),
                     std::move(phase),

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -170,7 +170,7 @@ public:
                   std::string opName,
                   std::optional<genny::PhaseNumber> phase,
                   std::optional<OperationThreshold> threshold = std::nullopt)
-        : _actorName(std::move(actorName)), _actorCount(actorCount), _opName(std::move(opName)), 
+        : _actorName(std::move(actorName)), _actorCount(actorCount), _opName(std::move(opName)),
           _phase(std::move(phase)), _threshold(threshold){};
 
     /**
@@ -217,7 +217,7 @@ public:
 
 private:
     /*
-     * Actor count and phase number will be used in Poplar metrics. Right now they 
+     * Actor count and phase number will be used in Poplar metrics. Right now they
      * are unused.
      */
     const std::string _actorName;

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -33,6 +33,8 @@ namespace genny::metrics {
 
 using count_type = long long;
 
+using actor_count_t = uint32_t;
+
 enum class OutcomeType : uint8_t { kSuccess = 0, kFailure = 1, kUnknown = 2 };
 
 /**
@@ -164,6 +166,7 @@ public:
     using OptionalPhaseNumber = std::optional<genny::PhaseNumber>;
 
     OperationImpl(std::string actorName,
+                  actor_count_t actorCount,
                   std::string opName,
                   std::optional<genny::PhaseNumber> phase,
                   std::optional<OperationThreshold> threshold = std::nullopt)

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -161,11 +161,14 @@ public:
     };
 
     using OptionalOperationThreshold = std::optional<OperationThreshold>;
+    using OptionalPhaseNumber = std::optional<genny::PhaseNumber>;
 
     OperationImpl(std::string actorName,
                   std::string opName,
+                  std::optional<genny::PhaseNumber> phase,
                   std::optional<OperationThreshold> threshold = std::nullopt)
-        : _actorName(std::move(actorName)), _opName(std::move(opName)), _threshold(threshold){};
+        : _actorName(std::move(actorName)), _opName(std::move(opName)), _phase(std::move(phase)), 
+          _threshold(threshold){};
 
     /**
      * @return the name of the actor running the operation.
@@ -212,6 +215,7 @@ public:
 private:
     const std::string _actorName;
     const std::string _opName;
+    OptionalPhaseNumber _phase;
     OptionalOperationThreshold _threshold;
     EventSeries _events;
 };

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -170,8 +170,8 @@ public:
                   std::string opName,
                   std::optional<genny::PhaseNumber> phase,
                   std::optional<OperationThreshold> threshold = std::nullopt)
-        : _actorName(std::move(actorName)), _opName(std::move(opName)), _phase(std::move(phase)), 
-          _threshold(threshold){};
+        : _actorName(std::move(actorName)), _actorCount(actorCount), _opName(std::move(opName)), 
+          _phase(std::move(phase)), _threshold(threshold){};
 
     /**
      * @return the name of the actor running the operation.
@@ -216,7 +216,12 @@ public:
     }
 
 private:
+    /*
+     * Actor count and phase number will be used in Poplar metrics. Right now they 
+     * are unused.
+     */
     const std::string _actorName;
+    const actor_count_t _actorCount;
     const std::string _opName;
     OptionalPhaseNumber _phase;
     OptionalOperationThreshold _threshold;

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -169,13 +169,12 @@ public:
     using OptionalPhaseNumber = std::optional<genny::PhaseNumber>;
 
     OperationImpl(std::string actorName,
-                  actor_count_t actorCount,
                   const RegistryT<ClockSource>& registry,
                   std::string opName,
                   std::optional<genny::PhaseNumber> phase,
                   std::optional<OperationThreshold> threshold = std::nullopt)
-        : _actorName(std::move(actorName)), _actorCount(actorCount), _registry(registry),
-          _opName(std::move(opName)), _phase(std::move(phase)), _threshold(threshold){};
+        : _actorName(std::move(actorName)), _registry(registry), _opName(std::move(opName)), 
+          _phase(std::move(phase)), _threshold(threshold){};
 
     /**
      * @return the name of the actor running the operation.
@@ -225,7 +224,6 @@ private:
      * are unused.
      */
     const std::string _actorName;
-    const actor_count_t _actorCount;
     const RegistryT<ClockSource>& _registry;
     const std::string _opName;
     OptionalPhaseNumber _phase;

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -33,7 +33,7 @@ namespace genny::metrics {
 
 using count_type = long long;
 
-using actor_count_t = uint32_t;
+using actor_count_t = size_t;
 
 enum class OutcomeType : uint8_t { kSuccess = 0, kFailure = 1, kUnknown = 2 };
 
@@ -173,8 +173,11 @@ public:
                   std::string opName,
                   std::optional<genny::PhaseNumber> phase,
                   std::optional<OperationThreshold> threshold = std::nullopt)
-        : _actorName(std::move(actorName)), _registry(registry), _opName(std::move(opName)),
-          _phase(std::move(phase)), _threshold(threshold){};
+        : _actorName(std::move(actorName)),
+          _registry(registry),
+          _opName(std::move(opName)),
+          _phase(std::move(phase)),
+          _threshold(threshold){};
 
     /**
      * @return the name of the actor running the operation.

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -174,8 +174,8 @@ public:
                   std::string opName,
                   std::optional<genny::PhaseNumber> phase,
                   std::optional<OperationThreshold> threshold = std::nullopt)
-        : _actorName(std::move(actorName)), _actorCount(actorCount), _opName(std::move(opName)),
-          _phase(std::move(phase)), _threshold(threshold){};
+        : _actorName(std::move(actorName)), _actorCount(actorCount), _registry(registry),
+          _opName(std::move(opName)), _phase(std::move(phase)), _threshold(threshold){};
 
     /**
      * @return the name of the actor running the operation.
@@ -226,6 +226,7 @@ private:
      */
     const std::string _actorName;
     const actor_count_t _actorCount;
+    const RegistryT<ClockSource>& _registry;
     const std::string _opName;
     OptionalPhaseNumber _phase;
     OptionalOperationThreshold _threshold;

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -111,6 +111,9 @@ struct OperationEventT final {
  */
 namespace v1 {
 
+template <typename Clocksource>
+class RegistryT;
+
 /**
  * Throw this to indicate the percentage of operations exceeding the
  * time limit went above the threshold.
@@ -167,6 +170,7 @@ public:
 
     OperationImpl(std::string actorName,
                   actor_count_t actorCount,
+                  const RegistryT<ClockSource>& registry,
                   std::string opName,
                   std::optional<genny::PhaseNumber> phase,
                   std::optional<OperationThreshold> threshold = std::nullopt)

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -173,7 +173,7 @@ public:
                   std::string opName,
                   std::optional<genny::PhaseNumber> phase,
                   std::optional<OperationThreshold> threshold = std::nullopt)
-        : _actorName(std::move(actorName)), _registry(registry), _opName(std::move(opName)), 
+        : _actorName(std::move(actorName)), _registry(registry), _opName(std::move(opName)),
           _phase(std::move(phase)), _threshold(threshold){};
 
     /**

--- a/src/metrics/test/metrics_test.cpp
+++ b/src/metrics/test/metrics_test.cpp
@@ -40,7 +40,7 @@ void assertDurationsEqual(RegistryClockSourceStub::duration dur1,
 TEST_CASE("metrics::OperationContext interface") {
     RegistryClockSourceStub::reset();
 
-    auto op = v1::OperationImpl<RegistryClockSourceStub>{"Actor", "Op", std::nullopt};
+    auto op = v1::OperationImpl<RegistryClockSourceStub>{"Actor", 1, "Op", std::nullopt};
 
     RegistryClockSourceStub::advance(5ns);
     auto ctx = std::make_optional<v1::OperationContextT<RegistryClockSourceStub>>(&op);

--- a/src/metrics/test/metrics_test.cpp
+++ b/src/metrics/test/metrics_test.cpp
@@ -40,7 +40,7 @@ void assertDurationsEqual(RegistryClockSourceStub::duration dur1,
 TEST_CASE("metrics::OperationContext interface") {
     RegistryClockSourceStub::reset();
 
-    auto op = v1::OperationImpl<RegistryClockSourceStub>{"Actor", "Op"};
+    auto op = v1::OperationImpl<RegistryClockSourceStub>{"Actor", "Op", std::nullopt};
 
     RegistryClockSourceStub::advance(5ns);
     auto ctx = std::make_optional<v1::OperationContextT<RegistryClockSourceStub>>(&op);

--- a/src/metrics/test/metrics_test.cpp
+++ b/src/metrics/test/metrics_test.cpp
@@ -41,7 +41,7 @@ TEST_CASE("metrics::OperationContext interface") {
     RegistryClockSourceStub::reset();
 
     auto dummy_metrics = v1::RegistryT<RegistryClockSourceStub>{};
-    auto op = v1::OperationImpl<RegistryClockSourceStub>{"Actor", 1, dummy_metrics, "Op", std::nullopt};
+    auto op = v1::OperationImpl<RegistryClockSourceStub>{"Actor", dummy_metrics, "Op", std::nullopt};
 
     RegistryClockSourceStub::advance(5ns);
     auto ctx = std::make_optional<v1::OperationContextT<RegistryClockSourceStub>>(&op);

--- a/src/metrics/test/metrics_test.cpp
+++ b/src/metrics/test/metrics_test.cpp
@@ -41,7 +41,8 @@ TEST_CASE("metrics::OperationContext interface") {
     RegistryClockSourceStub::reset();
 
     auto dummy_metrics = v1::RegistryT<RegistryClockSourceStub>{};
-    auto op = v1::OperationImpl<RegistryClockSourceStub>{"Actor", dummy_metrics, "Op", std::nullopt};
+    auto op =
+        v1::OperationImpl<RegistryClockSourceStub>{"Actor", dummy_metrics, "Op", std::nullopt};
 
     RegistryClockSourceStub::advance(5ns);
     auto ctx = std::make_optional<v1::OperationContextT<RegistryClockSourceStub>>(&op);
@@ -497,9 +498,8 @@ TEST_CASE("Registry counts the number of workers") {
     std::size_t expected1 = 3;
     std::size_t expected2 = 2;
 
-    REQUIRE(metrics.getWorkerCount("actor1", "op1") == expected1);
-    REQUIRE(metrics.getWorkerCount("actor2", "op1") == expected2);
-
+    REQUIRE(metrics.getWorkerCount("actor1", "op1") == 3);
+    REQUIRE(metrics.getWorkerCount("actor2", "op1") == 2);
 }
 
 }  // namespace

--- a/src/metrics/test/metrics_test.cpp
+++ b/src/metrics/test/metrics_test.cpp
@@ -483,5 +483,24 @@ TEST_CASE("Phases can set metrics") {
     }
 }
 
+TEST_CASE("Registry counts the number of workers") {
+    RegistryClockSourceStub::reset();
+    auto metrics = v1::RegistryT<RegistryClockSourceStub>{};
+
+    metrics.operation("actor1", "op1", 1u);
+    metrics.operation("actor1", "op1", 2u);
+    metrics.operation("actor1", "op1", 3u);
+
+    metrics.operation("actor2", "op1", 4u);
+    metrics.operation("actor2", "op1", 5u);
+
+    std::size_t expected1 = 3;
+    std::size_t expected2 = 2;
+
+    REQUIRE(metrics.getWorkerCount("actor1", "op1") == expected1);
+    REQUIRE(metrics.getWorkerCount("actor2", "op1") == expected2);
+
+}
+
 }  // namespace
 }  // namespace genny::metrics

--- a/src/metrics/test/metrics_test.cpp
+++ b/src/metrics/test/metrics_test.cpp
@@ -40,7 +40,8 @@ void assertDurationsEqual(RegistryClockSourceStub::duration dur1,
 TEST_CASE("metrics::OperationContext interface") {
     RegistryClockSourceStub::reset();
 
-    auto op = v1::OperationImpl<RegistryClockSourceStub>{"Actor", 1, "Op", std::nullopt};
+    auto dummy_metrics = v1::RegistryT<RegistryClockSourceStub>{};
+    auto op = v1::OperationImpl<RegistryClockSourceStub>{"Actor", 1, dummy_metrics, "Op", std::nullopt};
 
     RegistryClockSourceStub::advance(5ns);
     auto ctx = std::make_optional<v1::OperationContextT<RegistryClockSourceStub>>(&op);


### PR DESCRIPTION
Right now the actor counts and phase numbers aren't used for anything, but they'll be passed to poplar to used. I'm thinking the OperationImpl makes sense as the location where the two forms of metrics co-reside, because I think we can mostly create a new version of EventSeries to hold it.

Lotsa feedback welcome 😄 