### PR TITLE
WT-6697 Refactor existing LSWA workload into separate YAML files

### DIFF
--- a/src/phases/scale/LargeScalePhases.yml
+++ b/src/phases/scale/LargeScalePhases.yml
@@ -39,12 +39,12 @@ GlobalDefaults:
     - keys: {h: 1, i: 1}
 
   # Commonly used parameters.
-  DatabaseParam: &DatabaseParam {^Parameter: {Name: "Database", Default: db}}
-  CollectionCountParam: &CollectionCountParam {^Parameter: {Name: "CollectionCount", Default: 0}}
-  TrackProportionParam: &TrackProportionParam {^Parameter: {Name: "TrackProportion", Default: 0}}
-  DocumentCountParam: &DocumentCountParam {^Parameter: {Name: "DocumentCount", Default: 0}}
-  WritesParam: &WritesParam {^Parameter: {Name: "Writes", Default: 0}}
-  ReadsParam: &ReadsParam {^Parameter: {Name: "Reads", Default: 0}}
+  DatabaseParam: &DatabaseParam {^Parameter: {Name: "Database", Default: ""}}
+  CollectionCountParam: &CollectionCountParam {^Parameter: {Name: "CollectionCount", Default: -1}}
+  TrackProportionParam: &TrackProportionParam {^Parameter: {Name: "TrackProportion", Default: -1}}
+  DocumentCountParam: &DocumentCountParam {^Parameter: {Name: "DocumentCount", Default: -1}}
+  WritesParam: &WritesParam {^Parameter: {Name: "Writes", Default: -1}}
+  ReadsParam: &ReadsParam {^Parameter: {Name: "Reads", Default: -1}}
 
 LongLivedCreatorCmd:
   Repeat: 1

--- a/src/phases/scale/LargeScalePhases.yml
+++ b/src/phases/scale/LargeScalePhases.yml
@@ -1,7 +1,12 @@
 PhaseSchemaVersion: 2018-07-01
 Owner: Storage Engines
 
-# This section contains shared definitions that are used in the workload.
+# This is the set of shared phases for the Large Scale Workload Automation project.
+#
+# Since the LSWA workloads contain common phases, they've been separated in this phase file and can
+# be included in each workload as needed via the `ExternalPhaseConfig` functionality.
+
+# This section contains definitions that are used in the following phases.
 GlobalDefaults:
   Random10KInt: &rand_10k_int {^RandomInt: {min: 0, max: 10000}}
   Random10KInt: &rand_1k_int {^RandomInt: {min: 0, max: 1000}}

--- a/src/phases/scale/LargeScalePhases.yml
+++ b/src/phases/scale/LargeScalePhases.yml
@@ -10,46 +10,6 @@ GlobalDefaults:
   Random130String: &rand_100b_string {^RandomString: {length: 100}}
 
   Duration: &Duration 12 hours
-  TrackProportion: &TrackProportion 0
-
-  LongLivedDB: &LongLivedDB longlived  # name of the long lived database
-  LongLivedDocumentCount: &LongLivedDocumentCount 1000
-  LongLivedCollectionCount: &LongLivedCollectionCount 1000
-
-  RollingDB: &RollingDB rolling
-
-  # Note: if HotCollectionDB and HotDocumentDB reference the same
-  # database name, only one of their loaders should be enabled.
-  HotCollectionDB: &HotCollectionDB hotcoll
-  HotDocumentDB: &HotDocumentDB hotdoc
-
-  ScannerColdDB: &ScannerColdDB scancold
-  ScannerHotDB: &ScannerHotDB rolling
-
-  # Set to how many gigabytes we want the "cold" database to be.
-  # This database is initially created, but not used for anything,
-  # except for the snapshot scanner that scans all databases.
-  # We expect this to be larger than the amount of physical memory,
-  # so that we'll displace lots of hot data in the cache.
-  # CHANGE: the spec says 10TB of live data (total in all databases).
-  ScannerColdDBGigabytes: &ScannerColdDBGigabytes 150
-
-  # This list is used to scan all databases. By putting first the hot databases,
-  # which have high concentrations of updates, we'll be referencing more
-  # and "older" updates. That should stress the WiredTiger version history.
-  AllDB: &AllDB hotdoc,hotcoll,rolling,longlived,scancold
-
-  # According to the design, the number of writes should add up to 10K second.
-  LongLivedWrites: &LongLivedWrites 600 per 1 second          #  x5 threads
-  RollingWrites: &RollingWrites 1000 per 1 second             # x40 threads
-  HotDocumentWrites: &HotDocumentWrites 1000 per 1 second     # x40 threads
-  HotCollectionWrites: &HotCollectionWrites 1000 per 1 second # x40 threads
-
-  # According to the design, the number of reads should add up to 1K second.
-  LongLivedReads: &LongLivedReads 20 per 1 second            # x10 threads
-  LongLivedIndexReads: &LongLivedIndexReads 20 per 1 second  # x10 threads
-  RollingReads1: &RollingReads1 50 per 1 second              # x10 threads
-  RollingReads2: &RollingReads2 100 per 1 second             # x1 thread
 
   # We want about 200 bytes, 9 fields (they will all be indexed).
   RollingDocument: &RollingDocument
@@ -75,10 +35,10 @@ GlobalDefaults:
 
 LongLivedCreatorCmd:
   Repeat: 1
