### PR TITLE
PERF-2260 add other configurations

### DIFF
--- a/src/workloads/transactions/LLTInsertHighGtc.yml
+++ b/src/workloads/transactions/LLTInsertHighGtc.yml
@@ -1,15 +1,15 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on an Insert workload.
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml
@@ -36,39 +36,24 @@ GlobalDefaults:
 
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
-    OperationCommand:
-      Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
-
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
-    OperationCommand:
-      Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
-
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
-    OperationCommand:
-      Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
-
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
   SnapshotScannerMediumDuration: &SnapshotScannerMediumDuration 10 minutes
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
 
+  # The write concern. The intent is to use what is chosen as the default in 5.0.
+  InsertOperation: &InsertOperation
+    OperationName: insertOne
+    OperationCommand:
+      Document: *Doc
+      OperationOptions: &OperationOptions
+        WriteConcern:
+          Level: majority
+
 ActorTemplates:
-  - TemplateName: RemoveTemplate
+  - TemplateName: InsertTemplate
     Config:
-      Name: {^Parameter: {Name: "Name", Default: "Short.Remove.Baseline"}}
+      Name: {^Parameter: {Name: "Name", Default: "Short.Insert.Baseline"}}
       Type: CrudActor
       Threads: *ThreadsValue
       Phases:
@@ -80,33 +65,33 @@ ActorTemplates:
             Threads: *ThreadsValue
             CollectionCount: *CollectionCount
             Database: *dbname
-            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
+            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
             Blocking:  {^Parameter: {Name: "Blocking", Default: yes}}
             Operations:
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
 
   - TemplateName: ScanTemplate
     Config:
@@ -214,21 +199,21 @@ Actors:
         Blocking: None
 
 # Naming Conventions:
-# Operation.Duration.Load_level.Operation.Type_of_test
-# Operation:     Insert|Query|Update|Remove|Mixed
+# Duration.Operation.Type_of_test
 # Duration:      Short|Medium|Long
-# Type of test:  Baseline|Benchmark
+# Operation:     Insert|Query|Update|Remove|Mixed|Scan
+# Type of test:  Baseline|Benchmark|Snapshot
 #
 # Baseline without scans, benchmark with scans
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Short.Remove.Baseline
+      Name: Short.Insert.Baseline
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Short.Remove.Benchmark
+      Name: Short.Insert.Benchmark
       Active: [7]
       Blocking: none
 
@@ -241,16 +226,16 @@ Actors:
       Comment: SnapshotScannerShort
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Medium.Remove.Baseline
+      Name: Medium.Insert.Baseline
       Active: [9]
       Duration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Medium.Remove.Benchmark
+      Name: Medium.Insert.Benchmark
       Active: [11]
       Blocking: none
       Duration: *SnapshotScannerMediumDuration
@@ -265,16 +250,16 @@ Actors:
       ScanDuration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Long.Remove.Baseline
+      Name: Long.Insert.Baseline
       Active: [13]
       Duration: *SnapshotScannerLongDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Long.Remove.Benchmark
+      Name: Long.Insert.Benchmark
       Active: [15]
       Blocking: none
       Duration: *SnapshotScannerLongDuration

--- a/src/workloads/transactions/LLTInsertHighLtc.yml
+++ b/src/workloads/transactions/LLTInsertHighLtc.yml
@@ -1,15 +1,15 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on an Insert workload.
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
   # In-memory: Database size works out about 12GB.
   InitialDocumentCount: &InitialNumDocs 10000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml
@@ -36,39 +36,24 @@ GlobalDefaults:
 
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
-    OperationCommand:
-      Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
-
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
-    OperationCommand:
-      Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
-
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
-    OperationCommand:
-      Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
-
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
   SnapshotScannerMediumDuration: &SnapshotScannerMediumDuration 10 minutes
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
 
+  # The write concern. The intent is to use what is chosen as the default in 5.0.
+  InsertOperation: &InsertOperation
+    OperationName: insertOne
+    OperationCommand:
+      Document: *Doc
+      OperationOptions: &OperationOptions
+        WriteConcern:
+          Level: majority
+
 ActorTemplates:
-  - TemplateName: RemoveTemplate
+  - TemplateName: InsertTemplate
     Config:
-      Name: {^Parameter: {Name: "Name", Default: "Short.Remove.Baseline"}}
+      Name: {^Parameter: {Name: "Name", Default: "Short.Insert.Baseline"}}
       Type: CrudActor
       Threads: *ThreadsValue
       Phases:
@@ -80,33 +65,33 @@ ActorTemplates:
             Threads: *ThreadsValue
             CollectionCount: *CollectionCount
             Database: *dbname
-            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
+            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
             Blocking:  {^Parameter: {Name: "Blocking", Default: yes}}
             Operations:
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
 
   - TemplateName: ScanTemplate
     Config:
@@ -214,21 +199,21 @@ Actors:
         Blocking: None
 
 # Naming Conventions:
-# Operation.Duration.Load_level.Operation.Type_of_test
-# Operation:     Insert|Query|Update|Remove|Mixed
+# Duration.Operation.Type_of_test
 # Duration:      Short|Medium|Long
-# Type of test:  Baseline|Benchmark
+# Operation:     Insert|Query|Update|Remove|Mixed|Scan
+# Type of test:  Baseline|Benchmark|Snapshot
 #
 # Baseline without scans, benchmark with scans
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Short.Remove.Baseline
+      Name: Short.Insert.Baseline
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Short.Remove.Benchmark
+      Name: Short.Insert.Benchmark
       Active: [7]
       Blocking: none
 
