### PR TITLE
TIG-3028 Allow GlobalRate to be specified for background actors

### DIFF
--- a/src/cast_core/include/cast_core/actors/PhaseTimingRecorder.hpp
+++ b/src/cast_core/include/cast_core/actors/PhaseTimingRecorder.hpp
@@ -35,7 +35,8 @@ namespace genny::v1::actor {
  * is automatically instantiated by Genny's preprocessor by default.
  *
  * Reports:
- *   GennyInternal.PhaseTimingRecorder.Phase - Records an event at the end of each phase, with a duration the length of the phase.
+ *   GennyInternal.PhaseTimingRecorder.Phase - Records an event at the end of each phase, with a
+ * duration the length of the phase.
  *
  * Owner: 10gen/dev-prod-tips
  */

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -959,14 +959,14 @@ struct WithTransactionOperation : public BaseOperation {
                              metrics::Operation operation,
                              PhaseContext& context,
                              ActorId id)
-            : BaseOperation(context, opNode),
-              _onSession{onSession},
-              _collection{std::move(collection)},
-              _operation{operation} {
+        : BaseOperation(context, opNode),
+          _onSession{onSession},
+          _collection{std::move(collection)},
+          _operation{operation} {
         auto& opsInTxn = opNode["OperationsInTransaction"];
         if (!opsInTxn.isSequence()) {
             BOOST_THROW_EXCEPTION(InvalidConfigurationException(
-                 "'WithTransaction' requires an 'OperationsInTransaction' node of sequence type."));
+                "'WithTransaction' requires an 'OperationsInTransaction' node of sequence type."));
         }
         for (const auto&& [k, txnOp] : opsInTxn) {
             createTxnOps(txnOp, context, id);
@@ -992,7 +992,8 @@ private:
     void createTxnOps(const Node& txnOp, PhaseContext& context, ActorId id) {
         auto opName = txnOp["OperationName"].to<std::string>();
         // MongoDB does not support transactions within transactions.
-        std::set<std::string> excludeSet = {"startTransaction", "commitTransaction", "withTransaction"};
+        std::set<std::string> excludeSet = {
+            "startTransaction", "commitTransaction", "withTransaction"};
         if (excludeSet.find(opName) != excludeSet.end()) {
             BOOST_THROW_EXCEPTION(InvalidConfigurationException(
                 "Operation '" + opName + "' not supported inside a 'with_transaction' operation."));
@@ -1093,29 +1094,29 @@ private:
 
 std::unordered_map<std::string, OpCallback&> getOpConstructors() {
     // Maps the yaml 'OperationName' string to the appropriate constructor of 'BaseOperation' type.
-    std::unordered_map<std::string, OpCallback &> opConstructors = {
-        {"bulkWrite",         baseCallback<BaseOperation, OpCallback, BulkWriteOperation>},
-        {"countDocuments",    baseCallback<BaseOperation, OpCallback, CountDocumentsOperation>},
+    std::unordered_map<std::string, OpCallback&> opConstructors = {
+        {"bulkWrite", baseCallback<BaseOperation, OpCallback, BulkWriteOperation>},
+        {"countDocuments", baseCallback<BaseOperation, OpCallback, CountDocumentsOperation>},
         {"estimatedDocumentCount",
-                              baseCallback<BaseOperation, OpCallback, EstimatedDocumentCountOperation>},
-        {"createIndex",       baseCallback<BaseOperation, OpCallback, CreateIndexOperation>},
-        {"find",              baseCallback<BaseOperation, OpCallback, FindOperation>},
-        {"findOne",           baseCallback<BaseOperation, OpCallback, FindOneOperation>},
-        {"findOneAndUpdate",  baseCallback<BaseOperation, OpCallback, FindOneAndUpdateOperation>},
-        {"findOneAndDelete",  baseCallback<BaseOperation, OpCallback, FindOneAndDeleteOperation>},
+         baseCallback<BaseOperation, OpCallback, EstimatedDocumentCountOperation>},
+        {"createIndex", baseCallback<BaseOperation, OpCallback, CreateIndexOperation>},
+        {"find", baseCallback<BaseOperation, OpCallback, FindOperation>},
+        {"findOne", baseCallback<BaseOperation, OpCallback, FindOneOperation>},
+        {"findOneAndUpdate", baseCallback<BaseOperation, OpCallback, FindOneAndUpdateOperation>},
+        {"findOneAndDelete", baseCallback<BaseOperation, OpCallback, FindOneAndDeleteOperation>},
         {"findOneAndReplace", baseCallback<BaseOperation, OpCallback, FindOneAndReplaceOperation>},
-        {"insertMany",        baseCallback<BaseOperation, OpCallback, InsertManyOperation>},
-        {"startTransaction",  baseCallback<BaseOperation, OpCallback, StartTransactionOperation>},
+        {"insertMany", baseCallback<BaseOperation, OpCallback, InsertManyOperation>},
+        {"startTransaction", baseCallback<BaseOperation, OpCallback, StartTransactionOperation>},
         {"commitTransaction", baseCallback<BaseOperation, OpCallback, CommitTransactionOperation>},
-        {"withTransaction",   baseCallback<BaseOperation, OpCallback, WithTransactionOperation>},
-        {"setReadConcern",    baseCallback<BaseOperation, OpCallback, SetReadConcernOperation>},
-        {"drop",              baseCallback<BaseOperation, OpCallback, DropOperation>},
-        {"insertOne",         baseCallback<BaseOperation, OpCallback, InsertOneOperation>},
-        {"deleteOne",         baseCallback<BaseOperation, OpCallback, DeleteOneOperation>},
-        {"deleteMany",        baseCallback<BaseOperation, OpCallback, DeleteManyOperation>},
-        {"updateOne",         baseCallback<BaseOperation, OpCallback, UpdateOneOperation>},
-        {"updateMany",        baseCallback<BaseOperation, OpCallback, UpdateManyOperation>},
-        {"replaceOne",        baseCallback<BaseOperation, OpCallback, ReplaceOneOperation>}};
+        {"withTransaction", baseCallback<BaseOperation, OpCallback, WithTransactionOperation>},
+        {"setReadConcern", baseCallback<BaseOperation, OpCallback, SetReadConcernOperation>},
+        {"drop", baseCallback<BaseOperation, OpCallback, DropOperation>},
+        {"insertOne", baseCallback<BaseOperation, OpCallback, InsertOneOperation>},
+        {"deleteOne", baseCallback<BaseOperation, OpCallback, DeleteOneOperation>},
+        {"deleteMany", baseCallback<BaseOperation, OpCallback, DeleteManyOperation>},
+        {"updateOne", baseCallback<BaseOperation, OpCallback, UpdateOneOperation>},
+        {"updateMany", baseCallback<BaseOperation, OpCallback, UpdateManyOperation>},
+        {"replaceOne", baseCallback<BaseOperation, OpCallback, ReplaceOneOperation>}};
 
     return opConstructors;
 }

--- a/src/gennylib/include/gennylib/Orchestrator.hpp
+++ b/src/gennylib/include/gennylib/Orchestrator.hpp
@@ -21,12 +21,11 @@
 #include <shared_mutex>
 #include <vector>
 
+#include <gennylib/conventions.hpp>
+
 namespace genny {
 
 class Orchestrator;
-
-// May eventually want a proper type for Phase, but for now just a typedef is sufficient.
-using PhaseNumber = unsigned int;
 
 using OrchestratorCB = std::function<void(const Orchestrator*)>;
 
@@ -104,6 +103,10 @@ public:
      */
     bool continueRunning() const;
 
+    /**
+     * Sleep until the given phase ends or time out.
+     */
+    void sleepToPhaseEnd(const PhaseNumber pn, Duration timeout);
 
 private:
     mutable std::shared_mutex _mutex;

--- a/src/gennylib/include/gennylib/Orchestrator.hpp
+++ b/src/gennylib/include/gennylib/Orchestrator.hpp
@@ -104,9 +104,10 @@ public:
     bool continueRunning() const;
 
     /**
-     * Sleep until the given phase ends or time out.
+     * Sleep for the duration, also waking up if the phase changes before the
+     * duration passes.
      */
-    void sleepToPhaseEnd(const PhaseNumber pn, Duration timeout);
+    void sleepToPhaseEnd(Duration timeout, const PhaseNumber pn);
 
 private:
     mutable std::shared_mutex _mutex;

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -148,7 +148,7 @@ public:
                     const auto rate = _rateLimiter->getRate() > 1e9 ? 1e9 : _rateLimiter->getRate();
 
                     // Add ±5% jitter to avoid threads waking up at once.
-                    _sleeper->sleep_for(orchestrator, inPhase, std::chrono::nanoseconds(
+                    _sleeper->sleepFor(orchestrator, inPhase, std::chrono::nanoseconds(
                         int64_t(rate * (0.95 + 0.1 * (double(rand()) / RAND_MAX)))), !_doesBlock);
                     continue;
                 }

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -125,12 +125,6 @@ public:
             const auto rateLimiterName =
                 phaseContext["RateLimiterName"].maybe<std::string>().value_or(defaultRLName.str());
 
-            if (!_doesBlock) {
-                throw InvalidConfigurationException(
-                    "GlobalRate must be specified alongside either Duration or Repeat, otherwise "
-                    "there's no guarantee the rate limited operation will run in the correct "
-                    "phase");
-            }
             _rateLimiter =
                 phaseContext.workload().getRateLimiter(rateLimiterName, rateSpec.value());
         }

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -139,7 +139,8 @@ public:
                 const auto now = SteadyClock::now();
                 auto success = _rateLimiter->consumeIfWithinRate(now);
                 // If we don't block, we can trust the sleeper to check if the phase ended.
-                bool phaseStillGoing = !_doesBlock || !isDone(referenceStartingPoint, currentIteration, now);
+                bool phaseStillGoing =
+                    !_doesBlock || !isDone(referenceStartingPoint, currentIteration, now);
                 if (!success && phaseStillGoing) {
 
                     // Don't sleep for more than 1 second (1e9 nanoseconds). Otherwise rates
@@ -148,8 +149,11 @@ public:
                     const auto rate = _rateLimiter->getRate() > 1e9 ? 1e9 : _rateLimiter->getRate();
 
                     // Add ±5% jitter to avoid threads waking up at once.
-                    _sleeper->sleepFor(orchestrator, inPhase, std::chrono::nanoseconds(
-                        int64_t(rate * (0.95 + 0.1 * (double(rand()) / RAND_MAX)))), !_doesBlock);
+                    _sleeper->sleepFor(orchestrator,
+                                       inPhase,
+                                       std::chrono::nanoseconds(int64_t(
+                                           rate * (0.95 + 0.1 * (double(rand()) / RAND_MAX)))),
+                                       !_doesBlock);
                     continue;
                 }
                 break;
@@ -250,7 +254,8 @@ public:
     bool operator==(const ActorPhaseIterator& rhs) const {
         if (_iterationCheck) {
             _iterationCheck->sleepBefore(*_orchestrator, _inPhase);
-            _iterationCheck->limitRate(_referenceStartingPoint, _currentIteration, *_orchestrator, _inPhase);
+            _iterationCheck->limitRate(
+                _referenceStartingPoint, _currentIteration, *_orchestrator, _inPhase);
         }
         // clang-format off
         return

--- a/src/gennylib/include/gennylib/PhaseLoop.hpp
+++ b/src/gennylib/include/gennylib/PhaseLoop.hpp
@@ -138,12 +138,8 @@ public:
 
     constexpr void limitRate(const SteadyClock::time_point referenceStartingPoint,
                              const int64_t currentIteration,
-                             const Orchestrator& orchestrator,
+                             Orchestrator& orchestrator,
                              const PhaseNumber inPhase) {
-        // This function is called after each iteration, so we never rate limit the
-        // first iteration. This means the number of completed operations is always
-        // `n * GlobalRateLimiter::_burstSize + m` instead of an exact multiple of
-        // _burstSize. `m` here is the number of threads using the rate limiter.
         if (_rateLimiter) {
             while (true) {
                 const auto now = SteadyClock::now();
@@ -154,10 +150,6 @@ public:
                     // specified in seconds or lower resolution can cause the workloads to
                     // run visibly longer than the specified duration.
                     const auto rate = _rateLimiter->getRate() > 1e9 ? 1e9 : _rateLimiter->getRate();
-
-                    // Add ±5% jitter to avoid threads waking up at once.
-                    //std::this_thread::sleep_for(std::chrono::nanoseconds(
-                    //    int64_t(rate * (0.95 + 0.1 * (double(rand()) / RAND_MAX)))));
 
                     // Add ±5% jitter to avoid threads waking up at once.
                     _sleeper->sleep_for(orchestrator, inPhase, std::chrono::nanoseconds(

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -506,7 +506,11 @@ public:
         }
 
         return this->workload()._registry.operation(
-            this->_actor->operator[]("Name").to<std::string>(), stm.str(), id, _phaseNumber, internal);
+            this->_actor->operator[]("Name").to<std::string>(),
+            stm.str(),
+            id,
+            _phaseNumber,
+            internal);
     }
 
     const auto getPhaseNumber() const {

--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -26,7 +26,7 @@
 
 #include <gennylib/InvalidConfigurationException.hpp>
 #include <gennylib/Node.hpp>
-#include <gennylib/Orchestrator.hpp>
+
 
 namespace genny {
 
@@ -188,6 +188,9 @@ private:
     std::variant<std::monostate, BaseRateSpec, PercentileRateSpec> _spec;
 };
 
+
+// May eventually want a proper type for Phase, but for now just a typedef is sufficient.
+using PhaseNumber = unsigned int;
 
 struct PhaseRangeSpec {
     PhaseRangeSpec() = default;

--- a/src/gennylib/include/gennylib/v1/Sleeper.hpp
+++ b/src/gennylib/include/gennylib/v1/Sleeper.hpp
@@ -50,14 +50,14 @@ public:
     Sleeper(Sleeper&& other) = delete;
     Sleeper& operator=(Sleeper&& other) = delete;
 
-    constexpr void sleep_for(Orchestrator& o, const PhaseNumber pn,
+    constexpr void sleepFor(Orchestrator& orchestrator, const PhaseNumber phase,
             const Duration period, bool phaseChangeWakeup = false) const {
 
         if (phaseChangeWakeup) {
             // Using locks / condition variables is less efficient/safe, so we
             // only use this mechanism if the caller explicitly asked for it.
-            o.sleepToPhaseEnd(pn, period);
-        } else if (period.count() && o.currentPhase() == pn) {
+            orchestrator.sleepToPhaseEnd(phase, period);
+        } else if (period.count() && orchestrator.currentPhase() == phase) {
             std::this_thread::sleep_for(period);
         }
     }
@@ -66,8 +66,8 @@ public:
      * Sleep for duration before an operation. Checks that the current phase has
      * not ended before sleeping.
      */
-    constexpr void before(const Orchestrator& o, const PhaseNumber pn) const {
-        if (_before.count() && o.currentPhase() == pn) {
+    constexpr void before(const Orchestrator& orchestrator, const PhaseNumber phase) const {
+        if (_before.count() && orchestrator.currentPhase() == phase) {
             std::this_thread::sleep_for(_before);
         }
     }
@@ -75,8 +75,8 @@ public:
     /**
      * @see Sleeper::before
      */
-    constexpr void after(const Orchestrator& o, const PhaseNumber pn) const {
-        if (_after.count() && o.currentPhase() == pn) {
+    constexpr void after(const Orchestrator& orchestrator, const PhaseNumber phase) const {
+        if (_after.count() && orchestrator.currentPhase() == phase) {
             std::this_thread::sleep_for(_after);
         }
     }

--- a/src/gennylib/include/gennylib/v1/Sleeper.hpp
+++ b/src/gennylib/include/gennylib/v1/Sleeper.hpp
@@ -49,6 +49,13 @@ public:
     Sleeper(Sleeper&& other) = delete;
     Sleeper& operator=(Sleeper&& other) = delete;
 
+    constexpr void sleep_for(const Orchestrator& o, const PhaseNumber pn,
+            const Duration period, bool phaseChangeWakeup = false) const {
+        if (period.count() && o.currentPhase() == pn) {
+            std::this_thread::sleep_for(period);
+        }
+    }
+
     /**
      * Sleep for duration before an operation. Checks that the current phase has
      * not ended before sleeping.

--- a/src/gennylib/include/gennylib/v1/Sleeper.hpp
+++ b/src/gennylib/include/gennylib/v1/Sleeper.hpp
@@ -50,8 +50,10 @@ public:
     Sleeper(Sleeper&& other) = delete;
     Sleeper& operator=(Sleeper&& other) = delete;
 
-    constexpr void sleepFor(Orchestrator& orchestrator, const PhaseNumber phase,
-            const Duration period, bool phaseChangeWakeup = false) const {
+    constexpr void sleepFor(Orchestrator& orchestrator,
+                            const PhaseNumber phase,
+                            const Duration period,
+                            bool phaseChangeWakeup = false) const {
 
         if (phaseChangeWakeup) {
             // Using locks / condition variables is less efficient/safe, so we

--- a/src/gennylib/include/gennylib/v1/Sleeper.hpp
+++ b/src/gennylib/include/gennylib/v1/Sleeper.hpp
@@ -56,8 +56,8 @@ public:
         if (phaseChangeWakeup) {
             // Using locks / condition variables is less efficient/safe, so we
             // only use this mechanism if the caller explicitly asked for it.
-            orchestrator.sleepToPhaseEnd(phase, period);
-        } else if (period.count() && orchestrator.currentPhase() == phase) {
+            orchestrator.sleepToPhaseEnd(period, phase);
+        } else if (period.count() > 0 && orchestrator.currentPhase() == phase) {
             std::this_thread::sleep_for(period);
         }
     }
@@ -67,7 +67,7 @@ public:
      * not ended before sleeping.
      */
     constexpr void before(const Orchestrator& orchestrator, const PhaseNumber phase) const {
-        if (_before.count() && orchestrator.currentPhase() == phase) {
+        if (_before.count() > 0 && orchestrator.currentPhase() == phase) {
             std::this_thread::sleep_for(_before);
         }
     }
@@ -76,7 +76,7 @@ public:
      * @see Sleeper::before
      */
     constexpr void after(const Orchestrator& orchestrator, const PhaseNumber phase) const {
-        if (_after.count() && orchestrator.currentPhase() == phase) {
+        if (_after.count() > 0 && orchestrator.currentPhase() == phase) {
             std::this_thread::sleep_for(_after);
         }
     }

--- a/src/gennylib/include/gennylib/v1/Sleeper.hpp
+++ b/src/gennylib/include/gennylib/v1/Sleeper.hpp
@@ -52,14 +52,13 @@ public:
 
     constexpr void sleep_for(Orchestrator& o, const PhaseNumber pn,
             const Duration period, bool phaseChangeWakeup = false) const {
-        if (period.count() && o.currentPhase() == pn) {
-            if (phaseChangeWakeup) {
-                // Using locks / condition variables is less efficient/safe, so we
-                // only use this mechanism if the caller explicitly asked for it.
-                o.sleepToPhaseEnd(pn, period);
-            } else {
-                std::this_thread::sleep_for(period);
-            }
+
+        if (phaseChangeWakeup) {
+            // Using locks / condition variables is less efficient/safe, so we
+            // only use this mechanism if the caller explicitly asked for it.
+            o.sleepToPhaseEnd(pn, period);
+        } else if (period.count() && o.currentPhase() == pn) {
+            std::this_thread::sleep_for(period);
         }
     }
 

--- a/src/gennylib/src/Orchestrator.cpp
+++ b/src/gennylib/src/Orchestrator.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>  // std::max
 #include <cassert>
+#include <chrono>
 
 namespace {
 
@@ -160,12 +161,21 @@ void Orchestrator::abort() {
     _phaseChange.notify_all();
 }
 
-void Orchestrator::sleepToPhaseEnd(const Duration timeout, const PhaseNumber pn) {
+void Orchestrator::sleepToPhaseEnd(Duration timeout, const PhaseNumber pn) {
+    using SteadyClock = std::chrono::steady_clock;
+    const auto sleepEnd = SteadyClock::now() + timeout;
+
     reader lock{_mutex};
-    if (this->_current != pn || state == State::PhaseEnded) {
-        return;
+
+    // While loop to handle spurious wakeups.
+    while (this->_current == pn || state != State::PhaseEnded) {
+        const auto waitTimeout = sleepEnd - SteadyClock::now();
+        // If we've already passed the timeout then exit.
+        if (waitTimeout < Duration::zero()) {
+            return;
+        }
+        _phaseChange.wait_for(lock, waitTimeout);
     }
-    _phaseChange.wait_for(lock, timeout);
 }
 
 }  // namespace genny

--- a/src/gennylib/src/Orchestrator.cpp
+++ b/src/gennylib/src/Orchestrator.cpp
@@ -160,7 +160,7 @@ void Orchestrator::abort() {
     _phaseChange.notify_all();
 }
 
-void Orchestrator::sleepToPhaseEnd(const PhaseNumber pn, Duration timeout) {
+void Orchestrator::sleepToPhaseEnd(const Duration timeout, const PhaseNumber pn) {
     reader lock{_mutex};
     if (this->_current != pn || state == State::PhaseEnded) {
         return;

--- a/src/gennylib/src/Orchestrator.cpp
+++ b/src/gennylib/src/Orchestrator.cpp
@@ -160,4 +160,12 @@ void Orchestrator::abort() {
     _phaseChange.notify_all();
 }
 
+void Orchestrator::sleepToPhaseEnd(const PhaseNumber pn, Duration timeout) {
+    reader lock{_mutex};
+    if (this->_current != pn || state == State::PhaseEnded) {
+        return;
+    }
+    _phaseChange.wait_for(lock, timeout);
+}
+
 }  // namespace genny

--- a/src/gennylib/src/Orchestrator.cpp
+++ b/src/gennylib/src/Orchestrator.cpp
@@ -168,7 +168,7 @@ void Orchestrator::sleepToPhaseEnd(Duration timeout, const PhaseNumber pn) {
     reader lock{_mutex};
 
     // While loop to handle spurious wakeups.
-    while (this->_current == pn || state != State::PhaseEnded) {
+    while (this->_current == pn && state != State::PhaseEnded) {
         const auto waitTimeout = sleepEnd - SteadyClock::now();
         // If we've already passed the timeout then exit.
         if (waitTimeout < Duration::zero()) {

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -62,9 +62,8 @@ WorkloadContext::WorkloadContext(const Node& node,
                                 << " is deprecated in favor of ftdc.";
     }
 
-    auto metricsPath = ((*this)["Metrics"]["Path"])
-                           .maybe<std::string>()
-                           .value_or("build/CedarMetrics");
+    auto metricsPath =
+        ((*this)["Metrics"]["Path"]).maybe<std::string>().value_or("build/CedarMetrics");
     _registry = genny::metrics::Registry(std::move(format), std::move(metricsPath));
 
 

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -177,7 +177,7 @@ auto incProducer = std::make_shared<DefaultActorProducer<IncActor>>("IncActor");
 TEST_CASE("Global rate limiter can be used by phase loop", "[benchmark]") {
     using namespace std::chrono_literals;
 
-    SECTION("Fail if no Repeat or Duration") {
+    SECTION("Works with no Repeat or Duration") {
         NodeSource ns(R"(
 SchemaVersion: 2018-07-01
 Actors:
@@ -195,7 +195,7 @@ Actors:
         auto fun = [&]() {
             genny::ActorHelper ah{config, num_threads, {{"IncActor", incProducer}}};
         };
-        REQUIRE_THROWS_WITH(fun(), Matches(R"(.*alongside either Duration or Repeat.*)"));
+        //REQUIRE_THROWS_WITH(fun(), Matches(R"(.*alongside either Duration or Repeat.*)"));
     }
 
     // The rate interval needs to be large enough to avoid sporadic failures, which makes

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -213,7 +213,6 @@ Actors:
         t.join();
 
         const auto state = getCurState();
-        //REQUIRE_THROWS_WITH(fun(), Matches(R"(.*alongside either Duration or Repeat.*)"));
         REQUIRE(state == 72);
     }
 

--- a/src/metrics/include/metrics/metrics.hpp
+++ b/src/metrics/include/metrics/metrics.hpp
@@ -113,7 +113,7 @@ class MetricsClockSource {
 private:
     using clock_type = std::chrono::steady_clock;
     using report_clock_type = std::chrono::system_clock;
-    
+
 
 public:
     using duration = clock_type::duration;
@@ -187,8 +187,9 @@ public:
     explicit RegistryT(MetricsFormat format,
                        boost::filesystem::path pathPrefix,
                        bool assertMetricsBuffer = true)
-        : _format{std::move(format)}, _pathPrefix{std::move(pathPrefix)},
-        _internalPathPrefix{_pathPrefix / INTERNAL_DIR} {
+        : _format{std::move(format)},
+          _pathPrefix{std::move(pathPrefix)},
+          _internalPathPrefix{_pathPrefix / INTERNAL_DIR} {
         if (_format.useGrpc()) {
             boost::filesystem::create_directories(_pathPrefix);
             boost::filesystem::create_directories(_internalPathPrefix);

--- a/src/metrics/include/metrics/v2/event.hpp
+++ b/src/metrics/include/metrics/v2/event.hpp
@@ -393,8 +393,7 @@ public:
     using OptionalPhaseNumber = std::optional<genny::PhaseNumber>;
     typedef EventStream<ClockSource, StreamInterface> Stream;
 
-    GrpcClient(bool assertMetricsBuffer)
-        : _assertMetricsBuffer{assertMetricsBuffer} {}
+    GrpcClient(bool assertMetricsBuffer) : _assertMetricsBuffer{assertMetricsBuffer} {}
 
     Stream* createStream(const ActorId& actorId,
                          const std::string& name,

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -64,7 +64,8 @@ public:
         }
 
         std::stringstream msg;
-        msg << "Need one of ThenReturns, ThenExecuteAndIgnore or ThenThrows'" << toString(node) << "'";
+        msg << "Need one of ThenReturns, ThenExecuteAndIgnore or ThenThrows'" << toString(node)
+            << "'";
         throw std::invalid_argument(msg.str());
     }
 
@@ -92,7 +93,8 @@ public:
             NodeSource ns = toNode(this->_givenTemplate);
             genny::DefaultRandom rng;
             auto docGen = genny::DocumentGenerator(ns.root(), GeneratorArgs{rng, 2});
-            if (_runMode == RunMode::kIgnoreReturn) return;
+            if (_runMode == RunMode::kIgnoreReturn)
+                return;
             for (const auto&& nextValue : this->_thenReturns) {
                 auto expected = testing::toDocumentBson(nextValue);
                 auto actual = docGen();


### PR DESCRIPTION
The main actual change is to wake up all threads when the phase ends, so that the GlobalRate sleeps don't carry over to the next phase. Ended up being smaller than I expected since we could piggyback on the Orchestrator's CV.