### PR TITLE
TIG-2766 Warn of unused yaml structures

### DIFF
--- a/src/gennylib/include/gennylib/Node.hpp
+++ b/src/gennylib/include/gennylib/Node.hpp
@@ -32,6 +32,8 @@
 
 namespace genny {
 
+using UnusedNodes = std::vector<std::string>;
+
 /**
  * Source of all `genny::Node` instances.
  * This must outlive all `Node&`s handed out.
@@ -59,6 +61,9 @@ public:
      *   Likely a file-path from where the yaml was loaded.
      */
     NodeSource(std::string yaml, std::string path);
+
+    [[nodiscard]]
+    UnusedNodes unused() const;
 
 private:
     const YAML::Node _yaml;
@@ -103,6 +108,7 @@ public:
         return _value < rhs._value;
     }
 
+    [[nodiscard]]
     std::string toString() const;
 
     friend std::ostream& operator<<(std::ostream& out, const ::genny::v1::NodeKey& key) {
@@ -539,6 +545,10 @@ public:
 
     // Only intended to be used internally
     explicit Node(const v1::NodeKey::Path& path, const YAML::Node yaml);
+
+
+    [[nodiscard]]
+    UnusedNodes unused() const;
 
 private:
     friend class NodeImpl;

--- a/src/gennylib/src/Node.cpp
+++ b/src/gennylib/src/Node.cpp
@@ -171,9 +171,6 @@ public:
 
     UnusedNodes unused() const {
         UnusedNodes out{};
-        if (!this->_used) {
-            out.push_back(this->path());
-        }
         for (auto&& [_, child] : this->_children) {
             if (child->_impl->_yaml == _zombie) {
                 // Empty/zombie children
@@ -183,6 +180,9 @@ public:
             for(auto&& u : childUnused) {
                 out.push_back(u);
             }
+        }
+        if (!this->_used && (this->_children.empty() || !out.empty())) {
+            out.push_back(this->path());
         }
         return out;
     }

--- a/src/gennylib/src/Node.cpp
+++ b/src/gennylib/src/Node.cpp
@@ -177,7 +177,7 @@ public:
                 continue;
             }
             const auto childUnused = child->unused();
-            for(auto&& u : childUnused) {
+            for (auto&& u : childUnused) {
                 out.push_back(u);
             }
         }

--- a/src/gennylib/test/Node_test.cpp
+++ b/src/gennylib/test/Node_test.cpp
@@ -44,27 +44,33 @@ c: []
 n: { ested: [v, alue] }
 t: { value: 11 }
 "
-    )", ""};
+    )",
+                       ""};
     const auto& r = n.root();
 
-    const auto noneUsed = UnusedNodes {
-        // We do depth-first.
-        // TODO: why do we have a '/ ' and '' node?
-        "/ ",
-        "/a/0", "/a/1", "/a/2", "/a",
-        "/b",
-        "/c",
-        "/n/ested/0", "/n/ested/1", "/n/ested", "/n",
-        "/t/value",
-        "/t",
-        ""
-    };
+    const auto noneUsed = UnusedNodes{// We do depth-first.
+                                      // TODO: why do we have a '/ ' and '' node?
+                                      "/ ",
+                                      "/a/0",
+                                      "/a/1",
+                                      "/a/2",
+                                      "/a",
+                                      "/b",
+                                      "/c",
+                                      "/n/ested/0",
+                                      "/n/ested/1",
+                                      "/n/ested",
+                                      "/n",
+                                      "/t/value",
+                                      "/t",
+                                      ""};
 
     const auto onlyUsed = [=](std::initializer_list<std::string> ks) -> UnusedNodes {
         auto out = noneUsed;
-        for(auto&& k : ks) {
-            out.erase(std::remove_if(out.begin(), out.end(),
-                                   [&](const std::string& c) { return c == k; }), out.end());
+        for (auto&& k : ks) {
+            out.erase(std::remove_if(
+                          out.begin(), out.end(), [&](const std::string& c) { return c == k; }),
+                      out.end());
         }
         return out;
     };
@@ -81,7 +87,7 @@ t: { value: 11 }
         //
         // In the case of .to<X>, yaml-cpp's built-in conversions
         // for std containers doesn't consult with genny::Node.
-        REQUIRE(r["a"].to<std::vector<int>>() == std::vector<int>{1,2,3});
+        REQUIRE(r["a"].to<std::vector<int>>() == std::vector<int>{1, 2, 3});
         // We'd really like this to be the same REQUIRE as in the "All items in a list used" case.
         REQUIRE(n.unused() == onlyUsed({"/a"}));
     }
@@ -143,30 +149,30 @@ t: { value: 11 }
     }
     struct MyType {
         int value;
-        explicit MyType(const Node& n, int mult=1)
-        : value{(n["value"].maybe<int>().value_or(93) + 7)*mult} {}
+        explicit MyType(const Node& n, int mult = 1)
+            : value{(n["value"].maybe<int>().value_or(93) + 7) * mult} {}
     };
     SECTION("Using custom conversion counts as being used") {
         auto t = r["t"].to<MyType>(3);
-        REQUIRE(t.value == 54); // (11 + 7) * 3
+        REQUIRE(t.value == 54);  // (11 + 7) * 3
         REQUIRE(n.unused() == onlyUsed({"/t/value", "/t"}));
     }
     SECTION("Maybes also work") {
         auto t = r["t"].maybe<MyType>(3);
-        REQUIRE(t->value == 54); // (11 + 7) * 3
+        REQUIRE(t->value == 54);  // (11 + 7) * 3
         REQUIRE(n.unused() == onlyUsed({"/t/value", "/t"}));
     }
 
     SECTION("Maybes also work pt2") {
         auto t = r["t"].maybe<MyType>();
-        REQUIRE(t->value == 18); // (11 + 7) * (mult=1)
+        REQUIRE(t->value == 18);  // (11 + 7) * (mult=1)
         REQUIRE(n.unused() == onlyUsed({"/t/value", "/t"}));
     }
     SECTION("Maybes that fail to use the value don't use the value") {
         // Use the 'n' structure (n:{ested:[v,alue]}) which doesn't have
         // the "value" key that MyStruct wants to see.
         auto t = r["n"].maybe<MyType>(5);
-        REQUIRE(t->value == 500); // (93 + 7) * (mult=5)
+        REQUIRE(t->value == 500);  // (93 + 7) * (mult=5)
         REQUIRE(n.unused() == noneUsed);
     }
 }


### PR DESCRIPTION
80% of the solution needed to warn of potential mis-configuration. This is such a common annoyance that it seemed worthwhile to put out a "beta" solution:

1. Doesn't actually error on unused structures
2. Structures used via `.to<std::vector>` and other STL containers are reported as unused
3. The top-level root structure shows as unused (line noise). I didn't have the patience to fix that yet.

Before we look into handling these issues, I first want to see how useful this is / if it catches anything.