### PR TITLE
PERF-2087: Add workload for reshardCollection with reads and writes

### DIFF
--- a/src/cast_core/src/RunCommand.cpp
+++ b/src/cast_core/src/RunCommand.cpp
@@ -257,7 +257,8 @@ void actor::RunCommand::run() {
 
 actor::RunCommand::RunCommand(ActorContext& context)
     : Actor(context),
-      _client{std::move(context.client())},
+      _client{std::move(
+          context.client(context.get("ClientName").maybe<std::string>().value_or("Default")))},
       _loop{context, context, _client, RunCommand::id()} {}
 
 namespace {

--- a/src/workloads/sharding/ReshardCollection.yml
+++ b/src/workloads/sharding/ReshardCollection.yml
@@ -1,0 +1,154 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/sharding"
+Description: |
+  Runs the reshardCollection command while read and write operations are active on the collection
+  being resharded.
+
+  The workload consists of 5 phases:
+    1. Creating an empty sharded collection distributed across all shards in the cluster.
+    2. Populating the sharded collection with data.
+    3. Running read and write operations on the collection before it is resharded.
+    4. Running read and write operations on the collection while it is being resharded.
+    5. Running read and write operations on the collection after it has been resharded.
+
+GlobalDefaults:
+  Nop: &Nop {Nop: true}
+
+  Database: &Database test
+  # Collection0 is the default collection populated by the MonotonicLoader.
+  Collection: &Collection Collection0
+  Namespace: &Namespace test.Collection0
+
+  DocumentSize: &DocumentSize 10000  # = 10kB
+  DocumentSize80Pct: &DocumentSize80Pct 8000  # = 8kB
+  DocumentCount: &DocumentCount 100000  # for an approximate total of 1GB
+
+  ShardKeyValueMin: &ShardKeyValueMin 1
+  ShardKeyValueMax: &ShardKeyValueMax 100
+
+  ReadWriteOperations: &ReadWriteOperations
+  - OperationName: findOne
+    OperationCommand:
+      Filter: {_id: {^RandomInt: {min: 1, max: *DocumentCount}}}
+  - OperationName: updateOne
+    OperationCommand:
+      Filter: {_id: {^RandomInt: {min: 1, max: *DocumentCount}}}
+      Update: {$inc: {counter: 1}}
+      # Write operations can fail with a ShardInvalidatedForTargeting error response due to the
+      # routing information for the temporary resharding collection not being available on the
+      # donor shard. TODO: Investigate why mongos isn't automatically retrying on it.
+      ThrowOnFailure: false
+
+Clients:
+  # The reshardCollection command is expected to take a long to complete so we give the actor
+  # running it a much higher socket timeout.
+  ReshardCollection:
+    QueryOptions:
+      maxPoolSize: 1
+      socketTimeoutMS: 3600000  # = 1 hour
+
+Actors:
+- Name: CreateShardedCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationMetricsName: EnableSharding
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: *Database
+    - OperationMetricsName: ShardCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: *Namespace
+        # Hashed sharding will pre-split the chunk ranges and evenly distribute them across all of
+        # the shards.
+        key: {oldKey: hashed}
+        numInitialChunks: 60
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: LoadInitialData
+  Type: MonotonicLoader
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    BatchSize: 1000
+    Threads: 1
+    DocumentCount: *DocumentCount
+    Database: *Database
+    CollectionCount: 1
+    Document:
+      oldKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}}
+      newKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}}
+      counter: 0
+      padding: {^FastRandomString: {length: {^RandomInt: {min: *DocumentSize80Pct, max: *DocumentSize}}}}
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: ReshardCollection
+  Type: AdminCommand
+  Threads: 1
+  ClientName: ReshardCollection
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    # Until SERVER-53373 is implemented, donor shards aren't guaranteed to preserve enough history
+    # on their own for the atClusterTime read by recipient shards to succeed. We enable the
+    # WTPreserveSnapshotHistoryIndefinitely failpoint in the meantime. The testing-only multicast
+    # command in mongos runs the specified command across all shard primaries and secondaries. This
+    # ensures all nodes in the replica set shards preserve enough history, regardless of which the
+    # "nearest" read preference for collection cloning ends up targeting. TODO: Stop enabling the
+    # WTPreserveSnapshotHistoryIndefinitely failpoint once SERVER-53373 is implemented.
+    - OperationName: AdminCommand
+      OperationCommand:
+        multicast:
+          configureFailPoint: WTPreserveSnapshotHistoryIndefinitely
+          mode: alwaysOn
+    - OperationMetricsName: ReshardCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        reshardCollection: *Namespace
+        # There is a known bug where the config.chunks entries generated for the temporary
+        # resharding collection are identical to the config.chunks entries for the existing sharded
+        # collection. TODO: Use {newKey: 1} as the new shard key pattern after this issue has been
+        # addressed by SERVER-49526.
+        key: {oldKey: hashed, newKey: 1}
+  - *Nop
+
+- Name: ReadWriteCollectionBeingResharded
+  Type: CrudActor
+  Database: *Database
+  Phases:
+  - *Nop
+  - *Nop
+  - MetricsName: BeforeResharding
+    Duration: 10 seconds
+    Threads: 100
+    Collection: *Collection
+    Operations: *ReadWriteOperations
+  - MetricsName: DuringResharding
+    Blocking: None
+    Threads: 100
+    Collection: *Collection
+    Operations: *ReadWriteOperations
+  - MetricsName: AfterResharding
+    Duration: 10 seconds
+    Threads: 100
+    Collection: *Collection
+    Operations: *ReadWriteOperations
+
+AutoRun:
+  Requires:
+    mongodb_setup:
+    - shard-lite

