### PR TITLE
TIG-2650 Use longer timeouts for generated tasks

### DIFF
--- a/src/python/gennylib/auto_tasks.py
+++ b/src/python/gennylib/auto_tasks.py
@@ -345,7 +345,14 @@ class ConfigWriter:
 
             t = c.task(task.name)
             t.priority(5)
-            t.commands([CommandDefinition().function("f_run_dsi_workload").vars(bootstrap)])
+            t.commands(
+                [
+                    CommandDefinition()
+                    .command("timeout.update")
+                    .params({"exec_timeout_secs": 86400, "timeout_secs": 7200}),  # 24 hours
+                    CommandDefinition().function("f_run_dsi_workload").vars(bootstrap),
+                ]
+            )
         return c
 
 

--- a/src/python/tests/auto_tasks_test.py
+++ b/src/python/tests/auto_tasks_test.py
@@ -78,6 +78,12 @@ class BaseTestClass(unittest.TestCase):
         self.assertEqual(op.output_file, to_file)
 
 
+TIMEOUT_COMMAND = {
+    "command": "timeout.update",
+    "params": {"exec_timeout_secs": 86400, "timeout_secs": 7200},
+}
+
+
 class AutoTasksTests(BaseTestClass):
     def test_all_tasks(self):
         self.assert_result(
@@ -88,19 +94,21 @@ class AutoTasksTests(BaseTestClass):
                     {
                         "name": "empty_unmodified",
                         "commands": [
+                            TIMEOUT_COMMAND,
                             {
                                 "func": "f_run_dsi_workload",
                                 "vars": {
                                     "test_control": "empty_unmodified",
                                     "auto_workload_path": "scale/EmptyUnmodified.yml",
                                 },
-                            }
+                            },
                         ],
                         "priority": 5,
                     },
                     {
                         "name": "multi_a",
                         "commands": [
+                            TIMEOUT_COMMAND,
                             {
                                 "func": "f_run_dsi_workload",
                                 "vars": {
@@ -108,13 +116,14 @@ class AutoTasksTests(BaseTestClass):
                                     "auto_workload_path": "src/Multi.yml",
                                     "mongodb_setup": "a",
                                 },
-                            }
+                            },
                         ],
                         "priority": 5,
                     },
                     {
                         "name": "multi_b",
                         "commands": [
+                            TIMEOUT_COMMAND,
                             {
                                 "func": "f_run_dsi_workload",
                                 "vars": {
@@ -122,7 +131,7 @@ class AutoTasksTests(BaseTestClass):
                                     "auto_workload_path": "src/Multi.yml",
                                     "mongodb_setup": "b",
                                 },
-                            }
+                            },
                         ],
                         "priority": 5,
                     },


### PR DESCRIPTION
https://spruce.mongodb.com/version/5f43e30a32f4171537ac59ee/tasks