### PR TITLE
TIG-3063: Fix curator download on Ubuntu 18.04

### DIFF
--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -172,7 +172,7 @@ class CuratorDownloader(Downloader):
             self._linux_distro = "macos"
 
         if "ubuntu" in self._linux_distro:
-            self._linux_distro = "ubuntu1604"
+            self._linux_distro = "ubuntu"
 
         if self._linux_distro in ("amazon2", "rhel8", "rhel62"):
             self._linux_distro = "rhel70"


### PR DESCRIPTION
Downloading curator currently fails on Ubuntu 18.04 because the changes from mongodb/curator@0a6a6d1c254c9238a0bd944d6060466b0db50024 moved the compile task from Ubuntu 16.04 to Ubuntu 18.04.

https://evergreen.mongodb.com/task/curator_ubuntu_push_2230334f0369ea999b8fd2ada0de61e4b4a6e2b0_21_06_01_22_47_01 shows "ubuntu" as the new build variant name.

```
$ ./run-genny -v install --linux-distro=ubuntu1804 
[debug] [genny.download      ] Downloading          name=curator timestamp=2021-06-05T16:54:38Z url=https://s3.amazonaws.com/boxes.10gen.com/build/curator/curator-dist-ubuntu1604-2230334f0369ea999b8fd2ada0de61e4b4a6e2b0.tar.gz
...
urllib.error.HTTPError: HTTP Error 404: Not Found
```