-  Database: *LongLivedDB
-  CollectionCount: *LongLivedCollectionCount
+  Database: &LongLivedDB {^Parameter: {Name: "DB", Default: db}}
+  CollectionCount: &LongLivedCollectionCount {^Parameter: {Name: "CollectionCount", Default: 0}}
   Threads: 10
-  DocumentCount: *LongLivedDocumentCount
+  DocumentCount: &LongLivedDocumentCount {^Parameter: {Name: "DocumentCount", Default: 0}}
   BatchSize: 1000
   Document:
     # Each document ranges in size from about 90 to 150 bytes (average 120)
@@ -131,7 +91,7 @@ RollingSetupCmd:
   CollectionWindowSize: 3600
   Document: *RollingDocument
   DocumentCount: 10
-  TrackProportion: *TrackProportion
+  TrackProportion: &TrackProportion {^Parameter: {Name: "TrackProportion", Default: 0}}
   Indexes: *RollingIndexes
 
 RollingManageCmd:
@@ -143,14 +103,14 @@ RollingWriterCmd:
   Duration: *Duration
   TrackProportion: *TrackProportion
   Document: *RollingDocument
-  GlobalRate: *RollingWrites
+  GlobalRate: &RollingWrites {^Parameter: {Name: "Writes", Default: 0}}
 
 RollingReader1Cmd:
   Duration: *Duration
   TrackProportion: *TrackProportion
   # Distribution is a linear distribution from 0 to 1
   Distribution: 0.8
-  GlobalRate: *RollingReads1
+  GlobalRate: &RollingReads1 {^Parameter: {Name: "Reads", Default: 0}}
 
 RollingReader2Cmd:
   Duration: *Duration
@@ -158,11 +118,11 @@ RollingReader2Cmd:
   Distribution: 0.25
   # Filter modifies the find to use whatever filter you pass to it
   Filter: {a: 1}
-  GlobalRate: *RollingReads2
+  GlobalRate: &RollingReads2 {^Parameter: {Name: "Reads", Default: 0}}
 
 HotDocumentLoaderCmd:
   Repeat: 1
-  Database: *HotDocumentDB
+  Database: &HotDocumentDB {^Parameter: {Name: "DB", Default: db}}
   CollectionCount: 1
   Threads: 1
   DocumentCount: 1
@@ -181,11 +141,11 @@ HotDocumentUpdaterCmd:
       - WriteCommand: updateOne
         Filter: {first : first}
         Update: {$set: {second: *rand_1k_int}}
-  GlobalRate: *HotDocumentWrites
+  GlobalRate: &HotDocumentWrites {^Parameter: {Name: "Writes", Default: 0}}
 
 HotCollectionLoaderCmd:
   Repeat: 1
-  Database: *HotCollectionDB
+  Database: &HotCollectionDB {^Parameter: {Name: "DB", Default: db}}
   CollectionCount: 1
   Threads: 1
   DocumentCount: 1
@@ -203,7 +163,7 @@ HotCollectionUpdaterCmd:
       WriteOperations:
       - WriteCommand: insertOne
         Document: { a : *rand_1k_int}
-  GlobalRate: *HotCollectionWrites
+  GlobalRate: &HotCollectionWrites {^Parameter: {Name: "Writes", Default: 0}}
 
 HotCollectionDeleterCmd:
   Duration: *Duration
@@ -212,8 +172,8 @@ HotCollectionDeleterCmd:
 
 ScannerLoaderCmd:
   Repeat: 1
-  Database: *ScannerColdDB
-  CollectionCount: *ScannerColdDBGigabytes
+  Database: &ScannerColdDB {^Parameter: {Name: "DB", Default: db}}
+  CollectionCount: &ScannerColdDBGigabytes {^Parameter: {Name: "CollectionCount", Default: 0}}
   Threads: 1
   DocumentCount: 50000
   BatchSize: 1000

--- a/src/phases/scale/LargeScalePhases.yml
+++ b/src/phases/scale/LargeScalePhases.yml
@@ -33,12 +33,20 @@ GlobalDefaults:
     - keys: {g: 1, h: 1}
     - keys: {h: 1, i: 1}
 
+  # Commonly used parameters.
+  DatabaseParam: &DatabaseParam {^Parameter: {Name: "Database", Default: db}}
+  CollectionCountParam: &CollectionCountParam {^Parameter: {Name: "CollectionCount", Default: 0}}
+  TrackProportionParam: &TrackProportionParam {^Parameter: {Name: "TrackProportion", Default: 0}}
+  DocumentCountParam: &DocumentCountParam {^Parameter: {Name: "DocumentCount", Default: 0}}
+  WritesParam: &WritesParam {^Parameter: {Name: "Writes", Default: 0}}
+  ReadsParam: &ReadsParam {^Parameter: {Name: "Reads", Default: 0}}
+
 LongLivedCreatorCmd:
   Repeat: 1
-  Database: &LongLivedDB {^Parameter: {Name: "DB", Default: db}}
-  CollectionCount: &LongLivedCollectionCount {^Parameter: {Name: "CollectionCount", Default: 0}}
+  Database: *DatabaseParam
+  CollectionCount: *CollectionCountParam
   Threads: 10
-  DocumentCount: &LongLivedDocumentCount {^Parameter: {Name: "DocumentCount", Default: 0}}
+  DocumentCount: *DocumentCountParam
   BatchSize: 1000
   Document:
     # Each document ranges in size from about 90 to 150 bytes (average 120)
@@ -65,24 +73,24 @@ LongLivedCreatorCmd:
 
 LongLivedIndexReaderCmd:
   Duration: *Duration
