### PR TITLE
PERF-2089 Update ^RandomDate Generator to accept other generators as input

### DIFF
--- a/src/value_generators/include/value_generators/DocumentGenerator.hpp
+++ b/src/value_generators/include/value_generators/DocumentGenerator.hpp
@@ -36,6 +36,22 @@ public:
     using std::invalid_argument::invalid_argument;
 };
 
+/**
+ * Throw this to indicate a bad date format is received.
+ */
+class InvalidDateFormat : public InvalidValueGeneratorSyntax {
+public:
+    using InvalidValueGeneratorSyntax::InvalidValueGeneratorSyntax;
+};
+
+/**
+ * Throw this to indicate no parser can be found for a generator.
+ */
+class UnknownParserException : public InvalidValueGeneratorSyntax {
+public:
+    using InvalidValueGeneratorSyntax::InvalidValueGeneratorSyntax;
+};
+
 struct GeneratorArgs {
     DefaultRandom& rng;
     ActorId actorId;

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -681,7 +681,7 @@ const static auto formats = {
 
 class DateToIntGenerator : public Generator<int64_t> {
 public:
-    explicit DateToIntGenerator(UniqueGenerator<bsoncxx::types::b_date>& generator)
+    explicit DateToIntGenerator(UniqueGenerator<bsoncxx::types::b_date>&& generator)
         : _generator{std::move(generator)} {}
     int64_t evaluate() override {
         auto date = _generator->evaluate();
@@ -694,7 +694,7 @@ private:
 
 class CastDoubleToInt64Generator : public Generator<int64_t> {
 public:
-    explicit CastDoubleToInt64Generator(UniqueGenerator<double>& generator)
+    explicit CastDoubleToInt64Generator(UniqueGenerator<double>&& generator)
         : _generator{std::move(generator)} {}
     int64_t evaluate() override {
         return (int64_t)_generator->evaluate();
@@ -706,7 +706,7 @@ private:
 
 class DateStringParserGenerator : public Generator<int64_t> {
 public:
-    explicit DateStringParserGenerator(UniqueGenerator<std::string>& generator)
+    explicit DateStringParserGenerator(UniqueGenerator<std::string>&& generator)
         : _generator{std::move(generator)} {}
     int64_t evaluate() override {
         auto datetime = _generator->evaluate();
@@ -1218,7 +1218,7 @@ int64_t parseStringToMillis(const std::string& datetime) {
  */
 UniqueGenerator<int64_t> dateStringTimeGenerator(const Node& node, GeneratorArgs generatorArgs) {
     auto generator = stringGenerator(node, generatorArgs);
-    return std::make_unique<DateStringParserGenerator>(generator);
+    return std::make_unique<DateStringParserGenerator>(std::move(generator));
 }
 
 /**
@@ -1230,7 +1230,7 @@ UniqueGenerator<int64_t> dateStringTimeGenerator(const Node& node, GeneratorArgs
  */
 UniqueGenerator<int64_t> doubleTimeGenerator(const Node& node, GeneratorArgs generatorArgs) {
     auto generator = doubleGenerator(node, generatorArgs);
-    return std::make_unique<CastDoubleToInt64Generator>(generator);
+    return std::make_unique<CastDoubleToInt64Generator>(std::move(generator));
 }
 
 /**
@@ -1258,7 +1258,7 @@ UniqueGenerator<int64_t> dateTimeGenerator(const Node& node, GeneratorArgs gener
     if (auto parserPair = extractKnownParser(node, generatorArgs, dateParsers)) {
         // known parser type
         auto generator = parserPair->first(node[parserPair->second], generatorArgs);
-        return std::make_unique<DateToIntGenerator>(generator);
+        return std::make_unique<DateToIntGenerator>(std::move(generator));
     }
     // This is an internal private function, we have no sane way to interpret a scalar here,
     // so throw an exception.

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -154,7 +154,7 @@ using Parser = std::function<O(const Node&, GeneratorArgs)>;
 // Pre-declaring all at once
 // Documentation is at the implementations-site.
 const static boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
-const static boost::posix_time::ptime max_date(boost::gregorian::date(2050, 1, 1));
+const static boost::posix_time::ptime max_date(boost::gregorian::date(2150, 1, 1));
 
 UniqueGenerator<int64_t> intGenerator(const Node& node, GeneratorArgs generatorArgs);
 UniqueGenerator<int64_t> int64GeneratorBasedOnDistribution(const Node& node,

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -68,7 +68,8 @@ public:
             if (_runMode == RunMode::kExpectException) {
                 try {
                     NodeSource ns = toNode(this->_givenTemplate);
-                    genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 1});
+                    auto docGen = genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 1});
+                    docGen();
                     FAIL("Expected exception " << this->_expectedExceptionMessage.as<std::string>()
                                                << " but none occurred");
                 } catch (const std::exception& x) {

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -594,6 +594,55 @@ Tests:
     ThenReturns:
     - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
 
+  # Date: Random Dates from RandomInt.
+  - Name: RandomWithInt
+    GivenTemplate:
+      date: {^RandomDate: {min: {^RandomInt: {min: 1369875424299, max: 1369875424299}}, max: {^RandomInt: {min: 1369875424300, max: 1369875424300}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
+
+  # Date: Random Dates From RandomDouble.
+  - Name: RandomFromRandomhDouble
+    GivenTemplate:
+      date: {^RandomDate: {min: {^RandomDouble: {min: 1369875424299, max: 1369875424300}}, max: {^RandomDouble: {min: 1369875424300, max: 1369875424301}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
+
+  # Date: Random Dates from FastRandomStrings.
+  - Name: RandomDateFromFastRandomString
+    GivenTemplate:
+      date: {^RandomDate: {min: {^FastRandomString: {length: 1, alphabet: "0"}}, max: {^FastRandomString: {length: 1, alphabet: "1"}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "0" } } }
+
+  # Date: Random Dates From RandomStrings.
+  - Name: RandomDateFromRandomString
+    GivenTemplate:
+      date: {^RandomDate: {min: {^RandomString: {length: 1, alphabet: "0"}}, max: {^RandomString: {length: 1, alphabet: "1"}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "0" } } }
+
+  # Date: Random Dates from Join.
+  - Name: RandomDateFromJoin
+    GivenTemplate:
+      date: {^RandomDate: {min: {^Join: {array: ["2013","05","30T07:27:04.299+06:30"], sep: "-"}}, max: {^Join: {array: ["2013","05","30 06:27:04.300+05:30"], sep: "-"}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
+
+  # Date: Random Dates from Choose.
+  - Name: RandomDateFromChoose
+    GivenTemplate:
+      date: {^RandomDate: {min: {^Choose: {from: ["2013-05-30T07:27:04.299+06:30"]}}, max: {^Choose: {from: ["2013-05-30 06:27:04.300+05:30"]}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
+
+  # Date: RandomDates with invalid generator.
+  # Test that the correct exception type is raised.
+  - Name: RandomDateException
+    GivenTemplate:
+      date: {^RandomDate: {min: {^RandomString: {len: 1, alphabet: "0"}}}}
+    ThenThrows: InvalidValueGeneratorSyntax
+
   - Name: SimpleIncrement
     GivenTemplate:
       int: {^Inc: {start: 1, multiplier: 100, step: 1}}

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -550,6 +550,7 @@ Tests:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
     - { "date" : { "$date" : { "$numberLong" : "183360228161" } } }
+    - { "date" : { "$date" : { "$numberLong" : "120037897059" } } }
 
   # Date: 2020-01-01T00:00:00.000 (only one possible value here).
   - Name: RandomDateSingle
@@ -558,6 +559,8 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+    # Note: this generator can only return a single value.
+    - { "date" : { "$date" : { "$numberLong" : "1577836800000" } } }
     - { "date" : { "$date" : { "$numberLong" : "1577836800000" } } }
 
   # Date: Half Open interval: ["2020-01-01 00:00:00", "2020-06-01T12:00:00").
@@ -567,7 +570,8 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "1578819502267" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1587960410217" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1578875595873" } } }
 
   # Date: Half Open interval: ["1970-01-01", "2030-01-01").
   - Name: RandomDateFull
@@ -576,7 +580,8 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "4364371621225" } } }
+    - { "date" : { "$date" : { "$numberLong" : "4331882451667" } } }
+    - { "date" : { "$date" : { "$numberLong" : "3407482044257" } } }
 
   # Date: Half Open interval: ["2030-01-01", "2040-01-01").
   - Name: RandomDateFuture
@@ -585,7 +590,8 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "1918332607011" } } }
+    - { "date" : { "$date" : { "$numberLong" : "2190504376964" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1945898374006" } } }
 
   # Date: Half Open interval: ["2020-01-01", "2020-01-01").
   - Name: RandomDateULL
@@ -613,12 +619,30 @@ Tests:
     ThenReturns:
     - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
 
+  # Date: Random Dates from RandomInt Range (note the maximum min value is always less than the minimum max value).
+  - Name: RandomWithIntRange
+    GivenTemplate:
+      date: {^RandomDate: {min: {^RandomInt: {min: 0, max: 1369875424299}}, max: {^RandomInt: {min: 1369875424300, max: 1569875424300}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1329214233880" } } }
+    - { "date" : { "$date" : { "$numberLong" : "929477800105" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1110305120066" } } }
+
   # Date: Random Dates From RandomDouble.
   - Name: RandomFromRandomDouble
     GivenTemplate:
       date: {^RandomDate: {min: {^RandomDouble: {min: 1369875424299, max: 1369875424300}}, max: {^RandomDouble: {min: 1369875424300, max: 1369875424301}}}}
     ThenReturns:
     - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
+
+  # Date: Random Dates from RandomDouble Range (note the maximum min value is always less than the minimum max value).
+  - Name: RandomWithDoubleRange
+    GivenTemplate:
+      date: {^RandomDate: {min: {^RandomDouble: {min: 0, max: 1369875424299}}, max: {^RandomDouble: {min: 1369875424300, max: 1569875424300}}}}
+    ThenReturns:
+      - { "date" : { "$date" : { "$numberLong" : "740112225988" } } }
+      - { "date" : { "$date" : { "$numberLong" : "1385668773851" } } }
+      - { "date" : { "$date" : { "$numberLong" : "891111511599" } } }
 
   # Date: Random Dates from FastRandomStrings.
   - Name: RandomDateFromFastRandomString
@@ -627,12 +651,28 @@ Tests:
     ThenReturns:
     - { "date" : { "$date" : { "$numberLong" : "0" } } }
 
+  # Date: Random Dates from FastRandomStrings.
+  - Name: RandomDateFromFastRandomStringRange
+    GivenTemplate:
+      date: {^RandomDate: {min: {^FastRandomString: {length: 13, alphabet: "0123456789"}}, max: {^FastRandomString: {length: 14, alphabet: "123456789"}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "58178820845576" } } }
+    - { "date" : { "$date" : { "$numberLong" : "54692158564694" } } }
+
   # Date: Random Dates From RandomStrings.
   - Name: RandomDateFromRandomString
     GivenTemplate:
       date: {^RandomDate: {min: {^RandomString: {length: 1, alphabet: "0"}}, max: {^RandomString: {length: 1, alphabet: "1"}}}}
     ThenReturns:
     - { "date" : { "$date" : { "$numberLong" : "0" } } }
+
+  # Date: Random Dates From RandomStrings.
+  - Name: RandomDateFromRandomStringRange
+    GivenTemplate:
+      date: {^RandomDate: {min: {^RandomString: {length: 13, alphabet: "0123456789"}}, max: {^RandomString: {length: 14, alphabet: "123456789"}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "15634284905399" } } }
+    - { "date" : { "$date" : { "$numberLong" : "48656235710126" } } }
 
   # Date: Random Dates from Join.
   - Name: RandomDateFromJoin
@@ -644,9 +684,10 @@ Tests:
   # Date: Random Dates from Choose.
   - Name: RandomDateFromChoose
     GivenTemplate:
-      date: {^RandomDate: {min: {^Choose: {from: ["2013-05-30T07:27:04.299+06:30"]}}, max: {^Choose: {from: ["2013-05-30 06:27:04.300+05:30"]}}}}
+      date: {^RandomDate: {min: {^Choose: {from: ["2013-05-30T07:27:04.299+06:30", "1970-01-01"]}}, max: {^Choose: {from: ["2023-05-30 06:27:04.300+05:30"]}}}}
     ThenReturns:
-    - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1396475999152" } } } # 2014-04-02 must be due to min choice 1
+    - { "date" : { "$date" : { "$numberLong" : "196060573322" } } }  # 1976-03-19 must be due to min choice 2
 
   # Date: Random Dates from Mixed Generators.
   - Name: RandomDateMixed
@@ -673,8 +714,6 @@ Tests:
         }
       }
     ThenThrows: InvalidValueGeneratorSyntax
-
-
 
   - Name: SimpleIncrement
     GivenTemplate:

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -510,6 +510,18 @@ Tests:
     # Check with linux command line `date --utc -d@$((1453689676330 / 1000.0))  +"%Y-%m-%dT%H:%M:%S.%3N"`
     - { "date" : { "$date" : { "$numberLong" : "1453689676330" } } }
 
+  # Date: min equal max is invalid.
+  - Name: RandomDateMinEqualMax
+    GivenTemplate:
+      date: {^RandomDate: {min: "2020-01-01", max: "2020-01-01"}}
+    ThenThrows: InvalidValueGeneratorSyntax
+
+  # Date: min must be less than max.
+  - Name: RandomDateInvalidMinMax
+    GivenTemplate:
+      date: {^RandomDate: {min: "2021-01-01", max: "2020-01-01"}}
+    ThenThrows: InvalidValueGeneratorSyntax
+
   # Date: Half Open interval: ["2020-01-01", "2021-01-01").
   - Name: RandomDateMinMax
     GivenTemplate:
@@ -527,8 +539,8 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "1778468968160" } } }
-    - { "date" : { "$date" : { "$numberLong" : "1871664110292" } } }
+    - { "date" : { "$date" : { "$numberLong" : "2179678398958" } } }
+    - { "date" : { "$date" : { "$numberLong" : "2459238321326" } } }
 
   # Date: Half Open interval: ["1970-01-01", "2021-01-01"). 1970-01-01 is the default min date.
   - Name: RandomDateMax
@@ -564,7 +576,7 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "1454812640684" } } }
+    - { "date" : { "$date" : { "$numberLong" : "1939750253947" } } }
 
   # Date: Half Open interval: ["2030-01-01", "2040-01-01").
   - Name: RandomDateFuture
@@ -602,7 +614,7 @@ Tests:
     - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
 
   # Date: Random Dates From RandomDouble.
-  - Name: RandomFromRandomhDouble
+  - Name: RandomFromRandomDouble
     GivenTemplate:
       date: {^RandomDate: {min: {^RandomDouble: {min: 1369875424299, max: 1369875424300}}, max: {^RandomDouble: {min: 1369875424300, max: 1369875424301}}}}
     ThenReturns:
@@ -636,12 +648,33 @@ Tests:
     ThenReturns:
     - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
 
+  # Date: Random Dates from Mixed Generators.
+  - Name: RandomDateMixed
+    GivenTemplate:
+      date: {^RandomDate: {min: {^Join: {array: ["2013","05","30T07:27:04.299+06:30"], sep: "-"}}, max: {^Choose: {from: ["2013-05-30 06:27:04.300+05:30"]}}}}
+    ThenReturns:
+    - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
+
   # Date: RandomDates with invalid generator.
   # Test that the correct exception type is raised.
   - Name: RandomDateException
     GivenTemplate:
       date: {^RandomDate: {min: {^RandomString: {len: 1, alphabet: "0"}}}}
     ThenThrows: InvalidValueGeneratorSyntax
+
+  # Date: RandomDates with invalid min / max.
+  # Test that the correct exception type is raised.
+  - Name: RandomDateException
+    GivenTemplate:
+      date: {
+        ^RandomDate: {
+          min: {^Choose: {from: ["2013-05-31T07:27:04.299+06:30", "2013-05-31 06:27:04.300+05:30"]}},
+          max: {^Choose: {from: ["2013-05-30 06:27:04.300+05:30", "2013-05-30T07:27:04.299+06:30"]}}
+        }
+      }
+    ThenThrows: InvalidValueGeneratorSyntax
+
+
 
   - Name: SimpleIncrement
     GivenTemplate:

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -539,8 +539,8 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "2179678398958" } } }
-    - { "date" : { "$date" : { "$numberLong" : "2459238321326" } } }
+    - { "date" : { "$date" : { "$numberLong" : "4185670857742" } } }
+    - { "date" : { "$date" : { "$numberLong" : "5397029274960" } } }
 
   # Date: Half Open interval: ["1970-01-01", "2021-01-01"). 1970-01-01 is the default min date.
   - Name: RandomDateMax
@@ -576,7 +576,7 @@ Tests:
     ThenReturns:
     # The $date notation is extended json
     # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
-    - { "date" : { "$date" : { "$numberLong" : "1939750253947" } } }
+    - { "date" : { "$date" : { "$numberLong" : "4364371621225" } } }
 
   # Date: Half Open interval: ["2030-01-01", "2040-01-01").
   - Name: RandomDateFuture
@@ -656,7 +656,7 @@ Tests:
     - { "date" : { "$date" : { "$numberLong" : "1369875424299" } } }
 
   # Date: RandomDates with invalid generator.
-  # Test that the correct exception type is raised.
+  # Test that the correct exception type is raised (in this case RandomString does not have a len attribute).
   - Name: RandomDateException
     GivenTemplate:
       date: {^RandomDate: {min: {^RandomString: {len: 1, alphabet: "0"}}}}

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -158,19 +158,15 @@ Actors:
             # Generate a random date with a TZ offset.
             kolkata: {^RandomDate: {min: "2015-01-01T00:00:00+05:30", max: "2016-01-01T00:00:00+05:30"}}
 
-            # Generator inputs can be mixed and matched as desired.
-            fixedToNow: {^RandomDate: {min: "2021-01-01", max: {^Now: {}}}}
-            joinedDateToMax: {^RandomDate: {min: {^Join: {array: ["2013","05","30T07:27:04.299+06:30"], sep: "-"}}}}
-            minDateToChoices{^RandomDate: { max: {^Choose: {from: ["2013-05-30 06:27:04.300+05:30", "2013-05-30T07:27:04.299+06:30"]}}}}
+            # # Generator inputs can be mixed and matched as desired.
+            # fixedToNow: {^RandomDate: {min: "2021-01-01", max: {^Now: {}}}}
+            # joinedDateToMax: {^RandomDate: {min: {^Join: {array: ["2013","05","30T07:27:04.299+06:30"], sep: "-"}}}}
+            # minDateToChoices{^RandomDate: { max: {^Choose: {from: ["2013-05-30 06:27:04.300+05:30", "2013-05-30T07:27:04.299+06:30"]}}}}
 
-            # As min must be less than max, care must be taken to ensure that the min value range is always less than the max value range.
-            # Other wise you might get unexpected results. For example the following should fail 25% of the time
-            # (whenever 2100-05-31T06:27:04.299 is selected). 
-            probablyNotWhatYouWant: {
-              ^RandomDate: {
-                min: {^Choose: {from: ["2011-05-31T07:27:04.299", "2012-05-31T07:27:04.299", "2013-05-31T07:27:04.299", "2100-05-31T06:27:04.299"]}},
-                max: {^Now: {}}
-              }
+            # # As min must be less than max, care must be taken to ensure that the min value range is always less than the max value range.
+            # # Other wise you might get unexpected results. For example the following should fail 25% of the time
+            # # (whenever 2100-05-31 is selected). 
+            # probablyNotWhatYouWant: {^RandomDate: {min: {^Choose: {from: ["2014-05-31", "2012-05-31", "2013-05-31", "2100-05-31"]}}, max: {^Now: {}} }}
 
         - WriteCommand: insertOne  # Nested Generators
           # You can nest generators to make complex values.

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -119,11 +119,23 @@ Actors:
             # (see https://docs.mongodb.com/manual/reference/bson-types/#date). However, nanos can be
             # specified, but will be ignored.
             # The min / max range is a half open interval, that is from min (inclusive) to max (exclusive).
+            #
             # Default min is 1970-01-01.
-            # Default max is 2030-01-01. But you can specify a date greater than this value.
-            # max must be greater than min (so by extension max cannot be 1970-01-01).
+            # Default max is 2150-01-01. But you can specify a date greater than this value.
+            #
+            # min and max are evaluated once and max must be greater than min (so by extension max cannot be 1970-01-01).
             # The generated date uses the extended json $date notation 
             # (see https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date).
+            #
+            # RandomDate supports other generators as input (generators that produce string or numeric types):
+            # * ^RandomInt
+            # * ^RandomDouble
+            # * ^FastRandomString
+            # * ^RandomString
+            # * ^Join
+            # * ^Choose
+            # * ^Now
+            # * ^RandomDate
 
             # Generate a random date in 2015. That is the Half Open interval : ["2015-01-01 00:00:00.000", "2016-01-01 00:00:00.000")
             year2015: {^RandomDate: {min: "2015-01-01", max: "2016-01-01"}}
@@ -145,6 +157,20 @@ Actors:
 
             # Generate a random date with a TZ offset.
             kolkata: {^RandomDate: {min: "2015-01-01T00:00:00+05:30", max: "2016-01-01T00:00:00+05:30"}}
+
+            # Generator inputs can be mixed and matched as desired.
+            fixedToNow: {^RandomDate: {min: "2021-01-01", max: {^Now: {}}}}
+            joinedDateToMax: {^RandomDate: {min: {^Join: {array: ["2013","05","30T07:27:04.299+06:30"], sep: "-"}}}}
+            minDateToChoices{^RandomDate: { max: {^Choose: {from: ["2013-05-30 06:27:04.300+05:30", "2013-05-30T07:27:04.299+06:30"]}}}}
+
+            # As min must be less than max, care must be taken to ensure that the min value range is always less than the max value range.
+            # Other wise you might get unexpected results. For example the following should fail 25% of the time
+            # (whenever 2100-05-31T06:27:04.299 is selected). 
+            probablyNotWhatYouWant: {
+              ^RandomDate: {
+                min: {^Choose: {from: ["2011-05-31T07:27:04.299", "2012-05-31T07:27:04.299", "2013-05-31T07:27:04.299", "2100-05-31T06:27:04.299"]}},
+                max: {^Now: {}}
+              }
 
         - WriteCommand: insertOne  # Nested Generators
           # You can nest generators to make complex values.


### PR DESCRIPTION
**dateStringParserGenerator** calls **stringGenerator**. As a result, it supports all the generators (even if they don't make sense like ^IP).
