### PR TITLE
TIG-2434 Add simplified RunCommand workload

### DIFF
--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -1,0 +1,27 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/stm"
+
+Actors:
+- Name: ServerStatusInsertFind
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Repeat: 100
+    Database: test
+    Operations:
+    - OperationMetricsName: ServerStatus
+      OperationName: RunCommand
+      OperationCommand:
+        serverStatus: 1
+    - OperationName: RunCommand
+      OperationCommand:
+        insert: myCollection
+        documents: [{name: {^RandomString: {length: {^RandomInt: {min: 2, max: 5}}}}, rating: 10, address: someAddress, cuisine: italian}]
+    - OperationMetricsName: Find
+      OperationCommand:
+        find: restaurants
+        filter: {rating: {$gte: 9}, cuisine: italian}
+        projection: {name: 1, rating: 1, address: 1}
+        sort: {name: 1}
+        limit: 5
+      OperationName: RunCommand


### PR DESCRIPTION
Adding simplified RunCommand workload to run it as integration test in DSI CI.

This is the copy of [RunCommand](https://github.com/mongodb/genny/blob/5813b65a7caef9101f3502012e78c97ee817ba3f/src/workloads/docs/RunCommand.yml) workload leaving just _ServerStatusInsertFind_ actor with 100 repeats instead of 5 min duration.