-  Database: *LongLivedDB
-  CollectionCount: *LongLivedCollectionCount
-  DocumentCount: *LongLivedDocumentCount
+  Database: *DatabaseParam
+  CollectionCount: *CollectionCountParam
+  DocumentCount: *DocumentCountParam
   Filter: {x0: *rand_10k_int}
 
 LongLivedReaderCmd:
   Duration: *Duration
-  Database: *LongLivedDB
-  CollectionCount: *LongLivedCollectionCount
-  DocumentCount: *LongLivedDocumentCount
+  Database: *DatabaseParam
+  CollectionCount: *CollectionCountParam
+  DocumentCount: *DocumentCountParam
   Filter: {_id: *rand_10k_int}
 
 LongLivedWriterCmd:
   Duration: *Duration
   MetricsName: Update
-  Database: *LongLivedDB
-  CollectionCount: *LongLivedCollectionCount
-  DocumentCount: *LongLivedDocumentCount
+  Database: *DatabaseParam
+  CollectionCount: *CollectionCountParam
+  DocumentCount: *DocumentCountParam
   UpdateFilter: {_id: *rand_10k_int}
   Update: {$inc: {x1: 1}}
 
@@ -91,7 +99,7 @@ RollingSetupCmd:
   CollectionWindowSize: 3600
   Document: *RollingDocument
   DocumentCount: 10
-  TrackProportion: &TrackProportion {^Parameter: {Name: "TrackProportion", Default: 0}}
+  TrackProportion: *TrackProportionParam
   Indexes: *RollingIndexes
 
 RollingManageCmd:
@@ -101,28 +109,28 @@ RollingManageCmd:
 
 RollingWriterCmd:
   Duration: *Duration
-  TrackProportion: *TrackProportion
+  TrackProportion: *TrackProportionParam
   Document: *RollingDocument
-  GlobalRate: &RollingWrites {^Parameter: {Name: "Writes", Default: 0}}
+  GlobalRate: *WritesParam
 
 RollingReader1Cmd:
   Duration: *Duration
-  TrackProportion: *TrackProportion
+  TrackProportion: *TrackProportionParam
   # Distribution is a linear distribution from 0 to 1
   Distribution: 0.8
-  GlobalRate: &RollingReads1 {^Parameter: {Name: "Reads", Default: 0}}
+  GlobalRate: *ReadsParam
 
 RollingReader2Cmd:
   Duration: *Duration
-  TrackProportion: *TrackProportion
+  TrackProportion: *TrackProportionParam
   Distribution: 0.25
   # Filter modifies the find to use whatever filter you pass to it
   Filter: {a: 1}
-  GlobalRate: &RollingReads2 {^Parameter: {Name: "Reads", Default: 0}}
+  GlobalRate: *ReadsParam
 
 HotDocumentLoaderCmd:
   Repeat: 1
-  Database: &HotDocumentDB {^Parameter: {Name: "DB", Default: db}}
+  Database: *DatabaseParam
   CollectionCount: 1
   Threads: 1
   DocumentCount: 1
@@ -141,11 +149,11 @@ HotDocumentUpdaterCmd:
       - WriteCommand: updateOne
         Filter: {first : first}
         Update: {$set: {second: *rand_1k_int}}
-  GlobalRate: &HotDocumentWrites {^Parameter: {Name: "Writes", Default: 0}}
+  GlobalRate: *WritesParam
 
 HotCollectionLoaderCmd:
   Repeat: 1
-  Database: &HotCollectionDB {^Parameter: {Name: "DB", Default: db}}
+  Database: *DatabaseParam
   CollectionCount: 1
   Threads: 1
   DocumentCount: 1
@@ -163,7 +171,7 @@ HotCollectionUpdaterCmd:
       WriteOperations:
       - WriteCommand: insertOne
         Document: { a : *rand_1k_int}
-  GlobalRate: &HotCollectionWrites {^Parameter: {Name: "Writes", Default: 0}}
+  GlobalRate: *WritesParam
 
 HotCollectionDeleterCmd:
   Duration: *Duration
@@ -172,8 +180,8 @@ HotCollectionDeleterCmd:
 
 ScannerLoaderCmd:
   Repeat: 1
-  Database: &ScannerColdDB {^Parameter: {Name: "DB", Default: db}}
-  CollectionCount: &ScannerColdDBGigabytes {^Parameter: {Name: "CollectionCount", Default: 0}}
+  Database: *DatabaseParam
+  CollectionCount: *CollectionCountParam
   Threads: 1
   DocumentCount: 50000
   BatchSize: 1000

