### PR TITLE
TIG-2805 allow specifying ignoreError at the phase level

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -230,9 +230,11 @@ ThrowMode decodeThrowMode(const Node& operation, PhaseContext& phaseContext) {
     // TODO: TIG-2805 Remove this mode once the underlying drivers issue is addressed.
     static const char* ignoreKey = "RecordFailure";
 
-    bool throwOnFailure =
-        operation[throwKey] ? operation[throwKey].to<bool>() : phaseContext[throwKey].maybe<bool>().value_or(true);
-    bool ignoreFailure = operation[ignoreKey] ? true: false;
+    bool throwOnFailure = operation[throwKey] ? operation[throwKey].to<bool>()
+                                              : phaseContext[throwKey].maybe<bool>().value_or(true);
+    bool ignoreFailure = operation[ignoreKey]
+        ? operation[ignoreKey].to<bool>()
+        : phaseContext[ignoreKey].maybe<bool>().value_or(false);
     if (ignoreFailure) {
         return ThrowMode::kSwallowAndRecord;
     }

--- a/src/workloads/docs/CrudActor.yml
+++ b/src/workloads/docs/CrudActor.yml
@@ -36,6 +36,8 @@ Actors:
         - {a: 1}
         - {a: {^RandomString: {length: {^RandomInt: {min: 3, max: 5}}}}}
         - {b: {^RandomInt: {min: 5, max: 15}}}
+      ThrowOnFailure: false  # Whether to throw an exception if an operation fails
+#      RecordFailure: true  # If ThrowOnFailure is false, whether the failed operations should be recorded.
   - Repeat: 1
     Collection: test
     Operation:


### PR DESCRIPTION
Followup to #393 

This works around the C++ driver issue.

green patch: https://evergreen.mongodb.com/build/sys_perf_linux_3_node_replSet_maintenance_events_patch_e36da1b27ef763f4d7367ddf0f2f97259c0deac3_5fd21592d1fe071a9dcae722_20_12_10_12_50_50