### PR TITLE
PERF-2182 set transactionLifetimeLimitSeconds and ScanDuration

### DIFF
--- a/src/workloads/scale/LLTInsert.yml
+++ b/src/workloads/scale/LLTInsert.yml
@@ -71,6 +71,23 @@ Clients:
 
 # Odd phases do operations, even phases quiesce.
 Actors:
+# Ensure that transactionLifetimeLimitSeconds supports all the possible ScanDurations.
+# i.e. greater than SnapshotScannerLongDuration.
+- Name: SetTransactionLifetimeLimit
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Operation:
+          OperationName: RunCommand
+          OperationCommand:
+            setParameter: 1
+            transactionLifetimeLimitSeconds: 3600
+
 - Name: InitialLoad
   Type: Loader
   ClientName: Loader
@@ -199,6 +216,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -236,6 +254,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -273,6 +292,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -326,6 +346,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -363,6 +384,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -400,6 +422,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward

--- a/src/workloads/scale/LLTMixed.yml
+++ b/src/workloads/scale/LLTMixed.yml
@@ -172,6 +172,23 @@ Clients:
 
 # Odd phases do operations, even phases quiesce.
 Actors:
+# Ensure that transactionLifetimeLimitSeconds supports all the possible ScanDurations.
+# i.e. greater than SnapshotScannerLongDuration.
+- Name: SetTransactionLifetimeLimit
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Operation:
+          OperationName: RunCommand
+          OperationCommand:
+            setParameter: 1
+            transactionLifetimeLimitSeconds: 3600
+
 - Name: InitialLoad
   Type: Loader
   ClientName: Loader
@@ -305,6 +322,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -342,6 +360,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -379,6 +398,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -433,6 +453,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -470,6 +491,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -507,6 +529,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward

--- a/src/workloads/scale/LLTQuery.yml
+++ b/src/workloads/scale/LLTQuery.yml
@@ -90,6 +90,23 @@ Clients:
 
 # Odd phases do operations, even phases quiesce.
 Actors:
+# Ensure that transactionLifetimeLimitSeconds supports all the possible ScanDurations.
+# i.e. greater than SnapshotScannerLongDuration.
+- Name: SetTransactionLifetimeLimit
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Operation:
+          OperationName: RunCommand
+          OperationCommand:
+            setParameter: 1
+            transactionLifetimeLimitSeconds: 3600
+
 - Name: InitialLoad
   Type: Loader
   ClientName: Loader
@@ -219,6 +236,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -256,6 +274,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -293,6 +312,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -347,6 +367,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -384,6 +405,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -421,6 +443,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward

--- a/src/workloads/scale/LLTRemove.yml
+++ b/src/workloads/scale/LLTRemove.yml
@@ -86,6 +86,23 @@ Clients:
 
 # Odd phases do operations, even phases quiesce.
 Actors:
+# Ensure that transactionLifetimeLimitSeconds supports all the possible ScanDurations.
+# i.e. greater than SnapshotScannerLongDuration.
+- Name: SetTransactionLifetimeLimit
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Operation:
+          OperationName: RunCommand
+          OperationCommand:
+            setParameter: 1
+            transactionLifetimeLimitSeconds: 3600
+
 - Name: InitialLoad
   Type: Loader
   ClientName: Loader
@@ -215,6 +232,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -252,6 +270,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -289,6 +308,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -343,6 +363,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -380,6 +401,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -417,6 +439,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward

--- a/src/workloads/scale/LLTUpdate.yml
+++ b/src/workloads/scale/LLTUpdate.yml
@@ -108,6 +108,23 @@ Clients:
 
 # Odd phases do operations, even phases quiesce.
 Actors:
+# Ensure that transactionLifetimeLimitSeconds supports all the possible ScanDurations.
+# i.e. greater than SnapshotScannerLongDuration.
+- Name: SetTransactionLifetimeLimit
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Operation:
+          OperationName: RunCommand
+          OperationCommand:
+            setParameter: 1
+            transactionLifetimeLimitSeconds: 3600
+
 - Name: InitialLoad
   Type: Loader
   ClientName: Loader
@@ -237,6 +254,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -274,6 +292,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -311,6 +330,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -365,6 +385,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
+        ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -402,6 +423,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward
@@ -439,6 +461,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
         GenerateCollectionNames: true
         CollectionSortOrder: forward


### PR DESCRIPTION
Patches:
  * [V4.2 Correct Mixed and set ScanDuration once](https://spruce.mongodb.com/version/6081ad610305b96b7aece298/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
  * [Master Correct Mixed and set ScanDuration once](https://spruce.mongodb.com/version/6081acaa61837d07d0709c66/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
