### PR TITLE
PERF-2360: Add new workload for untargeted sharded $lookup

### DIFF
--- a/src/workloads/execution/ShardedLookup.yml
+++ b/src/workloads/execution/ShardedLookup.yml
@@ -50,9 +50,9 @@ Actors:
   Phases:
   - *Nop
   - Repeat: 1
-    BatchSize: &BatchSize 1000
+    BatchSize: 1000
     Threads: 1
-    DocumentCount: 10000
+    DocumentCount: &NumDocs 3000
     Database: *Database
     CollectionCount: 2    # Loader will populate 'Collection0' then 'Collection1'.
     Document:
@@ -108,7 +108,9 @@ Actors:
               as: matches
             }
           }]
-        cursor: {batchSize: *BatchSize}
+        # To get meaningful results, the entire result set should fit in a single batch. This should
+        # be possible since both collections are small.
+        cursor: {batchSize: *NumDocs}
 
 AutoRun:
   - When:

--- a/src/workloads/execution/ShardedLookup.yml
+++ b/src/workloads/execution/ShardedLookup.yml
@@ -17,6 +17,8 @@ Actors:
   - Repeat: 1
     Database: admin
     Operations:
+    # Shard Collection0 and Collection1 using hashed sharding to ensure that the chunks are evenly
+    # distributed across the shards.
     - OperationMetricsName: EnableSharding
       OperationName: AdminCommand
       OperationCommand:
@@ -25,7 +27,6 @@ Actors:
       OperationName: AdminCommand
       OperationCommand:
         shardCollection: test.Collection0
-        # Hashed sharding will ensure that the chunks are evenly distributed across the shards.
         key: {shardKey: hashed}
         numInitialChunks: &NumChunks 6
     - OperationMetricsName: ShardForeignCollection
@@ -34,6 +35,11 @@ Actors:
         shardCollection: test.Collection1
         key: {shardKey: hashed}
         numInitialChunks: *NumChunks
+    # Disable the balancer so that it can't skew results while the $lookups are running.
+    - OperationMetricsName: DisableBalancer
+      OperationName: AdminCommand
+      OperationCommand:
+        balancerStop: 1
   - &Nop {Nop: true}
   - *Nop
   - *Nop

--- a/src/workloads/execution/ShardedLookup.yml
+++ b/src/workloads/execution/ShardedLookup.yml
@@ -1,0 +1,116 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+
+GlobalDefaults:
+  Nop: &Nop {Nop: true}
+
+  Database: &Database test
+
+  LocalCollection: &LocalCollection Collection0
+  LocalNamespace: &LocalNamespace test.Collection0
+
+  ForeignCollection: &ForeignCollection Collection1
+  ForeignNamespace: &ForeignNamespace test.Collection1
+
+  DocumentCount: &DocumentCount 5000
+  BatchSize: &BatchSize 1000
+  NumChunks: &NumChunks 5
+
+Actors:
+- Name: CreateShardedCollections
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationMetricsName: EnableSharding
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: *Database
+    - OperationMetricsName: ShardLocalCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: *LocalNamespace
+        key: {shardKey: hashed}
+        numInitialChunks: *NumChunks
+    - OperationMetricsName: ShardForeignCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: *ForeignNamespace
+        key: {shardKey: hashed}
+        numInitialChunks: *NumChunks
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: LoadInitialData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    BatchSize: *BatchSize
+    Threads: 1
+    DocumentCount: *DocumentCount
+    Database: *Database
+    CollectionCount: 2    # Loader will populate 'Collection0' then 'Collection1'.
+    Document:
+      shardKey: {^RandomInt: {min: 1, max: 100}}
+      date: &Date {^RandomDate: {min: "2020-01-01", max: "2021-01-01"}}
+      int: {^RandomInt: {min: 1, max: 100}}
+  - *Nop
+  - *Nop
+
+- Name: Quiesce
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        fsync: 1
+  - *Nop
+
+- Name: RunLookups
+  Type: RunCommand
+  Database: *Database
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 10    # Untargeted $lookup from sharded collection to sharded collection
+    Database: *Database
+    Operations:
+    - OperationMetricsName: UntargetedLookupShardedToSharded
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: *LocalCollection
+        pipeline:
+          [{
+            $lookup: {
+              from: *ForeignCollection,
+              let: {localInt: "$int"},
+              pipeline: [{
+                $match: {
+                  $expr: {
+                    $and: [
+                      {$eq: ["$int", "$$localInt"]},
+                      {$lte: ["$date", *Date]}
+                    ]
+                  }
+                }
+              }],
+              as: matches
+            }
+          }]
+        cursor: {batchSize: *BatchSize}
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq: shard-lite-all-feature-flags

--- a/src/workloads/execution/ShardedLookup.yml
+++ b/src/workloads/execution/ShardedLookup.yml
@@ -7,7 +7,7 @@ Description: |
     1. Creating empty sharded collections distributed across all shards in the cluster.
     2. Populating collections with data.
     3. Fsync.
-    4. Running targeted $lookup from a sharded collection.
+    4. Running untargeted $lookup from a sharded collection.
 
 Actors:
 - Name: CreateShardedCollections
