### PR TITLE
TIG-2521 Convert mixed_writes_replica to use FTDC-based metrics reporting

### DIFF
--- a/src/workloads/scale/MixedWrites.yml
+++ b/src/workloads/scale/MixedWrites.yml
@@ -42,3 +42,7 @@ AutoRun:
     mongodb_setup:
     - replica-delay-mixed
     - replica
+
+Metrics:
+  Format: ftdc
+  Path: build/genny-metrics


### PR DESCRIPTION
Only downside of this is it converts mixed_writes_replica_delay_mixed to FTDC-based output as well. That task is currently green so that's unnecessary and we'd lose change point triaging on it, but we can currently only specify metrics format for the workload not for workload-mongodbsetup pairs.

PB showing it works / fixes the problem: https://evergreen.mongodb.com/version/5eb2e7e62fbabe2124677a54

(Ignore the purple in that PB that's from TIG-2522)