### PR TITLE
PERF-2240 4.2 doesn't support hints on remove operations

### DIFF
--- a/src/workloads/scale/LLTMixed.yml
+++ b/src/workloads/scale/LLTMixed.yml
@@ -127,7 +127,6 @@ GlobalDefaults:
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
       OperationOptions: 
-        Hint: price_1_ts_1_cuid_1
         Comment: PtcRemoveOperation
         WriteConcern:
           Level: majority
@@ -137,7 +136,6 @@ GlobalDefaults:
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
       OperationOptions: 
-        Hint: price_1_cuid_1
         WriteConcern:
           Level: majority
 
@@ -146,7 +144,6 @@ GlobalDefaults:
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
       OperationOptions: 
-        Hint: caid_1_price_1_cuid_1
         WriteConcern:
           Level: majority
 

--- a/src/workloads/scale/LLTRemove.yml
+++ b/src/workloads/scale/LLTRemove.yml
@@ -37,16 +37,11 @@ GlobalDefaults:
   # SecondaryDocumentCount: &SecondaryNumDocs 1000000
   CollectionCount: &CollectionCount 4
 
-  # The query operation name indicates the index in use (see LLTIndexes) :
-  #  * Ptc => price_1_ts_1_cuid_1
-  #  * Pc  => price_1_cuid_1
-  #  * Cpc => caid_1_price_1_cuid_1
   PtcRemoveOperation: &PtcRemoveOperation
     OperationName: deleteOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
       OperationOptions:
-        Hint: price_1_ts_1_cuid_1
         WriteConcern:
           Level: majority
 
@@ -55,7 +50,6 @@ GlobalDefaults:
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
       OperationOptions:
-        Hint: price_1_cuid_1
         WriteConcern:
           Level: majority
 
@@ -64,7 +58,6 @@ GlobalDefaults:
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
       OperationOptions:
-        Hint: caid_1_price_1_cuid_1
         WriteConcern:
           Level: majority
 


### PR DESCRIPTION
[4.9 patch](https://spruce.mongodb.com/version/607ecf0f5623436443aa20d1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[4.2 patch](https://spruce.mongodb.com/version/607ecf7bd1fe07323e55bcdc/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
