### PR TITLE
WT-7075 Prevent MongoDB yielding in the LSWA workload

### DIFF
--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -107,6 +107,8 @@ struct CollectionScanner::PhaseConfig {
         } else if (scanTypeString == "snapshot") {
             transactionOptions = mongocxx::options::transaction{};
             auto readConcern = mongocxx::read_concern{};
+            // The read concern must be "snapshot" to prevent mongod from yielding and breaking the
+            // transaction into multiple shorter ones.
             readConcern.acknowledge_level(mongocxx::read_concern::level::k_snapshot);
             transactionOptions->read_concern(readConcern);
             scanType = ScanType::kSnapshot;

--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -107,7 +107,7 @@ struct CollectionScanner::PhaseConfig {
         } else if (scanTypeString == "snapshot") {
             transactionOptions = mongocxx::options::transaction{};
             auto readConcern = mongocxx::read_concern{};
-            readConcern.acknowledge_level(mongocxx::read_concern::level::k_majority);
+            readConcern.acknowledge_level(mongocxx::read_concern::level::k_snapshot);
             transactionOptions->read_concern(readConcern);
             scanType = ScanType::kSnapshot;
         } else if (scanTypeString == "standard") {

--- a/src/phases/scale/LargeScalePhases.yml
+++ b/src/phases/scale/LargeScalePhases.yml
@@ -14,7 +14,7 @@ GlobalDefaults:
   Random30String: &rand_30b_string {^RandomString: {length: 30}}
   Random130String: &rand_100b_string {^RandomString: {length: 100}}
 
-  Duration: &Duration 12 hours
+  Duration: &Duration 2 hours
 
   # We want about 200 bytes, 9 fields (they will all be indexed).
   RollingDocument: &RollingDocument
@@ -65,7 +65,7 @@ LongLivedCreatorCmd:
     x6: *rand_4b_int
     x7: *rand_4b_int
     x8: *rand_4b_int
-    s0: {^RandomString: {length: {^RandomInt: {min: 20, max: 80}}}}
+    s0: {^RandomString: {length: {^RandomInt: {min: 2000, max: 8000}}}}
   Indexes:
   - keys: {x0: 1}
   - keys: {x1: 1}
@@ -237,9 +237,9 @@ SnapshotScanner5GigabytesCmd:
   GlobalRate: 1 per 5 minutes
 
 # Leave out the ScanDuration since we'll be supplying the ScanRateMegaBytes option.
-SnapshotScanner5GigabytesFixedRateCmd:
+SnapshotScanner10GigabytesFixedRateCmd:
   Duration: *Duration
-  ScanSizeBytes: 500000000
+  ScanSizeBytes: 10000000000
   ScanType: snapshot
   CollectionSkip: 300
   CollectionSortOrder: forward

--- a/src/phases/scale/LargeScalePhases.yml
+++ b/src/phases/scale/LargeScalePhases.yml
@@ -14,7 +14,7 @@ GlobalDefaults:
   Random30String: &rand_30b_string {^RandomString: {length: 30}}
   Random130String: &rand_100b_string {^RandomString: {length: 100}}
 
-  Duration: &Duration 2 hours
+  Duration: &Duration 12 hours
 
   # We want about 200 bytes, 9 fields (they will all be indexed).
   RollingDocument: &RollingDocument
@@ -55,7 +55,7 @@ LongLivedCreatorCmd:
   DocumentCount: *DocumentCountParam
   BatchSize: 1000
   Document:
-    # Each document ranges in size from about 90 to 150 bytes (average 120)
+    # Each document ranges in size from about 2000 to 8000 bytes (average 5000)
     x0: *rand_10k_int
     x1: *rand_4b_int
     x2: *rand_4b_int

--- a/src/workloads/scale/ScanWithLongLived.yml
+++ b/src/workloads/scale/ScanWithLongLived.yml
@@ -73,17 +73,17 @@ Actors:
         DocumentCount: *LongLivedDocumentCount
         IdFilter: *binomial_10k_int
 
-- Name: SnapshotScanner5Gigabytes
+- Name: SnapshotScanner10Gigabytes
   Type: CollectionScanner
   Threads: 10
   Database: *LongLivedDB
-  ScanRateMegabytes: 5 per 1 second
+  ScanRateMegabytes: 10 per 1 second
   Phases:
   - {Nop: true}
   - {Nop: true}
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
-      Key: SnapshotScanner5GigabytesFixedRateCmd
+      Key: SnapshotScanner10GigabytesFixedRateCmd
 
 AutoRun:
   Requires:


### PR DESCRIPTION
@sulabhM 
I'm just putting this here to make it visible to you.

We're not seeing much lookaside usage yet but the transaction length looks good and the yielding has been solved. Reducing the document count and increasing the size hasn't helped as we'd anticipated.