--- a/src/phases/scale/LargeScalePhases.yml
+++ b/src/phases/scale/LargeScalePhases.yml
@@ -1,0 +1,274 @@
+PhaseSchemaVersion: 2018-07-01
+Owner: Storage Engines
+
+# This section contains shared definitions that are used in the workload.
+GlobalDefaults:
+  Random10KInt: &rand_10k_int {^RandomInt: {min: 0, max: 10000}}
+  Random10KInt: &rand_1k_int {^RandomInt: {min: 0, max: 1000}}
+  Random4ByteInt: &rand_4b_int {^RandomInt: {min: 0, max: 2147483647}}
+  Random30String: &rand_30b_string {^RandomString: {length: 30}}
+  Random130String: &rand_100b_string {^RandomString: {length: 100}}
+
+  Duration: &Duration 12 hours
+  TrackProportion: &TrackProportion 0
+
+  LongLivedDB: &LongLivedDB longlived  # name of the long lived database
+  LongLivedDocumentCount: &LongLivedDocumentCount 1000
+  LongLivedCollectionCount: &LongLivedCollectionCount 1000
+
+  RollingDB: &RollingDB rolling
+
+  # Note: if HotCollectionDB and HotDocumentDB reference the same
+  # database name, only one of their loaders should be enabled.
+  HotCollectionDB: &HotCollectionDB hotcoll
+  HotDocumentDB: &HotDocumentDB hotdoc
+
+  ScannerColdDB: &ScannerColdDB scancold
+  ScannerHotDB: &ScannerHotDB rolling
+
+  # Set to how many gigabytes we want the "cold" database to be.
+  # This database is initially created, but not used for anything,
+  # except for the snapshot scanner that scans all databases.
+  # We expect this to be larger than the amount of physical memory,
+  # so that we'll displace lots of hot data in the cache.
+  # CHANGE: the spec says 10TB of live data (total in all databases).
+  ScannerColdDBGigabytes: &ScannerColdDBGigabytes 150
+
+  # This list is used to scan all databases. By putting first the hot databases,
+  # which have high concentrations of updates, we'll be referencing more
+  # and "older" updates. That should stress the WiredTiger version history.
+  AllDB: &AllDB hotdoc,hotcoll,rolling,longlived,scancold
+
+  # According to the design, the number of writes should add up to 10K second.
+  LongLivedWrites: &LongLivedWrites 600 per 1 second          #  x5 threads
+  RollingWrites: &RollingWrites 1000 per 1 second             # x40 threads
+  HotDocumentWrites: &HotDocumentWrites 1000 per 1 second     # x40 threads
+  HotCollectionWrites: &HotCollectionWrites 1000 per 1 second # x40 threads
+
+  # According to the design, the number of reads should add up to 1K second.
+  LongLivedReads: &LongLivedReads 20 per 1 second            # x10 threads
+  LongLivedIndexReads: &LongLivedIndexReads 20 per 1 second  # x10 threads
+  RollingReads1: &RollingReads1 50 per 1 second              # x10 threads
+  RollingReads2: &RollingReads2 100 per 1 second             # x1 thread
+
+  # We want about 200 bytes, 9 fields (they will all be indexed).
+  RollingDocument: &RollingDocument
+    a: *rand_30b_string
+    b: *rand_30b_string
+    c: *rand_30b_string
+    d: *rand_30b_string
+    e: *rand_30b_string
+    f: *rand_30b_string
+    g: *rand_4b_int
+    h: *rand_4b_int
+    i: *rand_4b_int
+  RollingIndexes: &RollingIndexes
+    - keys: {a: 1}
+    - keys: {b: 1}
+    - keys: {c: 1}
+    - keys: {d: 1}
+    - keys: {e: 1}
+    - keys: {f: 1}
+    - keys: {i: 1, g: 1}
+    - keys: {g: 1, h: 1}
+    - keys: {h: 1, i: 1}
+
+LongLivedCreatorCmd:
+  Repeat: 1
+  Database: *LongLivedDB
+  CollectionCount: *LongLivedCollectionCount
+  Threads: 10
+  DocumentCount: *LongLivedDocumentCount
+  BatchSize: 1000
+  Document:
+    # Each document ranges in size from about 90 to 150 bytes (average 120)
+    x0: *rand_10k_int
+    x1: *rand_4b_int
+    x2: *rand_4b_int
+    x3: *rand_4b_int
+    x4: *rand_4b_int
+    x5: *rand_4b_int
+    x6: *rand_4b_int
+    x7: *rand_4b_int
+    x8: *rand_4b_int
+    s0: {^RandomString: {length: {^RandomInt: {min: 20, max: 80}}}}
+  Indexes:
+  - keys: {x0: 1}
+  - keys: {x1: 1}
+  - keys: {x2: 1}
+  - keys: {x3: 1}
+  - keys: {x4: 1}
+  - keys: {x5: 1}
+  - keys: {x6: 1}
+  - keys: {x7: 1}
+  - keys: {x8: 1}
+
+LongLivedIndexReaderCmd:
+  Duration: *Duration
+  Database: *LongLivedDB
+  CollectionCount: *LongLivedCollectionCount
+  DocumentCount: *LongLivedDocumentCount
+  Filter: {x0: *rand_10k_int}
+
+LongLivedReaderCmd:
+  Duration: *Duration
+  Database: *LongLivedDB
+  CollectionCount: *LongLivedCollectionCount
+  DocumentCount: *LongLivedDocumentCount
+  Filter: {_id: *rand_10k_int}
+
+LongLivedWriterCmd:
+  Duration: *Duration
+  MetricsName: Update
+  Database: *LongLivedDB
+  CollectionCount: *LongLivedCollectionCount
+  DocumentCount: *LongLivedDocumentCount
+  UpdateFilter: {_id: *rand_10k_int}
+  Update: {$inc: {x1: 1}}
+
+RollingSetupCmd:
+  Repeat: 1
+  CollectionWindowSize: 3600
+  Document: *RollingDocument
+  DocumentCount: 10
+  TrackProportion: *TrackProportion
+  Indexes: *RollingIndexes
+
+RollingManageCmd:
+  Duration: *Duration
+  GlobalRate: 1 per 1 second
+  Indexes: *RollingIndexes
+
+RollingWriterCmd:
+  Duration: *Duration
+  TrackProportion: *TrackProportion
+  Document: *RollingDocument
+  GlobalRate: *RollingWrites
+
+RollingReader1Cmd:
+  Duration: *Duration
+  TrackProportion: *TrackProportion
+  # Distribution is a linear distribution from 0 to 1
+  Distribution: 0.8
+  GlobalRate: *RollingReads1
+
+RollingReader2Cmd:
+  Duration: *Duration
+  TrackProportion: *TrackProportion
+  Distribution: 0.25
+  # Filter modifies the find to use whatever filter you pass to it
+  Filter: {a: 1}
+  GlobalRate: *RollingReads2
+
+HotDocumentLoaderCmd:
+  Repeat: 1
+  Database: *HotDocumentDB
+  CollectionCount: 1
+  Threads: 1
+  DocumentCount: 1
+  BatchSize: 1
+  Document:
+    first: first
+    second: *rand_1k_int
+
+HotDocumentUpdaterCmd:
+  Duration: *Duration
+  Collection: Collection0
+  Operations:
+  - OperationName: bulkWrite
+    OperationCommand:
+      WriteOperations:
+      - WriteCommand: updateOne
+        Filter: {first : first}
+        Update: {$set: {second: *rand_1k_int}}
+  GlobalRate: *HotDocumentWrites
+
+HotCollectionLoaderCmd:
+  Repeat: 1
+  Database: *HotCollectionDB
+  CollectionCount: 1
+  Threads: 1
+  DocumentCount: 1
+  BatchSize: 1
+  Document:
+    first: first
+    second: *rand_1k_int
+
+HotCollectionUpdaterCmd:
+  Duration: *Duration
+  Collection: Collection0
+  Operations:
+  - OperationName: bulkWrite
+    OperationCommand:
+      WriteOperations:
+      - WriteCommand: insertOne
+        Document: { a : *rand_1k_int}
+  GlobalRate: *HotCollectionWrites
+
+HotCollectionDeleterCmd:
+  Duration: *Duration
+  Collection: Collection0
+  GlobalRate: 1000 per 1 second
+
+ScannerLoaderCmd:
+  Repeat: 1
+  Database: *ScannerColdDB
+  CollectionCount: *ScannerColdDBGigabytes
+  Threads: 1
+  DocumentCount: 50000
+  BatchSize: 1000
+  Document:
+    a0: *rand_100b_string
+    a1: *rand_100b_string
+    a2: *rand_100b_string
+    a3: *rand_100b_string
+    a4: *rand_100b_string
+    a5: *rand_100b_string
+    a6: *rand_100b_string
+    a7: *rand_100b_string
+    a8: *rand_100b_string
+    a9: *rand_100b_string
+    a10: *rand_100b_string
+    a11: *rand_100b_string
+    a12: *rand_100b_string
+    a13: *rand_100b_string
+    a14: *rand_100b_string
+    a15: *rand_100b_string
+    a16: *rand_100b_string
+    a17: *rand_100b_string
+    a18: *rand_100b_string
+    a19: *rand_100b_string
+
+SnapshotScanner1GigabytesCmd:
+  Duration: *Duration
+  ScanSizeBytes: 1000000000
+  ScanDuration: 2 minutes
+  ScanType: snapshot
+  # starting at 1 minute old, and going older
+  CollectionSkip: 60
+  CollectionSortOrder: forward
+  GlobalRate: 1 per 1 minute
+  # Note: to peform an index scan use the Filter config.
+  # We'd need to know the layout of the collections we're using.
+  # Filter: {a : 1}
+
+SnapshotScanner5GigabytesCmd:
+  Duration: *Duration
+  ScanSizeBytes: 5000000000
+  ScanDuration: 10 minutes
+  ScanType: snapshot
+  # starting at 5 minutes old, and going older
+  CollectionSkip: 300
+  CollectionSortOrder: forward
+  GlobalRate: 1 per 5 minutes
+
+SnapshotScannerAllCmd:
+  Duration: *Duration
+  Documents: 100000000000
+  ScanType: snapshot
+  #GlobalRate: 1 per 24 hours   # CHANGE
+  #Note: using "2 per 1" hour kicks off two scans at the top of the hour!
+  GlobalRate: 1 per 30 minutes
+
+OplogTrailerCmd:
+  Duration: *Duration

