### PR TITLE
PERF-2260 low Ltc workloads with baseline per duration, rename phases to sort together

### DIFF
--- a/src/workloads/transactions/LLTInsertLowLtc.yml
+++ b/src/workloads/transactions/LLTInsertLowLtc.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Query workload.
+  Workload to Benchmark the effect of LongLivedTransactions on an Insert workload.
 
 GlobalDefaults:
   # These values should match those are the top of LLTPhases.yml
   dbname: &dbname llt
-  MaxPhases: &MaxPhases 20
+  MaxPhases: &MaxPhases 16
 
   # The Sample Document Shape.
   Document: &Doc
@@ -33,50 +33,30 @@ GlobalDefaults:
   # WIP make a copy of the workload once these values are tuned correctly and
   # the workload runs consistently.
   # Not In-memory: Database size works out about 30GB.
-  # InitialDocumentCount: &InitialNumDocs 49000000
-  # SecondaryDocumentCount: &SecondaryNumDocs 1000000
+  #InitialDocumentCount: &InitialNumDocs 49000000
+  #SecondaryDocumentCount: &SecondaryNumDocs 1000000
   CollectionCount: &CollectionCount 4
 
-  # The query operation name indicates the index in use (see LLTIndexes) :
-  #  * Ptc => price_1_ts_1_cuid_1
-  #  * Pc  => price_1_cuid_1
-  #  * Cpc => caid_1_price_1_cuid_1
-  PtcQueryOperation: &PtcQueryOperation
-    OperationName: findOne
-    OperationCommand:
-      Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      Options:
-        Hint: price_1_ts_1_cuid_1
-        Comment: PtcQueryOperation
+  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
+  ThreadsValue: &ThreadsValue 8
 
-  PcQueryOperation: &PcQueryOperation
-    OperationName: findOne
-    OperationCommand:
-      Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      Options:
-        Hint: price_1_cuid_1
-        Comment: PcQueryOperation
-
-  CpcQueryOperation: &CpcQueryOperation
-    OperationName: findOne
-    OperationCommand:
-      Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      Options:
-        Hint: caid_1_price_1_cuid_1
-        Comment: CpcQueryOperation
-
-  # Low Baseline / Benchmark
-  LowGlobalRate: &LowGlobalRate 400 per 1 second
-  LowThreads: &LowThreads 8
-
-  # Low Baseline / Benchmark
-  HighGlobalRate: &HighGlobalRate 800 per 1 second
-  HighThreads: &HighThreads 16
+#  # Low Baseline / Benchmark
+#  GlobalRateValue: &GlobalRateValue 800 per 1 second
+#  ThreadsValue: &ThreadsValue 16
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
   SnapshotScannerMediumDuration: &SnapshotScannerMediumDuration 10 minutes
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
+
+  # The write concern. The intent is to use what is chosen as the default in 5.0.
+  InsertOperation: &InsertOperation
+    OperationName: insertOne
+    OperationCommand:
+      Document: *Doc
+      OperationOptions: &OperationOptions
+        WriteConcern:
+          Level: majority
 
 Clients:
   Default:
@@ -142,7 +122,7 @@ Actors:
   Database: *dbname
   Phases:
     OnlyActiveInPhases:
