### PR TITLE
Add Now and RandomDate Generators

### DIFF
--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -663,7 +663,7 @@ public:
 // see https://www.boost.org/doc/libs/1_75_0/doc/html/date_time/date_time_io.html.
 // We strive to use smart pointers where possible. In this case this is not possible
 // but not a huge deal as these objects are statically allocated.
-const std::array formats = {
+const static auto formats = {
     std::locale(std::locale::classic(),
                 new boost::local_time::local_time_input_facet("%Y-%m-%dT%H:%M:%s%ZP")),
     std::locale(std::locale::classic(),

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -659,7 +659,7 @@ public:
     }
 };
 
-// The 2 formats also cover "%Y-%m-%d", timezones are not permissible,
+// The 2 formats also cover "%Y-%m-%d", timezones are not parsed,
 // %z, %Q are output only https://www.boost.org/doc/libs/1_75_0/doc/html/date_time/date_time_io.html.
 const std::locale formats[] = {
     std::locale(std::locale::classic(),new boost::posix_time::time_input_facet("%Y-%m-%dT%H:%M:%S.%F")),

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -749,7 +749,8 @@ public:
     }
 
 private:
-    const ValueType _values;};
+    const ValueType _values;
+};
 
 /**
  * @tparam O

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -674,24 +674,24 @@ const static boost::posix_time::ptime max_date(boost::gregorian::date(2030, 1, 1
 
 static std::chrono::milliseconds parseDateAsMillis(
     const std::string& datetime, const boost::posix_time::ptime& default_time = epoch) {
-    boost::posix_time::ptime pt;
+    boost::posix_time::ptime utc_time{boost::posix_time::not_a_date_time};
     auto millis = 0LL;
 
     // Empty datetime is 0.
     if (!datetime.empty()) {
         for (const auto& format : formats) {
-            std::istringstream is{datetime};
-            is.imbue(format);
-            boost::local_time::local_date_time ldt{boost::local_time::not_a_date_time};
-            if (is >> ldt) {
-                pt = ldt.utc_time();
+            std::istringstream date_stream{datetime};
+            date_stream.imbue(format);
+            boost::local_time::local_date_time local_date{boost::local_time::not_a_date_time};
+            if (date_stream >> local_date) {
+                utc_time = local_date.utc_time();
 
-                millis = (pt - epoch).total_milliseconds();
+                millis = (utc_time - epoch).total_milliseconds();
                 break;
             }
         }
 
-        if (pt == boost::posix_time::ptime()) {
+        if (utc_time == boost::posix_time::not_a_date_time) {
             try {
                 // Last gasp try to interpret unsigned long long.
                 millis = std::stoull(datetime);

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -131,7 +131,7 @@ struct convert<genny::ValGenTestCase> {
 
 }  // namespace YAML
 
-TEMPLATE_TEST_CASE("YAML Tests", "[vector][template]", genny::ValGenTestCase) {
+TEMPLATE_TEST_CASE("YAML Tests", "", genny::ValGenTestCase) {
     genny::testing::runTestCaseYaml<TestType>(
         "/src/value_generators/test/DocumentGeneratorTestCases.yml");
 }

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -131,7 +131,7 @@ struct convert<genny::ValGenTestCase> {
 
 }  // namespace YAML
 
-TEMPLATE_TEST_CASE("YAML Tests", "", genny::ValGenTestCase) {
+TEMPLATE_TEST_CASE("YAML Tests", "[vector][template]", genny::ValGenTestCase) {
     genny::testing::runTestCaseYaml<TestType>(
         "/src/value_generators/test/DocumentGeneratorTestCases.yml");
 }

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -498,4 +498,40 @@ Tests:
     #    - { "int" : { "$numberLong" : "2000000000"}, "string" : "2000000000" }
     - "string": "2"
 
+  # Now moves with time so would always fail.
+  # - Name: Now
+  #   GivenTemplate:
+  #     date: {^Now: {}}
+  #   ThenReturns:
+  #   - { "date" : { "$date" : { "$numberLong" : "1453689676330" } } }
 
+  - Name: DateMinMax
+    GivenTemplate:
+      date: {^Date: {min: "2020-01-01", max: "2021-01-01"}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1606971090942" } } }
+
+  # The tests with no max generate different values every time as max moves.
+  # - Name: DateMin
+  #   GivenTemplate:
+  #     date: {^Date: {min: "2020-01-01"}}
+  #   ThenReturns:
+  #   - { "date" : { "$date" : { "$numberLong" : "1606971090942" } } }
+
+  - Name: DateMax
+    GivenTemplate:
+      date: {^Date: {max: "2021-01-01"}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1023097804925" } } }
+
+  - Name: DateSingle
+    GivenTemplate:
+      date: {^Date: {max: "2020-01-01", max: "2020-01-01"}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1468895229847" } } }
+
+  - Name: DateRange
+    GivenTemplate:
+      date: {^Date: {max: "2020-01-01 00:00:00", max: "2020-06-01T12:00:00"}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "179757581005" } } }

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -498,7 +498,7 @@ Tests:
     #    - { "int" : { "$numberLong" : "2000000000"}, "string" : "2000000000" }
     - "string": "2"
 
-  # Now moves with time so would always fail.
+  # Now moves with time so would always fail until PERF-2086 is available.
   - Name: Now
     GivenTemplate:
       date: {^Now: {}}
@@ -526,6 +526,7 @@ Tests:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
     - { "date" : { "$date" : { "$numberLong" : "1778468968160" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1871664110292" } } }
 
   # Date: Half Open interval: ["1970-01-01", "2021-01-01"). 1970-01-01 is the default min date.
   - Name: RandomDateMax
@@ -534,7 +535,7 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "1498334384475" } } }
+    - { "date" : { "$date" : { "$numberLong" : "183360228161" } } }
 
   # Date: 2020-01-01T00:00:00.000 (only one possible value here).
   - Name: RandomDateSingle
@@ -552,7 +553,7 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "1579337896873" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1578819502267" } } }
 
   # Date: Half Open interval: ["1970-01-01", "2030-01-01").
   - Name: RandomDateFull
@@ -561,7 +562,7 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "141219154995" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1454812640684" } } }
 
   # Date: Half Open interval: ["2030-01-01", "2040-01-01").
   - Name: RandomDateFuture
@@ -570,7 +571,7 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "2135891573152" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1918332607011" } } }
 
   # Date: Half Open interval: ["2020-01-01", "2020-01-01").
   - Name: RandomDateULL

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -499,39 +499,95 @@ Tests:
     - "string": "2"
 
   # Now moves with time so would always fail.
-  # - Name: Now
-  #   GivenTemplate:
-  #     date: {^Now: {}}
-  #   ThenReturns:
-  #   - { "date" : { "$date" : { "$numberLong" : "1453689676330" } } }
-
-  - Name: DateMinMax
+  - Name: Now
     GivenTemplate:
-      date: {^Date: {min: "2020-01-01", max: "2021-01-01"}}
+      date: {^Now: {}}
     ThenReturns:
+    # The $date notation is extended json
+    # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    # Check with linux command line `date --utc -d@$((1453689676330 / 1000.0))  +"%Y-%m-%dT%H:%M:%S.%3N"`
+    - { "date" : { "$date" : { "$numberLong" : "1453689676330" } } }
+
+  # Date: Half Open interval: ["2020-01-01", "2021-01-01").
+  - Name: RandomDateMinMax
+    GivenTemplate:
+      date: {^RandomDate: {min: "2020-01-01", max: "2021-01-01"}}
+    ThenReturns:
+    # The $date notation is extended json
+    # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    # Check with linux command line `date --utc -d@$((1606971090942 / 1000.0))  +"%Y-%m-%dT%H:%M:%S.%3N"`
     - { "date" : { "$date" : { "$numberLong" : "1606971090942" } } }
 
-  # The tests with no max generate different values every time as max moves.
-  # - Name: DateMin
-  #   GivenTemplate:
-  #     date: {^Date: {min: "2020-01-01"}}
-  #   ThenReturns:
-  #   - { "date" : { "$date" : { "$numberLong" : "1606971090942" } } }
-
-  - Name: DateMax
+  # Date: Half Open interval: ["2020-01-01", "2030-01-01"). 2030-01-01 is the default max date.
+  - Name: RandomDateMin
     GivenTemplate:
-      date: {^Date: {max: "2021-01-01"}}
+      date: {^RandomDate: {min: "2020-01-01"}}
     ThenReturns:
-    - { "date" : { "$date" : { "$numberLong" : "1023097804925" } } }
+    # The $date notation is extended json
+    # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    - { "date" : { "$date" : { "$numberLong" : "1778468968160" } } }
 
-  - Name: DateSingle
+  # Date: Half Open interval: ["1970-01-01", "2021-01-01"). 1970-01-01 is the default min date.
+  - Name: RandomDateMax
     GivenTemplate:
-      date: {^Date: {max: "2020-01-01", max: "2020-01-01"}}
+      date: {^RandomDate: {max: "2021-01-01"}}
     ThenReturns:
-    - { "date" : { "$date" : { "$numberLong" : "1468895229847" } } }
+    # The $date notation is extended json
+    # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    - { "date" : { "$date" : { "$numberLong" : "1498334384475" } } }
 
-  - Name: DateRange
+  # Date: 2020-01-01T00:00:00.000 (only one possible value here).
+  - Name: RandomDateSingle
     GivenTemplate:
-      date: {^Date: {max: "2020-01-01 00:00:00", max: "2020-06-01T12:00:00"}}
+      date: {^RandomDate: {min: "2020-01-01", max: "2020-01-01T00:00:00.001"}}
     ThenReturns:
-    - { "date" : { "$date" : { "$numberLong" : "179757581005" } } }
+    # The $date notation is extended json
+    # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    - { "date" : { "$date" : { "$numberLong" : "1577836800000" } } }
+
+  # Date: Half Open interval: ["2020-01-01 00:00:00", "2020-06-01T12:00:00").
+  - Name: RandomDateRange
+    GivenTemplate:
+      date: {^RandomDate: {min: "2020-01-01 00:00:00", max: "2020-06-01T12:00:00"}}
+    ThenReturns:
+    # The $date notation is extended json
+    # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    - { "date" : { "$date" : { "$numberLong" : "1579337896873" } } }
+
+  # Date: Half Open interval: ["1970-01-01", "2030-01-01").
+  - Name: RandomDateFull
+    GivenTemplate:
+      date: {^RandomDate: {}}
+    ThenReturns:
+    # The $date notation is extended json
+    # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    - { "date" : { "$date" : { "$numberLong" : "141219154995" } } }
+
+  # Date: Half Open interval: ["2030-01-01", "2040-01-01").
+  - Name: RandomDateFuture
+    GivenTemplate:
+      date: {^RandomDate: {min: "2030-01-01", max: "2040-01-01"}}
+    ThenReturns:
+    # The $date notation is extended json
+    # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    - { "date" : { "$date" : { "$numberLong" : "2135891573152" } } }
+
+  # Date: Half Open interval: ["2020-01-01", "2020-01-01").
+  - Name: RandomDateULL
+    GivenTemplate:
+      date: {^RandomDate: {min: 1577836800000, max: 1577836800001}}
+    ThenReturns:
+    # The $date notation is extended json
+    # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    - { "date" : { "$date" : { "$numberLong" : "1577836800000" } } }
+
+  # Date: Random Dates including tz offset.
+  # Ensure that the generated value is correct '2013-05-30T00:57:04.299'.
+  # Note the +05:30 (Asia/Kolkata) v +06:30 (with incremented hour in the datetime string).
+  # As a result, the test fails if the TZ is not correctly processed (max will be less than min).
+  - Name: RandomDateKolkata
+    GivenTemplate:
+      date: {^RandomDate: {min: "2013-05-30T07:27:04.299+06:30", max: "2013-05-30 06:27:04.300+05:30"}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
+

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -115,23 +115,36 @@ Actors:
             # Generate the current Date
             now: {^Now: {}}
 
-            # Generate a Date in 2015
-            year2015: {^Date: {min: "2015-01-01", max: "2016-01-01"}}
+            # ^RandomDate max precision is to the millisecond as bson dates are to the millisecond
+            # (see https://docs.mongodb.com/manual/reference/bson-types/#date). However, nanos can be
+            # specified, but will be ignored.
+            # The min / max range is a half open interval, that is from min (inclusive) to max (exclusive).
+            # Default min is 1970-01-01.
+            # Default max is 2030-01-01. But you can specify a date greater than this value.
+            # min must be greater than max (so by extension max cannot be 1970-01-01).
+            # The generated date uses the extended json $date notation 
+            # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
 
-            # Generate a Date from 2015
-            greaterThan2105: {^Date: {min: "2015-01-01"}}
+            # Generate a random date in 2015. That is the Half Open interval : ["2015-01-01 00:00:00.000", "2016-01-01 00:00:00.000")
+            year2015: {^RandomDate: {min: "2015-01-01", max: "2016-01-01"}}
 
-            # Generate a Date less than 2015
-            lessThan2105: {^Date: {max: "2015-01-01"}}
+            # Generate a random date from 2015 to the default max date of 2030-01-01
+            greaterThan2105: {^RandomDate: {min: "2015-01-01"}}
 
-            # Generate the exact Date 2015-01-01T00:00:00Z.
-            exact: {^Date: {min: "2015-01-01", max: "2015-01-01"}}
+            # Generate a random date less than 2015 (but greater than 1970-01-01)
+            lessThan2105: {^RandomDate: {max: "2015-01-01"}}
 
-            # Generate date.
-            zulu: {^Date: {min: "2015-01-01T00:00:00Z", max: "2016-01-01T00:00:00Z"}}
+            # Generate the exact Date 2015-01-01T00:00:00Z (as the min / max range only contains one possibility).
+            exact: {^RandomDate: {min: "2015-01-01", max: "2015-01-01 00:00:00.001"}}
 
-            # Generate date.
-            utc: {^Date: {min: "2015-01-01T00:00:00+00:00", max: "2016-01-01T00:00:00+00:00"}}
+            # Generate a random date.
+            zulu: {^RandomDate: {min: "2015-01-01T00:00:00Z", max: "2016-01-01T00:00:00Z"}}
+
+            # Generate a random date.
+            utc: {^RandomDate: {min: "2015-01-01T00:00:00+00:00", max: "2016-01-01T00:00:00+00:00"}}
+
+            # Generate a random date with a TZ offset.
+            kolkata: {^RandomDate: {min: "2015-01-01T00:00:00+05:30", max: "2016-01-01T00:00:00+05:30"}}
 
         - WriteCommand: insertOne  # Nested Generators
           # You can nest generators to make complex values.

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -121,7 +121,7 @@ Actors:
             # The min / max range is a half open interval, that is from min (inclusive) to max (exclusive).
             # Default min is 1970-01-01.
             # Default max is 2030-01-01. But you can specify a date greater than this value.
-            # min must be greater than max (so by extension max cannot be 1970-01-01).
+            # max must be greater than min (so by extension max cannot be 1970-01-01).
             # The generated date uses the extended json $date notation 
             # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
 

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -112,6 +112,9 @@ Actors:
             # Generate the actor ID as a string
             actorString: {^ActorIdString: {}}
 
+            # Generate the current Date
+            now: {^Now: {}}
+
         - WriteCommand: insertOne  # Nested Generators
           # You can nest generators to make complex values.
           Document:

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -115,6 +115,24 @@ Actors:
             # Generate the current Date
             now: {^Now: {}}
 
+            # Generate a Date in 2015
+            year2015: {^Date: {min: "2015-01-01", max: "2016-01-01"}}
+
+            # Generate a Date from 2015
+            greaterThan2105: {^Date: {min: "2015-01-01"}}
+
+            # Generate a Date less than 2015
+            lessThan2105: {^Date: {max: "2015-01-01"}}
+
+            # Generate the exact Date 2015-01-01T00:00:00Z.
+            exact: {^Date: {min: "2015-01-01", max: "2015-01-01"}}
+
+            # Generate date.
+            zulu: {^Date: {min: "2015-01-01T00:00:00Z", max: "2016-01-01T00:00:00Z"}}
+
+            # Generate date.
+            utc: {^Date: {min: "2015-01-01T00:00:00+00:00", max: "2016-01-01T00:00:00+00:00"}}
+
         - WriteCommand: insertOne  # Nested Generators
           # You can nest generators to make complex values.
           Document:


### PR DESCRIPTION
The general ethos is to support  ISO-8601 and  "%Y-%m-%d". Other formats could be added but are not for the moment.

Parsers support is to the milliseconds (for easy cut and paste) in the input string but the actual precision is to seconds.
Timezone specifiers as the end of the input strings are not supported(they don't throw an error but they also are not applied unless they happend to be 'Z' or '+00:00').