### PR TITLE
TIG-3059 Use perf.send for all sys-perf and performance projects.

### DIFF
--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -64,7 +64,7 @@ WorkloadContext::WorkloadContext(const Node& node,
 
     auto metricsPath = ((*this)["Metrics"]["Path"])
                            .maybe<std::string>()
-                           .value_or("build/CedarMetrics");
+                           .value_or("build/WorkloadOutput/CedarMetrics");
     _registry = genny::metrics::Registry(std::move(format), std::move(metricsPath));
 
 

--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -65,7 +65,7 @@ def _get_export_args(
 
 
 _DATE_FORMAT = "%Y-%m-%dT%H%M%SZ"
-_METRICS_PATH = "build/CedarMetrics"
+_METRICS_PATH = "build/WorkloadOutput/CedarMetrics"
 
 
 def _cleanup_metrics():


### PR DESCRIPTION
Changes the CedarMetrics location to match the DSI-side changes.