--- a/src/workloads/scale/LargeScaleModel.yml
+++ b/src/workloads/scale/LargeScaleModel.yml
@@ -94,34 +94,9 @@ Actors:
   TrackProportion: *TrackProportion
   Phases:
   - {Nop: true}
-  - Repeat: 1
-    Database: *LongLivedDB
-    CollectionCount: *LongLivedCollectionCount
-    Threads: 10
-    DocumentCount: *LongLivedDocumentCount
-    BatchSize: 1000
-    Document:
-      # Each document ranges in size from about 90 to 150 bytes (average 120)
-      x0: *rand_10k_int
-      x1: *rand_4b_int
-      x2: *rand_4b_int
-      x3: *rand_4b_int
-      x4: *rand_4b_int
-      x5: *rand_4b_int
-      x6: *rand_4b_int
-      x7: *rand_4b_int
-      x8: *rand_4b_int
-      s0: {^RandomString: {length: {^RandomInt: {min: 20, max: 80}}}}
-    Indexes:
-    - keys: {x0: 1}
-    - keys: {x1: 1}
-    - keys: {x2: 1}
-    - keys: {x3: 1}
-    - keys: {x4: 1}
-    - keys: {x5: 1}
-    - keys: {x6: 1}
-    - keys: {x7: 1}
-    - keys: {x8: 1}
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: LongLivedCreatorCmd
   - {Nop: true}
 
 - Name: LongLivedIndexReader
