### PR TITLE
PERF-2175 load phase

### DIFF
--- a/src/phases/scale/LLTPhases.yml
+++ b/src/phases/scale/LLTPhases.yml
@@ -6,11 +6,12 @@ Description: |
 
 GlobalDefaults:
   dbname: &dbname llt
-  DocumentCount: &NumDocs 10000000
+  InitialDocumentCount: &InitialNumDocs 10000000
+  SecondaryDocumentCount: &SecondaryNumDocs 10000000
+
   Document: &Doc
     ts: {^Now: {}}
     caid: {^RandomInt: {min: 0, max: 1000}}
-    #  int0: &int {^RandomInt: {distribution: binomial, t: 200, p: 0.5}}
     cuid: {^RandomInt: {min: 0, max: 100000}}
     prod: {^RandomInt: {min: 0, max: 10000}}
     prid: {^RandomDouble: {min: 0.0, max: 1000.0}}
@@ -25,7 +26,7 @@ LoaderPhase:
     Repeat: 1
     BatchSize: 100
     Threads: 4
-    DocumentCount: { ^Parameter: { Name: "DocumentCount", Default: *NumDocs } }
+    DocumentCount: { ^Parameter: { Name: "DocumentCount", Default: *InitialNumDocs } }
     Database: *dbname
     CollectionCount: 4
     Document: *Doc

--- a/src/phases/scale/LLTPhases.yml
+++ b/src/phases/scale/LLTPhases.yml
@@ -1,0 +1,32 @@
+PhaseSchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  File to hold common LLT workload phases.
+
+
+GlobalDefaults:
+  dbname: &dbname llt
+  DocumentCount: &NumDocs 10000000
+  Document: &Doc
+    ts: {^Now: {}}
+    caid: {^RandomInt: {min: 0, max: 1000}}
+    #  int0: &int {^RandomInt: {distribution: binomial, t: 200, p: 0.5}}
+    cuid: {^RandomInt: {min: 0, max: 100000}}
+    prod: {^RandomInt: {min: 0, max: 10000}}
+    prid: {^RandomDouble: {min: 0.0, max: 1000.0}}
+    data: {^Join: {array: ["aaaaaaaaaa", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
+
+  LLTIndexes: &LLTIndexes
+    - keys: {cuid: 1, data: 1}
+    - keys: {caid: 1, prid: 1, cuid: 1}
+    - keys: {prid: 1, ts: 1, cuid: 1}
+
+LoaderPhase:
+    Repeat: 1
+    BatchSize: 100
+    Threads: 4
+    DocumentCount: { ^Parameter: { Name: "DocumentCount", Default: *NumDocs } }
+    Database: *dbname
+    CollectionCount: 4
+    Document: *Doc
+    Indexes: { ^Parameter: { Name: "Indexes", Default: *LLTIndexes } }

--- a/src/workloads/scale/InsertLLT.yml
+++ b/src/workloads/scale/InsertLLT.yml
@@ -1,0 +1,54 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  Workload to Benchmark the effect of LongLivedTransactions on an Insert workload.
+
+GlobalDefaults:
+  # These two values should match those are the top of LLTPhases.yml
+  dbname: &dbname llt
+  DocumentCount: &NumDocs 10000000
+
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 500
+
+ActorTemplates:
+  - TemplateName: LoaderTemplate
+    Config:
+      Name: {^Parameter: {Name: "Name", Default: "InitialLoad"}}
+      Type: Loader
+      Database: *dbname
+      ClientName: Loader
+      Threads: {^Parameter: {Name: "Threads", Default: 1}}
+      Phases:
+        OnlyActiveInPhases:
+          Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+          NopInPhasesUpTo: 10
+          PhaseConfig:
+            ExternalPhaseConfig:
+              Path: ../../phases/scale/LLTPhases.yml
+              Key: LoaderPhase
+
+Actors:
+# Setup
+- ActorFromTemplate:
+    TemplateName: LoaderTemplate
+    TemplateParameters:
+      Name: InitialLoad
+      Threads: 4
+- ActorFromTemplate:
+    TemplateName: LoaderTemplate
+    TemplateParameters:
+      Name: InitialLoadWithIndexes
+      Threads: 4
+      OnlyActiveInPhase: 2
+      Indexes: {}
+
+
+AutoRun:
+  Requires:
+    mongodb_setup:
+    - replica
+    - single-replica

--- a/src/workloads/scale/InsertLLT.yml
+++ b/src/workloads/scale/InsertLLT.yml
@@ -4,10 +4,10 @@ Description: |
   Workload to Benchmark the effect of LongLivedTransactions on an Insert workload.
 
 GlobalDefaults:
-  # These two values should match those are the top of LLTPhases.yml
+  # These values should match those are the top of LLTPhases.yml
   dbname: &dbname llt
-  DocumentCount: &NumDocs 10000000
-
+  InitialDocumentCount: &InitialNumDocs 10000000
+  SecondaryDocumentCount: &SecondaryNumDocs 10000000
 
 Clients:
   Default:
@@ -43,6 +43,7 @@ Actors:
     TemplateParameters:
       Name: InitialLoadWithIndexes
       Threads: 4
+      DocumentCount: *SecondaryNumDocs
       OnlyActiveInPhase: 2
       Indexes: {}
 


### PR DESCRIPTION
This [patch](https://evergreen.mongodb.com/task/sys_perf_linux_1_node_replSet_insert_llt_patch_fccad833c9081bf0cd61364afdb4ec01ceeb42fa_604152b13e8e8645bfb2ba56_21_03_04_21_36_21)  is for the first commit but there is not a huge change in functionality.

I want to create 2 workloads with difference values for InitialDocumentCount and SecondaryDocumentCount (an in-memory and not in-memory configuration).

I could do an in-memory test phase (the current workload) , drop the database and then run the test again with different values for the not in-memory but I think keeping them separate is simpler.

At the moment, it looks like I will need to make a copy og src/workloads/scale/InsertLLT.yml and update the values. This seems a very verbose approach. Is there a better way to do this or is there any way to move more of the boiler plate into src/phases/scale/LLTPhases.yml?

It would be nice if the ActorTemplates could also live in src/phases/scale/LLTPhases.yml.
