### PR TITLE
TIG-2585 Add rate limit based on metrics feedback

### DIFF
--- a/src/canaries/benchmark/canaries_benchmark.cpp
+++ b/src/canaries/benchmark/canaries_benchmark.cpp
@@ -14,9 +14,9 @@
 
 #include <testlib/helpers.hpp>
 
+#include <iostream>
 #include <limits>
 #include <vector>
-#include <iostream>
 
 #include <boost/log/trivial.hpp>
 
@@ -34,7 +34,8 @@ using namespace genny::canaries;
  * programs. The CPU cache benchmarks are sensitive to context switching overhead.
  */
 TEST_CASE("Measure Phaseloop Overhead", "[benchmark]") {
-    std::vector<std::string> loopNames{"simple", "metrics", "phase", "real", "metrics-ftdc", "real-ftdc"};
+    std::vector<std::string> loopNames{
+        "simple", "metrics", "phase", "real", "metrics-ftdc", "real-ftdc"};
 
     auto printRes = [&](std::vector<Nanosecond>& loopTimings, std::string_view name) {
         BOOST_LOG_TRIVIAL(info) << "Total duration for " << name << ":";
@@ -79,7 +80,6 @@ TEST_CASE("Measure Phaseloop Overhead", "[benchmark]") {
         // Compare FTDC loops with metrics/real loops.
         REQUIRE((mf - m) * threshold < mf);
         REQUIRE((rf - r) * threshold < r);
-
     };
 
     SECTION("nop") {

--- a/src/canaries/src/Loops.cpp
+++ b/src/canaries/src/Loops.cpp
@@ -111,7 +111,7 @@ Nanosecond Loops<Task, Args...>::metricsLoop(Args&&... args) {
 template <class Task, class... Args>
 Nanosecond Loops<Task, Args...>::metricsFtdcLoop(Args&&... args) {
     boost::filesystem::path ph =
-            boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+        boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
     auto metricsPath = (ph / "genny-metrics").string();
     auto format = genny::metrics::MetricsFormat("ftdc");
 
@@ -183,7 +183,7 @@ Nanosecond Loops<Task, Args...>::metricsFtdcPhaseLoop(Args&&... args) {
     auto task = Task(std::forward<Args>(args)...);
 
     boost::filesystem::path ph =
-            boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+        boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
     auto metricsPath = (ph / "genny-metrics").string();
     auto format = genny::metrics::MetricsFormat("ftdc");
 

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -162,7 +162,7 @@ public:
                 }
                 break;
             }
-            _rateLimiter->addIter();
+            _rateLimiter->notifyOfIteration();
         }
     }
 

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -133,7 +133,8 @@ public:
                     "there's no guarantee the rate limited operation will run in the correct "
                     "phase");
             }
-            _rateLimiter = phaseContext.workload().getRateLimiter(rateLimiterName, rateSpec.value());
+            _rateLimiter =
+                phaseContext.workload().getRateLimiter(rateLimiterName, rateSpec.value());
         }
     }
 

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -152,6 +152,9 @@ public:
             if (auto pval = std::get_if<RateSpec>(&rateSpec)) {
                 _rateLimiter =
                     phaseContext.workload().getRateLimiter(rateLimiterName, (*pval));
+            } else if (auto pval = std::get_if<PercentileRateSpec>(&rateSpec)) {
+                _rateLimiter =
+                    phaseContext.workload().getRateLimiter(rateLimiterName, (*pval));
             }
         }
     }

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -117,7 +117,7 @@ public:
             throw InvalidConfigurationException(msg.str());
         }
 
-        const auto rateSpec = phaseContext["GlobalRate"].maybe<BaseRateSpec>();
+        const auto rateSpec = phaseContext["GlobalRate"].maybe<RateSpec>();
         const auto rateLimiterName =
             phaseContext["RateLimiterName"].maybe<std::string>().value_or("defaultRateLimiter");
 

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -181,6 +181,7 @@ public:
                 }
                 break;
             }
+            _rateLimiter->addIter();
         }
     }
 

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -25,8 +25,6 @@
 #include <unordered_map>
 #include <utility>
 #include <variant>
-#include <iostream>
-#include <iomanip>
 
 #include <boost/exception/exception.hpp>
 #include <boost/throw_exception.hpp>
@@ -124,12 +122,14 @@ public:
         // First treat as a RateSpec, then try as a PercentileRateSpec.
         try {
             auto optionalSpec = phaseContext["GlobalRate"].maybe<RateSpec>();
-            if (optionalSpec) rateSpec = optionalSpec.value();
+            if (optionalSpec)
+                rateSpec = optionalSpec.value();
         } catch (InvalidConfigurationException e) {
             try {
                 auto optionalSpec = phaseContext["GlobalRate"].maybe<PercentileRateSpec>();
-                if (optionalSpec) rateSpec = optionalSpec.value();
-            } catch(InvalidConfigurationException e2) {
+                if (optionalSpec)
+                    rateSpec = optionalSpec.value();
+            } catch (InvalidConfigurationException e2) {
                 throw e;
             }
         }
@@ -150,11 +150,9 @@ public:
                     "phase");
             }
             if (auto pval = std::get_if<RateSpec>(&rateSpec)) {
-                _rateLimiter =
-                    phaseContext.workload().getRateLimiter(rateLimiterName, (*pval));
+                _rateLimiter = phaseContext.workload().getRateLimiter(rateLimiterName, (*pval));
             } else if (auto pval = std::get_if<PercentileRateSpec>(&rateSpec)) {
-                _rateLimiter =
-                    phaseContext.workload().getRateLimiter(rateLimiterName, (*pval));
+                _rateLimiter = phaseContext.workload().getRateLimiter(rateLimiterName, (*pval));
             }
         }
     }

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -253,7 +253,7 @@ public:
      *
      * @private
      */
