### PR TITLE
Perf 2239 Set multiplier default value to 0 in ^Inc value generator

### DIFF
--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -788,7 +788,7 @@ public:
     IncGenerator(const Node& node, GeneratorArgs generatorArgs)
         : _step{node["step"].maybe<int64_t>().value_or(1)} {
         _counter = node["start"].maybe<int64_t>().value_or(1) +
-            generatorArgs.actorId * node["multiplier"].maybe<int64_t>().value_or(1);
+            generatorArgs.actorId * node["multiplier"].maybe<int64_t>().value_or(0);
     }
 
     int64_t evaluate() override {

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -837,6 +837,6 @@ Tests:
     GivenTemplate:
       int: {^Inc: {}}
     ThenReturns:
+    - "int" : { "$numberLong" :"1"}
+    - "int" : { "$numberLong" :"2"}
     - "int" : { "$numberLong" :"3"}
-    - "int" : { "$numberLong" :"4"}
-    - "int" : { "$numberLong" :"5"}


### PR DESCRIPTION
One symbol change to set multiplier default value to 0 in ^Inc value generator.

It appears that current multiplier default value 1 in ^Inc value generator is not helpful - if we generate data with a single thread, 0 makes sense. If we generate data with multiple threads, it should be a large value. So after a team discussion it was decided to change the default for multiplier to 0.