### PR TITLE
TIG-2505 Update poplar version in genny

### DIFF
--- a/src/lamplib/tasks/download.py
+++ b/src/lamplib/tasks/download.py
@@ -133,7 +133,7 @@ class CuratorDownloader(Downloader):
 
     # Note that DSI also downloads Curator, the location is specified in defaults.yml.
     # Please try to keep the two versions consistent.
-    CURATOR_VERSION = "198c374fe4cb245570858f07c6d4d2e4ae13ede5"
+    CURATOR_VERSION = "cd30712870fa84767e6dc3559c9a1ec9ac8e654f"
     CURATOR_ROOT = os.getcwd()
 
     def __init__(self, os_family, distro):


### PR DESCRIPTION
Not running locally since the MacOS version of the curator waterfall hasn't run yet, but if it passes the evergreen tests we should be good.

Will run a patch to see if this actually fixes MAKE-1256 but either way we should still merge to fix MAKE-1257.