@@ -241,16 +226,16 @@ Actors:
       Comment: SnapshotScannerShort
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Medium.Remove.Baseline
+      Name: Medium.Insert.Baseline
       Active: [9]
       Duration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Medium.Remove.Benchmark
+      Name: Medium.Insert.Benchmark
       Active: [11]
       Blocking: none
       Duration: *SnapshotScannerMediumDuration
@@ -265,16 +250,16 @@ Actors:
       ScanDuration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Long.Remove.Baseline
+      Name: Long.Insert.Baseline
       Active: [13]
       Duration: *SnapshotScannerLongDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Long.Remove.Benchmark
+      Name: Long.Insert.Benchmark
       Active: [15]
       Blocking: none
       Duration: *SnapshotScannerLongDuration

--- a/src/workloads/transactions/LLTInsertLowGtc.yml
+++ b/src/workloads/transactions/LLTInsertLowGtc.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on an Insert workload.
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
   GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
   ThreadsValue: &ThreadsValue 8
@@ -36,39 +36,24 @@ GlobalDefaults:
 
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
-    OperationCommand:
-      Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
-
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
-    OperationCommand:
-      Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
-
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
-    OperationCommand:
-      Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
-
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
   SnapshotScannerMediumDuration: &SnapshotScannerMediumDuration 10 minutes
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
 
+  # The write concern. The intent is to use what is chosen as the default in 5.0.
+  InsertOperation: &InsertOperation
+    OperationName: insertOne
+    OperationCommand:
+      Document: *Doc
+      OperationOptions: &OperationOptions
+        WriteConcern:
+          Level: majority
+
 ActorTemplates:
-  - TemplateName: RemoveTemplate
+  - TemplateName: InsertTemplate
     Config:
-      Name: {^Parameter: {Name: "Name", Default: "Short.Remove.Baseline"}}
+      Name: {^Parameter: {Name: "Name", Default: "Short.Insert.Baseline"}}
       Type: CrudActor
       Threads: *ThreadsValue
       Phases:
@@ -80,33 +65,33 @@ ActorTemplates:
             Threads: *ThreadsValue
             CollectionCount: *CollectionCount
             Database: *dbname
-            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
+            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
             Blocking:  {^Parameter: {Name: "Blocking", Default: yes}}
             Operations:
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
+              - *InsertOperation
 
   - TemplateName: ScanTemplate
     Config:
@@ -214,21 +199,21 @@ Actors:
         Blocking: None
 
 # Naming Conventions:
-# Operation.Duration.Load_level.Operation.Type_of_test
-# Operation:     Insert|Query|Update|Remove|Mixed
+# Duration.Operation.Type_of_test
 # Duration:      Short|Medium|Long
-# Type of test:  Baseline|Benchmark
+# Operation:     Insert|Query|Update|Remove|Mixed|Scan
+# Type of test:  Baseline|Benchmark|Snapshot
 #
 # Baseline without scans, benchmark with scans
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Short.Remove.Baseline
+      Name: Short.Insert.Baseline
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Short.Remove.Benchmark
+      Name: Short.Insert.Benchmark
       Active: [7]
       Blocking: none
 
@@ -241,16 +226,16 @@ Actors:
       Comment: SnapshotScannerShort
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Medium.Remove.Baseline
+      Name: Medium.Insert.Baseline
       Active: [9]
       Duration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Medium.Remove.Benchmark
+      Name: Medium.Insert.Benchmark
       Active: [11]
       Blocking: none
       Duration: *SnapshotScannerMediumDuration
@@ -265,16 +250,16 @@ Actors:
       ScanDuration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Long.Remove.Baseline
+      Name: Long.Insert.Baseline
       Active: [13]
       Duration: *SnapshotScannerLongDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: InsertTemplate
     TemplateParameters:
-      Name: Long.Remove.Benchmark
+      Name: Long.Insert.Benchmark
       Active: [15]
       Blocking: none
       Duration: *SnapshotScannerLongDuration

--- a/src/workloads/transactions/LLTInsertLowLtc.yml
+++ b/src/workloads/transactions/LLTInsertLowLtc.yml
@@ -4,6 +4,14 @@ Description: |
   Workload to Benchmark the effect of LongLivedTransactions on an Insert workload.
 
 GlobalDefaults:
+  # Start: The following block gets updated for the other configurations.
+  # In-memory: Database size works out about 12GB.
+  InitialDocumentCount: &InitialNumDocs 10000000
+  SecondaryDocumentCount: &SecondaryNumDocs 10000000
+  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
+  ThreadsValue: &ThreadsValue 8
+  # End: The previous block gets updated for the other configurations.
+
   # These values should match those are the top of LLTPhases.yml
   dbname: &dbname llt
   MaxPhases: &MaxPhases 16
@@ -26,14 +34,7 @@ GlobalDefaults:
   LoadThreads: &LoadThreads 4
   LoadBatchSize: &LoadBatchSize 1000
 
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
-  SecondaryDocumentCount: &SecondaryNumDocs 10000000
-
   CollectionCount: &CollectionCount 4
-
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes

