### PR TITLE
PERF-2077 incrementing counter

### DIFF
--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -183,7 +183,7 @@ public:
                                       ActorId actorId,
                                       std::optional<genny::PhaseNumber> phase = std::nullopt) {
         StreamPtr stream = nullptr;
-        
+
         auto& opsByType = this->_ops[actorName];
         auto& opsByThread = opsByType[opName];
         if (_format.useGrpc() && opsByThread.find(actorId) == opsByThread.end()) {

--- a/src/value_generators/include/value_generators/DocumentGenerator.hpp
+++ b/src/value_generators/include/value_generators/DocumentGenerator.hpp
@@ -39,6 +39,7 @@ public:
 struct GeneratorArgs {
     DefaultRandom& rng;
     ActorId actorId;
+    int64_t& counter;
 };
 
 

--- a/src/value_generators/include/value_generators/DocumentGenerator.hpp
+++ b/src/value_generators/include/value_generators/DocumentGenerator.hpp
@@ -39,7 +39,6 @@ public:
 struct GeneratorArgs {
     DefaultRandom& rng;
     ActorId actorId;
-    int64_t& counter;
 };
 
 

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -743,8 +743,10 @@ private:
 class IncGenerator : public Generator<int64_t> {
 public:
     IncGenerator(const Node& node, GeneratorArgs generatorArgs)
-        : _step{node["step"].maybe<int64_t>().value_or(1)} 
-        {_counter = node["start"].maybe<int64_t>().value_or(1) + generatorArgs.actorId * node["multiplier"].maybe<int64_t>().value_or(1);}
+        : _step{node["step"].maybe<int64_t>().value_or(1)} {
+        _counter = node["start"].maybe<int64_t>().value_or(1) +
+            generatorArgs.actorId * node["multiplier"].maybe<int64_t>().value_or(1);
+    }
 
     int64_t evaluate() override {
         auto inc_value = _counter;

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -65,10 +65,12 @@ public:
 
     void run() const {
         DYNAMIC_SECTION("DocGenYamlTestCaseRunner " << name()) {
+            int64_t counter=1;
+            //int64_t * pcounter = &counter;
             if (_runMode == RunMode::kExpectException) {
                 try {
                     NodeSource ns = toNode(this->_givenTemplate);
-                    genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 1});
+                    genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 1, counter});
                     FAIL("Expected exception " << this->_expectedExceptionMessage.as<std::string>()
                                                << " but none occurred");
                 } catch (const std::exception& x) {
@@ -79,7 +81,7 @@ public:
             }
 
             NodeSource ns = toNode(this->_givenTemplate);
-            auto docGen = genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 2});
+            auto docGen = genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 2, counter});
             for (const auto&& nextValue : this->_thenReturns) {
                 auto expected = testing::toDocumentBson(nextValue);
                 auto actual = docGen();

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -83,8 +83,8 @@ public:
             for (const auto&& nextValue : this->_thenReturns) {
                 auto expected = testing::toDocumentBson(nextValue);
                 auto actual = docGen();
-                // After implementing TIG-2839 uncomment the line below and remove the two lines underneath it
-                // as it is a workaround suggested in HELP-21664
+                // After implementing TIG-2839 uncomment the line below and remove the two lines
+                // underneath it as it is a workaround suggested in HELP-21664
                 // REQUIRE(toString(expected.view()) == toString(actual.view()));
                 auto expectedFix = bsoncxx::from_json(toString(expected.view()));
                 REQUIRE(toString(expectedFix.view()) == toString(actual.view()));

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -65,12 +65,10 @@ public:
 
     void run() const {
         DYNAMIC_SECTION("DocGenYamlTestCaseRunner " << name()) {
-            int64_t counter=1;
-            //int64_t * pcounter = &counter;
             if (_runMode == RunMode::kExpectException) {
                 try {
                     NodeSource ns = toNode(this->_givenTemplate);
-                    genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 1, counter});
+                    genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 1});
                     FAIL("Expected exception " << this->_expectedExceptionMessage.as<std::string>()
                                                << " but none occurred");
                 } catch (const std::exception& x) {
@@ -81,11 +79,15 @@ public:
             }
 
             NodeSource ns = toNode(this->_givenTemplate);
-            auto docGen = genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 2, counter});
+            auto docGen = genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 2});
             for (const auto&& nextValue : this->_thenReturns) {
                 auto expected = testing::toDocumentBson(nextValue);
                 auto actual = docGen();
-                REQUIRE(toString(expected.view()) == toString(actual.view()));
+                // After implementing TIG-2839 uncomment the line below and remove the two lines underneath it
+                // as it is a workaround suggested in HELP-21664
+                // REQUIRE(toString(expected.view()) == toString(actual.view()));
+                auto expectedFix = bsoncxx::from_json(toString(expected.view()));
+                REQUIRE(toString(expectedFix.view()) == toString(actual.view()));
             }
         }
     }

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -498,7 +498,7 @@ Tests:
     GivenTemplate:
       int: {^ActorId: {}}
     ThenReturns:
-    - { "int" : { "$numberLong" : "2000000000"}, "string" : "2000000000" }
+    - { "int" : { "$numberLong" : "2000000000"}}
 
   # Now moves with time so would always fail until PERF-2086 is available.
   - Name: Now

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -592,3 +592,22 @@ Tests:
     ThenReturns:
     - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
 