@@ -25,8 +25,9 @@ Actors:
       OperationName: AdminCommand
       OperationCommand:
         shardCollection: test.Collection0
+        # Hashed sharding will ensure that the chunks are evenly distributed across the shards.
         key: {shardKey: hashed}
-        numInitialChunks: &NumChunks 5
+        numInitialChunks: &NumChunks 6
     - OperationMetricsName: ShardForeignCollection
       OperationName: AdminCommand
       OperationCommand:
@@ -45,7 +46,7 @@ Actors:
   - Repeat: 1
     BatchSize: &BatchSize 1000
     Threads: 1
-    DocumentCount: 5000
+    DocumentCount: 10000
     Database: *Database
     CollectionCount: 2    # Loader will populate 'Collection0' then 'Collection1'.
     Document:

--- a/src/workloads/execution/ShardedLookup.yml
+++ b/src/workloads/execution/ShardedLookup.yml
@@ -1,20 +1,13 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
+Description: |
+  This test exercises the behavior of $lookup against a sharded foreign collection.
 
-GlobalDefaults:
-  Nop: &Nop {Nop: true}
-
-  Database: &Database test
-
-  LocalCollection: &LocalCollection Collection0
-  LocalNamespace: &LocalNamespace test.Collection0
-
-  ForeignCollection: &ForeignCollection Collection1
-  ForeignNamespace: &ForeignNamespace test.Collection1
-
-  DocumentCount: &DocumentCount 5000
-  BatchSize: &BatchSize 1000
-  NumChunks: &NumChunks 5
+  The workload consists of the following phases:
+    1. Creating empty sharded collections distributed across all shards in the cluster.
+    2. Populating collections with data.
+    3. Fsync.
+    4. Running targeted $lookup from a sharded collection.
 
 Actors:
 - Name: CreateShardedCollections
@@ -27,20 +20,20 @@ Actors:
     - OperationMetricsName: EnableSharding
       OperationName: AdminCommand
       OperationCommand:
-        enableSharding: *Database
+        enableSharding: &Database test
     - OperationMetricsName: ShardLocalCollection
       OperationName: AdminCommand
       OperationCommand:
-        shardCollection: *LocalNamespace
+        shardCollection: test.Collection0
         key: {shardKey: hashed}
-        numInitialChunks: *NumChunks
+        numInitialChunks: &NumChunks 5
     - OperationMetricsName: ShardForeignCollection
       OperationName: AdminCommand
       OperationCommand:
-        shardCollection: *ForeignNamespace
+        shardCollection: test.Collection1
         key: {shardKey: hashed}
         numInitialChunks: *NumChunks
-  - *Nop
+  - &Nop {Nop: true}
   - *Nop
   - *Nop
 
@@ -50,9 +43,9 @@ Actors:
   Phases:
   - *Nop
   - Repeat: 1
-    BatchSize: *BatchSize
+    BatchSize: &BatchSize 1000
     Threads: 1
-    DocumentCount: *DocumentCount
+    DocumentCount: 5000
     Database: *Database
     CollectionCount: 2    # Loader will populate 'Collection0' then 'Collection1'.
     Document:
@@ -89,11 +82,11 @@ Actors:
     - OperationMetricsName: UntargetedLookupShardedToSharded
       OperationName: RunCommand
       OperationCommand:
-        aggregate: *LocalCollection
+        aggregate: Collection0
         pipeline:
           [{
             $lookup: {
-              from: *ForeignCollection,
+              from: Collection1,
               let: {localInt: "$int"},
               pipeline: [{
                 $match: {


### PR DESCRIPTION
This new workload currently contains a phase which runs untargeted $lookups (not eligible for shard targeting) on a sharded collection into another sharded collection. We anticipate adding new phases to this workload to test other kinds of sharded $lookups, e.g. targeted $lookups and $lookups on unsharded collections into sharded collections. We will either add new phases to this workload or create a new, corresponding workload for sharded $graphLookup.

Here is the [workload proposal document](https://docs.google.com/document/d/1JLTTS7jJDiMxrhT2yMNSW7YA07KtVgoUbB9jXEKpujU/). It includes the following table showing some example output and robustness results:

<meta charset="utf-8"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:10pt;"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">UntargetedLookupShardedToSharded data over 5 trials:</span></p><div dir="ltr" style="margin-left:0pt;" align="left">
Trial | Avg Latency | 95% Latency
-- | -- | -- 
1 | 5622326682 | 5737675489
2 | 5734970962 | 5849303387
3 | 5623881720 | 5748353800
4 | 5691124866 | 5771233556
5 | 5644313673 | 5724696416
(max-min)/med | 0.01995712617 | 0.02167698359

</div>

Here is an example [patch build result](https://spruce.mongodb.com/task/sys_perf_linux_shard_lite_all_feature_flags_sharded_lookup_patch_a11aba2bf9f18a8e73a23099519ad45a2939d238_60c36de630661579ddf38b03_21_06_11_14_06_39/logs?execution=1).

Last patch before merge: https://spruce.mongodb.com/version/60e5a7da3627e06703ed9d05/tasks