--- a/src/workloads/transactions/LLTMixedHighGtc.yml
+++ b/src/workloads/transactions/LLTMixedHighGtc.yml
@@ -209,7 +209,7 @@ ActorTemplates:
       Threads: *ThreadsValue
       Phases:
         OnlyActiveInPhases:
-          Active:  {^Parameter: {Name: "OnlyActiveInPhase", Default: [5]}}
+          Active:  {^Parameter: {Name: "Active", Default: [5]}}
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             GlobalRate: *GlobalRateValue
@@ -234,7 +234,7 @@ ActorTemplates:
       Threads: *ThreadsValue
       Phases:
         OnlyActiveInPhases:
-          Active:  {^Parameter: {Name: "OnlyActiveInPhase", Default: [5]}}
+          Active:  {^Parameter: {Name: "Active", Default: [5]}}
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             GlobalRate: *GlobalRateValue
@@ -263,7 +263,7 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "OnlyActiveInPhase", Default: [7]}}# [7]
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}

--- a/src/workloads/transactions/LLTMixedHighGtc.yml
+++ b/src/workloads/transactions/LLTMixedHighGtc.yml
@@ -5,11 +5,11 @@ Description: |
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml

--- a/src/workloads/transactions/LLTMixedHighLtc.yml
+++ b/src/workloads/transactions/LLTMixedHighLtc.yml
@@ -209,7 +209,7 @@ ActorTemplates:
       Threads: *ThreadsValue
       Phases:
         OnlyActiveInPhases:
-          Active:  {^Parameter: {Name: "OnlyActiveInPhase", Default: [5]}}
+          Active:  {^Parameter: {Name: "Active", Default: [5]}}
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             GlobalRate: *GlobalRateValue
@@ -234,7 +234,7 @@ ActorTemplates:
       Threads: *ThreadsValue
       Phases:
         OnlyActiveInPhases:
-          Active:  {^Parameter: {Name: "OnlyActiveInPhase", Default: [5]}}
+          Active:  {^Parameter: {Name: "Active", Default: [5]}}
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             GlobalRate: *GlobalRateValue
@@ -263,7 +263,7 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "OnlyActiveInPhase", Default: [7]}}# [7]
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}

--- a/src/workloads/transactions/LLTMixedHighLtc.yml
+++ b/src/workloads/transactions/LLTMixedHighLtc.yml
@@ -8,8 +8,8 @@ GlobalDefaults:
   # In-memory: Database size works out about 12GB.
   InitialDocumentCount: &InitialNumDocs 10000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml

--- a/src/workloads/transactions/LLTMixedLowGtc.yml
+++ b/src/workloads/transactions/LLTMixedLowGtc.yml
@@ -209,7 +209,7 @@ ActorTemplates:
       Threads: *ThreadsValue
       Phases:
         OnlyActiveInPhases:
-          Active:  {^Parameter: {Name: "OnlyActiveInPhase", Default: [5]}}
+          Active:  {^Parameter: {Name: "Active", Default: [5]}}
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             GlobalRate: *GlobalRateValue
@@ -234,7 +234,7 @@ ActorTemplates:
       Threads: *ThreadsValue
       Phases:
         OnlyActiveInPhases:
-          Active:  {^Parameter: {Name: "OnlyActiveInPhase", Default: [5]}}
+          Active:  {^Parameter: {Name: "Active", Default: [5]}}
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             GlobalRate: *GlobalRateValue
@@ -263,7 +263,7 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "OnlyActiveInPhase", Default: [7]}}# [7]
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}

--- a/src/workloads/transactions/LLTMixedLowGtc.yml
+++ b/src/workloads/transactions/LLTMixedLowGtc.yml
@@ -5,8 +5,8 @@ Description: |
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
   GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
   ThreadsValue: &ThreadsValue 8

--- a/src/workloads/transactions/LLTMixedLowLtc.yml
+++ b/src/workloads/transactions/LLTMixedLowLtc.yml
@@ -209,7 +209,7 @@ ActorTemplates:
       Threads: *ThreadsValue
       Phases:
         OnlyActiveInPhases:
-          Active:  {^Parameter: {Name: "OnlyActiveInPhase", Default: [5]}}
+          Active:  {^Parameter: {Name: "Active", Default: [5]}}
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             GlobalRate: *GlobalRateValue
@@ -234,7 +234,7 @@ ActorTemplates:
       Threads: *ThreadsValue
       Phases:
         OnlyActiveInPhases:
-          Active:  {^Parameter: {Name: "OnlyActiveInPhase", Default: [5]}}
+          Active:  {^Parameter: {Name: "Active", Default: [5]}}
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             GlobalRate: *GlobalRateValue
@@ -263,7 +263,7 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "OnlyActiveInPhase", Default: [7]}}# [7]
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}

--- a/src/workloads/transactions/LLTQueryHighGtc.yml
+++ b/src/workloads/transactions/LLTQueryHighGtc.yml
@@ -1,15 +1,15 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on a Query workload.
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml
@@ -36,29 +36,33 @@ GlobalDefaults:
 
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
+  # The query operation name indicates the index in use (see LLTIndexes) :
+  #  * Ptc => price_1_ts_1_cuid_1
+  #  * Pc  => price_1_cuid_1
+  #  * Cpc => caid_1_price_1_cuid_1
+  PtcQueryOperation: &PtcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: price_1_ts_1_cuid_1
+        Comment: PtcQueryOperation
 
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
+  PcQueryOperation: &PcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: price_1_cuid_1
+        Comment: PcQueryOperation
 
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
+  CpcQueryOperation: &CpcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: caid_1_price_1_cuid_1
+        Comment: CpcQueryOperation
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
@@ -66,9 +70,9 @@ GlobalDefaults:
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
 
 ActorTemplates:
