### PR TITLE
TIG-2819 Update toolchain download URLs to point to new S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ Here're the steps to get Genny up and running locally:
     The ones from mongodbtoolchain v3 are safe bets if you're
     unsure. (mongodbtoolchain is internal to MongoDB).
 
-3.  Make sure you have [libmongocrypt installed](https://github.com/mongodb/libmongocrypt#installing-libmongocrypt-from-distribution-packages)
-
-4.  `./run-genny install [--linux-distro ubuntu1804/rhel7/amazon2/arch]`
+3.  `./run-genny install [--linux-distro ubuntu1804/rhel7/amazon2/arch]`
 
     This command downloads Genny's toolchain, compiles Genny, creates its
     virtualenv, and installs Genny to `dist/`. You can rerun this command
@@ -47,17 +45,6 @@ Here're the steps to get Genny up and running locally:
     If you get python errors, ensure you have a modern version of python3.
     On a Mac, run `brew install python3` (assuming you have [homebrew installed](https://brew.sh/))
     and then restart your shell.
-    
-### Errors Mentioning zstd and libmongocrypt
-There is currently a leak in Genny's toolchain requiring zstd and libmongocrypt to be installed.
-If the `./run-genny install` phase above errors mentioning these, you may need to install them separately.
-
-On macOS, you can `brew install zstd` and `brew install mongodb/brew/libmongocrypt`. On Ubuntu, you
-can apt-install zstd, but will need to manually install libmongocrypt using the instructions in its
-[source repo](https://github.com/mongodb/libmongocrypt). If choosing to build from source, make sure
-you run `make install` to install globally after cmaking the project.
-
-After installing these dependencies, re-running the `./run-genny install` phase above should work.
 
 ## IDEs and Whatnot
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -82,26 +82,24 @@ buildvariants:
   tasks:
   - name: tg_compile
 
-# TODO: TIG-2819
-#- name: ubuntu1804
-#  display_name: Ubuntu 18.04
-#  modules: [mongo]
-#  expansions:
-#    distro: ubuntu1804
-#  run_on:
-#  - ubuntu1804-build
-#  tasks:
-#  - name: tg_compile
-#  - name: t_push
+- name: ubuntu1804
+  display_name: Ubuntu 18.04
+  modules: [mongo]
+  expansions:
+    distro: ubuntu1804
+  run_on:
+  - ubuntu1804-build
+  tasks:
+  - name: tg_compile
+  - name: t_push
 
-# TODO: Re-enable after TIG-2819
-#- name: macos-1014
-#  display_name: macOS Mojave
-#  modules: [mongo]
-#  run_on:
-#  - macos-1014
-#  tasks:
-#  - name: tg_compile
+- name: macos-1014
+  display_name: macOS Mojave
+  modules: [mongo]
+  run_on:
+  - macos-1014
+  tasks:
+  - name: tg_compile
 
 - name: centos6-perf
   display_name: CentOS 6 for Performance

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -91,7 +91,6 @@ buildvariants:
   - ubuntu1804-build
   tasks:
   - name: tg_compile
-  - name: t_push
 
 - name: macos-1014
   display_name: macOS Mojave

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -157,8 +157,8 @@ class ToolchainDownloader(Downloader):
     # These build IDs are from the genny-toolchain Evergreen task.
     # https://evergreen.mongodb.com/waterfall/genny-toolchain
 
-    TOOLCHAIN_BUILD_ID = "0db5d1544746c1570371f51109a0a312a7215b65_20_10_01_06_38_39"
-    TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
+    AWS_BUCKET = "https://dsi-donot-remove.s3-us-west-2.amazonaws.com/genny-toolchain"
+    TOOLCHAIN_GIT_HASH = "815d1e868681f2a712f5518431d5bba44d40d014"
     TOOLCHAIN_ROOT = "/data/mci"  # TODO BUILD-7624 change this to /opt.
 
     def __init__(
@@ -181,11 +181,9 @@ class ToolchainDownloader(Downloader):
 
     def _get_url(self):
         prefix = "macos_1014" if self._os_family == "Darwin" else self._linux_distro
-        return (
-            "https://s3.amazonaws.com/mciuploads/genny-toolchain/"
-            "genny_toolchain_{}_{}/gennytoolchain.tgz".format(
-                prefix, ToolchainDownloader.TOOLCHAIN_BUILD_ID
-            )
+        print(f"{self.AWS_BUCKET}/{self.TOOLCHAIN_GIT_HASH}/genny-toolchain-{prefix}.tgz")
+        return(
+            f"{self.AWS_BUCKET}/{self.TOOLCHAIN_GIT_HASH}/genny-toolchain-{prefix}.tgz"
         )
 
     def _can_ignore(self):


### PR DESCRIPTION
See https://github.com/10gen/vcpkg/pull/11 for more details. This makes genny download the toolchain from S3. Because the git rev is not constant amongst all the binaries, I added a workaround where we touch a file in the gennytoolchain repo with the githash as the name and check that it's the same githash as is requested. (The git hash is the hash of the final vcpkg change, but the macos gennytoolchain artifact was created before the commit was merged, and therefore its git hash is different). 