### PR TITLE
PERF-2305 Add ScanContinuous mode for snapshots CollectionScans

### DIFF
--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -99,7 +99,8 @@ struct CollectionScanner::PhaseConfig {
         std::vector<std::string> dbnames;
         boost::split(dbnames, databaseNames,boost::is_any_of(","));
 
-        for (const auto& dbname : dbnames) {
+        for (auto& dbname : dbnames) {
+            boost::trim(dbname);
             databases.push_back((*actor->_client)[dbname]);
         }
         const auto now = SteadyClock::now();

--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -447,6 +447,7 @@ void CollectionScanner::run() {
                                 BOOST_LOG_TRIVIAL(debug)
                                     << "Scanner id: " << this->_index << " sleeping " << secs;
                                 std::this_thread::sleep_for(sleepDuration);
+                                finished = true;
                             }
                         }
                     } while(!finished);

--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -97,7 +97,8 @@ struct CollectionScanner::PhaseConfig {
           findOptions{context["FindOptions"].maybe<mongocxx::options::find>().value_or(mongocxx::options::find{})} {
         // The list of databases is comma separated.
         std::vector<std::string> dbnames;
-        boost::split(dbnames, databaseNames, [](char c) { return (c == ','); });
+        boost::split(dbnames, databaseNames,boost::is_any_of(","));
+
         for (const auto& dbname : dbnames) {
             databases.push_back((*actor->_client)[dbname]);
         }

--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -420,7 +420,9 @@ void CollectionScanner::run() {
                 try {
                     mongocxx::client_session session = _client->start_session({});
                     session.start_transaction(*config->transactionOptions);
-                    // This loop should run at least once.
+                    // Initialize 'finished' to true so that the loop will execute exactly once if
+                    // ScanContinuous is false. If ScanContinuous is true 'finished' is
+                    // re-evaluated within the loop.
                     auto finished = true;
                     do {
                         BOOST_LOG_TRIVIAL(debug)

--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -70,6 +70,7 @@ struct CollectionScanner::PhaseConfig {
     SortOrderType sortOrder;
     int64_t collectionSkip;
     std::optional<TimeSpec> scanDuration;
+    bool scanContinuous = false;
     bool selectClusterTimeOnly = false;
     bool queryCollectionList;
     std::optional<mongocxx::options::transaction> transactionOptions;
@@ -91,6 +92,7 @@ struct CollectionScanner::PhaseConfig {
           scanSizeBytes{context["ScanSizeBytes"].maybe<IntegerSpec>().value_or(0)},
           collectionSkip{context["CollectionSkip"].maybe<IntegerSpec>().value_or(0)},
           scanDuration{context["ScanDuration"].maybe<TimeSpec>()},
+          scanContinuous{context["ScanContinuous"].maybe<bool>().value_or(false)},
           selectClusterTimeOnly{context["SelectClusterTimeOnly"].maybe<bool>().value_or(false)},
           findOptions{context["FindOptions"].maybe<mongocxx::options::find>().value_or(mongocxx::options::find{})} {
         // The list of databases is comma separated.
@@ -134,6 +136,19 @@ struct CollectionScanner::PhaseConfig {
             if (scanType != ScanType::kSnapshot) {
                 BOOST_THROW_EXCEPTION(InvalidConfigurationException(
                     "ScanDuration must be used with snapshot scans."));
+            }
+        }
+        if (scanContinuous) {
+            auto os = std::ostringstream();
+            if (scanType != ScanType::kSnapshot) {
+                os << "ScanContinuous is only valid with snapshot scans.";
+            }
+            if (!scanDuration) {
+                os <<  "ScanContinuous is only valid with a scan duration.";
+            }
+            auto err = os.str();
+            if (!err.empty()) {
+                BOOST_THROW_EXCEPTION(InvalidConfigurationException(err));
             }
         }
         auto sortOrderString = context["CollectionSortOrder"].maybe<std::string>().value_or("none");
@@ -405,26 +420,36 @@ void CollectionScanner::run() {
                 try {
                     mongocxx::client_session session = _client->start_session({});
                     session.start_transaction(*config->transactionOptions);
-                    collectionScan(config, collections, _rateLimiter, session);
-                    // If a scan duration was specified, we must make the scan
-                    // last at least that long.  We'll do this within any
-                    // running transaction, so we keep the "long running
-                    // transaction" active as long as we've been asked to.
-                    // However, honor the phase's duration if specified.
-                    if (config->scanDuration) {
-                        const SteadyClock::time_point now = SteadyClock::now();
-                        auto stop = started + (*config->scanDuration).value;
-                        if (config->stopPhase && *config->stopPhase < stop) {
-                            stop = *config->stopPhase;
+                    auto finished = true;
+                    do {
+                        BOOST_LOG_TRIVIAL(info)
+                            << "Scanner id: " << this->_index << " scanning";
+                        collectionScan(config, collections, _rateLimiter, session);
+                        // If a scan duration was specified, we must make the scan
+                        // last at least that long.
+                        // For non-continuous scans (default behaviour) we'll do this within any
+                        // running transaction by keeping the "long running transaction" active
+                        // as long as we've been asked to.
+                        // For continuous scans we repeat the collectionScan
+                        // within the transaction until we have reached the scan duration.
+                        // However, honor the phase's duration if specified.
+                        if (config->scanDuration) {
+                            const SteadyClock::time_point now = SteadyClock::now();
+                            auto stop = started + (*config->scanDuration).value;
+                            if (config->stopPhase && *config->stopPhase < stop) {
+                                stop = *config->stopPhase;
+                            }
+                            finished = stop > now;
+                            if (!finished && config->scanContinuous) {
+                                auto sleepDuration = stop - now;
+                                auto secs = sleepDuration.count() / (1000 * 1000 * 1000);
+                                BOOST_LOG_TRIVIAL(info)
+                                    << "Scanner id: " << this->_index << " sleeping " << secs;
+                                std::this_thread::sleep_for(sleepDuration);
+                                finished = true;
+                            }
                         }
-                        if (stop > now) {
-                            auto sleepDuration = stop - now;
-                            auto secs = sleepDuration.count() / (1000 * 1000 * 1000);
-                            BOOST_LOG_TRIVIAL(info)
-                                << "Scanner id: " << this->_index << " sleeping " << secs;
-                            std::this_thread::sleep_for(sleepDuration);
-                        }
-                    }
+                    } while(!finished);
                     session.commit_transaction();
                 } catch (const mongocxx::operation_exception& e) {
                     if(e.has_error_label(transientTransactionLabel) ) {

--- a/src/workloads/docs/CollectionScanner.yml
+++ b/src/workloads/docs/CollectionScanner.yml
@@ -106,3 +106,20 @@ Actors:
     ScanType: snapshot
     ScanDuration: 2 minutes    # the duration of each scan, transactions held open this long.
     GlobalRate: 1 per 4 minutes
+
+# Each time this snapshot scanner runs, two databases are fully scanned.
+# This is done within a snapshot transaction, which is specified to be
+# held open for a full 2 minutes. If it completes before 2 minutes,
+# the scan will repeat until the duration is reached.
+- Name: ContinousScanner
+  Type: CollectionScanner
+  Threads: 10
+  Database: hot
+  Phases:
+  - {Nop: true}
+  - {Nop: true}
+  - {Nop: true}
+  - Duration: 10 minutes       # the duration of this phase
+    ScanType: snapshot
+    ScanDuration: 2 minutes    # the duration of each scan, transactions held open this long.
+    ScanContinuous: true   # the snapshot scan will repeat rather than sleep to honor the scan duration.

--- a/src/workloads/scale/LLTInsert.yml
+++ b/src/workloads/scale/LLTInsert.yml
@@ -218,6 +218,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -256,6 +257,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -294,6 +296,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -348,6 +351,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -386,6 +390,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -424,6 +429,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:

--- a/src/workloads/scale/LLTMixed.yml
+++ b/src/workloads/scale/LLTMixed.yml
@@ -324,6 +324,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -362,6 +363,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -400,6 +402,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -455,6 +458,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -493,6 +497,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -531,6 +536,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:

--- a/src/workloads/scale/LLTQuery.yml
+++ b/src/workloads/scale/LLTQuery.yml
@@ -238,6 +238,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -276,6 +277,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -314,6 +316,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -369,6 +372,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -407,6 +411,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -445,6 +450,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:

--- a/src/workloads/scale/LLTRemove.yml
+++ b/src/workloads/scale/LLTRemove.yml
@@ -234,6 +234,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -272,6 +273,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -310,6 +312,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -365,6 +368,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -403,6 +407,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -441,6 +446,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:

--- a/src/workloads/scale/LLTUpdate.yml
+++ b/src/workloads/scale/LLTUpdate.yml
@@ -256,6 +256,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -294,6 +295,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -332,6 +334,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -387,6 +390,7 @@ Actors:
         Duration: *SnapshotScannerShortDuration
         ScanDuration: *SnapshotScannerShortDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -425,6 +429,7 @@ Actors:
         Duration: *SnapshotScannerMediumDuration
         ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
@@ -463,6 +468,7 @@ Actors:
         Duration: *SnapshotScannerLongDuration
         ScanDuration: *SnapshotScannerLongDuration
         ScanType: snapshot
+        ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:

--- a/src/workloads/scale/ScanWithLongLived.yml
+++ b/src/workloads/scale/ScanWithLongLived.yml
@@ -30,8 +30,8 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1, 2, 3]
-      NopInPhasesUpTo: 10
+      Active: [0, 1, 2]
+      NopInPhasesUpTo: 2
       PhaseConfig:
         LogEvery: 15 minutes
         Blocking: None

--- a/src/workloads/scale/ScanWithLongLived.yml
+++ b/src/workloads/scale/ScanWithLongLived.yml
@@ -24,6 +24,17 @@ Clients:
       maxPoolSize: 5000
 
 Actors:
+# Guard Against timeout for no output.
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1, 2, 3]
+      PhaseConfig:
+        LogEvery: 15 minutes
+        Blocking: None
+
 - Name: LongLivedCreator
   Type: MonotonicLoader
   Threads: 10

--- a/src/workloads/scale/ScanWithLongLived.yml
+++ b/src/workloads/scale/ScanWithLongLived.yml
@@ -31,6 +31,7 @@ Actors:
   Phases:
     OnlyActiveInPhases:
       Active: [1, 2, 3]
+      NopInPhasesUpTo: 10
       PhaseConfig:
         LogEvery: 15 minutes
         Blocking: None


### PR DESCRIPTION
The current implementation sleeps for to make up the time to ScanDuration. This means that the transaction is open but inactive for a portion of the lifetime.

This new flag allows a transaction to be kept open and active for the the full ScanDuration.

This is required for the longer (60 Minutes+ ScanDuration) LLT tests.  