### PR TITLE
TIG-2836 hide genny internal metrics by default

### DIFF
--- a/src/cast_core/src/RollingCollections.cpp
+++ b/src/cast_core/src/RollingCollections.cpp
@@ -187,7 +187,7 @@ struct Setup : public RunOperation {
         }
     }
 
-    ~Setup() override = default; 
+    ~Setup() override = default;
 
     void run() override {
         BOOST_LOG_TRIVIAL(info) << "Creating " << _collectionWindowSize << " initial collections.";

--- a/src/cast_core/src/RollingCollections.cpp
+++ b/src/cast_core/src/RollingCollections.cpp
@@ -187,7 +187,7 @@ struct Setup : public RunOperation {
         }
     }
 
-    ~Setup() override = default;
+    ~Setup() override = default; 
 
     void run() override {
         BOOST_LOG_TRIVIAL(info) << "Creating " << _collectionWindowSize << " initial collections.";

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -72,8 +72,7 @@ void reportMetrics(genny::metrics::Registry& metrics,
     auto finishTime = metrics::clock::now();
     // The "Setup" operation is a genny internal operation. We want the trend graph to be hidden by
     // default to not confuse users, so we prefix it with "canary_" to hit the
-    // CANARY_EXCLUSION_REGEX in
-    // https://github.com/evergreen-ci/evergreen/blob/9cb08ad5091b0c4d24d50d1c2f325ea42282eb3d/public/static/app/common/constants.js#L144
+    // CANARY_EXCLUSION_REGEX in https://git.io/Jtjdr
     auto actorSetup = metrics.operation("canary_" + workloadName, "Setup", 0u);
     auto outcome = success ? metrics::OutcomeType::kSuccess : metrics::OutcomeType::kFailure;
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finishTime - startTime);
@@ -159,8 +158,7 @@ DefaultDriver::OutcomeCode doRunLogic(const DefaultDriver::ProgramOptions& optio
 
     // The "ActorStarted" and "ActorFinished" operations are genny internal operations. We want the
     // trend graph to be hidden by default to not confuse users, so we prefix them with "canary_"
-    // to hit the CANARY_EXCLUSION_REGEX in
-    // https://github.com/evergreen-ci/evergreen/blob/9cb08ad5091b0c4d24d50d1c2f325ea42282eb3d/public/static/app/common/constants.js#L144
+    // to hit the CANARY_EXCLUSION_REGEX in https://git.io/Jtjdr
     auto startedActors = metrics.operation("canary_" + workloadName, "ActorStarted", 0u);
     auto finishedActors = metrics.operation("canary_" + workloadName, "ActorFinished", 0u);
 

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -70,7 +70,7 @@ void reportMetrics(genny::metrics::Registry& metrics,
                    bool success,
                    metrics::clock::time_point startTime) {
     auto finishTime = metrics::clock::now();
-    auto actorSetup = metrics.operation(workloadName, "Setup", 0u);
+    auto actorSetup = metrics.operation("canary_" + workloadName, "Setup", 0u);
     auto outcome = success ? metrics::OutcomeType::kSuccess : metrics::OutcomeType::kFailure;
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finishTime - startTime);
     actorSetup.report(std::move(finishTime), std::move(duration), std::move(outcome));
@@ -153,8 +153,8 @@ DefaultDriver::OutcomeCode doRunLogic(const DefaultDriver::ProgramOptions& optio
 
     reportMetrics(metrics, workloadName, true, startTime);
 
-    auto startedActors = metrics.operation(workloadName, "ActorStarted", 0u);
-    auto finishedActors = metrics.operation(workloadName, "ActorFinished", 0u);
+    auto startedActors = metrics.operation("canary_" + workloadName, "ActorStarted", 0u);
+    auto finishedActors = metrics.operation("canary_" + workloadName, "ActorFinished", 0u);
 
     std::atomic<DefaultDriver::OutcomeCode> outcomeCode = DefaultDriver::OutcomeCode::kSuccess;
 

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -70,6 +70,10 @@ void reportMetrics(genny::metrics::Registry& metrics,
                    bool success,
                    metrics::clock::time_point startTime) {
     auto finishTime = metrics::clock::now();
+    // The "Setup" operation is a genny internal operation. We want the trend graph to be hidden by
+    // default to not confuse users, so we prefix it with "canary_" to hit the
+    // CANARY_EXCLUSION_REGEX in
+    // https://github.com/evergreen-ci/evergreen/blob/9cb08ad5091b0c4d24d50d1c2f325ea42282eb3d/public/static/app/common/constants.js#L144
     auto actorSetup = metrics.operation("canary_" + workloadName, "Setup", 0u);
     auto outcome = success ? metrics::OutcomeType::kSuccess : metrics::OutcomeType::kFailure;
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finishTime - startTime);
@@ -153,6 +157,10 @@ DefaultDriver::OutcomeCode doRunLogic(const DefaultDriver::ProgramOptions& optio
 
     reportMetrics(metrics, workloadName, true, startTime);
 
+    // The "ActorStarted" and "ActorFinished" operations are genny internal operations. We want the
+    // trend graph to be hidden by default to not confuse users, so we prefix them with "canary_"
+    // to hit the CANARY_EXCLUSION_REGEX in
+    // https://github.com/evergreen-ci/evergreen/blob/9cb08ad5091b0c4d24d50d1c2f325ea42282eb3d/public/static/app/common/constants.js#L144
     auto startedActors = metrics.operation("canary_" + workloadName, "ActorStarted", 0u);
     auto finishedActors = metrics.operation("canary_" + workloadName, "ActorFinished", 0u);
 


### PR DESCRIPTION
[Patch showing (for example) ](https://evergreen.mongodb.com/task/sys_perf_linux_3_node_replSet_insert_remove_patch_f4054ff40c1c8309eefdbc87e84e8e8403e51281_603c10a67742ae2eaf0c43fb_21_02_28_21_56_21##hidden=Genny-Setup%252CHelloWorld-DefaultMetricsName.0%252CHelloWorld-DefaultMetricsName.1%252CHelloWorld-DefaultMetricsName.2%252CInsertRemoveTest.Insert%252CInsertRemoveTest.Remove%252CInsertRemove.Setup%252CInsertRemove.ActorStarted%252CInsertRemove.ActorFinished%252Cfio%252Ccpu_noise%252Ciperf%252Ccanary_InsertRemove.ActorFinished%252Ccanary_InsertRemove.Setup%252CNetworkBandwidth%252Cfio_latency_test_write_clat_mean%252Cfio_latency_test_read_clat_mean%252Cfio_iops_test_write_iops%252Cfio_iops_test_read_iops%252Cfio_streaming_bandwidth_test_write_iops%252Cfio_streaming_bandwidth_test_read_iops%252Ccanary_server-cpuloop-10x%252Ccanary_client-cpuloop-1x%252Ccanary_client-cpuloop-10x%252Ccanary_server-sleep-10ms%252Ccanary_ping%252Cinsert_remove%252Ccanary_InsertRemove.ActorStarted&comparehashes=f4054ff40c1c8309eefdbc87e84e8e8403e51281&threads=maxonly&selected.NetworkBandwidth=MAX&selected.fio_latency_test_write_clat_mean=MAX&selected.fio_latency_test_read_clat_mean=MAX&selected.fio_iops_test_write_iops=MAX&selected.fio_iops_test_read_iops=MAX&selected.fio_streaming_bandwidth_test_write_iops=MAX&selected.fio_streaming_bandwidth_test_read_iops=MAX&selected.canary_server-cpuloop-10x=MAX&selected.canary_client-cpuloop-1x=MAX&selected.canary_client-cpuloop-10x=MAX&selected.canary_server-sleep-10ms=MAX&selected.canary_ping=MAX&selected.iperf=MAX&selected.fio=MAX&selected.cpu_noise=MAX&selected.InsertRemoveTest.Insert=MAX&selected.InsertRemoveTest.Remove=MAX&selected.canary_InsertRemove.ActorFinished=MAX&selected.canary_InsertRemove.ActorStarted=MAX&selected.canary_InsertRemove.Setup=MAX&selected.insert_remove=MAX)`InsertRemove.ActorFinished` -> `canary_InsertRemove.ActorFinished`