### PR TITLE
PERF-2001: InCacheSnapshotReads & OutOfCacheSnapshotReads

### DIFF
--- a/src/cast_core/include/cast_core/actors/MultiCollectionUpdate.hpp
+++ b/src/cast_core/include/cast_core/actors/MultiCollectionUpdate.hpp
@@ -49,7 +49,6 @@ private:
     struct PhaseConfig;
     genny::DefaultRandom _rng;
 
-    metrics::Operation _updateOp;
     mongocxx::pool::entry _client;
     PhaseLoop<PhaseConfig> _loop;
 };

--- a/src/workloads/docs/LongLivedWriter.yml
+++ b/src/workloads/docs/LongLivedWriter.yml
@@ -48,6 +48,7 @@ Actors:
   Phases:
   - {Nop: true}
   - Duration: 3 minutes
+    MetricsName: Update
     Database: *DB
     CollectionCount: *CollectionCount
     DocumentCount: *DocumentCount

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -98,6 +98,7 @@ Actors:
   Phases:
   - *Nop
   - Duration: &phase2_duration 10 minutes
+    MetricsName: Update
     GlobalRate: 100 per 31 milliseconds
     Database: *DB
     CollectionCount: 10  # This is specifically 1% of collections
@@ -123,3 +124,4 @@ AutoRun:
     - single-replica
     - standalone
     - replica-noflowcontrol
+    - replica-1dayhistory-15gbwtcache

--- a/src/workloads/scale/InCacheSnapshotReads.yml
+++ b/src/workloads/scale/InCacheSnapshotReads.yml
@@ -63,7 +63,7 @@ Actors:
   - *Nop
   - &select_timestamp
     Repeat: 1
-    selectClusterTimeOnly: true
+    SelectClusterTimeOnly: true
   - Duration: *test_duration
     MetricsName: Scan-Current
     ScanType: point-in-time

--- a/src/workloads/scale/InCacheSnapshotReads.yml
+++ b/src/workloads/scale/InCacheSnapshotReads.yml
@@ -1,0 +1,80 @@
+SchemaVersion: 2018-07-01
+Owner: Replication
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 400
+
+GlobalDefaults:
+  CollectionCount: &CollectionCount 10
+  DocumentCount: &DocumentCount 100000
+  RandomRange: &RandomRange 1000   # DocumentCount / 100
+
+Actors:
+- Name: Loader
+  Type: Loader
+  Threads: 10
+  Phases:
+  - Repeat: 1
+    Database: &DB test
+    CollectionCount: *CollectionCount   # 100mb total
+    Threads: 10
+    DocumentCount: *DocumentCount   # 10mb / collection
+    BatchSize: 10000
+    Document:
+      x: &randomInt {^RandomInt: {min: 0, max: *RandomRange}}
+      y: 0
+      a: &randomString {^RandomString: {length: 100}}
+    Indexes:
+    - keys: {x: 1}
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: MultiCollectionUpdate
+  Type: MultiCollectionUpdate
+  Threads: 32
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 2000
+    MetricsName: Update
+    Database: *DB
+    CollectionCount: *CollectionCount
+    UpdateFilter: &update_filter {x: *randomInt}
+    Update: &update_operation {$inc: {y: 1}, $set: {x: *randomInt, a: *randomString}}
+  - *Nop
+  - Duration: &test_duration 2 minutes
+    MetricsName: Update-With-Scan
+    Database: *DB
+    CollectionCount: *CollectionCount
+    UpdateFilter: *update_filter
+    Update: *update_operation
+
+- Name: PointInTimeScanner
+  Type: CollectionScanner
+  Threads: 16
+  Database: *DB
+  Phases:
+  - *Nop
+  - &select_timestamp
+    Repeat: 1
+    selectClusterTimeOnly: true
+  - Duration: *test_duration
+    MetricsName: Scan-Current
+    ScanType: point-in-time
+  - *Nop
+  - Duration: *test_duration
+    MetricsName: Scan-History
+    ScanType: point-in-time
+  - Duration: *test_duration
+    MetricsName: Scan-History-With-Update
+    ScanType: point-in-time
+
+AutoRun:
+  Requires:
+    mongodb_setup: [replica-1dayhistory-15gbwtcache]

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -21,3 +21,4 @@ AutoRun:
     - single-replica
     - standalone
     - shard
+    - replica-1dayhistory-15gbwtcache

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -72,6 +72,7 @@ Actors:
   Phases:
   - {Nop: true}
   - Duration: 10 minutes
+    MetricsName: Update
     Database: *DB
     CollectionCount: *CollectionCount
     DocumentCount: *DocumentCount

