### PR TITLE
TIG-2470 Change AutoRun syntax

### DIFF
--- a/src/python/gennylib/genny_auto_tasks.py
+++ b/src/python/gennylib/genny_auto_tasks.py
@@ -24,6 +24,20 @@ class AutoRunSpec():
         self.required_dict = required_dict
         # A dictionary representing the yaml within the PrepareEnvironmentWith section of the workload AutoRun yaml
         self.prepare_environment_with = prepare_environment_with
+        AutoRunSpec._rename_prepare_environment(prepare_environment_with)
+
+    @staticmethod
+    def _rename_prepare_environment(prepare_environment_with: dict):
+        # Temporary limitation and workaround until we switch to the new f_run_dsi_workload
+        # (or similarly-named) evergreen function in TIG-2474.
+        if prepare_environment_with is None:
+            return
+        if "mongodb_setup" in prepare_environment_with:
+            prepare_environment_with["setup"] = prepare_environment_with["mongodb_setup"]
+            del(prepare_environment_with["mongodb_setup"])
+        if len(prepare_environment_with) > 1:
+            raise Exception(
+                f"Can only provide 'mongodb_setup' (or 'setup') in PrepareEnvironmentWith")
 
     @staticmethod
     def create_from_workload_yaml(workload_yaml):

--- a/src/python/tests/auto_tasks_test.py
+++ b/src/python/tests/auto_tasks_test.py
@@ -98,7 +98,7 @@ class AutoTasksTest(unittest.TestCase):
         mock_safe_load.return_value = {
             'AutoRun': {
                 'PrepareEnvironmentWith': {
-                    'setup': ['first', 'second']
+                    'mongodb_setup': ['first', 'second']
                 }
             }
         }

--- a/src/python/tests/auto_tasks_test.py
+++ b/src/python/tests/auto_tasks_test.py
@@ -310,6 +310,7 @@ class AutoTasksTest(unittest.TestCase):
             env_dict = tc[1]
             expected = tc[2]
 
-            autorun_spec = AutoRunSpec.create_from_workload_yaml(workload_yaml)
-            actual = workload_should_autorun(autorun_spec, env_dict)
-            self.assertEqual(expected, actual)
+            with self.subTest(tc):
+                autorun_spec = AutoRunSpec.create_from_workload_yaml(workload_yaml)
+                actual = workload_should_autorun(autorun_spec, env_dict)
+                self.assertEqual(expected, actual)

