### PR TITLE
Use ensurepip and wheel for more robust installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here're the steps to get Genny up and running locally:
     -   Ubuntu 18.04: `sudo apt install build-essential`
     -   Red Hat/CentOS 7/Amazon Linux 2:
         `sudo yum groupinstall "Development Tools"`
-    -   Arch: Everything should already be set up.
+    -   Arch: `apk add bash clang gcc musl-dev linux-headers`
     -   macOS: `xcode-select --install`
     -   Windows: <https://visualstudio.microsoft.com/>
 

--- a/run-genny
+++ b/run-genny
@@ -92,6 +92,14 @@ if ! python3 -c 'import sys; sys.exit(1 if "Python3.framework" in sys.prefix els
     exit 1
 fi
 
+
+if ! _pip --version >/dev/null 2>&1; then
+    # ensurepip is built-in as of 3.4.
+    /usr/bin/env python3 -m ensurepip --upgrade
+    _pip install --upgrade pip
+fi
+
+
 if ! _pip --version >/dev/null 2>&1; then
     echo >&2 "Your installation of python does not contain pip."
     echo >&2 "On macOS you can run:"

--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -1,3 +1,4 @@
+wheel==0.36.2
 pymongo>=3.9
 click==7.1.2
 click-option-group==0.5.2


### PR DESCRIPTION
I was trying to install genny on my phone using [iSH](https://ish.app/) which uses a pretty stripped-down version of Arch. I needed `pip` and `wheel` installed. Also the README saying it's ready to go was..a bit too optimistic.

(FWIW the install still bails due to no version of curator and the toolchain, but this at least uncovered a few new assumptions.)