+  - Name: Inc0
+    GivenTemplate:
+      int: {^Inc: {multiplier: 100, step: 1}}
+    ThenReturns:
+    - "int": { "$numberLong" : "201"}
+
+  - Name: Inc1
+    GivenTemplate:
+      int : {^Inc: {multiplier: 100, step: 1}}
+    ThenReturns:
+    - "int": { "$numberLong" : "202"}
+
+  - Name: Inc2
+    GivenTemplate:
+      int: {^Inc: {multiplier: 200, step: 1}}
+    ThenReturns:
+    - "int" : { "$numberLong" :"403"}
+
+

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -488,15 +488,17 @@ Tests:
     - a: "64.83.195.254"
     - a: "12.171.202.78"
 
-  # The commented portions of this test should work, but do not. This appears to be due to a bson or
-  # testlib error in formatting of bson. One case will have an extra whitespace than the other.
   - Name: Actor ID
     GivenTemplate:
-      # int: {^ActorId: {}}
       string: {^ActorIdString: {}}
     ThenReturns:
-    #    - { "int" : { "$numberLong" : "2000000000"}, "string" : "2000000000" }
     - "string": "2"
+
+  - Name: Actor ID
+    GivenTemplate:
+      int: {^ActorId: {}}
+    ThenReturns:
+    - { "int" : { "$numberLong" : "2000000000"}, "string" : "2000000000" }
 
   # Now moves with time so would always fail until PERF-2086 is available.
   - Name: Now
@@ -592,22 +594,34 @@ Tests:
     ThenReturns:
     - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
 
-  - Name: Inc0
+  - Name: SimpleIncrement
     GivenTemplate:
-      int: {^Inc: {multiplier: 100, step: 1}}
+      int: {^Inc: {start: 1, multiplier: 100, step: 1}}
     ThenReturns:
     - "int": { "$numberLong" : "201"}
-
-  - Name: Inc1
-    GivenTemplate:
-      int : {^Inc: {multiplier: 100, step: 1}}
-    ThenReturns:
     - "int": { "$numberLong" : "202"}
+    - "int": { "$numberLong" : "203"}
 
-  - Name: Inc2
+  - Name: IncrementWithStep
     GivenTemplate:
-      int: {^Inc: {multiplier: 200, step: 1}}
+      int: {^Inc: {start: 100, multiplier: 200, step: 2}}
     ThenReturns:
+    - "int" : { "$numberLong" :"500"}
+    - "int" : { "$numberLong" :"502"}
+    - "int" : { "$numberLong" :"504"}
+
+  - Name: IncrementWithDefaultStart
+    GivenTemplate:
+      int: {^Inc: {multiplier: 200, step: 2}}
+    ThenReturns:
+    - "int" : { "$numberLong" :"401"}
     - "int" : { "$numberLong" :"403"}
+    - "int" : { "$numberLong" :"405"}
 
-
+  - Name: IncrementAllDeafults
+    GivenTemplate:
+      int: {^Inc: {}}
+    ThenReturns:
+    - "int" : { "$numberLong" :"3"}
+    - "int" : { "$numberLong" :"4"}
+    - "int" : { "$numberLong" :"5"}


### PR DESCRIPTION
Here is the first draft of the incrementing counter https://jira.mongodb.org/browse/PERF-2077 for discussion. I don't like it at all - not what it does, not code itself... Don't think that it is ready for a merge in any way. But after wasting a lot of time trying to figure out architecture / new C++ features / yaml / etc, it looks like I can utilize some help and I decided that bringing it out as a PR may be a good way to solicit some help. Here is the list of questions I have for now (and I probably didn't get to all questions yet].

1. It looks like the current DocumentGenerator architecture doesn't allow to have a shared counter between Actors - as its instances are per Actor.  [It appears that a shared counter may be in the workload context - but it appears that it will require much more changes, including architecture.]

2. If we have it per Actor, can we have multiple parallel threads per Actor? Do we need synchronization for the counter here? [I guess for document generation we probably don't need it]

3. So, as discussed in https://jira.mongodb.org/browse/PERF-2077, it appears that we basically have only multiplier and step as parameters. Not sure how we can use 'start' here - I guess we may hardcode 1 here, but it doesn't sound exciting.

4. It doesn't look like the test architecture used allows to verify if incrementing actually works (in DocumentGeneratorTestCases.yml). It appears that every iteration of the loop in DocGenYamlTestCaseRunner.cpp  
for (const auto&& nextValue : this->_thenReturns) {
resets the counter, so we can test only for the hardcoded initial counter value.

5. It appears that we have a problem with the assert in DocGenYamlTestCaseRunner.cpp - it does fail differing in a space (either you have it or not):
.../src/value_generators/test/DocGenYamlTestCaseRunner.cpp:88: FAILED:
  REQUIRE( toString(expected.view()) == toString(actual.view()) )
with expansion:
  "{ "int" : { "$numberLong" : "202" } }"
  ==
  "{ "int" : { "$numberLong" : "202"} }"
Actually it looks like it is not a new issue: https://github.com/mongodb/genny/blob/master/src/value_generators/test/DocumentGeneratorTestCases.yml#L491-L492

 Any input / feedback would be much appreciated.

Thanks,
Alex