### PR TITLE
TIG-2497 Use non-blocking gRPC calls in Genny metrics

### DIFF
--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -22,8 +22,8 @@
 #include <string>
 
 #include <boost/core/noncopyable.hpp>
-#include <boost/log/trivial.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/log/trivial.hpp>
 
 #include <gennylib/Actor.hpp>
 #include <gennylib/Orchestrator.hpp>

--- a/src/metrics/include/metrics/v2/event.hpp
+++ b/src/metrics/include/metrics/v2/event.hpp
@@ -103,7 +103,7 @@ public:
           _response{},
           _context{},
           _cq{},
-          _tag{(void*)1},
+          _tag{(void*)1}, // Doesn't actually matter what this is, just be consistent.
           _stream{_stub->AsyncStreamEvents(&_context, &_response, &_cq, _tag)} {
         _options.set_no_compression().set_buffer_hint();
         finish_call();  // We expect a response from the initial construction.

--- a/src/metrics/include/metrics/v2/event.hpp
+++ b/src/metrics/include/metrics/v2/event.hpp
@@ -128,12 +128,17 @@ public:
                                      << " and actor ID " << _actorId << ", but no stream existed.";
             return;
         }
-
-        _stream->WritesDone(_tag);
         if (!finish_call()) {
             BOOST_LOG_TRIVIAL(warning)
                 << "Closing gRPC stream for operation name " << _name << " and actor ID "
                 << _actorId << ", but not all writes completed.";
+        }
+
+        _stream->WritesDone(_tag);
+        if (!finish_call()) {
+            BOOST_LOG_TRIVIAL(warning)
+                << "Failed to write to stream for operation name " << _name << " and actor ID "
+                << _actorId << ".";       
         }
 
         grpc::Status status; 

--- a/src/metrics/include/metrics/v2/event.hpp
+++ b/src/metrics/include/metrics/v2/event.hpp
@@ -103,7 +103,9 @@ public:
           _response{},
           _context{},
           _cq{},
-          _grpcTag{(void*)1}, // Doesn't actually matter what this is, just be consistent.
+          // This is used by the gRPC system to distinguish calls.
+          // We only ever have 1 message in flight at a time, so it doesn't matter to us.
+          _grpcTag{(void*)1},
           _stream{_stub->AsyncStreamEvents(&_context, &_response, &_cq, _grpcTag)} {
         _options.set_no_compression().set_buffer_hint();
         finishCall();  // We expect a response from the initial construction.
@@ -162,6 +164,8 @@ private:
             _cq.Next(&gotTag, &ok);
 
             _inFlight = false;
+            // Basic sanity check that the returned tag is expected.
+            // (and ok status).
             return gotTag == _grpcTag && ok;
         }
         return true;

--- a/src/metrics/include/metrics/v2/event.hpp
+++ b/src/metrics/include/metrics/v2/event.hpp
@@ -157,12 +157,12 @@ public:
 private:
     bool finishCall() {
         if (_inFlight) {
-            void* got_tag;
+            void* gotTag;
             bool ok = false;
-            _cq.Next(&got_tag, &ok);
+            _cq.Next(&gotTag, &ok);
 
             _inFlight = false;
-            return got_tag == _grpcTag && ok;
+            return gotTag == _grpcTag && ok;
         }
         return true;
     }


### PR DESCRIPTION
gRPC can only have one call "in-flight" per stream, so what this does is for every operation that writes to the stream, check if there's already an in-flight operation. If so, block until it completes then do the write.

Hopefully this corrects the performance problem. If not we might have to do something more complicated like adding buffers or more streams per thread.

[Patch-build](https://evergreen.mongodb.com/version/5e90c155a4cf47259c6d318b) where I modified InsertRemove to use FTDC outputs.