### PR TITLE
Fix onSession handling for createIndex

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -154,9 +154,9 @@ struct CreateIndexOperation : public BaseOperation {
 
         this->doBlock(_operation, [&](metrics::OperationContext& ctx) {
             _onSession
-                ? _collection.create_index(keys.view(), indexOptions.view(), _operationOptions)
-                : _collection.create_index(
-                      session, keys.view(), indexOptions.view(), _operationOptions);
+                ? _collection.create_index(
+                      session, keys.view(), indexOptions.view(), _operationOptions)
+                : _collection.create_index(keys.view(), indexOptions.view(), _operationOptions);
             return std::make_optional(std::move(keys));
         });
     }


### PR DESCRIPTION
I saw this while looking at other things.
Thankfully no usages of `createIndex` with session opts in any workload yamls.
I checked other places where we ternary on `_onSession` and everywhere else is fine.