@@ -132,11 +107,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    Database: *LongLivedDB
-    CollectionCount: *LongLivedCollectionCount
-    DocumentCount: *LongLivedDocumentCount
-    Filter: {x0: *rand_10k_int}
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: LongLivedIndexReaderCmd
 
 - Name: LongLivedReader
   Type: MultiCollectionQuery
@@ -146,11 +119,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    Database: *LongLivedDB
-    CollectionCount: *LongLivedCollectionCount
-    DocumentCount: *LongLivedDocumentCount
-    Filter: {_id: *rand_10k_int}
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: LongLivedReaderCmd
 
 - Name: LongLivedWriter
   Type: MultiCollectionUpdate
@@ -160,13 +131,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    MetricsName: Update
-    Database: *LongLivedDB
-    CollectionCount: *LongLivedCollectionCount
-    DocumentCount: *LongLivedDocumentCount
-    UpdateFilter: {_id: *rand_10k_int}
-    Update: {$inc: {x1: 1}}
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: LongLivedWriterCmd
 
 - Name: RollingSetup
   Type: RollingCollections
@@ -178,12 +145,9 @@ Actors:
   Threads: 1
   Phases:
   - {Nop: true}
-  - Repeat: 1
-    CollectionWindowSize: 3600
-    Document: *RollingDocument
-    DocumentCount: 10
-    TrackProportion: *TrackProportion
-    Indexes: *RollingIndexes
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: RollingSetupCmd
   - {Nop: true}
 
 - Name: RollingManage
@@ -196,9 +160,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    GlobalRate: 1 per 1 second
-    Indexes: *RollingIndexes
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: RollingManageCmd
 
 - Name: RollingWriter
   Type: RollingCollections
@@ -208,10 +172,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    TrackProportion: *TrackProportion
-    Document: *RollingDocument
-    GlobalRate: *RollingWrites
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: RollingWriterCmd
 
 - Name: RollingReader1
   Type: RollingCollections
@@ -221,11 +184,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    TrackProportion: *TrackProportion
-    # Distribution is a linear distribution from 0 to 1
-    Distribution: 0.8
-    GlobalRate: *RollingReads1
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: RollingReader1Cmd
 
 - Name: RollingReader2
   Type: RollingCollections
@@ -235,12 +196,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    TrackProportion: *TrackProportion
-    Distribution: 0.25
-    # Filter modifies the find to use whatever filter you pass to it
-    Filter: {a: 1}
-    GlobalRate: *RollingReads2
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: RollingReader2Cmd
 
 - Name: HotDocumentLoader
   Type: Loader
@@ -248,15 +206,9 @@ Actors:
   Threads: 1
   Phases:
   - {Nop: true}
-  - Repeat: 1
-    Database: *HotDocumentDB
-    CollectionCount: 1
-    Threads: 1
-    DocumentCount: 1
-    BatchSize: 1
-    Document:
-      first: first
-      second: *rand_1k_int
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: HotDocumentLoaderCmd
   - {Nop: true}
 
 - Name: HotDocumentUpdater
@@ -267,16 +219,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    Collection: Collection0
-    Operations:
-    - OperationName: bulkWrite
-      OperationCommand:
-        WriteOperations:
-        - WriteCommand: updateOne
-          Filter: {first : first}
-          Update: {$set: {second: *rand_1k_int}}
-    GlobalRate: *HotDocumentWrites
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: HotDocumentUpdaterCmd
 
 - Name: HotCollectionLoader
   Type: Loader
@@ -284,15 +229,9 @@ Actors:
   Threads: 1
   Phases:
   - {Nop: true}
-  - Repeat: 1
-    Database: *HotCollectionDB
-    CollectionCount: 1
-    Threads: 1
-    DocumentCount: 1
-    BatchSize: 1
-    Document:
-      first: first
-      second: *rand_1k_int
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: HotCollectionLoaderCmd
   - {Nop: true}
 
 - Name: HotCollectionUpdater
@@ -303,15 +242,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    Collection: Collection0
-    Operations:
-    - OperationName: bulkWrite
-      OperationCommand:
-        WriteOperations:
-        - WriteCommand: insertOne
-          Document: { a : *rand_1k_int}
-    GlobalRate: *HotCollectionWrites
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: HotCollectionUpdaterCmd
 
 - Name: HotCollectionDeleter
   Type: Deleter
@@ -320,9 +253,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    Collection: Collection0
-    GlobalRate: 1000 per 1 second
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: HotCollectionDeleterCmd
 
 # Create the cold database only.  For the hot database, we'll
 # use the rolling collection or the longlived collection, as they
@@ -337,33 +270,9 @@ Actors:
     # Each collection is ~100M.  Assuming N is equal to ScannerColdDBGigabytes.
     # Each thread has N collections, and with 10 threads, that's
     # 10*N collections, or N gigabytes of space.
