### PR TITLE
PERF-2241 guard against timeout

### DIFF
--- a/src/workloads/scale/LLTInsert.yml
+++ b/src/workloads/scale/LLTInsert.yml
@@ -112,6 +112,18 @@ Actors:
       PhaseConfig:
         Repeat: 1
 
+# Guard Against timeout for no output.
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0, 4, 9, 14, 19]
+      NopInPhasesUpTo: 20
+      PhaseConfig:
+        LogEvery: 15 minutes
+        Blocking: None
+
 # <-----  4 threads @ 25% in batches of 50
 - Name: InsertBaseline.Low.50
   Type: MultiCollectionInsert


### PR DESCRIPTION
Small change to guard against no output timeout. Waiting on the [patch](https://spruce.mongodb.com/version/6064475f9ccd4e677aaba416/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) to complete.

 