-    v1::GlobalRateLimiter* getRateLimiter(const std::string& name, const RateSpec& spec);
+    v1::GlobalRateLimiter* getRateLimiter(const std::string& name, const BaseRateSpec& spec);
 
     // Like above, but for percentile rates.
     v1::GlobalRateLimiter* getRateLimiter(const std::string& name, const PercentileRateSpec& spec);

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -253,10 +253,7 @@ public:
      *
      * @private
      */
-    v1::GlobalRateLimiter* getRateLimiter(const std::string& name, const BaseRateSpec& spec);
-
-    // Like above, but for percentile rates.
-    v1::GlobalRateLimiter* getRateLimiter(const std::string& name, const PercentileRateSpec& spec);
+    v1::GlobalRateLimiter* getRateLimiter(const std::string& name, const RateSpec& spec);
 
     metrics::Registry& getMetrics() {
         return _registry;

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -255,6 +255,9 @@ public:
      */
     v1::GlobalRateLimiter* getRateLimiter(const std::string& name, const RateSpec& spec);
 
+    // Like above, but for percentile rates.
+    v1::GlobalRateLimiter* getRateLimiter(const std::string& name, const PercentileRateSpec& spec);
+
     metrics::Registry& getMetrics() {
         return _registry;
     }

--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -475,6 +475,13 @@ struct convert<genny::PercentileRateSpec> {
         auto percentYaml = Load(strRepr.substr(0, percentPos));
         auto percent = percentYaml.as<genny::IntegerSpec>();
 
+        if (percent.value > 100) {
+            std::stringstream msg;
+            msg << "Invalid value for PercentileRateSpec field, integer cannot be greater than 100."
+                   " Saw: " << percent.value;
+            throw genny::InvalidConfigurationException(msg.str());
+        }
+
         rhs = genny::PercentileRateSpec(percent);
 
         return true;

--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -468,7 +468,8 @@ struct convert<genny::PercentileRateSpec> {
         if (percentPos == std::string::npos) {
             std::stringstream msg;
             msg << "Invalid value for PercentileRateSpec field, expected an integer followed by %."
-                   " Saw: " << strRepr;
+                   " Saw: "
+                << strRepr;
             throw genny::InvalidConfigurationException(msg.str());
         }
 
@@ -478,7 +479,8 @@ struct convert<genny::PercentileRateSpec> {
         if (percent.value > 100) {
             std::stringstream msg;
             msg << "Invalid value for PercentileRateSpec field, integer cannot be greater than 100."
-                   " Saw: " << percent.value;
+                   " Saw: "
+                << percent.value;
             throw genny::InvalidConfigurationException(msg.str());
         }
 

--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -115,21 +115,21 @@ inline bool operator==(const TimeSpec& lhs, const TimeSpec& rhs) {
 using Duration = typename TimeSpec::ValueT;
 
 /**
- * RateSpec defined as X operations per Y duration.
+ * BaseRateSpec defined as X operations per Y duration.
  */
-struct RateSpec {
-    RateSpec() = default;
-    ~RateSpec() = default;
+struct BaseRateSpec {
+    BaseRateSpec() = default;
+    ~BaseRateSpec() = default;
 
-    RateSpec(TimeSpec t, IntegerSpec i) : per{t.count()}, operations{i.value} {}
+    BaseRateSpec(TimeSpec t, IntegerSpec i) : per{t.count()}, operations{i.value} {}
 
     // Allow construction with integers for testing.
-    RateSpec(int64_t t, int64_t i) : per{t}, operations{i} {}
+    BaseRateSpec(int64_t t, int64_t i) : per{t}, operations{i} {}
     std::chrono::nanoseconds per;
     int64_t operations;
 };
 
-inline bool operator==(const RateSpec& lhs, const RateSpec& rhs) {
+inline bool operator==(const BaseRateSpec& lhs, const BaseRateSpec& rhs) {
     return (lhs.per == rhs.per) && (lhs.operations == rhs.operations);
 }
 
@@ -403,14 +403,14 @@ struct convert<genny::PhaseRangeSpec> {
  * The syntax is interpreted as operations per unit of time.
  */
 template <>
-struct convert<genny::RateSpec> {
-    static Node encode(const genny::RateSpec& rhs) {
+struct convert<genny::BaseRateSpec> {
+    static Node encode(const genny::BaseRateSpec& rhs) {
         std::stringstream msg;
         msg << rhs.operations << " per " << rhs.per.count() << " nanoseconds";
         return Node{msg.str()};
     }
 
-    static bool decode(const Node& node, genny::RateSpec& rhs) {
+    static bool decode(const Node& node, genny::BaseRateSpec& rhs) {
         if (node.IsSequence() || node.IsMap()) {
             return false;
         }
@@ -435,7 +435,7 @@ struct convert<genny::RateSpec> {
         auto timeUnitYaml = Load(strRepr.substr(spacePos + delimiter.size()));
         auto timeUnit = timeUnitYaml.as<genny::TimeSpec>();
 
-        rhs = genny::RateSpec(timeUnit, opCount);
+        rhs = genny::BaseRateSpec(timeUnit, opCount);
 
         return true;
     }

--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -578,9 +578,6 @@ struct convert<genny::RateSpec> {
         msg << "Invalid value for RateSpec field, expected a space separated integer and time unit,"
             << " or integer followed by %. Saw: " << strRepr;
         throw genny::InvalidConfigurationException(msg.str());
-
-        
-
     }
 };
 

--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -173,13 +173,13 @@ public:
 
     std::optional<PercentileRateSpec> getPercentileSpec() const {
         if (auto pval = std::get_if<PercentileRateSpec>(&_spec)) {
-                return *pval;
+            return *pval;
         } else {
             return std::nullopt;
         }
     }
 
-    inline bool operator==(const RateSpec& rhs) {
+    bool operator==(const RateSpec& rhs) {
         // Equality is well-behaved for variants if it is for their contents.
         return _spec == rhs._spec;
     }
@@ -516,7 +516,8 @@ struct convert<genny::PercentileRateSpec> {
 
         if (percent.value > 100) {
             std::stringstream msg;
-            msg << "Invalid value for PercentileRateSpec field, integer cannot be greater than 100."
+            msg << "Invalid value for PercentileRateSpec field, integer must be between 0 and 100, "
+                   "inclusive."
                    " Saw: "
                 << percent.value;
             throw genny::InvalidConfigurationException(msg.str());
@@ -566,13 +567,15 @@ struct convert<genny::RateSpec> {
             auto baseSpec = nodeYaml.as<genny::BaseRateSpec>();
             rhs = genny::RateSpec(baseSpec);
             return true;
-        } catch (genny::InvalidConfigurationException e) {}
+        } catch (genny::InvalidConfigurationException e) {
+        }
 
         try {
             auto percentileSpec = nodeYaml.as<genny::PercentileRateSpec>();
             rhs = genny::RateSpec(percentileSpec);
             return true;
-        } catch (genny::InvalidConfigurationException e) {}
+        } catch (genny::InvalidConfigurationException e) {
+        }
 
         std::stringstream msg;
         msg << "Invalid value for RateSpec field, expected a space separated integer and time unit,"
@@ -580,7 +583,6 @@ struct convert<genny::RateSpec> {
         throw genny::InvalidConfigurationException(msg.str());
     }
 };
-
 
 
 /**

--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -503,7 +503,7 @@ struct convert<genny::PercentileRateSpec> {
         const std::string delimiter = "%";
         auto percentPos = strRepr.find(delimiter);
 
-        if (percentPos == std::string::npos) {
+        if (percentPos == std::string::npos || percentPos != strRepr.size() - 1) {
             std::stringstream msg;
             msg << "Invalid value for PercentileRateSpec field, expected an integer followed by %."
                    " Saw: "

--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -151,6 +151,44 @@ inline bool operator==(const PercentileRateSpec& lhs, const PercentileRateSpec& 
     return (lhs.percent == rhs.percent);
 }
 
+/**
+ * RateSpec defined as either X operations per Y duration or Z% of max throughput each phase.
+ */
+class RateSpec {
+public:
+    RateSpec() = default;
+    ~RateSpec() = default;
+
+    RateSpec(BaseRateSpec s) : _spec{s} {}
+
+    RateSpec(PercentileRateSpec s) : _spec{s} {}
+
+    std::optional<BaseRateSpec> getBaseSpec() const {
+        if (auto pval = std::get_if<BaseRateSpec>(&_spec)) {
+            return *pval;
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    std::optional<PercentileRateSpec> getPercentileSpec() const {
+        if (auto pval = std::get_if<PercentileRateSpec>(&_spec)) {
+                return *pval;
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    inline bool operator==(const RateSpec& rhs) {
+        // Equality is well-behaved for variants if it is for their contents.
+        return _spec == rhs._spec;
+    }
+
+private:
+    std::variant<std::monostate, BaseRateSpec, PercentileRateSpec> _spec;
+};
+
+
 struct PhaseRangeSpec {
     PhaseRangeSpec() = default;
     ~PhaseRangeSpec() = default;
@@ -397,7 +435,7 @@ struct convert<genny::PhaseRangeSpec> {
 };
 
 /**
- * Convert between YAML and genny::RateSpec
+ * Convert between YAML and genny::BaseRateSpec
  *
  * The YAML syntax accepts [genny::Integer] per [genny::Time]
  * The syntax is interpreted as operations per unit of time.
@@ -489,6 +527,63 @@ struct convert<genny::PercentileRateSpec> {
         return true;
     }
 };
+
+/**
+ * Convert between YAML and genny::RateSpec
+ *
+ * The YAML syntax accepts either [genny::Integer] per [genny::Time]
+ * or [genny::Integer]%
+ *
+ * The syntax is interpreted as operations per unit of time or
+ * percentage of max throughput.
+ */
+template <>
+struct convert<genny::RateSpec> {
+    static Node encode(const genny::RateSpec& rhs) {
+        std::stringstream msg;
+
+        if (auto spec = rhs.getBaseSpec()) {
+            msg << spec->operations << " per " << spec->per.count() << " nanoseconds";
+        } else if (auto spec = rhs.getPercentileSpec()) {
+            msg << spec->percent << "%";
+        } else {
+            throw genny::InvalidConfigurationException("Cannot encode empty RateSpec.");
+        }
+
+        return Node{msg.str()};
+    }
+
+    static bool decode(const Node& node, genny::RateSpec& rhs) {
+        if (node.IsSequence() || node.IsMap()) {
+            return false;
+        }
+
+        auto strRepr = node.as<std::string>();
+        auto nodeYaml = Load(strRepr);
+
+        // First treat as a BaseRateSpec, then try as a PercentileRateSpec.
+        try {
+            auto baseSpec = nodeYaml.as<genny::BaseRateSpec>();
+            rhs = genny::RateSpec(baseSpec);
+            return true;
+        } catch (genny::InvalidConfigurationException e) {}
+
+        try {
+            auto percentileSpec = nodeYaml.as<genny::PercentileRateSpec>();
+            rhs = genny::RateSpec(percentileSpec);
+            return true;
+        } catch (genny::InvalidConfigurationException e) {}
+
+        std::stringstream msg;
+        msg << "Invalid value for RateSpec field, expected a space separated integer and time unit,"
+            << " or integer followed by %. Saw: " << strRepr;
+        throw genny::InvalidConfigurationException(msg.str());
+
+        
+
+    }
+};
+
 
 
 /**

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -89,12 +89,18 @@ public:
     bool consumeIfWithinRate(const typename ClockT::time_point& now) {
 
         // Logic for percentile rates.
-        if (_fullSpeed) {
+        bool curFullSpeed = _fullSpeed.load();
+        if (curFullSpeed) {
             _burstCount++;
             auto _nsSincePhase = ClockT::now().time_since_epoch().count() - _lastEmptiedTimeNS;
 
             // 3 iterations or 1 minute, whichever is longer.
             if (_iters >= _numUsers * 3 && _nsSincePhase >= _nsPerMinute) {
+                const auto success =
+                    _fullSpeed.compare_exchange_weak(curFullSpeed, false);
+                if (!success) {
+                    return true;
+                }
                 // Reconfigure as a "normal" rate limiter running for the first time.
                 _burstSize = _burstCount * _percent.value() / 100;
                 _rateNS = _nsSincePhase;
@@ -204,7 +210,7 @@ private:
     int64_t _burstSize;
     int64_t _rateNS;
     const std::optional<int64_t> _percent;
-    bool _fullSpeed;
+    std::atomic<bool> _fullSpeed;
 
     // Number of threads using this rate limiter.
     int64_t _numUsers = 0;

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -64,16 +64,16 @@ public:
 
 public:
     explicit BaseGlobalRateLimiter(const RateSpec& rs) {
-            if (auto spec = rs.getBaseSpec()) {
-                _burstSize = spec->operations;
-                _rateNS = spec->per.count();
-                _fullSpeed = false;
-            } else if (auto spec = rs.getPercentileSpec()) {
-                _burstSize = 0;
-                _rateNS = 0;
-                _percent = spec->percent;
-                _fullSpeed = true;
-            }
+        if (auto spec = rs.getBaseSpec()) {
+            _burstSize = spec->operations;
+            _rateNS = spec->per.count();
+            _fullSpeed = false;
+        } else if (auto spec = rs.getPercentileSpec()) {
+            _burstSize = 0;
+            _rateNS = 0;
+            _percent = spec->percent;
+            _fullSpeed = true;
+        }
     }
 
     // No copies or moves.
@@ -143,7 +143,7 @@ public:
         return success;
     }
 
-    
+
     constexpr int64_t getRate() const {
         return _rateNS;
     }
@@ -184,10 +184,9 @@ public:
     const int64_t _nsPerMinute = 60000000000;
 
 private:
-
     /**
-     * Logic for percentile rates. We "break in" the rate limiter for 1 minutes or 3 iterations, whichever is longer,
-     * to determine the limit to set.
+     * Logic for percentile rates. We "break in" the rate limiter for 1 minutes or 3 iterations,
+     * whichever is longer, to determine the limit to set.
      */
     std::optional<bool> isBreakin() {
         bool curFullSpeed = _fullSpeed.load();
@@ -200,8 +199,7 @@ private:
 
         // 3 iterations or 1 minute, whichever is longer.
         if (_iters >= _numUsers * 3 && nsSincePhaseStarted >= _nsPerMinute) {
-            const auto success =
-                _fullSpeed.compare_exchange_weak(curFullSpeed, false);
+            const auto success = _fullSpeed.compare_exchange_weak(curFullSpeed, false);
             if (!success) {
                 return true;
             }

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -99,10 +99,10 @@ public:
         bool curFullSpeed = _fullSpeed.load();
         if (curFullSpeed) {
             _burstCount++;
-            auto _nsSincePhase = ClockT::now().time_since_epoch().count() - _lastEmptiedTimeNS;
+            auto nsSincePhaseStarted = ClockT::now().time_since_epoch().count() - _lastEmptiedTimeNS;
 
             // 3 iterations or 1 minute, whichever is longer.
-            if (_iters >= _numUsers * 3 && _nsSincePhase >= _nsPerMinute) {
+            if (_iters >= _numUsers * 3 && nsSincePhaseStarted >= _nsPerMinute) {
                 const auto success =
                     _fullSpeed.compare_exchange_weak(curFullSpeed, false);
                 if (!success) {
@@ -110,7 +110,7 @@ public:
                 }
                 // Reconfigure as a "normal" rate limiter running for the first time.
                 _burstSize = _burstCount * _percent.value() / 100;
-                _rateNS = _nsSincePhase;
+                _rateNS = nsSincePhaseStarted;
                 _lastEmptiedTimeNS = ClockT::now().time_since_epoch().count() - _rateNS;
                 _burstCount = 0;
                 _fullSpeed = false;

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -92,7 +92,7 @@ public:
         if (_fullSpeed) {
             _burstCount++;
             auto _nsSincePhase = ClockT::now().time_since_epoch().count() - _lastEmptiedTimeNS;
-            
+
             // 3 iterations or 1 minute, whichever is longer.
             if (_iters >= _numUsers * 3 && _nsSincePhase >= _nsPerMinute) {
                 // Reconfigure as a "normal" rate limiter running for the first time.
@@ -102,7 +102,7 @@ public:
                 _burstCount = 0;
                 _fullSpeed = false;
             }
-            return true; 
+            return true;
         }
 
         // This if-block deviates from the "burst" behavior of the default token-bucket
@@ -187,6 +187,7 @@ public:
     }
 
     const int64_t _nsPerMinute = 60000000000;
+
 private:
     // Manually align _lastEmptiedTimeNS and _burstCount here to vastly improve performance.
     // Lazily initialized by the first call to consumeIfWithinRate().
@@ -204,7 +205,7 @@ private:
     int64_t _rateNS;
     const std::optional<int64_t> _percent;
     bool _fullSpeed;
-    
+
     // Number of threads using this rate limiter.
     int64_t _numUsers = 0;
 };

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -213,7 +213,7 @@ private:
 
     // Note that the rate limiter as-is doesn't use the burst size, but it is cleaner to
     // store the burst size and the rate together, since they're specified together in
-    // the YAML as BaseRateSpec.
+    // the YAML as RateSpec.
     int64_t _burstSize;
     int64_t _rateNS;
     std::optional<int64_t> _percent;

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -63,7 +63,7 @@ public:
                   "Clock representation must be nano seconds");
 
 public:
-    explicit BaseGlobalRateLimiter(const RateSpec& rs)
+    explicit BaseGlobalRateLimiter(const BaseRateSpec& rs)
         : _burstSize(rs.operations), _rateNS(rs.per.count()), _fullSpeed{false} {};
 
     explicit BaseGlobalRateLimiter(const PercentileRateSpec& rs)
@@ -206,7 +206,7 @@ private:
 
     // Note that the rate limiter as-is doesn't use the burst size, but it is cleaner to
     // store the burst size and the rate together, since they're specified together in
-    // the YAML as RateSpec.
+    // the YAML as BaseRateSpec.
     int64_t _burstSize;
     int64_t _rateNS;
     const std::optional<int64_t> _percent;

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -148,12 +148,17 @@ public:
         _numUsers++;
     }
 
+    void addIter() {
+        _iters++;
+    }
+
     /**
      * The rate limiter should be reset to allow one thread to run _burstSize number of times before
      * the start of each phase.
      */
     void resetLastEmptied() noexcept {
         _lastEmptiedTimeNS = ClockT::now().time_since_epoch().count() - _rateNS;
+        _iters = 0;
     }
 
 private:
@@ -163,6 +168,8 @@ private:
     alignas(BaseGlobalRateLimiter::CacheLineSize) std::atomic_int64_t _lastEmptiedTimeNS = 0;
     // _burstCount stores the remaining
     alignas(BaseGlobalRateLimiter::CacheLineSize) std::atomic_int64_t _burstCount = 0;
+    // number of iterations this phase
+    alignas(BaseGlobalRateLimiter::CacheLineSize) std::atomic_int64_t _iters = 0;
 
     // Note that the rate limiter as-is doesn't use the burst size, but it is cleaner to
     // store the burst size and the rate together, since they're specified together in

--- a/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
+++ b/src/gennylib/include/gennylib/v1/GlobalRateLimiter.hpp
@@ -183,7 +183,7 @@ public:
         _numUsers++;
     }
 
-    void addIter() {
+    void notifyOfIteration() {
         _iters++;
     }
 

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -119,6 +119,23 @@ v1::GlobalRateLimiter* WorkloadContext::getRateLimiter(const std::string& name,
     return rl;
 }
 
+v1::GlobalRateLimiter* WorkloadContext::getRateLimiter(const std::string& name,
+                                                       const PercentileRateSpec& spec) {
+    if (this->isDone()) {
+        BOOST_THROW_EXCEPTION(std::logic_error("Cannot create rate-limiters after setup"));
+    }
+    if (_rateLimiters.count(name) == 0) {
+        _rateLimiters.emplace(std::make_pair(name, std::make_unique<v1::GlobalRateLimiter>(spec)));
+    }
+    auto rl = _rateLimiters[name].get();
+    rl->addUser();
+
+    // Reset the rate-limiter at the start of every Phase
+    this->_orchestrator->addPrePhaseStartHook(
+        [rl](const Orchestrator*) { rl->resetLastEmptied(); });
+    return rl;
+}
+
 DefaultRandom& WorkloadContext::getRNGForThread(ActorId id) {
     if (this->isDone()) {
         BOOST_THROW_EXCEPTION(std::logic_error("Cannot create RNGs after setup"));

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -103,7 +103,7 @@ mongocxx::pool::entry WorkloadContext::client(const std::string& name, size_t in
 }
 
 v1::GlobalRateLimiter* WorkloadContext::getRateLimiter(const std::string& name,
-                                                       const RateSpec& spec) {
+                                                       const BaseRateSpec& spec) {
     if (this->isDone()) {
         BOOST_THROW_EXCEPTION(std::logic_error("Cannot create rate-limiters after setup"));
     }

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -105,7 +105,7 @@ mongocxx::pool::entry WorkloadContext::client(const std::string& name, size_t in
 v1::GlobalRateLimiter* WorkloadContext::getRateLimiter(const std::string& name,
                                                        const RateSpec& spec) {
     if (this->isDone()) {
-        BOOST_THROW_EXCEPTION(std::logic_error("Cannot create rate-limiters after setup"));
+        BOOST_THROW_EXCEPTION(std::logic_error("Cannot create rate-limiters after setup. Name tried: " + name));
     }
     if (_rateLimiters.count(name) == 0) {
         _rateLimiters.emplace(std::make_pair(name, std::make_unique<v1::GlobalRateLimiter>(spec)));

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -105,7 +105,8 @@ mongocxx::pool::entry WorkloadContext::client(const std::string& name, size_t in
 v1::GlobalRateLimiter* WorkloadContext::getRateLimiter(const std::string& name,
                                                        const RateSpec& spec) {
     if (this->isDone()) {
-        BOOST_THROW_EXCEPTION(std::logic_error("Cannot create rate-limiters after setup. Name tried: " + name));
+        BOOST_THROW_EXCEPTION(
+            std::logic_error("Cannot create rate-limiters after setup. Name tried: " + name));
     }
     if (_rateLimiters.count(name) == 0) {
         _rateLimiters.emplace(std::make_pair(name, std::make_unique<v1::GlobalRateLimiter>(spec)));

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -103,7 +103,7 @@ mongocxx::pool::entry WorkloadContext::client(const std::string& name, size_t in
 }
 
 v1::GlobalRateLimiter* WorkloadContext::getRateLimiter(const std::string& name,
-                                                       const BaseRateSpec& spec) {
+                                                       const RateSpec& spec) {
     if (this->isDone()) {
         BOOST_THROW_EXCEPTION(std::logic_error("Cannot create rate-limiters after setup"));
     }
@@ -119,22 +119,6 @@ v1::GlobalRateLimiter* WorkloadContext::getRateLimiter(const std::string& name,
     return rl;
 }
 
-v1::GlobalRateLimiter* WorkloadContext::getRateLimiter(const std::string& name,
-                                                       const PercentileRateSpec& spec) {
-    if (this->isDone()) {
-        BOOST_THROW_EXCEPTION(std::logic_error("Cannot create rate-limiters after setup"));
-    }
-    if (_rateLimiters.count(name) == 0) {
-        _rateLimiters.emplace(std::make_pair(name, std::make_unique<v1::GlobalRateLimiter>(spec)));
-    }
-    auto rl = _rateLimiters[name].get();
-    rl->addUser();
-
-    // Reset the rate-limiter at the start of every Phase
-    this->_orchestrator->addPrePhaseStartHook(
-        [rl](const Orchestrator*) { rl->resetLastEmptied(); });
-    return rl;
-}
 
 DefaultRandom& WorkloadContext::getRNGForThread(ActorId id) {
     if (this->isDone()) {

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -84,7 +84,7 @@ TEST_CASE("Percentile rate limiting") {
     struct DummyTemplateValue {};
     using MyDummyClock = DummyClock<DummyTemplateValue>;
 
-    const int64_t percent = 50; // 50%
+    const int64_t percent = 50;  // 50%
     const PercentileRateSpec rs{percent};
     v1::BaseGlobalRateLimiter<MyDummyClock> grl{rs};
     grl.addUser();
@@ -93,7 +93,8 @@ TEST_CASE("Percentile rate limiting") {
         grl.resetLastEmptied();
         auto now = MyDummyClock::now();
 
-        // consumeIfWithinRate() should succeed because we allow as many ops as desired until limiting.
+        // consumeIfWithinRate() should succeed because we allow as many ops as desired until
+        // limiting.
         for (int i = 0; i < 9; i++) {
             REQUIRE(grl.consumeIfWithinRate(now));
             grl.addIter();

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -97,7 +97,7 @@ TEST_CASE("Percentile rate limiting") {
         // limiting.
         for (int i = 0; i < 9; i++) {
             REQUIRE(grl.consumeIfWithinRate(now));
-            grl.addIter();
+            grl.notifyOfIteration();
         }
 
         // Increment the clock by a minute.
@@ -124,7 +124,7 @@ TEST_CASE("Percentile rate limiting") {
         now = MyDummyClock::now();
         for (int i = 0; i < 10; i++) {
             REQUIRE(grl.consumeIfWithinRate(now));
-            grl.addIter();
+            grl.notifyOfIteration();
         }
     }
 }

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -80,6 +80,54 @@ TEST_CASE("Global rate limiter") {
     }
 }
 
+TEST_CASE("Percentile rate limiting") {
+    struct DummyTemplateValue {};
+    using MyDummyClock = DummyClock<DummyTemplateValue>;
+
+    const int64_t percent = 50; // 50%
+    const PercentileRateSpec rs{percent};
+    v1::BaseGlobalRateLimiter<MyDummyClock> grl{rs};
+    grl.addUser();
+
+    SECTION("Limits Rate") {
+        grl.resetLastEmptied();
+        auto now = MyDummyClock::now();
+
+        // consumeIfWithinRate() should succeed because we allow as many ops as desired until limiting.
+        for (int i = 0; i < 9; i++) {
+            REQUIRE(grl.consumeIfWithinRate(now));
+            grl.addIter();
+        }
+
+        // Increment the clock by a minute.
+        MyDummyClock::nowRaw += grl._nsPerMinute;
+        // Tenth call sets the rate limit.
+        REQUIRE(grl.consumeIfWithinRate(now));
+        // Now we should only be able to call exactly half as many times.
+        now = MyDummyClock::now();
+        for (int i = 0; i < 5; i++) {
+            REQUIRE(grl.consumeIfWithinRate(now));
+        }
+        REQUIRE(!grl.consumeIfWithinRate(now));
+
+        // Then it works again a minute later.
+        MyDummyClock::nowRaw += grl._nsPerMinute;
+        now = MyDummyClock::now();
+        for (int i = 0; i < 5; i++) {
+            REQUIRE(grl.consumeIfWithinRate(now));
+        }
+        REQUIRE(!grl.consumeIfWithinRate(now));
+
+        // Then starting a new phase clears the limit.
+        grl.resetLastEmptied();
+        now = MyDummyClock::now();
+        for (int i = 0; i < 10; i++) {
+            REQUIRE(grl.consumeIfWithinRate(now));
+            grl.addIter();
+        }
+    }
+}
+
 
 class IncActor : public Actor {
 public:

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Global rate limiter") {
 
     const int64_t per = 3;
     const int64_t burst = 2;
-    const RateSpec rs{per, burst};  // 2 operations per 3 ticks.
+    const BaseRateSpec rs{per, burst};  // 2 operations per 3 ticks.
     v1::BaseGlobalRateLimiter<MyDummyClock> grl{rs};
 
     SECTION("Limits Rate") {

--- a/src/gennylib/test/conventions_test.cpp
+++ b/src/gennylib/test/conventions_test.cpp
@@ -176,6 +176,7 @@ TEST_CASE("genny::PercentileRateSpec conversions") {
         REQUIRE_THROWS(YAML::Load("%").as<PercentileRateSpec>());
         REQUIRE_THROWS(YAML::Load("%15").as<PercentileRateSpec>());
         REQUIRE_THROWS(YAML::Load("28.999%").as<RateSpec>());
+        REQUIRE_THROWS(YAML::Load("28.999%").as<RateSpec>());
         REQUIRE_THROWS(YAML::Load("").as<RateSpec>());
     }
 

--- a/src/gennylib/test/conventions_test.cpp
+++ b/src/gennylib/test/conventions_test.cpp
@@ -158,15 +158,9 @@ TEST_CASE("genny::RateSpec conversions") {
 
 TEST_CASE("genny::PercentileRateSpec conversions") {
     SECTION("Can convert to genny::PercentileRateSpec") {
-        REQUIRE(YAML::Load("GlobalRate: 50%")["GlobalRate"]
-                    .as<PercentileRateSpec>()
-                    .percent == 50);
-        REQUIRE(YAML::Load("GlobalRate: 78%")["GlobalRate"]
-                    .as<PercentileRateSpec>()
-                    .percent == 78);
-        REQUIRE(YAML::Load("GlobalRate: 5%")["GlobalRate"]
-                    .as<PercentileRateSpec>()
-                    .percent == 5);
+        REQUIRE(YAML::Load("GlobalRate: 50%")["GlobalRate"].as<PercentileRateSpec>().percent == 50);
+        REQUIRE(YAML::Load("GlobalRate: 78%")["GlobalRate"].as<PercentileRateSpec>().percent == 78);
+        REQUIRE(YAML::Load("GlobalRate: 5%")["GlobalRate"].as<PercentileRateSpec>().percent == 5);
     }
 
     SECTION("Barfs on invalid values") {

--- a/src/gennylib/test/conventions_test.cpp
+++ b/src/gennylib/test/conventions_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Conventions used by PhaseLoop") {
     REQUIRE(*(phaseContext["Repeat"].maybe<IntegerSpec>()) == IntegerSpec{1});
     REQUIRE(phaseContext["SleepBefore"].maybe<TimeSpec>().value_or(TimeSpec{33}) == TimeSpec{33});
     REQUIRE(phaseContext["SleepAfter"].maybe<TimeSpec>().value_or(TimeSpec{33}) == TimeSpec{33});
-    REQUIRE(phaseContext["Rate"].maybe<RateSpec>() == std::nullopt);
+    REQUIRE(phaseContext["Rate"].maybe<BaseRateSpec>() == std::nullopt);
     REQUIRE(phaseContext["RateLimiterName"].maybe<std::string>().value_or("defaultRateLimiter") ==
             "defaultRateLimiter");
 };
@@ -125,34 +125,34 @@ TEST_CASE("genny::IntegerSpec conversions") {
     }
 }
 
-TEST_CASE("genny::RateSpec conversions") {
-    SECTION("Can convert to genny::RateSpec") {
+TEST_CASE("genny::BaseRateSpec conversions") {
+    SECTION("Can convert to genny::BaseRateSpec") {
         REQUIRE(YAML::Load("GlobalRate: 300 per 2 nanoseconds")["GlobalRate"]
-                    .as<RateSpec>()
+                    .as<BaseRateSpec>()
                     .operations == 300);
         REQUIRE(YAML::Load("GlobalRate: 300 per 2 nanoseconds")["GlobalRate"]
-                    .as<RateSpec>()
+                    .as<BaseRateSpec>()
                     .per.count() == 2);
     }
 
     SECTION("Barfs on invalid values") {
-        REQUIRE_THROWS(YAML::Load("-1 per -1 nanosecond").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("-1 per -1 nanosecond").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("1 pe 1000 nanoseconds").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("per").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("nanoseconds per 1").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("1per2second").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("0per").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("xper").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("{foo}").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("").as<RateSpec>());
+        REQUIRE_THROWS(YAML::Load("-1 per -1 nanosecond").as<BaseRateSpec>());
+        REQUIRE_THROWS(YAML::Load("-1 per -1 nanosecond").as<BaseRateSpec>());
+        REQUIRE_THROWS(YAML::Load("1 pe 1000 nanoseconds").as<BaseRateSpec>());
+        REQUIRE_THROWS(YAML::Load("per").as<BaseRateSpec>());
+        REQUIRE_THROWS(YAML::Load("nanoseconds per 1").as<BaseRateSpec>());
+        REQUIRE_THROWS(YAML::Load("1per2second").as<BaseRateSpec>());
+        REQUIRE_THROWS(YAML::Load("0per").as<BaseRateSpec>());
+        REQUIRE_THROWS(YAML::Load("xper").as<BaseRateSpec>());
+        REQUIRE_THROWS(YAML::Load("{foo}").as<BaseRateSpec>());
+        REQUIRE_THROWS(YAML::Load("").as<BaseRateSpec>());
     }
 
     SECTION("Can encode") {
         YAML::Node n;
-        n["GlobalRate"] = RateSpec{20, 30};
-        REQUIRE(n["GlobalRate"].as<RateSpec>().per.count() == 20);
-        REQUIRE(n["GlobalRate"].as<RateSpec>().operations == 30);
+        n["GlobalRate"] = BaseRateSpec{20, 30};
+        REQUIRE(n["GlobalRate"].as<BaseRateSpec>().per.count() == 20);
+        REQUIRE(n["GlobalRate"].as<BaseRateSpec>().operations == 30);
     }
 }
 
@@ -169,9 +169,9 @@ TEST_CASE("genny::PercentileRateSpec conversions") {
         REQUIRE_THROWS(YAML::Load("300 per 2 nanoseconds").as<PercentileRateSpec>());
         REQUIRE_THROWS(YAML::Load("%").as<PercentileRateSpec>());
         REQUIRE_THROWS(YAML::Load("%15").as<PercentileRateSpec>());
-        REQUIRE_THROWS(YAML::Load("28.999%").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("28.999%").as<RateSpec>());
-        REQUIRE_THROWS(YAML::Load("").as<RateSpec>());
+        REQUIRE_THROWS(YAML::Load("28.999%").as<PercentileRateSpec>());
+        REQUIRE_THROWS(YAML::Load("28.999%").as<PercentileRateSpec>());
+        REQUIRE_THROWS(YAML::Load("").as<PercentileRateSpec>());
     }
 
     SECTION("Can encode") {

--- a/src/gennylib/test/conventions_test.cpp
+++ b/src/gennylib/test/conventions_test.cpp
@@ -156,6 +156,37 @@ TEST_CASE("genny::RateSpec conversions") {
     }
 }
 
+TEST_CASE("genny::PercentileRateSpec conversions") {
+    SECTION("Can convert to genny::PercentileRateSpec") {
+        REQUIRE(YAML::Load("GlobalRate: 50%")["GlobalRate"]
+                    .as<PercentileRateSpec>()
+                    .percent == 50);
+        REQUIRE(YAML::Load("GlobalRate: 78%")["GlobalRate"]
+                    .as<PercentileRateSpec>()
+                    .percent == 78);
+        REQUIRE(YAML::Load("GlobalRate: 5%")["GlobalRate"]
+                    .as<PercentileRateSpec>()
+                    .percent == 5);
+    }
+
+    SECTION("Barfs on invalid values") {
+        REQUIRE_THROWS(YAML::Load("-1%").as<PercentileRateSpec>());
+        REQUIRE_THROWS(YAML::Load("2899").as<PercentileRateSpec>());
+        REQUIRE_THROWS(YAML::Load("300 per 2 nanoseconds").as<PercentileRateSpec>());
+        REQUIRE_THROWS(YAML::Load("%").as<PercentileRateSpec>());
+        REQUIRE_THROWS(YAML::Load("%15").as<PercentileRateSpec>());
+        REQUIRE_THROWS(YAML::Load("28.999%").as<RateSpec>());
+        REQUIRE_THROWS(YAML::Load("").as<RateSpec>());
+    }
+
+    SECTION("Can encode") {
+        YAML::Node n;
+        n["GlobalRate"] = PercentileRateSpec{25};
+        REQUIRE(n["GlobalRate"].as<PercentileRateSpec>().percent == 25);
+    }
+}
+
+
 TEST_CASE("genny::PhaseRangeSpec conversions") {
     SECTION("Can convert to genny::PhaseRangeSpec") {
         auto yaml = YAML::Load("Phase: 0..20");

--- a/src/gennylib/test/conventions_test.cpp
+++ b/src/gennylib/test/conventions_test.cpp
@@ -184,16 +184,22 @@ TEST_CASE("genny::PercentileRateSpec conversions") {
 TEST_CASE("genny::RateSpec conversions") {
     SECTION("Can convert to genny::RateSpec") {
         REQUIRE(YAML::Load("GlobalRate: 25 per 5 seconds")["GlobalRate"]
-                    .as<RateSpec>().getBaseSpec()->operations == 25);
+                    .as<RateSpec>()
+                    .getBaseSpec()
+                    ->operations == 25);
         REQUIRE(YAML::Load("GlobalRate: 25 per 5 seconds")["GlobalRate"]
-                    .as<RateSpec>().getBaseSpec()->per.count() == 5000000000);
+                    .as<RateSpec>()
+                    .getBaseSpec()
+                    ->per.count() == 5000000000);
         REQUIRE_FALSE(YAML::Load("GlobalRate: 25 per 5 seconds")["GlobalRate"]
-                    .as<RateSpec>().getPercentileSpec());
+                          .as<RateSpec>()
+                          .getPercentileSpec());
 
         REQUIRE(YAML::Load("GlobalRate: 30%")["GlobalRate"]
-                    .as<RateSpec>().getPercentileSpec()->percent == 30);
-        REQUIRE_FALSE(YAML::Load("GlobalRate: 30%")["GlobalRate"]
-                    .as<RateSpec>().getBaseSpec());
+                    .as<RateSpec>()
+                    .getPercentileSpec()
+                    ->percent == 30);
+        REQUIRE_FALSE(YAML::Load("GlobalRate: 30%")["GlobalRate"].as<RateSpec>().getBaseSpec());
     }
 
     SECTION("Barfs on invalid values") {

--- a/src/gennylib/test/conventions_test.cpp
+++ b/src/gennylib/test/conventions_test.cpp
@@ -207,14 +207,14 @@ TEST_CASE("genny::RateSpec conversions") {
     SECTION("Can encode") {
         auto base = BaseRateSpec{20, 30};
         YAML::Node n1;
-        n["GlobalRate"] = RateSpec{base};
-        REQUIRE(n["GlobalRate"].as<RateSpec>().getBaseSpec()->per.count() == 20);
-        REQUIRE(n["GlobalRate"].as<RateSpec>().getBaseSpec()->operations == 30);
+        n1["GlobalRate"] = RateSpec{base};
+        REQUIRE(n1["GlobalRate"].as<RateSpec>().getBaseSpec()->per.count() == 20);
+        REQUIRE(n1["GlobalRate"].as<RateSpec>().getBaseSpec()->operations == 30);
 
         auto percentile = PercentileRateSpec{75};
         YAML::Node n2;
         n2["GlobalRate"] = RateSpec{percentile};
-        REQUIRE(n["GlobalRate"].as<RateSpec>().getPercentileSpec()->percent == 75);
+        REQUIRE(n2["GlobalRate"].as<RateSpec>().getPercentileSpec()->percent == 75);
     }
 }
 

--- a/src/workloads/docs/HelloWorld.yml
+++ b/src/workloads/docs/HelloWorld.yml
@@ -14,6 +14,10 @@ Actors:
     # MetricsName: 🐳Message
   - Message: Hello Phase 1 👬
     Repeat: 100
+    # To limit the throughput to a percentage of the max, specify global rate as a percent.
+    # This will run at max throughput for 1 minute or 3 iterations, whichever is longer,
+    # then limit to a fraction of that for the rest of the phase.
+    # GlobalRate: 80%
   - ExternalPhaseConfig:
       Path: ../../phases/HelloWorld/ExamplePhase2.yml
       Key: UseMe  # Only load the YAML structure from this top-level key.


### PR DESCRIPTION
Had a bit of difficulty managing the complexity of a rate being either a percent or the existing format, any thoughts on a way to improve that are welcome. I'd considered having the `RateSpec` be complicated enough to enclose both forms, but wasn't sure if we wanted those convention primitives to be that smart.

Patch running Insert-Remove for twice as long with a 50% rate limit: https://evergreen.mongodb.com/version/5f87a5152a60ed65c96234f6