-  - TemplateName: RemoveTemplate
+  - TemplateName: QueryTemplate
     Config:
-      Name: {^Parameter: {Name: "Name", Default: "Short.Remove.Baseline"}}
+      Name: {^Parameter: {Name: "Name", Default: "Short.Query.Baseline"}}
       Type: CrudActor
       Threads: *ThreadsValue
       Phases:
@@ -80,33 +84,33 @@ ActorTemplates:
             Threads: *ThreadsValue
             CollectionCount: *CollectionCount
             Database: *dbname
-            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
+            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
             Blocking:  {^Parameter: {Name: "Blocking", Default: yes}}
             Operations:
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
 
   - TemplateName: ScanTemplate
     Config:
@@ -118,11 +122,11 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "Active", Default: [7]}}
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
-            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
-            ScanDuration: {^Parameter: {Name: "ScanDuration", Default: *SnapshotScannerShortDuration}}
+            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
+            ScanDuration: {^Parameter: {Name: "ScanDuration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
             ScanType: snapshot
             ScanContinuous: true
             GenerateCollectionNames: true
@@ -221,14 +225,14 @@ Actors:
 #
 # Baseline without scans, benchmark with scans
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Short.Remove.Baseline
+      Name: Short.Query.Baseline
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Short.Remove.Benchmark
+      Name: Short.Query.Benchmark
       Active: [7]
       Blocking: none
 
@@ -241,16 +245,16 @@ Actors:
       Comment: SnapshotScannerShort
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Medium.Remove.Baseline
+      Name: Medium.Query.Baseline
       Active: [9]
       Duration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Medium.Remove.Benchmark
+      Name: Medium.Query.Benchmark
       Active: [11]
       Blocking: none
       Duration: *SnapshotScannerMediumDuration
@@ -265,16 +269,16 @@ Actors:
       ScanDuration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Long.Remove.Baseline
+      Name: Long.Query.Baseline
       Active: [13]
       Duration: *SnapshotScannerLongDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Long.Remove.Benchmark
+      Name: Long.Query.Benchmark
       Active: [15]
       Blocking: none
       Duration: *SnapshotScannerLongDuration

--- a/src/workloads/transactions/LLTQueryHighLtc.yml
+++ b/src/workloads/transactions/LLTQueryHighLtc.yml
@@ -1,15 +1,15 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on a Query workload.
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
   # In-memory: Database size works out about 12GB.
   InitialDocumentCount: &InitialNumDocs 10000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml
@@ -36,29 +36,33 @@ GlobalDefaults:
 
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
+  # The query operation name indicates the index in use (see LLTIndexes) :
+  #  * Ptc => price_1_ts_1_cuid_1
+  #  * Pc  => price_1_cuid_1
+  #  * Cpc => caid_1_price_1_cuid_1
+  PtcQueryOperation: &PtcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: price_1_ts_1_cuid_1
+        Comment: PtcQueryOperation
 
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
+  PcQueryOperation: &PcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: price_1_cuid_1
+        Comment: PcQueryOperation
 
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
+  CpcQueryOperation: &CpcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: caid_1_price_1_cuid_1
+        Comment: CpcQueryOperation
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
@@ -66,9 +70,9 @@ GlobalDefaults:
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
 
 ActorTemplates:
-  - TemplateName: RemoveTemplate
+  - TemplateName: QueryTemplate
     Config:
-      Name: {^Parameter: {Name: "Name", Default: "Short.Remove.Baseline"}}
+      Name: {^Parameter: {Name: "Name", Default: "Short.Query.Baseline"}}
       Type: CrudActor
       Threads: *ThreadsValue
       Phases:
@@ -80,33 +84,33 @@ ActorTemplates:
             Threads: *ThreadsValue
             CollectionCount: *CollectionCount
             Database: *dbname
-            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
+            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
             Blocking:  {^Parameter: {Name: "Blocking", Default: yes}}
             Operations:
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
 
   - TemplateName: ScanTemplate
     Config:
@@ -118,11 +122,11 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "Active", Default: [7]}}
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
-            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
-            ScanDuration: {^Parameter: {Name: "ScanDuration", Default: *SnapshotScannerShortDuration}}
+            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
+            ScanDuration: {^Parameter: {Name: "ScanDuration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
             ScanType: snapshot
             ScanContinuous: true
             GenerateCollectionNames: true
@@ -221,14 +225,14 @@ Actors:
 #
 # Baseline without scans, benchmark with scans
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Short.Remove.Baseline
+      Name: Short.Query.Baseline
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Short.Remove.Benchmark
+      Name: Short.Query.Benchmark
       Active: [7]
       Blocking: none
 
@@ -241,16 +245,16 @@ Actors:
       Comment: SnapshotScannerShort
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Medium.Remove.Baseline
+      Name: Medium.Query.Baseline
       Active: [9]
       Duration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Medium.Remove.Benchmark
+      Name: Medium.Query.Benchmark
       Active: [11]
       Blocking: none
       Duration: *SnapshotScannerMediumDuration
@@ -265,16 +269,16 @@ Actors:
       ScanDuration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Long.Remove.Baseline
+      Name: Long.Query.Baseline
       Active: [13]
       Duration: *SnapshotScannerLongDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Long.Remove.Benchmark
+      Name: Long.Query.Benchmark
       Active: [15]
       Blocking: none
       Duration: *SnapshotScannerLongDuration

--- a/src/workloads/transactions/LLTQueryLowGtc.yml
+++ b/src/workloads/transactions/LLTQueryLowGtc.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on a Query workload.
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
   GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
   ThreadsValue: &ThreadsValue 8
@@ -36,29 +36,33 @@ GlobalDefaults:
 
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
+  # The query operation name indicates the index in use (see LLTIndexes) :
+  #  * Ptc => price_1_ts_1_cuid_1
+  #  * Pc  => price_1_cuid_1
+  #  * Cpc => caid_1_price_1_cuid_1
+  PtcQueryOperation: &PtcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: price_1_ts_1_cuid_1
+        Comment: PtcQueryOperation
 
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
+  PcQueryOperation: &PcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: price_1_cuid_1
+        Comment: PcQueryOperation
 
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
+  CpcQueryOperation: &CpcQueryOperation
+    OperationName: findOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
-      OperationOptions:
-        WriteConcern:
-          Level: majority
+      Options:
+        Hint: caid_1_price_1_cuid_1
+        Comment: CpcQueryOperation
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
@@ -66,9 +70,9 @@ GlobalDefaults:
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
 
 ActorTemplates:
-  - TemplateName: RemoveTemplate
+  - TemplateName: QueryTemplate
     Config:
-      Name: {^Parameter: {Name: "Name", Default: "Short.Remove.Baseline"}}
+      Name: {^Parameter: {Name: "Name", Default: "Short.Query.Baseline"}}
       Type: CrudActor
       Threads: *ThreadsValue
       Phases:
@@ -80,33 +84,33 @@ ActorTemplates:
             Threads: *ThreadsValue
             CollectionCount: *CollectionCount
             Database: *dbname
-            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
+            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
             Blocking:  {^Parameter: {Name: "Blocking", Default: yes}}
             Operations:
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
+              - *PtcQueryOperation
+              - *PcQueryOperation
+              - *CpcQueryOperation
 
   - TemplateName: ScanTemplate
     Config:
@@ -118,11 +122,11 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "Active", Default: [7]}}
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
-            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
-            ScanDuration: {^Parameter: {Name: "ScanDuration", Default: *SnapshotScannerShortDuration}}
+            Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
+            ScanDuration: {^Parameter: {Name: "ScanDuration", Default: *SnapshotScannerShortDuration}}# *SnapshotScannerShortDuration
             ScanType: snapshot
             ScanContinuous: true
             GenerateCollectionNames: true
