### PR TITLE
TIG-2478 FTDC outputs for setup operation have negative totals

### DIFF
--- a/src/metrics/include/metrics/v2/event.hpp
+++ b/src/metrics/include/metrics/v2/event.hpp
@@ -241,10 +241,18 @@ public:
         _metrics.mutable_timers()->mutable_duration()->set_nanos(
             event.duration.getNanosecondsCount());
 
-        _metrics.mutable_timers()->mutable_total()->set_seconds(
-            Period<ClockSource>(finish - _last_finish).getSecondsCount());
-        _metrics.mutable_timers()->mutable_total()->set_nanos(
-            Period<ClockSource>(finish - _last_finish).getNanosecondsCount());
+        // If the EventStream was constructed after the end time was recorded.
+        if (finish < _last_finish) {
+            _metrics.mutable_timers()->mutable_total()->set_seconds(
+                event.duration.getSecondsCount());
+            _metrics.mutable_timers()->mutable_total()->set_nanos(
+                event.duration.getNanosecondsCount());
+        } else {
+            _metrics.mutable_timers()->mutable_total()->set_seconds(
+                Period<ClockSource>(finish - _last_finish).getSecondsCount());
+            _metrics.mutable_timers()->mutable_total()->set_nanos(
+                Period<ClockSource>(finish - _last_finish).getNanosecondsCount());
+        }
 
         _metrics.mutable_counters()->set_number(event.number);
         _metrics.mutable_counters()->set_ops(event.ops);


### PR DESCRIPTION
This just make sure that, if the _last_finished var is after the finish (i.e. if the EventStream was constructed and _last_finish was initialized to now after the finish time was recorded), we just use the duration as the total this time around, next recorded operation will work as normal since _last_finish will be updated.

If we expect a lot of edge cases like this, it might make sense to expose a synthetic_report equivalent for the gRPC stream.