### PR TITLE
TIG-2841 Revamp AutoRun syntax to be more powerful and expressive

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,17 +355,17 @@ AutoRun:
     ThenRun:
       - infrastructure_provisioning: foo
       - infrastructure_provisioning: bar
-      - arbitrary_bootstrap: baz
+      - arbitrary_key: baz
 ```
 
 In this case, it looks in the `bootstrap.yml` of `test_workload`, checks if `mongodb_setup`
-is either `replica` or `replica-noflowcontrol`, and also if `branch_name` is neither v4.0 or v4.2.
+is either `replica` or `replica-noflowcontrol`, and also if `branch_name` is neither `v4.0` nor `v4.2`.
 If both conditions are true, then we schedule several tasks. Let's say the workload name is
 `DemoWorkload`, 3 tasks are scheduled - `demo_workload_foo`, `demo_workload_bar`, and `demo_workload_baz`.
 The first task is passed in the bootstrap value `infrastructure_provisioning: foo`, the second
-is passed in `infrastructure_provisioning: bar` and the third `arbitrary_bootstrap: baz`.
+is passed in `infrastructure_provisioning: bar` and the third `arbitrary_key: baz`.
 
-This is a more complex example of AutoRun. Here's a more simple one representing usual usecases:
+This is a more complex example of AutoRun. Here's a more simple one representing a more common usecase:
 
 ```yaml
 AutoRun:
@@ -375,15 +375,14 @@ AutoRun:
 ```
 
 Let's say this is `DemoWorkload` again. In this case, if `mongodb_setup` is `standalone`
-we schedule `demo_workload` with no params.
+we schedule `demo_workload` with no additional params.
 
 A few notes on the syntax:
-- supports multiple When/ThenRun blocks per AutoRun. Each are evaluated independently.
-- When blocks can evaluate multiple conditions. All conditions must be true in this case.
+- Supports multiple When/ThenRun blocks per AutoRun. Each are evaluated independently.
+- When blocks can evaluate multiple conditions. All conditions must be true to schedule the task.
 - When supports $eq and $neq. Both can accept either a scalar or list of values.
 - For a list of values, $eq evaluates to true if it is equal to at least one.
 - For a list of values, $neq evaluates to true if it is equal to none of the values.
-- AutoRun will fail if the bootstrap value used in When does not exist in expansions.yml.
 - ThenRun blocks are optional.
 - Each item in the ThenRun list can only support one {bootstrap_key: bootstrap_value} pair.
 

--- a/README.md
+++ b/README.md
@@ -384,7 +384,18 @@ A few notes on the syntax:
 - For a list of values, $eq evaluates to true if it is equal to at least one.
 - For a list of values, $neq evaluates to true if it is equal to none of the values.
 - ThenRun blocks are optional.
+    - **Most usecases do not need to use ThenRun**
+    - If you do use ThenRun, please be judicious. If you have a task that is scheduled when
+      mongodb_setup == replica, it would be confusing if mongodb_setup was overwritten to standalone.
+      But it would be ok to overwrite mongodb_setup to replica-delay-mixed, as is done in the
+      [ParallelWorkload][pi] workload.
 - Each item in the ThenRun list can only support one {bootstrap_key: bootstrap_value} pair.
+- If using ThenRun but you would also like to schedule a task without any bootstrap overrides,
+  Add an extra pair to ThenRun with the original key/value, like done on line 189 [here][pi].
+- If using ThenRun, the new task name becomes <taskname>_<bootstrap-value>. In the ParallelWorkload example,
+  the task name becomes parallel_insert_replica_delay_mixed (name is automatically converted to snake_case).
+  The bootstrap-key is not included in the name for the purpose of not changing existing names and
+  thus deleting history. This may change after PM-2310.
 
 NB on patch-testing:
 
@@ -456,5 +467,6 @@ The toolchain isn't instrumented with sanitizers, so you may get
 
 
 [fp]: https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow#false-positives
+[pi]: https://github.com/mongodb/genny/blob/762b08ee3b71184d5f521e82f7ce6d6eeb3c0cc9/src/workloads/docs/ParallelInsert.yml#L183-L189
 
 

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -210,14 +210,7 @@ class Workload:
         """
         :return: tasks requested.
         """
-        # if not self.auto_run_info:
-        #     return [GeneratedTask(self.snake_case_base_name, None, None, self)]
-
-        # Only one base task can be added, even if there are multiple empty ThenRun sections.
-        # base_task_added = False
         tasks = []
-        # for block in self.auto_run_info:
-        # then_run = block.then_run
         if len(then_run) == 0:
             tasks += [GeneratedTask(self.snake_case_base_name, None, None, self)]
 
@@ -282,8 +275,6 @@ class Workload:
 
             if okay:
                 tasks += self.generate_requested_tasks(then_run)
-        print("GOT HERE")
-        print(tasks)
 
         return self._dedup_task(tasks)
 

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -256,8 +256,8 @@ class Workload:
         for block in self.auto_run_info:
             when = block.when
             then_run = block.then_run
+            okay = True
             for key, condition in when.items():
-                okay = False
                 if len(condition) != 1:
                     raise ValueError(
                         f"Need exactly one condition per key in When block."
@@ -267,21 +267,21 @@ class Workload:
                     acceptable_values = condition["$eq"]
                     if not isinstance(acceptable_values, list):
                         acceptable_values = [acceptable_values]
-                    if build.has(key, acceptable_values):
-                        okay = True
+                    if not build.has(key, acceptable_values):
+                        okay = False
                 elif "$neq" in condition:
                     acceptable_values = condition["$neq"]
                     if not isinstance(acceptable_values, list):
                         acceptable_values = [acceptable_values]
-                    if not build.has(key, acceptable_values):
-                        okay = True
+                    if build.has(key, acceptable_values):
+                        okay = False
                 else:
                     raise ValueError(
                         f"The only supported operators are $eq and $neq. Got ${condition.keys()}"
                     )
 
-                if okay:
-                    tasks += self.generate_requested_tasks(then_run)
+            if okay:
+                tasks += self.generate_requested_tasks(then_run)
 
         return self._dedup_task(tasks)
 

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -230,7 +230,6 @@ class Workload:
         if not self.auto_run_info:
             return [GeneratedTask(self.snake_case_base_name, None, None, self)]
 
-        # Only one base task can be added, even if there are multiple empty ThenRun sections.
         tasks = []
         for block in self.auto_run_info:
             tasks += self.generate_requested_tasks(block.then_run)
@@ -249,6 +248,7 @@ class Workload:
         for block in self.auto_run_info:
             when = block.when
             then_run = block.then_run
+            # All When conditions must be true. We set okay: False if any single one is not true.
             okay = True
             for key, condition in when.items():
                 if len(condition) != 1:
@@ -281,7 +281,7 @@ class Workload:
     @staticmethod
     def _dedup_task(tasks: List[GeneratedTask]) -> List[GeneratedTask]:
         """
-        Evergreen barfs if a task is declared mroe than once.
+        Evergreen barfs if a task is declared more than once.
 
         :return: unique tasks.
         """

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -282,12 +282,16 @@ class Workload:
 
             if okay:
                 tasks += self.generate_requested_tasks(then_run)
+        print("GOT HERE")
+        print(tasks)
 
         return self._dedup_task(tasks)
 
     @staticmethod
     def _dedup_task(tasks: List[GeneratedTask]) -> List[GeneratedTask]:
         """
+        Evergreen barfs if a task is declared mroe than once.
+
         :return: unique tasks.
         """
         # Sort the result to make checking dict equality in unittests easier.

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -140,7 +140,7 @@ class CurrentBuildInfo:
         :return: if the actual value from env[key] is in the list of acceptable values
         """
         if key not in self.conts:
-            raise Exception(f"Unknown key {key}. Know about {self.conts.keys()}")
+            return False
         actual = self.conts[key]
         return any(actual == acceptable_value for acceptable_value in acceptable_values)
 

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -378,7 +378,7 @@ class AutoTasksTests(BaseTestClass):
                 },
                 {
                     "When": {"mongodb_setup": {"$eq": ["matches", "matches", "matches2"]}},
-                    "ThenRun": [{"mongodb_setup": "e"}, {"mongodb_setup": "f"}],
+                    "ThenRun": [{"mongodb_setup": "e"}, {"mongodb_setup": "f"},],
                 },
             ]
         }

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -161,7 +161,7 @@ class AutoTasksTests(BaseTestClass):
                                 "vars": {
                                     "test_control": "multi_b",
                                     "auto_workload_path": "src/Multi.yml",
-                                    "arb_bootstrap_key": "b",   # test that arb bootstrap_key works
+                                    "arb_bootstrap_key": "b",  # test that arb bootstrap_key works
                                 },
                             },
                         ],
@@ -286,9 +286,7 @@ class AutoTasksTests(BaseTestClass):
                             "ThenRun": [
                                 {"mongodb_setup": "c"},
                                 {"mongodb_setup": "d"},
-                                {
-                                    "infrastructure_provisioning": "infra_a"
-                                },
+                                {"infrastructure_provisioning": "infra_a"},
                             ],
                         },
                         {

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -270,7 +270,7 @@ class AutoTasksTests(BaseTestClass):
         Tests When with multiple (true) conditions.
         Tests multiple When/ThenRun blocks.
         """
-        expansions = expansions_mock({"mongodb_setup": "matches", "branch": "4.4"})
+        expansions = expansions_mock({"mongodb_setup": "matches", "branch_name": "v4.4"})
         given_files = [
             expansions,
             MockFile(
@@ -281,7 +281,7 @@ class AutoTasksTests(BaseTestClass):
                         {
                             "When": {
                                 "mongodb_setup": {"$neq": ["something-else", "something-else-1"]},
-                                "branch": {"$neq": ["4.0", "4.2"]},
+                                "branch_name": {"$neq": ["v4.0", "v4.2"]},
                             },
                             "ThenRun": [
                                 {"mongodb_setup": "c"},
@@ -322,7 +322,7 @@ class AutoTasksTests(BaseTestClass):
         Tests When with multiple (one true, one false) conditions.
         Tests multiple When/ThenRun blocks.
         """
-        expansions = expansions_mock({"mongodb_setup": "matches", "branch": "4.2"})
+        expansions = expansions_mock({"mongodb_setup": "matches", "branch_name": "v4.2"})
         given_files = [
             expansions,
             MockFile(
@@ -333,7 +333,7 @@ class AutoTasksTests(BaseTestClass):
                         {
                             "When": {
                                 "mongodb_setup": {"$neq": ["something-else", "something-else-2"]},
-                                "branch": {"$neq": ["4.0", "4.2"]},  # this invalidates the When
+                                "branch_name": {"$neq": ["v4.0", "v4.2"]},  # this invalidates the When
                             },
                             "ThenRun": [
                                 {"mongodb_setup": "c"},

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -79,11 +79,10 @@ class BaseTestClass(unittest.TestCase):
 
         config = writer.write(tasks, write=False)
         parsed = json.loads(config.to_json())
-
         try:
             self.assertDictEqual(then_writes, parsed)
         except AssertionError:
-            # print(parsed)
+            print(parsed)
             raise
 
 
@@ -333,7 +332,9 @@ class AutoTasksTests(BaseTestClass):
                         {
                             "When": {
                                 "mongodb_setup": {"$neq": ["something-else", "something-else-2"]},
-                                "branch_name": {"$neq": ["v4.0", "v4.2"]},  # this invalidates the When
+                                "branch_name": {
+                                    "$neq": ["v4.0", "v4.2"]
+                                },  # this invalidates the When
                             },
                             "ThenRun": [
                                 {"mongodb_setup": "c"},

--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -183,7 +183,11 @@ Actors:
 AutoRun:
   - When:
       mongodb_setup:
-        $eq: replica
+        $eq:
+          - replica
+      branch_name:
+        $neq:
+          - v4.0
     ThenRun:
       - mongodb_setup: replica-delay-mixed
       - mongodb_setup: replica

--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -181,10 +181,9 @@ Actors:
   - *DropCollection
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - replica
-  PrepareEnvironmentWith:
-    mongodb_setup:
-    - replica-delay-mixed
-    - replica
+  - When:
+      mongodb_setup:
+        $eq: replica
+    ThenRun:
+      - mongodb_setup: replica-delay-mixed
+      - mongodb_setup: replica

--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -27,6 +27,6 @@ Actors:
       OperationName: RunCommand
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - standalone-dsi-integration-test
+  - When:
+      mongodb_setup:
+        $eq: standalone-dsi-integration-test

--- a/src/workloads/execution/BackgroundValidateCmd.yml
+++ b/src/workloads/execution/BackgroundValidateCmd.yml
@@ -120,3 +120,7 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq: standalone
+      branch_name:
+        $neq:
+          - v4.0
+          - v4.2

--- a/src/workloads/execution/BackgroundValidateCmd.yml
+++ b/src/workloads/execution/BackgroundValidateCmd.yml
@@ -117,5 +117,6 @@ Actors:
         background: true
 
 AutoRun:
-  Requires:
-    mongodb_setup: [standalone]
+  - When:
+      mongodb_setup:
+        $eq: standalone

--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -89,10 +89,11 @@ Actors:
         index: random_string
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - replica-all-feature-flags
-    - single-replica
-    - standalone
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - replica-all-feature-flags
+          - single-replica
+          - standalone

--- a/src/workloads/execution/CreateIndex.yml
+++ b/src/workloads/execution/CreateIndex.yml
@@ -66,3 +66,6 @@ AutoRun:
           - replica
           - single-replica
           - standalone
+      branch_name:
+        $neq:
+          - v4.0

--- a/src/workloads/execution/CreateIndex.yml
+++ b/src/workloads/execution/CreateIndex.yml
@@ -59,9 +59,10 @@ Actors:
         Repeat: 5
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - single-replica
-    - standalone
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - single-replica
+          - standalone

--- a/src/workloads/execution/CreateIndexSharded.yml
+++ b/src/workloads/execution/CreateIndexSharded.yml
@@ -101,7 +101,8 @@ Actors:
         Duration: 5 minutes
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - shard
-    - shard-lite
+  - When:
+      mongodb_setup:
+        $eq:
+          - shard
+          - shard-lite

--- a/src/workloads/execution/CreateIndexSharded.yml
+++ b/src/workloads/execution/CreateIndexSharded.yml
@@ -106,3 +106,6 @@ AutoRun:
         $eq:
           - shard
           - shard-lite
+      branch_name:
+        $neq:
+          - v4.0

--- a/src/workloads/execution/CumulativeWindows.yml
+++ b/src/workloads/execution/CumulativeWindows.yml
@@ -149,9 +149,10 @@ Actors:
           cursor: {batchSize: *batchSize}
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - standalone
-    - replica
-    - replica-all-feature-flags
-    - shard-lite
+  - When:
+      mongodb_setup:
+        $eq:
+          - standalone
+          - replica
+          - replica-all-feature-flags
+          - shard-lite

--- a/src/workloads/execution/CumulativeWindows.yml
+++ b/src/workloads/execution/CumulativeWindows.yml
@@ -156,3 +156,8 @@ AutoRun:
           - replica
           - replica-all-feature-flags
           - shard-lite
+      branch_name:
+        $neq:
+          - v4.0
+          - v4.2
+          - v4.4

--- a/src/workloads/execution/ExpressiveQueries.yml
+++ b/src/workloads/execution/ExpressiveQueries.yml
@@ -179,9 +179,10 @@ Actors:
         projection: *projection
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - single-replica
-    - standalone
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - single-replica
+          - standalone

--- a/src/workloads/execution/ExpressiveQueries.yml
+++ b/src/workloads/execution/ExpressiveQueries.yml
@@ -186,3 +186,6 @@ AutoRun:
           - replica
           - single-replica
           - standalone
+      branch_name:
+        $neq:
+          - v4.0

--- a/src/workloads/execution/ExternalSort.yml
+++ b/src/workloads/execution/ExternalSort.yml
@@ -98,5 +98,6 @@ Actors:
           executionStats
 
 AutoRun:
-  Requires:
-    mongodb_setup: [standalone]
+  - When:
+      mongodb_setup:
+        $eq: standalone

--- a/src/workloads/execution/ExternalSort.yml
+++ b/src/workloads/execution/ExternalSort.yml
@@ -101,3 +101,7 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq: standalone
+      branch_name:
+        $neq:
+          - v4.0
+          - v4.2

--- a/src/workloads/execution/PipelineUpdate.yml
+++ b/src/workloads/execution/PipelineUpdate.yml
@@ -244,3 +244,6 @@ AutoRun:
           - replica
           - replica-all-feature-flags
           - standalone
+      branch_name:
+        $neq:
+          - v4.0

--- a/src/workloads/execution/PipelineUpdate.yml
+++ b/src/workloads/execution/PipelineUpdate.yml
@@ -235,10 +235,12 @@ Actors:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: [{$replaceWith: *largeDocument}], multi: false}]
         writeConcern: {w: majority}
+
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - replica-all-feature-flags
-    - standalone
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - replica-all-feature-flags
+          - standalone

--- a/src/workloads/execution/SetWindowFieldsUnbounded.yml
+++ b/src/workloads/execution/SetWindowFieldsUnbounded.yml
@@ -182,3 +182,8 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq: standalone
+      branch_name:
+        $neq:
+          - v4.0
+          - v4.2
+          - v4.4

--- a/src/workloads/execution/SetWindowFieldsUnbounded.yml
+++ b/src/workloads/execution/SetWindowFieldsUnbounded.yml
@@ -179,6 +179,6 @@ Actors:
         allowDiskUse: true
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - standalone
+  - When:
+      mongodb_setup:
+        $eq: standalone

--- a/src/workloads/execution/SlidingWindows.yml
+++ b/src/workloads/execution/SlidingWindows.yml
@@ -128,9 +128,10 @@ Actors:
           cursor: {batchSize: *batchSize}
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - standalone
-    - replica
-    - replica-all-feature-flags
-    - shard-lite
+  - When:
+      mongodb_setup:
+        $eq:
+          - standalone
+          - replica
+          - replica-all-feature-flags
+          - shard-lite

--- a/src/workloads/execution/SlidingWindows.yml
+++ b/src/workloads/execution/SlidingWindows.yml
@@ -135,3 +135,8 @@ AutoRun:
           - replica
           - replica-all-feature-flags
           - shard-lite
+      branch_name:
+        $neq:
+          - v4.0
+          - v4.2
+          - v4.4

--- a/src/workloads/execution/UnionWith.yml
+++ b/src/workloads/execution/UnionWith.yml
@@ -261,3 +261,7 @@ AutoRun:
           - replica-all-feature-flags
           - shard-lite
           - standalone
+      branch_name:
+        $neq:
+          - v4.0
+          - v4.2

--- a/src/workloads/execution/UnionWith.yml
+++ b/src/workloads/execution/UnionWith.yml
@@ -253,10 +253,11 @@ Actors:
           cursor: {batchSize: *batchSize}
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - replica-all-feature-flags
-    - shard-lite
-    - standalone
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - replica-all-feature-flags
+          - shard-lite
+          - standalone

--- a/src/workloads/execution/ValidateCmd.yml
+++ b/src/workloads/execution/ValidateCmd.yml
@@ -56,5 +56,6 @@ Actors:
         validate: Collection0
 
 AutoRun:
-  Requires:
-    mongodb_setup: [standalone]
+  - When:
+      mongodb_setup:
+        $eq: standalone

--- a/src/workloads/issues/ConnectionsBuildup.yml
+++ b/src/workloads/issues/ConnectionsBuildup.yml
@@ -95,6 +95,6 @@ Actors:
     Blocking: None # must be Blocking:None
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - shard-single
+  - When:
+      mongodb_setup:
+        $eq: shard-single

--- a/src/workloads/networking/ServiceArchitectureWorkloads.yml
+++ b/src/workloads/networking/ServiceArchitectureWorkloads.yml
@@ -70,9 +70,10 @@ Actors:
     Nop: true
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - replica-noflowcontrol
-    - replica-all-feature-flags
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - replica-noflowcontrol
+          - replica-all-feature-flags

--- a/src/workloads/networking/TransportLayerConnectTiming.yml
+++ b/src/workloads/networking/TransportLayerConnectTiming.yml
@@ -27,6 +27,6 @@ Actors:
         replSetTestEgress: 1
 
 AutoRun:
-  Requires:
-    mongodb_setup: 
-    - replica-auth-cluster-delay
+  - When:
+      mongodb_setup:
+        $eq: replica-auth-cluster-delay

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -118,12 +118,13 @@ Actors:
     Limit: 20
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - replica-noflowcontrol
-    - replica-1dayhistory-15gbwtcache
-    - replica-all-feature-flags
-    - single-replica
-    - standalone
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - replica-noflowcontrol
+          - replica-1dayhistory-15gbwtcache
+          - replica-all-feature-flags
+          - single-replica
+          - standalone

--- a/src/workloads/scale/InCacheSnapshotReads.yml
+++ b/src/workloads/scale/InCacheSnapshotReads.yml
@@ -76,5 +76,6 @@ Actors:
     ScanType: point-in-time
 
 AutoRun:
-  Requires:
-    mongodb_setup: [replica-1dayhistory-15gbwtcache]
+  - When:
+      mongodb_setup:
+        $eq: replica-1dayhistory-15gbwtcache

--- a/src/workloads/scale/InsertBigDocs.yml
+++ b/src/workloads/scale/InsertBigDocs.yml
@@ -20,9 +20,10 @@ Actors:
       string0: {^FastRandomString: {length: 15000000}}
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - replica-all-feature-flags
-    - single-replica
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - replica-all-feature-flags
+          - single-replica

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -15,12 +15,13 @@ Actors:
     Database: test
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - single-replica
-    - standalone
-    - shard
-    - replica-1dayhistory-15gbwtcache
-    - replica-all-feature-flags
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - single-replica
+          - standalone
+          - shard
+          - replica-1dayhistory-15gbwtcache
+          - replica-all-feature-flags

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -80,12 +80,13 @@ Actors:
     Update: {$inc: {x1: 1}}
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - replica-all-feature-flags
-    - single-replica
-    - single-replica-15gbwtcache
-    - shard
-    - standalone
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - replica-all-feature-flags
+          - single-replica
+          - single-replica-15gbwtcache
+          - shard
+          - standalone

--- a/src/workloads/scale/MassDeleteRegression.yml
+++ b/src/workloads/scale/MassDeleteRegression.yml
@@ -54,6 +54,6 @@ Actors:
         Filter: {_id: {$lte: *docs}}
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - replica
+  - When:
+      mongodb_setup:
+        $eq: replica

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -294,13 +294,14 @@ Actors:
       OnlyActiveInPhase: 10
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - atlas
-    - replica
-    - single-replica
-    - standalone
-    - replica-noflowcontrol
-    - replica-1dayhistory-15gbwtcache
-    - replica-maintenance-events
-    - replica-all-feature-flags
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica
+          - single-replica
+          - standalone
+          - replica-noflowcontrol
+          - replica-1dayhistory-15gbwtcache
+          - replica-maintenance-events
+          - replica-all-feature-flags

--- a/src/workloads/scale/MixedWrites.yml
+++ b/src/workloads/scale/MixedWrites.yml
@@ -36,9 +36,9 @@ Actors:
           Timeout: 6000 milliseconds
 
 AutoRun:
-  Requires:
-    infrastructure_provisioning: [replica]
-  PrepareEnvironmentWith:
-    mongodb_setup:
-    - replica-delay-mixed
-    - replica
+  - When:
+      infrastructure_provisioning:
+        $eq: replica
+    ThenRun:
+      - mongodb_setup: replica-delay-mixed
+      - mongodb_setup: replica

--- a/src/workloads/scale/OutOfCacheScanner.yml
+++ b/src/workloads/scale/OutOfCacheScanner.yml
@@ -54,5 +54,6 @@ Actors:
     ScanType: Standard
 
 AutoRun:
-  Requires:
-    mongodb_setup: [single-replica-15gbwtcache]
+  - When:
+      mongodb_setup:
+        $eq: single-replica-15gbwtcache

--- a/src/workloads/scale/OutOfCacheSnapshotReads.yml
+++ b/src/workloads/scale/OutOfCacheSnapshotReads.yml
@@ -76,5 +76,6 @@ Actors:
     ScanType: point-in-time
 
 AutoRun:
-  Requires:
-    mongodb_setup: [replica-1dayhistory-15gbwtcache]
+  - When:
+      mongodb_setup:
+        $eq: replica-1dayhistory-15gbwtcache

--- a/src/workloads/scale/ScanWithLongLived.yml
+++ b/src/workloads/scale/ScanWithLongLived.yml
@@ -98,7 +98,8 @@ Actors:
       Key: SnapshotScanner10GigabytesFixedRateCmd
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - single-replica
-    - replica-noflowcontrol
+  - When:
+      mongodb_setup:
+        $eq:
+          - single-replica
+          - replica-noflowcontrol

--- a/src/workloads/selftests/GennyOverhead.yml
+++ b/src/workloads/selftests/GennyOverhead.yml
@@ -63,6 +63,6 @@ Actors:
     SleepAfter: 1 millisecond
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - standalone
+  - When:
+      mongodb_setup:
+        $eq: standalone

--- a/src/workloads/sharding/ReshardCollection.yml
+++ b/src/workloads/sharding/ReshardCollection.yml
@@ -145,6 +145,6 @@ Actors:
     Operations: *ReadWriteOperations
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-    - shard-lite-all-feature-flags
+  - When:
+      mongodb_setup:
+        $eq: shard-lite-all-feature-flags

--- a/src/workloads/transactions/LLTInsertHighGtc.yml
+++ b/src/workloads/transactions/LLTInsertHighGtc.yml
@@ -274,9 +274,10 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica

--- a/src/workloads/transactions/LLTInsertHighLtc.yml
+++ b/src/workloads/transactions/LLTInsertHighLtc.yml
@@ -274,9 +274,10 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica

--- a/src/workloads/transactions/LLTInsertLowGtc.yml
+++ b/src/workloads/transactions/LLTInsertLowGtc.yml
@@ -274,9 +274,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTInsertLowLtc.yml
+++ b/src/workloads/transactions/LLTInsertLowLtc.yml
@@ -274,9 +274,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTMixedHighGtc.yml
+++ b/src/workloads/transactions/LLTMixedHighGtc.yml
@@ -562,9 +562,10 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica

--- a/src/workloads/transactions/LLTMixedHighLtc.yml
+++ b/src/workloads/transactions/LLTMixedHighLtc.yml
@@ -562,9 +562,10 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica

--- a/src/workloads/transactions/LLTMixedLowGtc.yml
+++ b/src/workloads/transactions/LLTMixedLowGtc.yml
@@ -562,9 +562,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTMixedLowLtc.yml
+++ b/src/workloads/transactions/LLTMixedLowLtc.yml
@@ -562,9 +562,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTQueryHighGtc.yml
+++ b/src/workloads/transactions/LLTQueryHighGtc.yml
@@ -293,9 +293,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTQueryHighLtc.yml
+++ b/src/workloads/transactions/LLTQueryHighLtc.yml
@@ -293,9 +293,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTQueryLowGtc.yml
+++ b/src/workloads/transactions/LLTQueryLowGtc.yml
@@ -293,9 +293,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTQueryLowLtc.yml
+++ b/src/workloads/transactions/LLTQueryLowLtc.yml
@@ -293,9 +293,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTRemoveHighGtc.yml
+++ b/src/workloads/transactions/LLTRemoveHighGtc.yml
@@ -289,9 +289,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTRemoveHighLtc.yml
+++ b/src/workloads/transactions/LLTRemoveHighLtc.yml
@@ -289,9 +289,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTRemoveLowGtc.yml
+++ b/src/workloads/transactions/LLTRemoveLowGtc.yml
@@ -289,9 +289,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTRemoveLowLtc.yml
+++ b/src/workloads/transactions/LLTRemoveLowLtc.yml
@@ -289,9 +289,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTUpdateHighGtc.yml
+++ b/src/workloads/transactions/LLTUpdateHighGtc.yml
@@ -311,9 +311,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTUpdateHighLtc.yml
+++ b/src/workloads/transactions/LLTUpdateHighLtc.yml
@@ -311,9 +311,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTUpdateLowGtc.yml
+++ b/src/workloads/transactions/LLTUpdateLowGtc.yml
@@ -311,9 +311,11 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica
+

--- a/src/workloads/transactions/LLTUpdateLowLtc.yml
+++ b/src/workloads/transactions/LLTUpdateLowLtc.yml
@@ -311,9 +311,10 @@ Actors:
       ScanDuration: *SnapshotScannerLongDuration
 
 #AutoRun:
-#  Requires:
-#    mongodb_setup:
-#      - atlas
-#      - replica
-#      - replica-all-feature-flags
-#      - single-replica
+#  - When:
+#      mongodb_setup:
+#        $eq:
+#          - atlas
+#          - replica
+#          - replica-all-feature-flags
+#          - single-replica


### PR DESCRIPTION
Patches coming shortly. Existing `AutoRun` sections have been updated to the new syntax, and I've added info in the README (though ideally it would live in the TBD syntax primer). 

This ticket allows workloads to exclude running on certain branches, so I'm gonna file a new ticket to enable auto_tasks on the 4.0 and 4.2 branches. There will also be another genny ticket to add the branch exclusions for existing workloads that aren't compatible on those branches. I left that out here as the PR is already pretty big and I'd have to do some testing on the older branches to see which workloads can and can't run. Also will talk to product perf to see if they even want any of these workloads to be enabled in those branches.