-  - Repeat: 1
-    Database: *ScannerColdDB
-    CollectionCount: *ScannerColdDBGigabytes
-    Threads: 1
-    DocumentCount: 50000
-    BatchSize: 1000
-    Document:
-      a0: *rand_100b_string
-      a1: *rand_100b_string
-      a2: *rand_100b_string
-      a3: *rand_100b_string
-      a4: *rand_100b_string
-      a5: *rand_100b_string
-      a6: *rand_100b_string
-      a7: *rand_100b_string
-      a8: *rand_100b_string
-      a9: *rand_100b_string
-      a10: *rand_100b_string
-      a11: *rand_100b_string
-      a12: *rand_100b_string
-      a13: *rand_100b_string
-      a14: *rand_100b_string
-      a15: *rand_100b_string
-      a16: *rand_100b_string
-      a17: *rand_100b_string
-      a18: *rand_100b_string
-      a19: *rand_100b_string
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: ScannerLoaderCmd
   - {Nop: true}
   - {Nop: true}
 
@@ -381,17 +290,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    ScanSizeBytes: 1000000000
-    ScanDuration: 2 minutes
-    ScanType: snapshot
-     # starting at 1 minute old, and going older    
-    CollectionSkip: 60
-    CollectionSortOrder: forward
-    GlobalRate: 1 per 1 minute
-    # Note: to peform an index scan use the Filter config.
-    # We'd need to know the layout of the collections we're using.
-    # Filter: {a : 1}
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: SnapshotScanner1GigabytesCmd
 
 - Name: SnapshotScanner5Gigabytes
   Type: CollectionScanner
@@ -400,14 +301,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    ScanSizeBytes: 5000000000
-    ScanDuration: 10 minutes
-    ScanType: snapshot
-     # starting at 5 minutes old, and going older    
-    CollectionSkip: 300
-    CollectionSortOrder: forward
-    GlobalRate: 1 per 5 minutes
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: SnapshotScanner5GigabytesCmd
 
 # We scan all the documents in all databases.
 - Name: SnapshotScannerAll
@@ -417,12 +313,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
-    Documents: 100000000000
-    ScanType: snapshot
-    #GlobalRate: 1 per 24 hours   # CHANGE
-    #Note: using "2 per 1" hour kicks off two scans at the top of the hour!
-    GlobalRate: 1 per 30 minutes
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: SnapshotScannerAllCmd
 
 - Name: OplogTailer
   Type: RollingCollections
@@ -432,7 +325,9 @@ Actors:
   Phases:
   - {Nop: true}
   - {Nop: true}
-  - Duration: *Duration
+  - ExternalPhaseConfig:
+      Path: ../../phases/scale/LargeScalePhases.yml
+      Key: OplogTrailerCmd
 
 AutoRun:
   Requires:

--- a/src/workloads/scale/LargeScaleModel.yml
+++ b/src/workloads/scale/LargeScaleModel.yml
@@ -7,13 +7,6 @@ Owner: Storage Engines
 
 # This section contains shared definitions that are used in the workload.
 GlobalDefaults:
-  Random10KInt: &rand_10k_int {^RandomInt: {min: 0, max: 10000}}
-  Random10KInt: &rand_1k_int {^RandomInt: {min: 0, max: 1000}}
-  Random4ByteInt: &rand_4b_int {^RandomInt: {min: 0, max: 2147483647}}
-  Random30String: &rand_30b_string {^RandomString: {length: 30}}
-  Random130String: &rand_100b_string {^RandomString: {length: 100}}
-
-  Duration: &Duration 12 hours
   TrackProportion: &TrackProportion 0
 
   LongLivedDB: &LongLivedDB longlived  # name of the long lived database
@@ -55,28 +48,6 @@ GlobalDefaults:
   RollingReads1: &RollingReads1 50 per 1 second              # x10 threads
   RollingReads2: &RollingReads2 100 per 1 second             # x1 thread
 
-  # We want about 200 bytes, 9 fields (they will all be indexed).
-  RollingDocument: &RollingDocument
-    a: *rand_30b_string
-    b: *rand_30b_string
-    c: *rand_30b_string
-    d: *rand_30b_string
-    e: *rand_30b_string
-    f: *rand_30b_string
-    g: *rand_4b_int
-    h: *rand_4b_int
-    i: *rand_4b_int
-  RollingIndexes: &RollingIndexes
-    - keys: {a: 1}
-    - keys: {b: 1}
-    - keys: {c: 1}
-    - keys: {d: 1}
-    - keys: {e: 1}
-    - keys: {f: 1}
-    - keys: {i: 1, g: 1}
-    - keys: {g: 1, h: 1}
-    - keys: {h: 1, i: 1}
-
 Clients:
   Default:
     QueryOptions:
@@ -97,6 +68,9 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: LongLivedCreatorCmd
+      Parameters:
+        DB: *LongLivedDB
+        DocumentCount: *LongLivedDocumentCount
   - {Nop: true}
 
 - Name: LongLivedIndexReader
@@ -110,6 +84,9 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: LongLivedIndexReaderCmd
+      Parameters:
+        DB: *LongLivedDB
+        DocumentCount: *LongLivedDocumentCount
 
 - Name: LongLivedReader
   Type: MultiCollectionQuery
@@ -122,6 +99,9 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: LongLivedReaderCmd
+      Parameters:
+        DB: *LongLivedDB
+        DocumentCount: *LongLivedDocumentCount
 
 - Name: LongLivedWriter
   Type: MultiCollectionUpdate
@@ -134,6 +114,9 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: LongLivedWriterCmd
+      Parameters:
+        DB: *LongLivedDB
+        DocumentCount: *LongLivedDocumentCount
 
 - Name: RollingSetup
   Type: RollingCollections
