### PR TITLE
TIG-2773 Add throw to prevent false-positive warning

### DIFF
--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -76,6 +76,7 @@ public:
             case Format::kCsvFtdc:
                 return "csv-ftdc";
         }
+        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Impossible"));
     }
 
 private:


### PR DESCRIPTION
Older compilers don't see that the `case` statements are exhaustive.