### PR TITLE
PERF-2159 Adding options support for find and findOne in CrudActor

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -799,7 +799,11 @@ struct FindOperation : public BaseOperation {
           _onSession{onSession},
           _collection{std::move(collection)},
           _operation{operation},
-          _filter{opNode["Filter"].to<DocumentGenerator>(context, id)} {}
+          _filter{opNode["Filter"].to<DocumentGenerator>(context, id)} {
+        if (opNode["Options"]) {
+            _options = opNode["Options"].to<mongocxx::options::find>();
+        }
+    }
 
     void run(mongocxx::client_session& session) override {
         auto filter = _filter();
@@ -834,7 +838,11 @@ struct FindOneOperation : public BaseOperation {
           _onSession{onSession},
           _collection{std::move(collection)},
           _operation{operation},
-          _filter{opNode["Filter"].to<DocumentGenerator>(context, id)} {}
+          _filter{opNode["Filter"].to<DocumentGenerator>(context, id)} {
+        if (opNode["Options"]) {
+            _options = opNode["Options"].to<mongocxx::options::find>();
+        }
+    }
 
     void run(mongocxx::client_session& session) override {
         auto filter = _filter();

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -141,6 +141,39 @@ struct convert<mongocxx::options::count> {
 };
 
 template <>
+struct convert<mongocxx::options::find> {
+    using FindOptions = mongocxx::options::find;
+    static Node encode(const FindOptions& rhs) {
+        return {};
+    }
+
+    static bool decode(const Node& node, FindOptions& rhs) {
+        if (!node.IsMap()) {
+            return false;
+        }
+        if (node["Hint"]) {
+            auto h = node["Hint"].as<std::string>();
+            auto hint = mongocxx::hint(h);
+            rhs.hint(hint);
+        }
+        if (node["Limit"]) {
+            auto limit = node["Limit"].as<int>();
+            rhs.limit(limit);
+        }
+        if (node["MaxTime"]) {
+            auto maxTime = node["MaxTime"].as<genny::TimeSpec>();
+            rhs.max_time(std::chrono::milliseconds{maxTime});
+        }
+        if (node["ReadPreference"]) {
+            auto readPref = node["ReadPreference"].as<mongocxx::read_preference>();
+            rhs.read_preference(readPref);
+        }
+        return true;
+    }
+};
+
+
+template <>
 struct convert<mongocxx::options::estimated_document_count> {
     using CountOptions = mongocxx::options::estimated_document_count;
     static Node encode(const CountOptions& rhs) {

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -288,6 +288,30 @@ Tests:
       $readPreference:
         mode: secondaryPreferred
 
+  - Description: Read preference is 'secondaryPreferred' in find.
+    Operations:
+      - OperationName: find
+        OperationCommand:
+          Filter: { a : 1 }
+          Options:
+            ReadPreference:
+              ReadMode: secondaryPreferred
+    ExpectAllEvents:
+      $readPreference:
+        mode: secondaryPreferred
+
+  - Description: Read preference is 'secondaryPreferred' in findOne.
+    Operations:
+      - OperationName: findOne
+        OperationCommand:
+          Filter: { a : 1 }
+          Options:
+            ReadPreference:
+              ReadMode: secondaryPreferred
+    ExpectAllEvents:
+      $readPreference:
+        mode: secondaryPreferred
+
   - Description: Read preference is 'nearest' with MaxStaleness set.
     Operations:
       - OperationName: countDocuments


### PR DESCRIPTION
CrudActor ignores options for most operations including find. It does process some options only for four operations: BulkWrite, CountDocuments, EstimateDocumentCount, and StartTransaction. All options must be spell out in the code to be processed. It just ignores it otherwise without any error and warning.

So this PR adds support of a few options for find and findOne and adding a test that supposed to check it.

Ideally it would be good to get a warning when something in the yml file is ignored.

As I need it for PERF-2096 while it is not directly related to it - submitting this small PR separately.