--- a/src/python/tests/fixtures/auto_tasks_fixtures.py
+++ b/src/python/tests/fixtures/auto_tasks_fixtures.py
@@ -5,14 +5,10 @@ workload_should_autorun_cases = [
                 {
                     'AutoRun': {
                         'Requires': {
-                            'bootstrap': {
-                                'platform': 'linux',
-                                'storageEngine': 'wiredTiger'
-                            },
-                            'runtime': {
-                                'build_variant': 'variant1',
-                                'is_patch': 'true'
-                            }
+                                'platform': ['linux'],
+                                'storageEngine': ['wiredTiger'],
+                                'build_variant': ['variant1'],
+                                'is_patch': ['true']
                         }
                     }
                 },
@@ -32,16 +28,14 @@ workload_should_autorun_cases = [
                 {
                     'AutoRun': {
                         'Requires': {
-                            'bootstrap': {
-                                'platform': 'linux'
-                            }
+                                'platform': ['linux']
                         }
                     }
                 },
                 {
                     'bootstrap': {
                         'platform': 'linux',
-                        'storageEngine': 'wiredTiger'
+                        'storageEngine': 'wiredTiger',
                     },
                     'runtime': {
                         'build_variant': 'variant1',
@@ -53,10 +47,7 @@ workload_should_autorun_cases = [
             (
                 {
                     'AutoRun': {
-                        'Requires': {
-                            'runtime': {},
-                            'bootstrap': {}
-                        }
+                        'Requires': {}
                     }
                 },
                 {
@@ -93,13 +84,9 @@ workload_should_autorun_cases = [
                 {
                     'AutoRun': {
                         'Requires': {
-                            'bootstrap': {
-                                'platform': ['osx', 'windows', 'linux']
-                            },
-                            'runtime': {
-                                'build_variant': 'variant1',
-                                'is_patch': 'true'
-                            }
+                                'platform': ['osx', 'windows', 'linux'],
+                                'build_variant': ['variant1'],
+                                'is_patch': ['true']
                         }
                     }
                 },
@@ -119,13 +106,31 @@ workload_should_autorun_cases = [
                 {
                     'AutoRun': {
                         'Requires': {
-                            'bootstrap': {
-                                'platform': ['osx', 'windows', 'debian']
-                            },
-                            'runtime': {
-                                'build_variant': 'variant1',
-                                'is_patch': 'true'
+                                'platform': ['osx', 'windows', 'debian'],
+                                'build_variant': ['variant1'],
+                                'is_patch': ['true']
                             }
+                        }
+                },
+                {
+                    'bootstrap': {
+                        'platform': 'linux',
+                        'storageEngine': 'wiredTiger'
+                    },
+                    'runtime': {
+                        'build_variant': 'variant1',
+                        'is_patch': 'true'
+                    }
+                },
+                False
+            ),
+            (
+                {
+                    'AutoRun': {
+                        'Requires': {
+                                'platform': ['osx', 'windows', 'linux'],
+                                'build_variant': ['variant1'],
+                                'is_patch': ['false']
                         }
                     }
                 },
@@ -145,42 +150,12 @@ workload_should_autorun_cases = [
                 {
                     'AutoRun': {
                         'Requires': {
-                            'bootstrap': {
-                                'platform': ['osx', 'windows', 'linux']
-                            },
-                            'runtime': {
-                                'build_variant': 'variant1',
-                                'is_patch': 'false'
+                                'platform': ['linux'],
+                                'storageEngine': ['wiredTiger'],
+                                'build_variant': ['variant1'],
+                                'is_patch': ['true']
                             }
                         }
-                    }
-                },
-                {
-                    'bootstrap': {
-                        'platform': 'linux',
-                        'storageEngine': 'wiredTiger'
-                    },
-                    'runtime': {
-                        'build_variant': 'variant1',
-                        'is_patch': 'true'
-                    }
-                },
-                False
-            ),
-            (
-                {
-                    'AutoRun': {
-                        'Requires': {
-                            'bootstrap': {
-                                'platform': 'linux',
-                                'storageEngine': 'wiredTiger'
-                            },
-                            'runtime': {
-                                'build_variant': 'variant1',
-                                'is_patch': 'true'
-                            }
-                        }
-                    }
                 },
                 {
                     'bootstrap': {
@@ -198,19 +173,13 @@ workload_should_autorun_cases = [
                 {
                     'AutoRun': {
                         'Requires': {
-                            'bootstrap': {
-                                'platform': 'linux',
-                                'storageEngine': 'wiredTiger'
-                            },
-                            'runtime': {
-                                'build_variant': 'variant1',
-                                'is_patch': 'true'
-                            },
-                            'other': {
-                                'key': 'value'
+                                'platform': ['linux'],
+                                'storageEngine': ['wiredTiger'],
+                                'build_variant': ['variant1'],
+                                'is_patch': ['true'],
+                                'key': ['value']
                             }
                         }
-                    }
                 },
                 {
                     'bootstrap': {
@@ -228,11 +197,8 @@ workload_should_autorun_cases = [
                 {
                     'AutoRun': {
                         'Requires': {
-                            'bootstrap': {
-                                'platform': 'linux',
-                                'storageEngine': 'other'
-                            },
-
+                                'platform': ['linux'],
+                                'storageEngine': ['other']
                         }
                     }
                 },
@@ -252,8 +218,8 @@ workload_should_autorun_cases = [
                 {},
                 {
                     'bootstrap': {
-                        'platform': 'linux',
-                        'storageEngine': 'wiredTiger'
+                        'platform': ['linux'],
+                        'storageEngine': ['wiredTiger']
                     },
                     'runtime': {
                         'build_variant': 'variant1',
@@ -298,11 +264,9 @@ workload_should_autorun_cases = [
                 {
                     'AutoRun': {
                         'Requires': {
-                            'bootstrap': {
-                                'platform': 'linux',
-                                'storageEngine': 'wiredTiger'
-                            },
-                            'runtime': 'string-runtime'
+                                'platform': ['linux'],
+                                'storageEngine': ['wiredTiger'],
+                                'runtime': ['string-runtime']
                         }
                     }
                 },

--- a/src/python/tests/fixtures/auto_tasks_fixtures.py
+++ b/src/python/tests/fixtures/auto_tasks_fixtures.py
@@ -47,6 +47,24 @@ workload_should_autorun_cases = [
             (
                 {
                     'AutoRun': {
+                        'Requires': {
+                                'platform': ['linux']
+                        }
+                    }
+                },
+                {
+                    'expansions': {
+                        'platform': 'linux',
+                        'storageEngine': 'wiredTiger',
+                        'build_variant': 'variant1',
+                        'is_patch': 'true'
+                    }
+                },
+                True
+            ),
+            (
+                {
+                    'AutoRun': {
                         'Requires': {}
                     }
                 },

--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -182,11 +182,10 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup:
-        - replica
-        - replica-noflowcontrol
+    mongodb_setup:
+    - replica
+    - replica-noflowcontrol
   PrepareEnvironmentWith:
-    setup:
+    mongodb_setup:
     - replica-delay-mixed
     - replica

--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -186,6 +186,6 @@ AutoRun:
     - replica
     - replica-noflowcontrol
   PrepareEnvironmentWith:
-    mongodb_setup:
+    setup:
     - replica-delay-mixed
     - replica

--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -186,6 +186,6 @@ AutoRun:
     - replica
     - replica-noflowcontrol
   PrepareEnvironmentWith:
-    setup:
+    mongodb_setup:
     - replica-delay-mixed
     - replica

--- a/src/workloads/execution/BackgroundValidateCmd.yml
+++ b/src/workloads/execution/BackgroundValidateCmd.yml
@@ -118,5 +118,4 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: standalone
+    mongodb_setup: [standalone]

--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -90,5 +90,4 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: single-replica
+    mongodb_setup: [single-replica]

--- a/src/workloads/execution/CreateIndex.yml
+++ b/src/workloads/execution/CreateIndex.yml
@@ -66,5 +66,4 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: single-replica
+    mongodb_setup: [single-replica]

--- a/src/workloads/execution/CreateIndexSharded.yml
+++ b/src/workloads/execution/CreateIndexSharded.yml
@@ -110,7 +110,6 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup:
-        - shard
-        - shard-lite
+    mongodb_setup:
+    - shard
+    - shard-lite

--- a/src/workloads/execution/ExternalSort.yml
+++ b/src/workloads/execution/ExternalSort.yml
@@ -99,5 +99,4 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: standalone
+    mongodb_setup: [standalone]

--- a/src/workloads/execution/ValidateCmd.yml
+++ b/src/workloads/execution/ValidateCmd.yml
@@ -57,5 +57,4 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: standalone
+    mongodb_setup: standalone

--- a/src/workloads/execution/ValidateCmd.yml
+++ b/src/workloads/execution/ValidateCmd.yml
@@ -57,4 +57,4 @@ Actors:
 
 AutoRun:
   Requires:
-    mongodb_setup: standalone
+    mongodb_setup: [standalone]

--- a/src/workloads/networking/ServiceArchitectureWorkloads.yml
+++ b/src/workloads/networking/ServiceArchitectureWorkloads.yml
@@ -71,7 +71,6 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: 
-        - replica
-        - replica-noflowcontrol
+    mongodb_setup: 
+    - replica
+    - replica-noflowcontrol

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -118,9 +118,8 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: 
-        - replica
-        - single-replica
-        - standalone
-        - replica-noflowcontrol
+    mongodb_setup: 
+    - replica
+    - single-replica
+    - standalone
+    - replica-noflowcontrol

--- a/src/workloads/scale/InsertBigDocs.yml
+++ b/src/workloads/scale/InsertBigDocs.yml
@@ -21,7 +21,6 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: 
-        - replica
-        - single-replica
+    mongodb_setup: 
+    - replica
+    - single-replica

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -16,9 +16,8 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: 
-        - replica
-        - single-replica
-        - standalone
-        - shard
+    mongodb_setup: 
+    - replica
+    - single-replica
+    - standalone
+    - shard

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -80,10 +80,9 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup:
-        - replica
-        - standalone
-        - shard
-        - single-replica
-        - single-replica-15gbwtcache
+    mongodb_setup:
+    - replica
+    - standalone
+    - shard
+    - single-replica
+    - single-replica-15gbwtcache

--- a/src/workloads/scale/LargeScaleModel.yml
+++ b/src/workloads/scale/LargeScaleModel.yml
@@ -436,6 +436,5 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup:
-        - standalone
+    mongodb_setup:
+    - standalone

--- a/src/workloads/scale/MixedWrites.yml
+++ b/src/workloads/scale/MixedWrites.yml
@@ -39,6 +39,6 @@ AutoRun:
   Requires:
     infrastructure_provisioning: [replica]
   PrepareEnvironmentWith:
-    setup:
+    mongodb_setup:
     - replica-delay-mixed
     - replica

--- a/src/workloads/scale/MixedWrites.yml
+++ b/src/workloads/scale/MixedWrites.yml
@@ -39,6 +39,6 @@ AutoRun:
   Requires:
     infrastructure_provisioning: [replica]
   PrepareEnvironmentWith:
-    mongodb_setup:
+    setup:
     - replica-delay-mixed
     - replica

--- a/src/workloads/scale/MixedWrites.yml
+++ b/src/workloads/scale/MixedWrites.yml
@@ -37,11 +37,8 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap: { infrastructure_provisioning: [replica] }
+    infrastructure_provisioning: [replica]
   PrepareEnvironmentWith:
-    # Arguments to pass to the "prepare environment" evergreen function
-    #
-    # The 'setup' parameter dictates which mongodb_setup file to use.
-    setup:
+    mongodb_setup:
     - replica-delay-mixed
     - replica

--- a/src/workloads/scale/OutOfCacheScanner.yml
+++ b/src/workloads/scale/OutOfCacheScanner.yml
@@ -55,4 +55,4 @@ Actors:
 
 AutoRun:
   Requires:
-    mongodb_setup: single-replica-15gbwtcache
+    mongodb_setup: [single-replica-15gbwtcache]

--- a/src/workloads/scale/OutOfCacheScanner.yml
+++ b/src/workloads/scale/OutOfCacheScanner.yml
@@ -55,5 +55,4 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: single-replica-15gbwtcache
+    mongodb_setup: single-replica-15gbwtcache

--- a/src/workloads/selftests/GennyOverhead.yml
+++ b/src/workloads/selftests/GennyOverhead.yml
@@ -64,6 +64,5 @@ Actors:
 
 AutoRun:
   Requires:
-    bootstrap:
-      mongodb_setup: 
-        - standalone
+    mongodb_setup:
+    - standalone


### PR DESCRIPTION
TLDR: Slight change to the syntax for `AutoRun`.

This is the first part that will enable reading the state of the environment from `expansions.yml`.

Currently we an `AutoRun` section looks like this:

```yaml
AutoRun:
  Requires:
    bootstrap:
      mongodb_setup: replica
  PrepareEnvironmentWith:
    setup:
    - replica-delay-mixed
    - replica
```

This says "run when `${bootstrap.mongodb_setup} == 'standalone'`". But we want to be able to do this without the presence of `bootstrap.yml`. And the keys are actually unique so there's not `bootstrap.mongodb_setup` **and** `infrastructure_provisioning.mongodb_setup`; there's no reason to "namespace" the requires entries.

After state:

```yaml
AutoRun:
  Requires:
    mongodb_setup: replica
  PrepareEnvironmentWith:
    mongodb_setup:
    - replica-delay-mixed
    - replica
```

Also 

1. reduced some complexity by not allowing scalars and instead always require lists.
2. renamed the `setup` param for `PrepareEnvironmentWith` to be `mongodb_setup`