-      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Repeat: 1
@@ -153,62 +133,68 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+      Active: [1, 3, 5, 7, 9, 11, 13, 15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         LogEvery: 15 minutes
         Blocking: None
 
-- Name: QueryBaseline.Low
+# Naming Conventions:
+# Duration.Operation.Type_of_test
+# Duration:      Short|Medium|Long
+# Operation:     Insert|Query|Update|Remove|Mixed|Scan
+# Type of test:  Baseline|Benchmark|Snapshot
+#
+# Baseline without scans, benchmark with scans
+- Name: Short.Insert.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [5]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
         Operations: &Operations
-          - *PtcQueryOperation
-          - *PcQueryOperation
-          - *CpcQueryOperation
-          - *PtcQueryOperation
-          - *PcQueryOperation
-          - *CpcQueryOperation
-          - *PtcQueryOperation
-          - *PcQueryOperation
-          - *CpcQueryOperation
-          - *PtcQueryOperation
-          - *PcQueryOperation
-          - *CpcQueryOperation
-          - *PtcQueryOperation
-          - *PcQueryOperation
-          - *CpcQueryOperation
-          - *PtcQueryOperation
-          - *PcQueryOperation
-          - *CpcQueryOperation
-          - *PtcQueryOperation
-          - *PcQueryOperation
-          - *CpcQueryOperation
-          - *PtcQueryOperation
-          - *PcQueryOperation
-          - *CpcQueryOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
+          - *InsertOperation
 
-- Name: QueryBenchmark.Low.Short
+- Name: Short.Insert.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
-  Database: *dbname
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        Threads: *ThreadsValue
+        GlobalRate: *GlobalRateValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
@@ -216,7 +202,7 @@ Actors:
         Operations: *Operations
 
 ## A thread per collection doing a scan.
-- Name: SnapshotScannerShort
+- Name: Short.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -235,64 +221,41 @@ Actors:
         CollectionSortOrder: forward
         FindOptions:
           BatchSize: 1000
-          Hint: _id_ # Currently only support the index name.
+          Hint: _id_
           Comment: SnapshotScannerShort
 
-- Name: QueryBenchmark.Low.Medium
+- Name: Medium.Insert.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [9]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        Threads: *ThreadsValue
+        GlobalRate: *GlobalRateValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerMediumDuration
-        Blocking: none
         Operations: *Operations
 
-- Name: SnapshotScannerMedium
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [9]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerMediumDuration
-        ScanDuration: *SnapshotScannerMediumDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_ # Currently only support the index name.
-          Comment: SnapshotScannerMedium
-
-- Name: QueryBenchmark.Low.Long
+- Name: Medium.Insert.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [11]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        Threads: *ThreadsValue
+        GlobalRate: *GlobalRateValue
         CollectionCount: *CollectionCount
         Database: *dbname
-        Duration: *SnapshotScannerLongDuration
+        Duration: *SnapshotScannerMediumDuration
         Blocking: none
         Operations: *Operations
 
-- Name: SnapshotScannerLong
+- Name: Medium.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -301,98 +264,6 @@ Actors:
   Phases:
     OnlyActiveInPhases:
       Active: [11]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerLongDuration
-        ScanDuration: *SnapshotScannerLongDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_ # Currently only support the index name.
-          Comment: SnapshotScannerLong
-
-- Name: QueryBaseline.High
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [13]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Operations: *Operations
-
-- Name: QueryBenchmark.High.Short
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [15]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *Operations
-
-# A thread per collection doing a scan.
-- Name: SnapshotScannerShort
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [15]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerShortDuration
-        ScanDuration: *SnapshotScannerShortDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_ # Currently only support the index name.
-          Comment: SnapshotScannerShort
-
-- Name: QueryBenchmark.High.Medium
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerMediumDuration
-        Blocking: none
-        Operations: *Operations
-
-- Name: SnapshotScannerMedium
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
@@ -406,23 +277,38 @@ Actors:
           Hint: _id_
           Comment: SnapshotScannerMedium
 
-- Name: QueryBenchmark.High.Long
+- Name: Long.Insert.Baseline
   Type: CrudActor
-  Threads: *HighThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
-      Active: [19]
+      Active: [13]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
+        Threads: *ThreadsValue
+        GlobalRate: *GlobalRateValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerLongDuration
+        Operations: *Operations
+
+- Name: Long.Insert.Benchmark
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [15]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Threads: *ThreadsValue
+        GlobalRate: *GlobalRateValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerLongDuration
         Blocking: none
         Operations: *Operations
 
-- Name: SnapshotScannerLong
+- Name: Long.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -430,23 +316,24 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [19]
+      Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
-        ScanDuration: *SnapshotScannerLongDuration
+        ScanDuration: *SnapshotScannerMediumDuration
         ScanType: snapshot
         ScanContinuous: true
         GenerateCollectionNames: true
         CollectionSortOrder: forward
         FindOptions:
           BatchSize: 1000
-          Hint: _id_ # Currently only support the index name.
+          Hint: _id_
           Comment: SnapshotScannerLong
 
 #AutoRun:
 #  Requires:
 #    mongodb_setup:
+#      - atlas
 #      - replica
-#      - single-replica
 #      - replica-all-feature-flags
+#      - single-replica

--- a/src/workloads/transactions/LLTMixedLowLtc.yml
+++ b/src/workloads/transactions/LLTMixedLowLtc.yml
@@ -58,7 +58,7 @@ GlobalDefaults:
     OperationName: findOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      Options: 
+      Options:
         Hint: price_1_ts_1_cuid_1
         Comment: PtcQueryOperation
 
@@ -66,7 +66,7 @@ GlobalDefaults:
     OperationName: findOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      Options: 
+      Options:
         Hint: price_1_cuid_1
         Comment: PcQueryOperation
 
@@ -74,7 +74,7 @@ GlobalDefaults:
     OperationName: findOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      Options: 
+      Options:
         Hint: caid_1_price_1_cuid_1
         Comment: CpcQueryOperation
 
@@ -83,7 +83,7 @@ GlobalDefaults:
     OperationName: updateOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      Update: 
+      Update:
         $set:
           ts: {^Now: {}}
           data: {^Join: {array: ["bbbbbbbbbb", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
@@ -101,7 +101,7 @@ GlobalDefaults:
         $set:
           ts: {^Now: {}}
           prod: {^RandomInt: {min: 0, max: 10000}}
-      OperationOptions: 
+      OperationOptions:
         Upsert: false
         WriteConcern:
           Level: majority
@@ -115,7 +115,7 @@ GlobalDefaults:
         $set:
           ts: {^Now: {}}
           cuid: {^RandomInt: {min: 0, max: 100000}}
-      OperationOptions: 
+      OperationOptions:
         Upsert: false
         WriteConcern:
           Level: majority
@@ -126,7 +126,7 @@ GlobalDefaults:
     OperationName: deleteOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions: 
+      OperationOptions:
         Comment: PtcRemoveOperation
         WriteConcern:
           Level: majority
@@ -135,7 +135,7 @@ GlobalDefaults:
     OperationName: deleteOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions: 
+      OperationOptions:
         WriteConcern:
           Level: majority
 
@@ -143,17 +143,16 @@ GlobalDefaults:
     OperationName: deleteOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      OperationOptions: 
+      OperationOptions:
         WriteConcern:
           Level: majority
 
-  # Low Baseline / Benchmark
-  LowGlobalRate: &LowGlobalRate 200 per 1 second
-  LowThreads: &LowThreads 8
+  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
+  ThreadsValue: &ThreadsValue 8
 
-  # High Baseline / Benchmark
-  HighGlobalRate: &HighGlobalRate 400 per 1 second
-  HighThreads: &HighThreads 16
+#  # High Baseline / Benchmark
+#  GlobalRateValue: &GlobalRateValue 400 per 1 second
+#  ThreadsValue: &ThreadsValue 16
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
@@ -224,7 +223,7 @@ Actors:
   Database: *dbname
   Phases:
     OnlyActiveInPhases:
-      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Repeat: 1
@@ -235,27 +234,29 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+      Active: [1, 3, 5, 7, 9, 11, 13, 15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         LogEvery: 15 minutes
         Blocking: None
 
 # Naming Conventions:
-# Type_of_test.Thread_level.Duration
-# Type of test:  Insert/Query/Update/Remove Baseline/Benchmark
+# Operation.Duration.Load_level.Operation.Type_of_test
+# Operation:     Insert|Query|Update|Remove|Mixed
+# Duration:      Short|Medium|Long
+# Type of test:  Baseline|Benchmark
+#
 # Baseline without scans, benchmark with scans
-
-- Name: InsertBaseline.Low
+- Name: Short.Insert.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [5]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
@@ -269,16 +270,16 @@ Actors:
           - *InsertOperation
           - *InsertOperation
 
-- Name: QueryBaseline.Low
+- Name: Short.Query.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [5]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
@@ -292,16 +293,16 @@ Actors:
           - *PcQueryOperation
           - *CpcQueryOperation
 
-- Name: UpdateBaseline.Low
+- Name: Short.Update.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [5]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
@@ -315,16 +316,16 @@ Actors:
           - *PcUpdateOperation
           - *CpcUpdateOperation
 
-- Name: RemoveBaseline.Low
+- Name: Short.Remove.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [5]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
@@ -338,64 +339,64 @@ Actors:
           - *PcRemoveOperation
           - *CpcRemoveOperation
 
-- Name: InsertBenchmark.Low.Short
+- Name: Short.Insert.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
         Blocking: none
         Operations: *InsertOps
 
-- Name: QueryBenchmark.Low.Short
+- Name: Short.Query.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
         Blocking: none
         Operations: *QueryOps
 
-- Name: UpdateBenchmark.Low.Short
+- Name: Short.Update.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
         Blocking: none
         Operations: *UpdateOps
 
-- Name: RemoveBenchmark.Low.Short
+- Name: Short.Remove.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
@@ -403,7 +404,7 @@ Actors:
         Operations: *RemoveOps
 
 ## A thread per collection doing a scan.
-- Name: SnapshotScannerShort
+- Name: Short.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -411,7 +412,7 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [7,15]
+      Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerShortDuration
@@ -425,64 +426,124 @@ Actors:
           Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerShort
 
-- Name: InsertBenchmark.Low.Medium
+- Name: Medium.Insert.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [9]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerMediumDuration
+        Operations: *InsertOps
+
+- Name: Medium.Query.Baseline
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [9]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerMediumDuration
+        Operations: *QueryOps
+
+- Name: Medium.Update.Baseline
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [9]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerMediumDuration
+        Operations: *UpdateOps
+
+- Name: Medium.Remove.Baseline
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [9]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerMediumDuration
+        Operations: *RemoveOps
+
+- Name: Medium.Insert.Benchmark
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [11]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerMediumDuration
         Blocking: none
         Operations: *InsertOps
 
-- Name: QueryBenchmark.Low.Medium
+- Name: Medium.Query.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
-      Active: [9]
+      Active: [11]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerMediumDuration
         Blocking: none
         Operations: *QueryOps
 
-- Name: UpdateBenchmark.Low.Medium
+- Name: Medium.Update.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
-      Active: [9]
+      Active: [11]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerMediumDuration
         Blocking: none
         Operations: *UpdateOps
 
-- Name: RemoveBenchmark.Low.Medium
+- Name: Medium.Remove.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
-      Active: [9]
+      Active: [11]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerMediumDuration
@@ -490,7 +551,7 @@ Actors:
         Operations: *RemoveOps
 
 # A thread per collection doing a scan.
-- Name: SnapshotScannerMedium
+- Name: Medium.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -498,7 +559,7 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [9,17]
+      Active: [11]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
@@ -512,64 +573,124 @@ Actors:
           Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerMedium
 
-- Name: InsertBenchmark.Low.Long
+- Name: Long.Insert.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
-      Active: [11]
+      Active: [13]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerLongDuration
+        Operations: *InsertOps
+
+- Name: Long.Query.Baseline
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [13]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerLongDuration
+        Operations: *QueryOps
+
+- Name: Long.Update.Baseline
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [13]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerLongDuration
+        Operations: *UpdateOps
+
+- Name: Long.Remove.Baseline
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [13]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerLongDuration
+        Operations: *RemoveOps
+
+- Name: Long.Insert.Benchmark
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [15]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerLongDuration
         Blocking: none
         Operations: *InsertOps
 
-- Name: QueryBenchmark.Low.Long
+- Name: Long.Query.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
-      Active: [11]
+      Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerLongDuration
         Blocking: none
         Operations: *QueryOps
 
-- Name: UpdateBenchmark.Low.Long
+- Name: Long.Update.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
-      Active: [11]
+      Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerLongDuration
         Blocking: none
         Operations: *UpdateOps
 
-- Name: RemoveBenchmark.Low.Long
+- Name: Long.Remove.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
-      Active: [11]
+      Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerLongDuration
@@ -577,7 +698,7 @@ Actors:
         Operations: *RemoveOps
 
 # A thread per collection doing a scan.
-- Name: SnapshotScannerLong
+- Name: Long.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -585,7 +706,7 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [11,19]
+      Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
@@ -599,266 +720,10 @@ Actors:
           Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerLong
 
-- Name: InsertBaseline.High
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [13]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *InsertOps
-
-- Name: QueryBaseline.High
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [13]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *QueryOps
-
-- Name: UpdateBaseline.High
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [13]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *UpdateOps
-
-- Name: RemoveBaseline.High
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [13]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *RemoveOps
-
-- Name: InsertBenchmark.High.Short
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [15]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *InsertOps
-
-- Name: QueryBenchmark.High.Short
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [15]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *QueryOps
-
-- Name: UpdateBenchmark.High.Short
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [15]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *UpdateOps
-
-- Name: RemoveBenchmark.High.Short
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [15]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *RemoveOps
-
-- Name: InsertBenchmark.High.Medium
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerMediumDuration
-        Blocking: none
-        Operations: *InsertOps
-
-- Name: QueryBenchmark.High.Medium
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerMediumDuration
-        Blocking: none
-        Operations: *QueryOps
-
-- Name: UpdateBenchmark.High.Medium
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerMediumDuration
-        Blocking: none
-        Operations: *UpdateOps
-
-- Name: RemoveBenchmark.High.Medium
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerMediumDuration
-        Blocking: none
-        Operations: *RemoveOps
-
-- Name: InsertBenchmark.High.Long
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [19]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerLongDuration
-        Blocking: none
-        Operations: *InsertOps
-
-- Name: QueryBenchmark.High.Long
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [19]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerLongDuration
-        Blocking: none
-        Operations: *QueryOps
-
-- Name: UpdateBenchmerk.High.Long
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [19]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerLongDuration
-        Blocking: none
-        Operations: *UpdateOps
-
-- Name: RemoveBenchmark.High.Long
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [19]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerLongDuration
-        Blocking: none
-        Operations: *RemoveOps
-
-
 #AutoRun:
 #  Requires:
 #    mongodb_setup:
+#      - atlas
 #      - replica
-#      - single-replica
 #      - replica-all-feature-flags
+#      - single-replica

--- a/src/workloads/transactions/LLTQueryLowLtc.yml
+++ b/src/workloads/transactions/LLTQueryLowLtc.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on a Query workload.
 
 GlobalDefaults:
   # These values should match those are the top of LLTPhases.yml
   dbname: &dbname llt
-  MaxPhases: &MaxPhases 20
+  MaxPhases: &MaxPhases 16
 
   # The Sample Document Shape.
   Document: &Doc
@@ -37,37 +37,40 @@ GlobalDefaults:
   # SecondaryDocumentCount: &SecondaryNumDocs 1000000
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
+  # The query operation name indicates the index in use (see LLTIndexes) :
+  #  * Ptc => price_1_ts_1_cuid_1
+  #  * Pc  => price_1_cuid_1
+  #  * Cpc => caid_1_price_1_cuid_1
+  PtcQueryOperation: &PtcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: price_1_ts_1_cuid_1
+        Comment: PtcQueryOperation
 
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
+  PcQueryOperation: &PcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: price_1_cuid_1
+        Comment: PcQueryOperation
 
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
+  CpcQueryOperation: &CpcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: caid_1_price_1_cuid_1
+        Comment: CpcQueryOperation
 
-  # Low Baseline / Benchmark
-  LowGlobalRate: &LowGlobalRate 400 per 1 second
-  LowThreads: &LowThreads 8
+  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
+  ThreadsValue: &ThreadsValue 8
 
-  # Low Baseline / Benchmark
-  HighGlobalRate: &HighGlobalRate 800 per 1 second
-  HighThreads: &HighThreads 16
+#  # Low Baseline / Benchmark
+#  GlobalRateValue: &GlobalRateValue 800 per 1 second
+#  ThreadsValue: &ThreadsValue 16
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
@@ -138,7 +141,7 @@ Actors:
   Database: *dbname
   Phases:
     OnlyActiveInPhases:
-      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Repeat: 1
@@ -149,62 +152,69 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+      Active: [1, 3, 5, 7, 9, 11, 13, 15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         LogEvery: 15 minutes
         Blocking: None
 
-- Name: RemoveBaseline.Low
+# Naming Conventions:
+# Operation.Duration.Load_level.Operation.Type_of_test
+# Operation:     Insert|Query|Update|Remove|Mixed
+# Duration:      Short|Medium|Long
+# Type of test:  Baseline|Benchmark
+#
+# Baseline without scans, benchmark with scans
+- Name: Short.Query.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [5]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
         Operations: &Operations
-          - *PtcRemoveOperation
-          - *PcRemoveOperation
-          - *CpcRemoveOperation
-          - *PtcRemoveOperation
-          - *PcRemoveOperation
-          - *CpcRemoveOperation
-          - *PtcRemoveOperation
-          - *PcRemoveOperation
-          - *CpcRemoveOperation
-          - *PtcRemoveOperation
-          - *PcRemoveOperation
-          - *CpcRemoveOperation
-          - *PtcRemoveOperation
-          - *PcRemoveOperation
-          - *CpcRemoveOperation
-          - *PtcRemoveOperation
-          - *PcRemoveOperation
-          - *CpcRemoveOperation
-          - *PtcRemoveOperation
-          - *PcRemoveOperation
-          - *CpcRemoveOperation
-          - *PtcRemoveOperation
-          - *PcRemoveOperation
-          - *CpcRemoveOperation
+          - *PtcQueryOperation
+          - *PcQueryOperation
+          - *CpcQueryOperation
+          - *PtcQueryOperation
+          - *PcQueryOperation
+          - *CpcQueryOperation
+          - *PtcQueryOperation
+          - *PcQueryOperation
+          - *CpcQueryOperation
+          - *PtcQueryOperation
+          - *PcQueryOperation
+          - *CpcQueryOperation
+          - *PtcQueryOperation
+          - *PcQueryOperation
+          - *CpcQueryOperation
+          - *PtcQueryOperation
+          - *PcQueryOperation
+          - *CpcQueryOperation
+          - *PtcQueryOperation
+          - *PcQueryOperation
+          - *CpcQueryOperation
+          - *PtcQueryOperation
+          - *PcQueryOperation
+          - *CpcQueryOperation
 
-- Name: RemoveBenchmark.Low.Short
+- Name: Short.Query.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Database: *dbname
   Phases:
     OnlyActiveInPhases:
       Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
@@ -212,7 +222,7 @@ Actors:
         Operations: *Operations
 
 ## A thread per collection doing a scan.
-- Name: SnapshotScannerShort
+- Name: Short.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -234,23 +244,38 @@ Actors:
           Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerShort
 
-- Name: RemoveBenchmark.Low.Medium
+- Name: Medium.Query.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [9]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerMediumDuration
+        Operations: *Operations
+
+- Name: Medium.Query.Benchmark
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [11]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerMediumDuration
         Blocking: none
         Operations: *Operations
 
-- Name: SnapshotScannerMedium
+- Name: Medium.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -258,7 +283,7 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [9]
+      Active: [11]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
@@ -272,153 +297,38 @@ Actors:
           Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerMedium
 
-- Name: RemoveBenchmark.Low.Long
+- Name: Long.Query.Baseline
   Type: CrudActor
-  Threads: *LowThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [11]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerLongDuration
-        Blocking: none
-        Operations: *Operations
-
-- Name: SnapshotScannerLong
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [11]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerLongDuration
-        ScanDuration: *SnapshotScannerLongDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_ # Currently only support the index name.
-          Comment: SnapshotScannerLong
-
-- Name: RemoveBaseline.High
-  Type: CrudActor
-  Threads: *HighThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [13]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
-        Duration: *SnapshotScannerShortDuration
+        Duration: *SnapshotScannerLongDuration
         Operations: *Operations
 
-- Name: RemoveBenchmark.High.Short
+- Name: Long.Query.Benchmark
   Type: CrudActor
-  Threads: *HighThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *Operations
-
-# A thread per collection doing a scan.
-- Name: SnapshotScannerShort
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [15]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerShortDuration
-        ScanDuration: *SnapshotScannerShortDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_ # Currently only support the index name.
-          Comment: SnapshotScannerShort
-
-- Name: RemoveBenchmark.High.Medium
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerMediumDuration
-        Blocking: none
-        Operations: *Operations
-
-- Name: SnapshotScannerMedium
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerMediumDuration
-        ScanDuration: *SnapshotScannerMediumDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_
-          Comment: SnapshotScannerMedium
-
-- Name: RemoveBenchmark.High.Long
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [19]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerLongDuration
         Blocking: none
         Operations: *Operations
 
-- Name: SnapshotScannerLong
+- Name: Long.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -426,7 +336,7 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [19]
+      Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
@@ -443,6 +353,7 @@ Actors:
 #AutoRun:
 #  Requires:
 #    mongodb_setup:
+#      - atlas
 #      - replica
-#      - single-replica
 #      - replica-all-feature-flags
+#      - single-replica

--- a/src/workloads/transactions/LLTRemoveLowLtc.yml
+++ b/src/workloads/transactions/LLTRemoveLowLtc.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on an Update workload.
+  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
 
 GlobalDefaults:
   # These values should match those are the top of LLTPhases.yml
   dbname: &dbname llt
-  MaxPhases: &MaxPhases 20
+  MaxPhases: &MaxPhases 16
 
   # The Sample Document Shape.
   Document: &Doc
@@ -37,59 +37,36 @@ GlobalDefaults:
   # SecondaryDocumentCount: &SecondaryNumDocs 1000000
   CollectionCount: &CollectionCount 4
 
-  # The query operation name indicates the index in use:
-  #  * Ptc => price_1_ts_1_cuid_1
-  #  * Pc  => price_1_cuid_1
-  #  * Cpc => caid_1_price_1_cuid_1
-  PtcUpdateOperation: &PtcUpdateOperation
-    OperationName: updateOne
+  PtcRemoveOperation: &PtcRemoveOperation
+    OperationName: deleteOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      Update:
-        $set:
-          ts: {^Now: {}}
-          data: {^Join: {array: ["bbbbbbbbbb", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
       OperationOptions:
-        Upsert: false
         WriteConcern:
           Level: majority
-        Hint: price_1_ts_1_cuid_1
 
-  PcUpdateOperation: &PcUpdateOperation
-    OperationName: updateOne
+  PcRemoveOperation: &PcRemoveOperation
+    OperationName: deleteOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      Update:
-        $set:
-          ts: {^Now: {}}
-          prod: {^RandomInt: {min: 0, max: 10000}}
       OperationOptions:
-        Upsert: false
         WriteConcern:
           Level: majority
-        Hint: price_1_cuid_1
 
-  CpcUpdateOperation: &CpcUpdateOperation
-    OperationName: updateOne
+  CpcRemoveOperation: &CpcRemoveOperation
+    OperationName: deleteOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      Update:
-        $set:
-          ts: {^Now: {}}
-          cuid: {^RandomInt: {min: 0, max: 100000}}
       OperationOptions:
-        Upsert: false
         WriteConcern:
           Level: majority
-        Hint: caid_1_price_1_cuid_1
 
-  # Low Baseline / Benchmark
-  LowGlobalRate: &LowGlobalRate 400 per 1 second
-  LowThreads: &LowThreads 8
+  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
+  ThreadsValue: &ThreadsValue 8
 
-  # Low Baseline / Benchmark
-  HighGlobalRate: &HighGlobalRate 800 per 1 second
-  HighThreads: &HighThreads 16
+#  # Low Baseline / Benchmark
+#  GlobalRateValue: &GlobalRateValue 800 per 1 second
+#  ThreadsValue: &ThreadsValue 16
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
@@ -160,7 +137,7 @@ Actors:
   Database: *dbname
   Phases:
     OnlyActiveInPhases:
-      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Repeat: 1
@@ -171,62 +148,69 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+      Active: [1, 3, 5, 7, 9, 11, 13, 15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         LogEvery: 15 minutes
         Blocking: None
 
-- Name: UpdateBaseline.Low
+# Naming Conventions:
+# Operation.Duration.Load_level.Operation.Type_of_test
+# Operation:     Insert|Query|Update|Remove|Mixed
+# Duration:      Short|Medium|Long
+# Type of test:  Baseline|Benchmark
+#
+# Baseline without scans, benchmark with scans
+- Name: Short.Remove.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [5]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
         Operations: &Operations
-          - *PtcUpdateOperation
-          - *PcUpdateOperation
-          - *CpcUpdateOperation
-          - *PtcUpdateOperation
-          - *PcUpdateOperation
-          - *CpcUpdateOperation
-          - *PtcUpdateOperation
-          - *PcUpdateOperation
-          - *CpcUpdateOperation
-          - *PtcUpdateOperation
-          - *PcUpdateOperation
-          - *CpcUpdateOperation
-          - *PtcUpdateOperation
-          - *PcUpdateOperation
-          - *CpcUpdateOperation
-          - *PtcUpdateOperation
-          - *PcUpdateOperation
-          - *CpcUpdateOperation
-          - *PtcUpdateOperation
-          - *PcUpdateOperation
-          - *CpcUpdateOperation
-          - *PtcUpdateOperation
-          - *PcUpdateOperation
-          - *CpcUpdateOperation
+          - *PtcRemoveOperation
+          - *PcRemoveOperation
+          - *CpcRemoveOperation
+          - *PtcRemoveOperation
+          - *PcRemoveOperation
+          - *CpcRemoveOperation
+          - *PtcRemoveOperation
+          - *PcRemoveOperation
+          - *CpcRemoveOperation
+          - *PtcRemoveOperation
+          - *PcRemoveOperation
+          - *CpcRemoveOperation
+          - *PtcRemoveOperation
+          - *PcRemoveOperation
+          - *CpcRemoveOperation
+          - *PtcRemoveOperation
+          - *PcRemoveOperation
+          - *CpcRemoveOperation
+          - *PtcRemoveOperation
+          - *PcRemoveOperation
+          - *CpcRemoveOperation
+          - *PtcRemoveOperation
+          - *PcRemoveOperation
+          - *CpcRemoveOperation
 
-- Name: UpdateBenchmark.Low.Short
+- Name: Short.Remove.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Database: *dbname
   Phases:
     OnlyActiveInPhases:
       Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
@@ -234,7 +218,7 @@ Actors:
         Operations: *Operations
 
 ## A thread per collection doing a scan.
-- Name: SnapshotScannerShort
+- Name: Short.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -256,23 +240,38 @@ Actors:
           Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerShort
 
-- Name: UpdateBenchmark.Low.Medium
+- Name: Medium.Remove.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [9]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerMediumDuration
+        Operations: *Operations
+
+- Name: Medium.Remove.Benchmark
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [11]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerMediumDuration
         Blocking: none
         Operations: *Operations
 
-- Name: SnapshotScannerMedium
+- Name: Medium.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -280,7 +279,7 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [9]
+      Active: [11]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
@@ -294,153 +293,38 @@ Actors:
           Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerMedium
 
-- Name: UpdateBenchmark.Low.Long
+- Name: Long.Remove.Baseline
   Type: CrudActor
-  Threads: *LowThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [11]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerLongDuration
-        Blocking: none
-        Operations: *Operations
-
-- Name: SnapshotScannerLong
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [11]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerLongDuration
-        ScanDuration: *SnapshotScannerLongDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_ # Currently only support the index name.
-          Comment: SnapshotScannerLong
-
-- Name: UpdateBaseline.High
-  Type: CrudActor
-  Threads: *HighThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [13]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
-        Duration: *SnapshotScannerShortDuration
+        Duration: *SnapshotScannerLongDuration
         Operations: *Operations
 
-- Name: UpdateBenchmark.High.Short
+- Name: Long.Remove.Benchmark
   Type: CrudActor
-  Threads: *HighThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *Operations
-
-# A thread per collection doing a scan.
-- Name: SnapshotScannerShort
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [15]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerShortDuration
-        ScanDuration: *SnapshotScannerShortDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_ # Currently only support the index name.
-          Comment: SnapshotScannerShort
-
-- Name: UpdateBenchmark.High.Medium
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerMediumDuration
-        Blocking: none
-        Operations: *Operations
-
-- Name: SnapshotScannerMedium
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerMediumDuration
-        ScanDuration: *SnapshotScannerMediumDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_
-          Comment: SnapshotScannerMedium
-
-- Name: UpdateBenchmark.High.Long
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [19]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        GlobalRate: *HighGlobalRate
-        Threads: *HighThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerLongDuration
         Blocking: none
         Operations: *Operations
 
-- Name: SnapshotScannerLong
+- Name: Long.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -448,7 +332,7 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [19]
+      Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
@@ -465,6 +349,7 @@ Actors:
 #AutoRun:
 #  Requires:
 #    mongodb_setup:
+#      - atlas
 #      - replica
-#      - single-replica
 #      - replica-all-feature-flags
+#      - single-replica

--- a/src/workloads/transactions/LLTUpdateLowLtc.yml
+++ b/src/workloads/transactions/LLTUpdateLowLtc.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on an Insert workload.
+  Workload to Benchmark the effect of LongLivedTransactions on an Update workload.
 
 GlobalDefaults:
   # These values should match those are the top of LLTPhases.yml
   dbname: &dbname llt
-  MaxPhases: &MaxPhases 20
+  MaxPhases: &MaxPhases 16
 
   # The Sample Document Shape.
   Document: &Doc
@@ -33,31 +33,68 @@ GlobalDefaults:
   # WIP make a copy of the workload once these values are tuned correctly and
   # the workload runs consistently.
   # Not In-memory: Database size works out about 30GB.
-  #InitialDocumentCount: &InitialNumDocs 49000000
-  #SecondaryDocumentCount: &SecondaryNumDocs 1000000
+  # InitialDocumentCount: &InitialNumDocs 49000000
+  # SecondaryDocumentCount: &SecondaryNumDocs 1000000
   CollectionCount: &CollectionCount 4
 
-  # Low Baseline / Benchmark
-  LowGlobalRate: &LowGlobalRate 400 per 1 second
-  LowThreads: &LowThreads 8
+  # The query operation name indicates the index in use:
+  #  * Ptc => price_1_ts_1_cuid_1
+  #  * Pc  => price_1_cuid_1
+  #  * Cpc => caid_1_price_1_cuid_1
+  PtcUpdateOperation: &PtcUpdateOperation
+    OperationName: updateOne
+    OperationCommand:
+      Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          data: {^Join: {array: ["bbbbbbbbbb", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
+      OperationOptions:
+        Upsert: false
+        WriteConcern:
+          Level: majority
+        Hint: price_1_ts_1_cuid_1
+
+  PcUpdateOperation: &PcUpdateOperation
+    OperationName: updateOne
+    OperationCommand:
+      Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          prod: {^RandomInt: {min: 0, max: 10000}}
+      OperationOptions:
+        Upsert: false
+        WriteConcern:
+          Level: majority
+        Hint: price_1_cuid_1
+
+  CpcUpdateOperation: &CpcUpdateOperation
+    OperationName: updateOne
+    OperationCommand:
+      Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          cuid: {^RandomInt: {min: 0, max: 100000}}
+      OperationOptions:
+        Upsert: false
+        WriteConcern:
+          Level: majority
+        Hint: caid_1_price_1_cuid_1
 
   # Low Baseline / Benchmark
-  HighGlobalRate: &HighGlobalRate 800 per 1 second
-  HighThreads: &HighThreads 16
+  GlobalRateValue: &GlobalRateValue 400 per 1 second
+  ThreadsValue: &ThreadsValue 8
+
+#  # Low Baseline / Benchmark
+#  GlobalRateValue: &GlobalRateValue 800 per 1 second
+#  ThreadsValue: &ThreadsValue 16
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
   SnapshotScannerMediumDuration: &SnapshotScannerMediumDuration 10 minutes
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
-
-  # The write concern. The intent is to use what is chosen as the default in 5.0.
-  InsertOperation: &InsertOperation
-    OperationName: insertOne
-    OperationCommand:
-      Document: *Doc
-      OperationOptions: &OperationOptions
-        WriteConcern:
-          Level: majority
 
 Clients:
   Default:
@@ -123,7 +160,7 @@ Actors:
   Database: *dbname
   Phases:
     OnlyActiveInPhases:
-      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+      Active: [0, 2, 4, 6, 8, 10, 12, 14, 16]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Repeat: 1
@@ -134,61 +171,69 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+      Active: [1, 3, 5, 7, 9, 11, 13, 15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         LogEvery: 15 minutes
         Blocking: None
 
-- Name: InsertBaseline.Low
+# Naming Conventions:
+# Operation.Duration.Load_level.Operation.Type_of_test
+# Operation:     Insert|Query|Update|Remove|Mixed
+# Duration:      Short|Medium|Long
+# Type of test:  Baseline|Benchmark
+#
+# Baseline without scans, benchmark with scans
+- Name: Short.Update.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [5]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        GlobalRate: *LowGlobalRate
-        Threads: *LowThreads
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
         Operations: &Operations
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
-          - *InsertOperation
+          - *PtcUpdateOperation
+          - *PcUpdateOperation
+          - *CpcUpdateOperation
+          - *PtcUpdateOperation
+          - *PcUpdateOperation
+          - *CpcUpdateOperation
+          - *PtcUpdateOperation
+          - *PcUpdateOperation
+          - *CpcUpdateOperation
+          - *PtcUpdateOperation
+          - *PcUpdateOperation
+          - *CpcUpdateOperation
+          - *PtcUpdateOperation
+          - *PcUpdateOperation
+          - *CpcUpdateOperation
+          - *PtcUpdateOperation
+          - *PcUpdateOperation
+          - *CpcUpdateOperation
+          - *PtcUpdateOperation
+          - *PcUpdateOperation
+          - *CpcUpdateOperation
+          - *PtcUpdateOperation
+          - *PcUpdateOperation
+          - *CpcUpdateOperation
 
-- Name: InsertBenchmark.Low.Short
+- Name: Short.Update.Benchmark
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
+  Database: *dbname
   Phases:
     OnlyActiveInPhases:
       Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        Threads: *LowThreads
-        GlobalRate: *LowGlobalRate
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerShortDuration
@@ -196,7 +241,7 @@ Actors:
         Operations: *Operations
 
 ## A thread per collection doing a scan.
-- Name: SnapshotScannerShort
+- Name: Short.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -215,26 +260,41 @@ Actors:
         CollectionSortOrder: forward
         FindOptions:
           BatchSize: 1000
-          Hint: _id_
+          Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerShort
 
-- Name: InsertBenchmark.Low.Medium
+- Name: Medium.Update.Baseline
   Type: CrudActor
-  Threads: *LowThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [9]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        Threads: *LowThreads
-        GlobalRate: *LowGlobalRate
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Duration: *SnapshotScannerMediumDuration
+        Operations: *Operations
+
+- Name: Medium.Update.Benchmark
+  Type: CrudActor
+  Threads: *ThreadsValue
+  Phases:
+    OnlyActiveInPhases:
+      Active: [11]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerMediumDuration
         Blocking: none
         Operations: *Operations
 
-- Name: SnapshotScannerMedium
+- Name: Medium.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -242,7 +302,7 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [9]
+      Active: [11]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerMediumDuration
@@ -253,155 +313,41 @@ Actors:
         CollectionSortOrder: forward
         FindOptions:
           BatchSize: 1000
-          Hint: _id_
+          Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerMedium
 
-- Name: InsertBenchmark.Low.Long
+- Name: Long.Update.Baseline
   Type: CrudActor
-  Threads: *LowThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [11]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Threads: *LowThreads
-        GlobalRate: *LowGlobalRate
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerLongDuration
-        Blocking: none
-        Operations: *Operations
-
-- Name: SnapshotScannerLong
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [11]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerLongDuration
-        ScanDuration: *SnapshotScannerMediumDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_
-          Comment: SnapshotScannerLong
-
-- Name: InsertBaseline.High
-  Type: CrudActor
-  Threads: *HighThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [13]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        Threads: *HighThreads
-        GlobalRate: *HighGlobalRate
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
-        Duration: *SnapshotScannerShortDuration
+        Duration: *SnapshotScannerLongDuration
         Operations: *Operations
 
-- Name: InsertBenchmark.High.Short
+- Name: Long.Update.Benchmark
   Type: CrudActor
-  Threads: *HighThreads
+  Threads: *ThreadsValue
   Phases:
     OnlyActiveInPhases:
       Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        Threads: *HighThreads
-        GlobalRate: *HighGlobalRate
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerShortDuration
-        Blocking: none
-        Operations: *Operations
-
-- Name: SnapshotScannerShort
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [15]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerShortDuration
-        ScanDuration: *SnapshotScannerShortDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_
-          Comment: SnapshotScannerShort
-
-- Name: InsertBenchmark.High.Medium
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Threads: *HighThreads
-        GlobalRate: *HighGlobalRate
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Duration: *SnapshotScannerMediumDuration
-        Blocking: none
-        Operations: *Operations
-
-- Name: SnapshotScannerMedium
-  Type: CollectionScanner
-  Threads: *CollectionCount
-  CollectionCount: *CollectionCount
-  Database: *dbname
-  GenerateCollectionNames: true
-  Phases:
-    OnlyActiveInPhases:
-      Active: [17]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *SnapshotScannerMediumDuration
-        ScanDuration: *SnapshotScannerShortDuration
-        ScanType: snapshot
-        ScanContinuous: true
-        GenerateCollectionNames: true
-        CollectionSortOrder: forward
-        FindOptions:
-          BatchSize: 1000
-          Hint: _id_
-          Comment: SnapshotScannerMedium
-
-- Name: InsertBenchmark.High.Long
-  Type: CrudActor
-  Threads: *HighThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [19]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Threads: *HighThreads
-        GlobalRate: *HighGlobalRate
+        GlobalRate: *GlobalRateValue
+        Threads: *ThreadsValue
         CollectionCount: *CollectionCount
         Database: *dbname
         Duration: *SnapshotScannerLongDuration
         Blocking: none
         Operations: *Operations
 
-- Name: SnapshotScannerLong
+- Name: Long.Scan.Snapshot
   Type: CollectionScanner
   Threads: *CollectionCount
   CollectionCount: *CollectionCount
@@ -409,7 +355,7 @@ Actors:
   GenerateCollectionNames: true
   Phases:
     OnlyActiveInPhases:
-      Active: [19]
+      Active: [15]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *SnapshotScannerLongDuration
@@ -420,13 +366,13 @@ Actors:
         CollectionSortOrder: forward
         FindOptions:
           BatchSize: 1000
-          Hint: _id_
+          Hint: _id_ # Currently only support the index name.
           Comment: SnapshotScannerLong
 
-AutoRun:
-  Requires:
-    mongodb_setup:
-      - atlas
-      - replica
-      - replica-all-feature-flags
-      - single-replica
+#AutoRun:
+#  Requires:
+#    mongodb_setup:
+#      - atlas
+#      - replica
+#      - replica-all-feature-flags
+#      - single-replica


### PR DESCRIPTION
This commit creates the Low rate / Less than Cache workloads and adds a baseline for each phase. The current one only has a baseline for 1 minute, this doesn't sufficiently allow for comparision between the baseline and benchmark phases.

Additionally the phase names have been rewritten to sort close to each other.
Finally the LLTInsertLowLtc.yml is being temporarily disabled.

The next PR will add templates for the pahses to reduce the amount of duplication.
A final PR will then add the LowGtc, HighLtc and HighGtc workloads. 