### PR TITLE
PERF-2299 Test unbounded window functions, with spilling

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,12 +327,12 @@ cd genny
 evergreen set-module -m genny -i <ID> # Use the build ID from the previous step.
 ```
 
-In the browser window, select either `genny_patch_tasks` or `genny_auto_tasks`.
-`genny_patch_tasks` will run any workloads that you have added or modified locally
+In the browser window, select either `schedule_patch_auto_tasks` or `schedule_global_auto_tasks`.
+`schedule_patch_auto_tasks` will run any workloads that you have added or modified locally
 (based on your git history). This is useful if you want to test only the workload(s)
 you've been working on. 
 
-`genny_auto_tasks` automatically runs workloads based on the evergreen environment
+`schedule_global_auto_tasks` automatically runs workloads based on the evergreen environment
 (variables from `bootstrap.yml` and `runtime.yml` in DSI) and an optional AutoRun
 section in any workload, doing simple key-value matching between them. For example,
 suppose we have a `test_workload.yml` file in a `workloads/*/` subdirectory,
@@ -349,10 +349,10 @@ AutoRun:
 
 In this case, `test_workload` would be run whenever `bootstrap.yml`'s `mongodb_setup`
 variable has a value of `replica` or `single-replica`. In practice, the workload
-AutoRun sections are setup so that you can use `genny_auto_tasks` to run all relevant
+AutoRun sections are setup so that you can use `schedule_global_auto_tasks` to run all relevant
 workloads on a specific buildvariant.
 
-Both `genny_patch_tasks` and `genny_auto_tasks` will compile mongodb and then run
+Both `schedule_patch_auto_tasks` and `schedule_global_auto_tasks` will compile mongodb and then run
 the relevant workloads.
 
 NB:

--- a/src/workloads/execution/SetWindowFieldsUnbounded.yml
+++ b/src/workloads/execution/SetWindowFieldsUnbounded.yml
@@ -1,0 +1,184 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test exercises the behavior of $setWindowFields with an [unbounded, unbounded] window.
+  This case is interesting because it requires two passes over the documents (within each
+  partition): one pass to compute the window function, and one pass to write the new field to
+  each document.  If any partition is too large, it has to spill.  Also, internally we $sort by the
+  partition key, so that can also spill, depending on the collection size and available indexes.
+
+  We can divide this up into 4 cases:
+    1. Nothing spills.
+    2. Only the $sort spills.
+    3. Only the $_internalSetWindowFields spills.
+    4. Both the $sort and the $_internalSetWindowFields spill.
+
+  - To control whether the $sort spills, we can use an index, or not.
+  - To control whether the $_internalSetWindowFields spills, we can change the cardinality of
+    the partition key.
+
+Actors:
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: &db test
+    Threads: 1
+    CollectionCount: 1
+    # Through trial and error, it seems 60k documents, when divided into 12 partitions, does not spill,
+    # but divided into fewer partitions (10 partitions), fits in the memory limit.
+    DocumentCount: 60000
+    BatchSize: &batchSize 1000
+    Document:
+      # Each document has a unique _id. In phase 2 we use this to create evenly distributed
+      # partition keys.
+      _id: {^Inc: {}}
+      # This int field is what we sum. Its value shouldn't matter for this test.
+      int: &int {^RandomInt: {min: 1, max: 10000}}
+      # This string pads the doc size out to around 10KB.
+      string: &string {^RandomString: {length: 10000}}
+  - Nop: true
+  - Nop: true
+
+- Name: FixupDataAndCreateIndexes
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Nop: true
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        update: Collection0
+        updates: [
+          {
+            q: {},
+            u: [
+              {$set: {
+                ten_indexed: {$mod: ["$_id", 10]},
+                ten_unindexed: {$mod: ["$_id", 10]},
+                twelve_indexed: {$mod: ["$_id", 12]},
+                twelve_unindexed: {$mod: ["$_id", 12]},
+              }},
+            ],
+            multi: true,
+            upsert: false,
+          }
+        ]
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: Collection0
+        indexes: [
+          {key: {ten_indexed: 1}, name: "ten_indexed_1"},
+          {key: {twelve_indexed: 1}, name: "twelve_indexed_1"},
+        ]
+  - Nop: true
+
+- Name: SetWindowFieldsUnbounded
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Nop: true
+  - Nop: true
+  - Repeat: 10
+    Database: *db
+    Operations:
+
+    # Nothing spills:
+    # - $sort is indexed
+    # - partitions are small enough to fit in memory
+    - OperationMetricsName: NothingSpills
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline: [
+          {$setWindowFields: {
+            partitionBy: "$twelve_indexed",
+            output: {
+              total: {$sum: "$int"}
+            }
+          }},
+          {$project: {
+            partitionKey: 1,
+            percentage: {$divide: ["$int", "$total"]},
+            keepString: {$type: "$string"},
+          }}
+        ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+
+    # Only the sort spills:
+    # - $sort is not indexed
+    # - partitions are small enough to fit in memory
+    - OperationMetricsName: SortSpills
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline: [
+          {$setWindowFields: {
+            partitionBy: "$twelve_unindexed",
+            output: {
+              total: {$sum: "$int"}
+            }
+          }},
+          {$project: {
+            partitionKey: 1,
+            percentage: {$divide: ["$int", "$total"]},
+            keepString: {$type: "$string"},
+          }}
+        ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+
+    # Only the partitioning spills:
+    # - $sort is indexed
+    # - partitions are too big to fit in memory
+    - OperationMetricsName: PartitionSpills
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline: [
+          {$setWindowFields: {
+            partitionBy: "$ten_indexed",
+            output: {
+              total: {$sum: "$int"}
+            }
+          }},
+          {$project: {
+            partitionKey: 1,
+            percentage: {$divide: ["$int", "$total"]},
+            keepString: {$type: "$string"},
+          }}
+        ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+
+    # Both operations spill:
+    # - $sort is not indexed
+    # - partitions are too big to fit in memory
+    - OperationMetricsName: BothSpill
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline: [
+          {$setWindowFields: {
+            partitionBy: "$ten_unindexed",
+            output: {
+              total: {$sum: "$int"}
+            }
+          }},
+          {$project: {
+            partitionKey: 1,
+            percentage: {$divide: ["$int", "$total"]},
+            keepString: {$type: "$string"},
+          }}
+        ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+
+AutoRun:
+  Requires:
+    mongodb_setup:
+    - standalone

--- a/src/workloads/execution/SetWindowFieldsUnbounded.yml
+++ b/src/workloads/execution/SetWindowFieldsUnbounded.yml
@@ -27,7 +27,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     # Through trial and error, it seems 60k documents, when divided into 12 partitions, does not spill,
-    # but divided into fewer partitions (10 partitions), fits in the memory limit.
+    # but divided into fewer partitions (10 partitions), does spill.
     DocumentCount: 60000
     BatchSize: &batchSize 1000
     Document:


### PR DESCRIPTION
From the [patch build results](https://evergreen.mongodb.com/task/sys_perf_linux_1_node_replSet_set_window_fields_unbounded_patch_441bef2c968ab24fe52d910c26dc3ecac366d0eb_60ad6c221e2d175d3bf3b122_21_05_25_21_30_55#):
Test | 1 | 8 | Max
-- | -- | -- | --
SetWindowFields.BothSpill | 1,377,322,332 | &nbsp; | 1,377,322,332
SetWindowFields.NothingSpills | 100,871,471 | &nbsp; | 100,871,471
SetWindowFields.PartitionSpills | 226,255,058 | &nbsp; | 226,255,058
SetWindowFields.SortSpills | 1,436,059,760 | &nbsp; | 1,436,059,760

I'm surprised that "BothSpill" would be slightly faster than "SortSpills".  Maybe that's just noise?  It is under 5% difference.