### PR TITLE
PERF-2061 Remove references of geoHaystackIndex from workloads testcases

### DIFF
--- a/src/phases/execution/CreateIndexPhase.yml
+++ b/src/phases/execution/CreateIndexPhase.yml
@@ -78,27 +78,6 @@ Create2dSphereGeoJsonIndexesCmd:
       dropIndexes: Collection0
       index: 2dsphereGeoJsonIndex
 
-CreateGeoHaystackIndexesCmd:
-  Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
-  Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}
-  Database: *db
-  Operations:
-  - OperationMetricsName: CreateGeoHaystackIndexesCmd
-    OperationName: RunCommand
-    OperationCommand:
-      createIndexes: Collection0
-      indexes:
-      - key:
-          loc2d: "geoHaystack"
-          randomString: 1
-        bucketSize: 5
-        name: geoHaystackIndex
-  - OperationMetricsName: DropCreatedGeoHaystackIndexesCmd
-    OperationName: RunCommand
-    OperationCommand:
-      dropIndexes: Collection0
-      index: geoHaystackIndex
-
 CreateHashedIndexesCmd:
   Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
   Duration: {^Parameter: {Name: "Duration", Default: 60 seconds}}

--- a/src/workloads/execution/CreateIndex.yml
+++ b/src/workloads/execution/CreateIndex.yml
@@ -16,7 +16,6 @@ Actors:
   - *Nop
   - *Nop
   - *Nop
-  - *Nop
 
 - Name: IndexCollection
   Type: RunCommand
@@ -36,11 +35,6 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/execution/CreateIndexPhase.yml
       Key: Create2dSphereGeoJsonIndexesCmd
-      Parameters:
-        Repeat: 5
-  - ExternalPhaseConfig:
-      Path: ../../phases/execution/CreateIndexPhase.yml
-      Key: CreateGeoHaystackIndexesCmd
       Parameters:
         Repeat: 5
   - ExternalPhaseConfig:

--- a/src/workloads/execution/CreateIndexSharded.yml
+++ b/src/workloads/execution/CreateIndexSharded.yml
@@ -21,7 +21,6 @@ Actors:
   - *Nop
   - *Nop
   - *Nop
-  - *Nop
 
 - Name: ShardCollection
   Type: AdminCommand
@@ -44,7 +43,6 @@ Actors:
   - *Nop
   - *Nop
   - *Nop
-  - *Nop
 
 - Name: InsertData
   Type: Loader
@@ -57,7 +55,6 @@ Actors:
       Key: InsertData
       Parameters:
         db: *db
-  - *Nop
   - *Nop
   - *Nop
   - *Nop
@@ -85,11 +82,6 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/execution/CreateIndexPhase.yml
       Key: Create2dSphereGeoJsonIndexesCmd
-      Parameters:
-        Duration: 5 minutes
-  - ExternalPhaseConfig:
-      Path: ../../phases/execution/CreateIndexPhase.yml
-      Key: CreateGeoHaystackIndexesCmd
       Parameters:
         Duration: 5 minutes
   - ExternalPhaseConfig:


### PR DESCRIPTION
Evergreen: https://spruce.mongodb.com/version/5fb2daa50ae6060498b51321/tasks (the failures are not relevant; create_index_sharded failing on a standalone/repl set is expected).

This is my proposed fix for https://jira.mongodb.org/browse/PERF-2061. Another way to handle this would be to allow for geoHaystack indexes to only be created when running against version 4.4 or below, but a recent thread on slack seems to suggest that this isn't possible at the moment.