--- a/src/workloads/scale/LargeScaleModel.yml
+++ b/src/workloads/scale/LargeScaleModel.yml
@@ -161,6 +161,7 @@ Actors:
   - {Nop: true}
   - {Nop: true}
   - Duration: *Duration
+    MetricsName: Update
     Database: *LongLivedDB
     CollectionCount: *LongLivedCollectionCount
     DocumentCount: *LongLivedDocumentCount

--- a/src/workloads/scale/LargeScaleParallel.yml
+++ b/src/workloads/scale/LargeScaleParallel.yml
@@ -26,6 +26,7 @@ Actors:
       Path: *PhasePath
       Key: Update
     Duration: &Duration 1 hour
+    MetricsName: Update
     GlobalRate: 10 per 1 millisecond  # Target is 10 operations on every millisecond.
 
 - Name: Query

--- a/src/workloads/scale/LargeScaleSerial.yml
+++ b/src/workloads/scale/LargeScaleSerial.yml
@@ -25,6 +25,7 @@ Actors:
       Path: *PhasePath
       Key: Update
     Duration: &Duration 1 hour
+    MetricsName: Update
     GlobalRate: 10 per 1 millisecond  # Target is 10 operations on every millisecond.
   - *Nop
   - *Nop

--- a/src/workloads/scale/OutOfCacheSnapshotReads.yml
+++ b/src/workloads/scale/OutOfCacheSnapshotReads.yml
@@ -63,7 +63,7 @@ Actors:
   - *Nop
   - &select_timestamp
     Repeat: 1
-    selectClusterTimeOnly: true
+    SelectClusterTimeOnly: true
   - Repeat: 1
     MetricsName: Scan-Current
     ScanType: point-in-time

--- a/src/workloads/scale/OutOfCacheSnapshotReads.yml
+++ b/src/workloads/scale/OutOfCacheSnapshotReads.yml
@@ -1,0 +1,80 @@
+SchemaVersion: 2018-07-01
+Owner: Replication
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 400
+
+GlobalDefaults:
+  CollectionCount: &CollectionCount 20
+  DocumentCount: &DocumentCount 1000000
+  RandomRange: &RandomRange 10000   # DocumentCount / 100
+
+Actors:
+- Name: Loader
+  Type: Loader
+  Threads: 20
+  Phases:
+  - Repeat: 1
+    Database: &DB test
+    CollectionCount: *CollectionCount   # 20gb total
+    Threads: 20
+    DocumentCount: *DocumentCount   # 1gb / collection
+    BatchSize: 10000
+    Document:
+      x: &randomInt {^RandomInt: {min: 0, max: *RandomRange}}
+      y: 0
+      a: &randomString {^RandomString: {length: 1000}}
+    Indexes:
+    - keys: {x: 1}
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: MultiCollectionUpdate
+  Type: MultiCollectionUpdate
+  Threads: 32
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 2000
+    MetricsName: Update
+    Database: *DB
+    CollectionCount: *CollectionCount
+    UpdateFilter: &update_filter {x: *randomInt}
+    Update: &update_operation {$inc: {y: 1}, $set: {x: *randomInt, a: *randomString}}
+  - *Nop
+  - Duration: &update_duration 10 minutes
+    MetricsName: Update-With-Scan
+    Database: *DB
+    CollectionCount: *CollectionCount
+    UpdateFilter: *update_filter
+    Update: *update_operation
+
+- Name: PointInTimeScanner
+  Type: CollectionScanner
+  Threads: 16
+  Database: *DB
+  Phases:
+  - *Nop
+  - &select_timestamp
+    Repeat: 1
+    selectClusterTimeOnly: true
+  - Repeat: 1
+    MetricsName: Scan-Current
+    ScanType: point-in-time
+  - *Nop
+  - Repeat: 1
+    MetricsName: Scan-History
+    ScanType: point-in-time
+  - Duration: *update_duration
+    MetricsName: Scan-History-With-Update
+    ScanType: point-in-time
+
+AutoRun:
+  Requires:
+    mongodb_setup: [replica-1dayhistory-15gbwtcache]


### PR DESCRIPTION
One of the phase (PointInTimeScanner-Scan-History) in the OutOfCacheSnapshotReads workload is pretty noisy at the moment (see the workload doc in the ticket). But I would like to open a PR first to have some feedbacks while I continue tuning some parameters for the workloads.
This PR extends the existing CollectionScanner actor to read at a point in time using {level: "snapshot", atClusterTime: <TS>}. Since the driver doesn't support reading at a point in time at the moment, I had to write my own find and getMore commands to do the scan.