### PR TITLE
TIG-2819 Update toolchain build id

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -82,26 +82,23 @@ buildvariants:
   tasks:
   - name: tg_compile
 
-# TODO: TIG-2819
-#- name: ubuntu1804
-#  display_name: Ubuntu 18.04
-#  modules: [mongo]
-#  expansions:
-#    distro: ubuntu1804
-#  run_on:
-#  - ubuntu1804-build
-#  tasks:
-#  - name: tg_compile
-#  - name: t_push
+- name: ubuntu1804
+  display_name: Ubuntu 18.04
+  modules: [mongo]
+  expansions:
+    distro: ubuntu1804
+  run_on:
+  - ubuntu1804-build
+  tasks:
+  - name: tg_compile
 
-# TODO: Re-enable after TIG-2819
-#- name: macos-1014
-#  display_name: macOS Mojave
-#  modules: [mongo]
-#  run_on:
-#  - macos-1014
-#  tasks:
-#  - name: tg_compile
+- name: macos-1014
+  display_name: macOS Mojave
+  modules: [mongo]
+  run_on:
+  - macos-1014
+  tasks:
+  - name: tg_compile
 
 - name: centos6-perf
   display_name: CentOS 6 for Performance

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -157,7 +157,7 @@ class ToolchainDownloader(Downloader):
     # These build IDs are from the genny-toolchain Evergreen task.
     # https://evergreen.mongodb.com/waterfall/genny-toolchain
 
-    TOOLCHAIN_BUILD_ID = "0db5d1544746c1570371f51109a0a312a7215b65_20_10_01_06_38_39"
+    TOOLCHAIN_BUILD_ID = "a87abeac8267bebb649d12103399acc82bae8469_21_06_09_19_22_47"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
     TOOLCHAIN_ROOT = "/data/mci"  # TODO BUILD-7624 change this to /opt.
 


### PR DESCRIPTION
Somehow the very first waterfall commit worked https://evergreen.mongodb.com/waterfall/genny-toolchain lol. I'll take it. Might be an evergreen discrepancy between patch and waterfall builds 🤷 