@@ -221,14 +225,14 @@ Actors:
 #
 # Baseline without scans, benchmark with scans
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Short.Remove.Baseline
+      Name: Short.Query.Baseline
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Short.Remove.Benchmark
+      Name: Short.Query.Benchmark
       Active: [7]
       Blocking: none
 
@@ -241,16 +245,16 @@ Actors:
       Comment: SnapshotScannerShort
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Medium.Remove.Baseline
+      Name: Medium.Query.Baseline
       Active: [9]
       Duration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Medium.Remove.Benchmark
+      Name: Medium.Query.Benchmark
       Active: [11]
       Blocking: none
       Duration: *SnapshotScannerMediumDuration
@@ -265,16 +269,16 @@ Actors:
       ScanDuration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Long.Remove.Baseline
+      Name: Long.Query.Baseline
       Active: [13]
       Duration: *SnapshotScannerLongDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: QueryTemplate
     TemplateParameters:
-      Name: Long.Remove.Benchmark
+      Name: Long.Query.Benchmark
       Active: [15]
       Blocking: none
       Duration: *SnapshotScannerLongDuration

--- a/src/workloads/transactions/LLTQueryLowLtc.yml
+++ b/src/workloads/transactions/LLTQueryLowLtc.yml
@@ -4,6 +4,14 @@ Description: |
   Workload to Benchmark the effect of LongLivedTransactions on a Query workload.
 
 GlobalDefaults:
+  # Start: The following block gets updated for the other configurations.
+  # In-memory: Database size works out about 12GB.
+  InitialDocumentCount: &InitialNumDocs 10000000
+  SecondaryDocumentCount: &SecondaryNumDocs 10000000
+  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
+  ThreadsValue: &ThreadsValue 8
+  # End: The previous block gets updated for the other configurations.
+
   # These values should match those are the top of LLTPhases.yml
   dbname: &dbname llt
   MaxPhases: &MaxPhases 16
@@ -25,10 +33,6 @@ GlobalDefaults:
   # Loader Config.
   LoadThreads: &LoadThreads 4
   LoadBatchSize: &LoadBatchSize 1000
-
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
-  SecondaryDocumentCount: &SecondaryNumDocs 10000000
 
   CollectionCount: &CollectionCount 4
 
@@ -59,9 +63,6 @@ GlobalDefaults:
       Options:
         Hint: caid_1_price_1_cuid_1
         Comment: CpcQueryOperation
-
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes

--- a/src/workloads/transactions/LLTRemoveHighGtc.yml
+++ b/src/workloads/transactions/LLTRemoveHighGtc.yml
@@ -5,11 +5,11 @@ Description: |
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml

--- a/src/workloads/transactions/LLTRemoveHighLtc.yml
+++ b/src/workloads/transactions/LLTRemoveHighLtc.yml
@@ -8,8 +8,8 @@ GlobalDefaults:
   # In-memory: Database size works out about 12GB.
   InitialDocumentCount: &InitialNumDocs 10000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml

--- a/src/workloads/transactions/LLTRemoveLowGtc.yml
+++ b/src/workloads/transactions/LLTRemoveLowGtc.yml
@@ -5,8 +5,8 @@ Description: |
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
   GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
   ThreadsValue: &ThreadsValue 8

--- a/src/workloads/transactions/LLTUpdateHighGtc.yml
+++ b/src/workloads/transactions/LLTUpdateHighGtc.yml
@@ -1,15 +1,15 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on an Update workload.
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml
@@ -36,29 +36,51 @@ GlobalDefaults:
 
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
+  # The query operation name indicates the index in use:
+  #  * Ptc => price_1_ts_1_cuid_1
+  #  * Pc  => price_1_cuid_1
+  #  * Cpc => caid_1_price_1_cuid_1
+  PtcUpdateOperation: &PtcUpdateOperation
+    OperationName: updateOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          data: {^Join: {array: ["bbbbbbbbbb", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
       OperationOptions:
+        Upsert: false
         WriteConcern:
           Level: majority
+        Hint: price_1_ts_1_cuid_1
 
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
+  PcUpdateOperation: &PcUpdateOperation
+    OperationName: updateOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          prod: {^RandomInt: {min: 0, max: 10000}}
       OperationOptions:
+        Upsert: false
         WriteConcern:
           Level: majority
+        Hint: price_1_cuid_1
 
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
+  CpcUpdateOperation: &CpcUpdateOperation
+    OperationName: updateOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          cuid: {^RandomInt: {min: 0, max: 100000}}
       OperationOptions:
+        Upsert: false
         WriteConcern:
           Level: majority
+        Hint: caid_1_price_1_cuid_1
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
@@ -66,9 +88,9 @@ GlobalDefaults:
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
 
 ActorTemplates:
-  - TemplateName: RemoveTemplate
+  - TemplateName: UpdateTemplate
     Config:
-      Name: {^Parameter: {Name: "Name", Default: "Short.Remove.Baseline"}}
+      Name: {^Parameter: {Name: "Name", Default: "Short.Update.Baseline"}}
       Type: CrudActor
       Threads: *ThreadsValue
       Phases:
@@ -83,30 +105,30 @@ ActorTemplates:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
             Blocking:  {^Parameter: {Name: "Blocking", Default: yes}}
             Operations:
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
 
   - TemplateName: ScanTemplate
     Config:
@@ -118,7 +140,7 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "Active", Default: [7]}}
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
@@ -221,14 +243,14 @@ Actors:
 #
 # Baseline without scans, benchmark with scans
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Short.Remove.Baseline
+      Name: Short.Update.Baseline
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Short.Remove.Benchmark
+      Name: Short.Update.Benchmark
       Active: [7]
       Blocking: none
 
@@ -241,16 +263,16 @@ Actors:
       Comment: SnapshotScannerShort
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Medium.Remove.Baseline
+      Name: Medium.Update.Baseline
       Active: [9]
       Duration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Medium.Remove.Benchmark
+      Name: Medium.Update.Benchmark
       Active: [11]
       Blocking: none
       Duration: *SnapshotScannerMediumDuration
@@ -265,16 +287,16 @@ Actors:
       ScanDuration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Long.Remove.Baseline
+      Name: Long.Update.Baseline
       Active: [13]
       Duration: *SnapshotScannerLongDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Long.Remove.Benchmark
+      Name: Long.Update.Benchmark
       Active: [15]
       Blocking: none
       Duration: *SnapshotScannerLongDuration

--- a/src/workloads/transactions/LLTUpdateHighLtc.yml
+++ b/src/workloads/transactions/LLTUpdateHighLtc.yml
@@ -1,15 +1,15 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on an Update workload.
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
   # In-memory: Database size works out about 12GB.
   InitialDocumentCount: &InitialNumDocs 10000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
-  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
-  ThreadsValue: &ThreadsValue 8
+  GlobalRateValue: &GlobalRateValue 800 per 1 second
+  ThreadsValue: &ThreadsValue 16
   # End: The previous block gets updated for the other configurations.
 
   # These values should match those are the top of LLTPhases.yml
@@ -36,29 +36,51 @@ GlobalDefaults:
 
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
+  # The query operation name indicates the index in use:
+  #  * Ptc => price_1_ts_1_cuid_1
+  #  * Pc  => price_1_cuid_1
+  #  * Cpc => caid_1_price_1_cuid_1
+  PtcUpdateOperation: &PtcUpdateOperation
+    OperationName: updateOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          data: {^Join: {array: ["bbbbbbbbbb", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
       OperationOptions:
+        Upsert: false
         WriteConcern:
           Level: majority
+        Hint: price_1_ts_1_cuid_1
 
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
+  PcUpdateOperation: &PcUpdateOperation
+    OperationName: updateOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          prod: {^RandomInt: {min: 0, max: 10000}}
       OperationOptions:
+        Upsert: false
         WriteConcern:
           Level: majority
+        Hint: price_1_cuid_1
 
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
+  CpcUpdateOperation: &CpcUpdateOperation
+    OperationName: updateOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          cuid: {^RandomInt: {min: 0, max: 100000}}
       OperationOptions:
+        Upsert: false
         WriteConcern:
           Level: majority
+        Hint: caid_1_price_1_cuid_1
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
@@ -66,9 +88,9 @@ GlobalDefaults:
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
 
 ActorTemplates:
-  - TemplateName: RemoveTemplate
+  - TemplateName: UpdateTemplate
     Config:
-      Name: {^Parameter: {Name: "Name", Default: "Short.Remove.Baseline"}}
+      Name: {^Parameter: {Name: "Name", Default: "Short.Update.Baseline"}}
       Type: CrudActor
       Threads: *ThreadsValue
       Phases:
@@ -83,30 +105,30 @@ ActorTemplates:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
             Blocking:  {^Parameter: {Name: "Blocking", Default: yes}}
             Operations:
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
 
   - TemplateName: ScanTemplate
     Config:
@@ -118,7 +140,7 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "Active", Default: [7]}}
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
@@ -221,14 +243,14 @@ Actors:
 #
 # Baseline without scans, benchmark with scans
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Short.Remove.Baseline
+      Name: Short.Update.Baseline
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Short.Remove.Benchmark
+      Name: Short.Update.Benchmark
       Active: [7]
       Blocking: none
 
@@ -241,16 +263,16 @@ Actors:
       Comment: SnapshotScannerShort
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Medium.Remove.Baseline
+      Name: Medium.Update.Baseline
       Active: [9]
       Duration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Medium.Remove.Benchmark
+      Name: Medium.Update.Benchmark
       Active: [11]
       Blocking: none
       Duration: *SnapshotScannerMediumDuration
@@ -265,16 +287,16 @@ Actors:
       ScanDuration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Long.Remove.Baseline
+      Name: Long.Update.Baseline
       Active: [13]
       Duration: *SnapshotScannerLongDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Long.Remove.Benchmark
+      Name: Long.Update.Benchmark
       Active: [15]
       Blocking: none
       Duration: *SnapshotScannerLongDuration

--- a/src/workloads/transactions/LLTUpdateLowGtc.yml
+++ b/src/workloads/transactions/LLTUpdateLowGtc.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  Workload to Benchmark the effect of LongLivedTransactions on a Remove workload.
+  Workload to Benchmark the effect of LongLivedTransactions on an Update workload.
 
 GlobalDefaults:
   # Start: The following block gets updated for the other configurations.
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
+  # Not In-memory: Database size works out about 30GB.
+  InitialDocumentCount: &InitialNumDocs 49000000
   SecondaryDocumentCount: &SecondaryNumDocs 10000000
   GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
   ThreadsValue: &ThreadsValue 8
@@ -36,29 +36,51 @@ GlobalDefaults:
 
   CollectionCount: &CollectionCount 4
 
-  PtcRemoveOperation: &PtcRemoveOperation
-    OperationName: deleteOne
+  # The query operation name indicates the index in use:
+  #  * Ptc => price_1_ts_1_cuid_1
+  #  * Pc  => price_1_cuid_1
+  #  * Cpc => caid_1_price_1_cuid_1
+  PtcUpdateOperation: &PtcUpdateOperation
+    OperationName: updateOne
     OperationCommand:
       Filter: {price: {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          data: {^Join: {array: ["bbbbbbbbbb", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
       OperationOptions:
+        Upsert: false
         WriteConcern:
           Level: majority
+        Hint: price_1_ts_1_cuid_1
 
-  PcRemoveOperation: &PcRemoveOperation
-    OperationName: deleteOne
+  PcUpdateOperation: &PcUpdateOperation
+    OperationName: updateOne
     OperationCommand:
       Filter: {'price': {'$gte' : {^RandomDouble: { min: 0.0, max: 500.0 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          prod: {^RandomInt: {min: 0, max: 10000}}
       OperationOptions:
+        Upsert: false
         WriteConcern:
           Level: majority
+        Hint: price_1_cuid_1
 
-  CpcRemoveOperation: &CpcRemoveOperation
-    OperationName: deleteOne
+  CpcUpdateOperation: &CpcUpdateOperation
+    OperationName: updateOne
     OperationCommand:
       Filter: {'caid':  {'$gte': {^RandomInt: { min: 0, max: 1000 }}}}
+      Update:
+        $set:
+          ts: {^Now: {}}
+          cuid: {^RandomInt: {min: 0, max: 100000}}
       OperationOptions:
+        Upsert: false
         WriteConcern:
           Level: majority
+        Hint: caid_1_price_1_cuid_1
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes
@@ -66,9 +88,9 @@ GlobalDefaults:
   SnapshotScannerLongDuration: &SnapshotScannerLongDuration 60 minutes
 
 ActorTemplates:
-  - TemplateName: RemoveTemplate
+  - TemplateName: UpdateTemplate
     Config:
-      Name: {^Parameter: {Name: "Name", Default: "Short.Remove.Baseline"}}
+      Name: {^Parameter: {Name: "Name", Default: "Short.Update.Baseline"}}
       Type: CrudActor
       Threads: *ThreadsValue
       Phases:
@@ -83,30 +105,30 @@ ActorTemplates:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
             Blocking:  {^Parameter: {Name: "Blocking", Default: yes}}
             Operations:
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
-              - *PtcRemoveOperation
-              - *PcRemoveOperation
-              - *CpcRemoveOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
+              - *PtcUpdateOperation
+              - *PcUpdateOperation
+              - *CpcUpdateOperation
 
   - TemplateName: ScanTemplate
     Config:
@@ -118,7 +140,7 @@ ActorTemplates:
       GenerateCollectionNames: true
       Phases:
         OnlyActiveInPhases:
-          Active: {^Parameter: {Name: "Active", Default: [7]}}
+          Active: {^Parameter: {Name: "Active", Default: [7]}}# [7]
           NopInPhasesUpTo: *MaxPhases
           PhaseConfig:
             Duration: {^Parameter: {Name: "Duration", Default: *SnapshotScannerShortDuration}}
@@ -221,14 +243,14 @@ Actors:
 #
 # Baseline without scans, benchmark with scans
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Short.Remove.Baseline
+      Name: Short.Update.Baseline
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Short.Remove.Benchmark
+      Name: Short.Update.Benchmark
       Active: [7]
       Blocking: none
 
@@ -241,16 +263,16 @@ Actors:
       Comment: SnapshotScannerShort
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Medium.Remove.Baseline
+      Name: Medium.Update.Baseline
       Active: [9]
       Duration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Medium.Remove.Benchmark
+      Name: Medium.Update.Benchmark
       Active: [11]
       Blocking: none
       Duration: *SnapshotScannerMediumDuration
@@ -265,16 +287,16 @@ Actors:
       ScanDuration: *SnapshotScannerMediumDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Long.Remove.Baseline
+      Name: Long.Update.Baseline
       Active: [13]
       Duration: *SnapshotScannerLongDuration
 
 - ActorFromTemplate:
-    TemplateName: RemoveTemplate
+    TemplateName: UpdateTemplate
     TemplateParameters:
-      Name: Long.Remove.Benchmark
+      Name: Long.Update.Benchmark
       Active: [15]
       Blocking: none
       Duration: *SnapshotScannerLongDuration

--- a/src/workloads/transactions/LLTUpdateLowLtc.yml
+++ b/src/workloads/transactions/LLTUpdateLowLtc.yml
@@ -4,6 +4,14 @@ Description: |
   Workload to Benchmark the effect of LongLivedTransactions on an Update workload.
 
 GlobalDefaults:
+  # Start: The following block gets updated for the other configurations.
+  # In-memory: Database size works out about 12GB.
+  InitialDocumentCount: &InitialNumDocs 10000000
+  SecondaryDocumentCount: &SecondaryNumDocs 10000000
+  GlobalRateValue: &GlobalRateValue 1 per 2500 microsecond
+  ThreadsValue: &ThreadsValue 8
+  # End: The previous block gets updated for the other configurations.
+
   # These values should match those are the top of LLTPhases.yml
   dbname: &dbname llt
   MaxPhases: &MaxPhases 16
@@ -25,10 +33,6 @@ GlobalDefaults:
   # Loader Config.
   LoadThreads: &LoadThreads 4
   LoadBatchSize: &LoadBatchSize 1000
-
-  # In-memory: Database size works out about 12GB.
-  InitialDocumentCount: &InitialNumDocs 10000000
-  SecondaryDocumentCount: &SecondaryNumDocs 10000000
 
   CollectionCount: &CollectionCount 4
 
@@ -77,10 +81,6 @@ GlobalDefaults:
         WriteConcern:
           Level: majority
         Hint: caid_1_price_1_cuid_1
-
-  # Low Baseline / Benchmark
-  GlobalRateValue: &GlobalRateValue 400 per 1 second
-  ThreadsValue: &ThreadsValue 8
 
   # Scanner
   SnapshotScannerShortDuration: &SnapshotScannerShortDuration 1 minutes

--- a/src/workloads/transactions/README.md
+++ b/src/workloads/transactions/README.md
@@ -1,0 +1,21 @@
+Long Lived Transactions
+=====
+
+Currently, genny does not support parameterization, but the LLT workloads are highly repetitive.
+
+For the moment, the __LLT*LowLtc.yml__ files can be considered the source files for the other configurations.
+
+To generate the other configurations, run the following commands from the root directory:
+
+```bash
+for file in src/workloads/transactions/LLT*LowLtc.yml; do
+    sed -e 's/^  GlobalRateValue: .*$/  GlobalRateValue: \&GlobalRateValue 800 per 1 second/' \
+         -e 's/^  ThreadsValue: .*$/  ThreadsValue: \&ThreadsValue 16/' ${file} > ${file/Low/High}
+done
+for file in src/workloads/transactions/LLT*Ltc.yml; do
+    sed -e 's/^  InitialDocumentCount: .*$/  InitialDocumentCount: \&InitialNumDocs 49000000/' \
+        -e 's/^  SecondaryDocumentCount: .*$/  SecondaryDocumentCount: \&SecondaryNumDocs 10000000/' \
+        -e 's/^  # In-memory: Database size works out about 12GB.$/  # Not In-memory: Database size works out about 30GB./' \
+        ${file} > ${file/Ltc/Gtc}
+done
+```


### PR DESCRIPTION
Only the LLT*LowLtc.yml files changed. The parameters **InitialDocumentCount**, **SecondaryDocumentCount**, **GlobalRateValue** and **ThreadsValue** were moved to the start of the global block.

The remainder of the files were generated from the sed script in the new README.md.