### PR TITLE
Set FTDC as the default metrics reporting

### DIFF
--- a/scripts/dry-run-workloads.sh
+++ b/scripts/dry-run-workloads.sh
@@ -19,12 +19,18 @@ set -euo pipefail
 LAMP_VENV_DIR="$(dirname "${BASH_SOURCE[0]}")"
 ROOT_DIR="$(cd "${LAMP_VENV_DIR}/.." && pwd)"
 BUILD_DIR="${ROOT_DIR}/build"
+OUTPUT_DIR="${BUILD_DIR}/genny-metrics"
 
 if [[ -z "${GENNY+x}" && -e "$ROOT_DIR/scripts/genny" ]]; then
     GENNY="$ROOT_DIR/scripts/genny"
 fi
 
 GENNY_EXECUTABLE="${GENNY:-genny}"
+
+if [[ -d $OUTPUT_DIR ]]; then
+    echo "Clearing previous results in ${OUTPUT_DIR}"
+    rm $OUTPUT_DIR/*
+fi
 
 echo "Dry running with genny [$GENNY_EXECUTABLE]"
 

--- a/src/cast_core/test/LoggingActor_test.cpp
+++ b/src/cast_core/test/LoggingActor_test.cpp
@@ -39,6 +39,9 @@ Actors:
   Phases:
   - LogEvery: 3 milliseconds
     Blocking: None
+Metrics:
+  Format: cedar-csv
+  Path: build/genny-metrics
 )",
                           ""};
         ActorHelper ah(config.root(), 2, MongoTestFixture::connectionUri().to_string());

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -54,7 +54,7 @@ WorkloadContext::WorkloadContext(const Node& node,
     // Set the metrics format information.
     auto format = ((*this)["Metrics"]["Format"])
                       .maybe<metrics::MetricsFormat>()
-                      .value_or(metrics::MetricsFormat("cedar-csv"));
+                      .value_or(metrics::MetricsFormat("ftdc"));
 
     if (format != genny::metrics::MetricsFormat("ftdc")) {
         BOOST_LOG_TRIVIAL(info) << "Metrics format " << format.toString()

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -284,6 +284,7 @@ Actors:
   Phases:
   - GlobalRate: 3 per 500 milliseconds
     Duration: 1200 milliseconds
+
 )",
                       "");
         auto& config = ns.root();

--- a/src/metrics/test/metrics_test.cpp
+++ b/src/metrics/test/metrics_test.cpp
@@ -481,6 +481,10 @@ TEST_CASE("Phases can set metrics") {
           Phases:
           - Repeat: 1
             MetricsName: Phase1Metrics
+
+        Metrics:
+          Format: cedar-csv
+          Path: build/genny-metrics
         )",
                         "");
 
@@ -501,6 +505,10 @@ TEST_CASE("Phases can set metrics") {
       Threads: 1
       Phases:
       - Repeat: 1
+
+    Metrics:
+      Format: cedar-csv
+      Path: build/genny-metrics
     )",
                         "");
 

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -363,7 +363,3 @@ AutoRun:
     - replica-noflowcontrol
     - replica-1dayhistory-15gbwtcache
     - replica-maintenance-events
-
-Metrics:
-  Format: ftdc
-  Path: build/genny-metrics


### PR DESCRIPTION
It looks like the changes from [genny#375](https://github.com/mongodb/genny/pull/375) that actually set FTDC as the default were lost in the merges/fixes.

Patch, when it's done I'll skim for regressions: https://evergreen.mongodb.com/version/5fb82f15c9ec447cdd7d9b86