@@ -148,6 +131,8 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: RollingSetupCmd
+      Parameters:
+        TrackProportion: *TrackProportion
   - {Nop: true}
 
 - Name: RollingManage
@@ -175,6 +160,9 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: RollingWriterCmd
+      Parameters:
+        TrackProportion: *TrackProportion
+        Writes: *RollingWrites
 
 - Name: RollingReader1
   Type: RollingCollections
@@ -187,6 +175,9 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: RollingReader1Cmd
+      Parameters:
+        TrackProportion: *TrackProportion
+        Reads: *RollingReads1
 
 - Name: RollingReader2
   Type: RollingCollections
@@ -199,6 +190,9 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: RollingReader2Cmd
+      Parameters:
+        TrackProportion: *TrackProportion
+        Reads: *RollingReads2
 
 - Name: HotDocumentLoader
   Type: Loader
@@ -209,6 +203,8 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: HotDocumentLoaderCmd
+      Parameters:
+        DB: *HotDocumentDB
   - {Nop: true}
 
 - Name: HotDocumentUpdater
@@ -222,6 +218,8 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: HotDocumentUpdaterCmd
+      Parameters:
+        Writes: *HotDocumentWrites
 
 - Name: HotCollectionLoader
   Type: Loader
@@ -232,6 +230,8 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: HotCollectionLoaderCmd
+      Parameters:
+        DB: *HotCollectionDB
   - {Nop: true}
 
 - Name: HotCollectionUpdater
@@ -245,6 +245,8 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: HotCollectionUpdaterCmd
+      Parameters:
+        Writes: *HotCollectionWrites
 
 - Name: HotCollectionDeleter
   Type: Deleter
@@ -273,6 +275,9 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: ScannerLoaderCmd
+      Parameters:
+        DB: *ScannerColdDB
+        CollectionCount: *ScannerColdDBGigabytes
   - {Nop: true}
   - {Nop: true}
 

--- a/src/workloads/scale/LargeScaleModel.yml
+++ b/src/workloads/scale/LargeScaleModel.yml
@@ -70,6 +70,7 @@ Actors:
       Key: LongLivedCreatorCmd
       Parameters:
         Database: *LongLivedDB
+        CollectionCount: *LongLivedCollectionCount
         DocumentCount: *LongLivedDocumentCount
   - {Nop: true}
 
@@ -86,6 +87,7 @@ Actors:
       Key: LongLivedIndexReaderCmd
       Parameters:
         Database: *LongLivedDB
+        CollectionCount: *LongLivedCollectionCount
         DocumentCount: *LongLivedDocumentCount
 
 - Name: LongLivedReader
@@ -101,6 +103,7 @@ Actors:
       Key: LongLivedReaderCmd
       Parameters:
         Database: *LongLivedDB
+        CollectionCount: *LongLivedCollectionCount
         DocumentCount: *LongLivedDocumentCount
 
 - Name: LongLivedWriter
@@ -116,6 +119,7 @@ Actors:
       Key: LongLivedWriterCmd
       Parameters:
         Database: *LongLivedDB
+        CollectionCount: *LongLivedCollectionCount
         DocumentCount: *LongLivedDocumentCount
 
 - Name: RollingSetup

--- a/src/workloads/scale/LargeScaleModel.yml
+++ b/src/workloads/scale/LargeScaleModel.yml
@@ -69,7 +69,7 @@ Actors:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: LongLivedCreatorCmd
       Parameters:
-        DB: *LongLivedDB
+        Database: *LongLivedDB
         DocumentCount: *LongLivedDocumentCount
   - {Nop: true}
 
@@ -85,7 +85,7 @@ Actors:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: LongLivedIndexReaderCmd
       Parameters:
-        DB: *LongLivedDB
+        Database: *LongLivedDB
         DocumentCount: *LongLivedDocumentCount
 
 - Name: LongLivedReader
@@ -100,7 +100,7 @@ Actors:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: LongLivedReaderCmd
       Parameters:
-        DB: *LongLivedDB
+        Database: *LongLivedDB
         DocumentCount: *LongLivedDocumentCount
 
 - Name: LongLivedWriter
@@ -115,7 +115,7 @@ Actors:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: LongLivedWriterCmd
       Parameters:
-        DB: *LongLivedDB
+        Database: *LongLivedDB
         DocumentCount: *LongLivedDocumentCount
 
 - Name: RollingSetup
@@ -204,7 +204,7 @@ Actors:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: HotDocumentLoaderCmd
       Parameters:
-        DB: *HotDocumentDB
+        Database: *HotDocumentDB
   - {Nop: true}
 
 - Name: HotDocumentUpdater
@@ -231,7 +231,7 @@ Actors:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: HotCollectionLoaderCmd
       Parameters:
-        DB: *HotCollectionDB
+        Database: *HotCollectionDB
   - {Nop: true}
 
 - Name: HotCollectionUpdater
@@ -276,7 +276,7 @@ Actors:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: ScannerLoaderCmd
       Parameters:
-        DB: *ScannerColdDB
+        Database: *ScannerColdDB
         CollectionCount: *ScannerColdDBGigabytes
   - {Nop: true}
   - {Nop: true}


### PR DESCRIPTION
Since we'll be reusing configuration from the `LargeScaleModel` workload, we should take this opportunity to abstract each phase into a "phases" YAML so that it can be shared across workloads.

I've inspected the output with `genny evaluate` before and after this change. It's a bit hard to compare because the variables are assigned different numbers but it looks reasonable and follows the same structure.