### PR TITLE
TIG-2781 Reduce metrics buffer size

### DIFF
--- a/src/lamplib/tasks/download.py
+++ b/src/lamplib/tasks/download.py
@@ -220,7 +220,7 @@ class CuratorDownloader(Downloader):
 
     # Note that DSI also downloads Curator, the location is specified in defaults.yml.
     # Please try to keep the two versions consistent.
-    CURATOR_VERSION = "8b3ef73c55fdc45ef78383b0dcd4a84335b8eecb"
+    CURATOR_VERSION = "d3da25b63141aa192c5ef51b7d4f34e2f3fc3880"
     CURATOR_ROOT = os.getcwd()
 
     def __init__(self, os_family, distro):

--- a/src/metrics/include/metrics/v2/event.hpp
+++ b/src/metrics/include/metrics/v2/event.hpp
@@ -344,11 +344,11 @@ public:
 private:
     void run() {
         while (!_finishing) {
-            reapActor();
             std::unique_lock<std::mutex> lk(_cvLock);
             // We sleep for performance reasons, not correctness, so we don't need to
             // guard against spurious wakeups.
             _cv.wait_for(lk, std::chrono::milliseconds(GRPC_THREAD_SLEEP_MS));
+            reapActor();
         }
 
         // Drain buffer and finish.

--- a/src/metrics/test/metrics_test.cpp
+++ b/src/metrics/test/metrics_test.cpp
@@ -830,12 +830,10 @@ TEST_CASE("Events stream to gRPC") {
             OutcomeType::kSuccess                                           // outcome
         );
 
-        metricsBuffer.addAt(endTime, event, 1);
-        REQUIRE_FALSE(metricsBuffer.pop(false));
-        metricsBuffer.addAt(endTime, event, 1);
-        REQUIRE_FALSE(metricsBuffer.pop(false));
-        metricsBuffer.addAt(endTime, event, 1);
-        REQUIRE_FALSE(metricsBuffer.pop(false));
+        for (int i = 0; i < 6; i++) {
+            metricsBuffer.addAt(endTime, event, 1);
+            REQUIRE_FALSE(metricsBuffer.pop(false));
+        }
         metricsBuffer.addAt(endTime, event, 1);
         REQUIRE(metricsBuffer.pop(false));
     }


### PR DESCRIPTION
Previously the buffer would only start draining when it reached 25% capacity, requiring the buffer to be 4x larger than we need just to be safe. This PR greatly increases the grpc thread sleep and adds an actor-thread-side check of when the buffer is almost full, to then wake the grpc thread.

In most workloads the buffer drain is probably going to be determined by the actor thread check, but the grpc-side wakeup and check may still be used by workloads like `large_scale_model`.

[Patch](https://evergreen.mongodb.com/version/5fb5ae13a4cf4723df226a62) running `large_scale_model` and `mixed_workloads_genny` along with the poplar changes, showing similar `mixed_workloads_genny` throughput to a [patch](https://evergreen.mongodb.com/version/5fb54dd1a4cf4723df1e6330) with the current master (biggest difference I could find was 1%, which is probably noise).

When [poplar#61](https://github.com/evergreen-ci/poplar/pull/61) is merged and revendored into curator I'll update this with the revendored curator.