### PR TITLE
WT-7193 Cleanup Evergreen tasks for LSWA

### DIFF
--- a/src/phases/scale/LargeScalePhases.yml
+++ b/src/phases/scale/LargeScalePhases.yml
@@ -14,7 +14,7 @@ GlobalDefaults:
   Random30String: &rand_30b_string {^RandomString: {length: 30}}
   Random130String: &rand_100b_string {^RandomString: {length: 100}}
 
-  Duration: &Duration 12 hours
+  Duration: &Duration 2 hours
 
   # We want about 200 bytes, 9 fields (they will all be indexed).
   RollingDocument: &RollingDocument

--- a/src/workloads/scale/LargeScaleModel.yml
+++ b/src/workloads/scale/LargeScaleModel.yml
@@ -337,8 +337,3 @@ Actors:
   - ExternalPhaseConfig:
       Path: ../../phases/scale/LargeScalePhases.yml
       Key: OplogTrailerCmd
-
-AutoRun:
-  Requires:
-    mongodb_setup:
-    - standalone

--- a/src/workloads/scale/ScanWithLongLived.yml
+++ b/src/workloads/scale/ScanWithLongLived.yml
@@ -88,4 +88,5 @@ Actors:
 AutoRun:
   Requires:
     mongodb_setup:
-    - standalone
+    - single-replica
+    - replica-noflowcontrol


### PR DESCRIPTION
- Fix ScanWithLongLived to run for a shorter duration and use replica sets.
- Stop running LargeScaleModel since it generates BFs and doesn't do anything useful.