### PR TITLE
[nomerge] Create a global gRPC thread

### DIFF
--- a/src/gennylib/src/StubInterface.cpp
+++ b/src/gennylib/src/StubInterface.cpp
@@ -1,4 +1,5 @@
 #include <metrics/v2/event.hpp>
+#include <metrics/metrics.hpp>
 
 namespace genny::metrics::internals::v2 {
 
@@ -9,5 +10,7 @@ namespace genny::metrics::internals::v2 {
  */
 std::unique_ptr<poplar::PoplarEventCollector::StubInterface> CollectorStubInterface::_stub =
     nullptr;
+
+std::unique_ptr<ThreadObject> ConstructorClass::_thread = nullptr;
 
 }  // namespace genny::metrics::internals::v2

--- a/src/metrics/include/metrics/operation.hpp
+++ b/src/metrics/include/metrics/operation.hpp
@@ -234,7 +234,7 @@ public:
             _threshold->check(started, finished);
         }
         if (_useGrpc) {
-            _stream->addAt(finished, event, _registry.getWorkerCount(_actorName, _opName));
+            _stream->addAt(finished, std::move(event), _registry.getWorkerCount(_actorName, _opName));
         }
         if (_useCsv) {
             _events->addAt(finished, event);


### PR DESCRIPTION
This still needs cleanup and fails unit tests, but I figured I'd put it up for a look by y'all to see if there were any opinions on this methodology.

I originally tried having a separate gRPC thread for each actor thread, but that actually slowed things down (I guess that's a lot of context switching and thread overhead).

This branch makes a single global thread that manages gRPC calls. Actors just create gRPC jobs and append them to the queue, and the global gRPC thread continuously processes the jobs. This actually seems to do worse on the canary benchmarks, but there's some improvement in the insert-remove task.
 
[Patch 1](https://evergreen.mongodb.com/task/sys_perf_linux_standalone_insert_remove_patch_b4f1c5ed8af0ed6340c1795071ed061ae7facf14_5e95019d2a60ed1435a24874_20_04_14_00_20_02#) with CSV output (as a control) measures a throughput of 26,311 (of whatever unit is presented there).

[Patch 2](https://evergreen.mongodb.com/task/sys_perf_linux_standalone_insert_remove_patch_b4f1c5ed8af0ed6340c1795071ed061ae7facf14_5e95025cd6d80a3126f6b854_20_04_14_00_24_21/2#) with the current master shows a throughput of 20,351 units

[Patch 3](https://evergreen.mongodb.com/task/sys_perf_linux_standalone_insert_remove_patch_b4f1c5ed8af0ed6340c1795071ed061ae7facf14_5e954473e3c3312519b6ff7b_20_04_14_05_05_52#) with this PR shows a throughput of 21,707 units. That's an improvement of 6.6% of the throughput of the current master, and brings it up by 5% of the CSV version's throughput, bringing it from a 22.6% decrease in throughput from CSV version to a 17.4% decrease. Not sure how much noise we can expect in that sort of thing though.

My only worry is that, for long enough workloads with enough actors, the queue might get backed up. I'm not sure if that'd eventually make us run out of memory or if asio would just fail to post the job. Maybe we can check the queue size and, when trying to add to it, if it's too big we block until it's shorter?

Also, if we end up having to revert to synchronous operations I have no idea how that'd affect this. Probably not well.