--- a/src/workloads/sharding/ReshardCollection.yml
+++ b/src/workloads/sharding/ReshardCollection.yml
@@ -11,6 +11,13 @@ Description: |
     4. Running read and write operations on the collection while it is being resharded.
     5. Running read and write operations on the collection after it has been resharded.
 
+  The inserted documents have the following form:
+
+      {_id: 10, oldKey: 20, newKey: 30, counter: 0, padding: 'random string of bytes ...'}
+
+  The collection is initially sharded on {oldKey: 'hashed'} and then resharded on
+  {oldKey: 'hashed', newKey: 1}.
+
 GlobalDefaults:
   Nop: &Nop {Nop: true}
 

--- a/src/workloads/sharding/ReshardCollection.yml
+++ b/src/workloads/sharding/ReshardCollection.yml
@@ -26,8 +26,11 @@ GlobalDefaults:
   Collection: &Collection Collection0
   Namespace: &Namespace test.Collection0
 
-  DocumentSize: &DocumentSize 10000  # = 10kB
-  DocumentSize80Pct: &DocumentSize80Pct 8000  # = 8kB
+  # Note that the exact document size may exceed ApproxDocumentSize because of field names and other
+  # fields in the document.
+  ApproxDocumentSize: &ApproxDocumentSize 10000  # = 10kB
+  ApproxDocumentSize80Pct: &ApproxDocumentSize80Pct 8000  # = 8kB
+  # TODO: Increase DocumentCount to 4000000 so there will be ~20GB of data inserted on each shard.
   DocumentCount: &DocumentCount 100000  # for an approximate total of 1GB
 
   ShardKeyValueMin: &ShardKeyValueMin 1
@@ -94,7 +97,7 @@ Actors:
       oldKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}}
       newKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}}
       counter: 0
-      padding: {^FastRandomString: {length: {^RandomInt: {min: *DocumentSize80Pct, max: *DocumentSize}}}}
+      padding: {^FastRandomString: {length: {^RandomInt: {min: *ApproxDocumentSize80Pct, max: *ApproxDocumentSize}}}}
   - *Nop
   - *Nop
   - *Nop


### PR DESCRIPTION
Also adds support for "ClientName" in RunCommand actor for running operations through a connection pool other than the "Default" one.

Sys-perf patch build: https://evergreen.mongodb.com/task/sys_perf_linux_shard_lite_reshard_collection_patch_4b6a89a429c39a4f0848e7723f7bda9d22576cf9_5fff91fbd6d80a156b0ca5fe_21_01_14_00_37_52/1

Sys-perf patch build <span>#</span>2: https://evergreen.mongodb.com/task/sys_perf_linux_shard_lite_reshard_collection_patch_cc8671bcf846a6aeda28a5cf81aea750c2fca4bd_60073a961e2d17558c27f16a_21_01_19_20_04_06/0