### PR TITLE
PERF-2448 Benchmark an unsharded lookup in a sharded environment

### DIFF
--- a/src/workloads/execution/UnshardedLookup.yml
+++ b/src/workloads/execution/UnshardedLookup.yml
@@ -1,0 +1,70 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  Benchmark a $lookup from one unsharded collection to another in a sharded environment.
+
+Actors:
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: &db test
+    Threads: 1
+    DocumentCount: 1000
+    BatchSize: &batchSize 1000
+    CollectionCount: 2
+    Document:
+      shardKey: {^RandomInt: {min: 1, max: 1000}}
+      a: {^RandomInt: {min: 1, max: 1000}}
+      b: &string {^RandomString: {length: 10000}}
+  - &Nop {Nop: true}
+  - *Nop
+
+- Name: Quiesce
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        fsync: 1
+  - *Nop
+
+- Name: Lookup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 10
+    Database: *db
+    Operations:
+    - OperationMetricsName: Lookup
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [{
+            $lookup: {
+              from: "Collection1",
+              let: {a0: "$a"},
+              pipeline: [{
+                $match: {
+                  $expr: {$eq: ["$a", "$$a0"]},
+                }
+              }],
+              as: "joined"
+            }
+          }]
+        cursor: {batchSize: *batchSize}
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - shard-lite
+          - shard-lite-all-feature-flags

--- a/src/workloads/execution/UnshardedLookup.yml
+++ b/src/workloads/execution/UnshardedLookup.yml
@@ -11,11 +11,11 @@ Actors:
   - Repeat: 1
     Database: &db test
     Threads: 1
-    DocumentCount: 1000
-    BatchSize: &batchSize 1000
+    DocumentCount: 500
+    BatchSize: &batchSize 500
     CollectionCount: 2
     Document:
-      a: {^RandomInt: {min: 1, max: 1000}}
+      a: {^RandomInt: {min: 1, max: 500}}
       b: {^RandomInt: {min: 1, max: 100}}
       c: {^RandomString: {length: 10000}}
   - &Nop {Nop: true}
@@ -48,36 +48,38 @@ Actors:
       OperationCommand:
         aggregate: Collection0
         pipeline:
-          [{
-            $lookup: {
+          [
+            {$lookup: {
               from: "Collection1",
               let: {a0: "$a"},
-              pipeline: [{
-                $match: {
-                  $expr: {$eq: ["$$a0", "$a"]},
-                }
-              }],
+              pipeline: [{$match: {$expr: {$eq: ["$$a0", "$a"]}}}],
               as: "joined"
-            }
-          }]
+            }},
+            {$project: {a: 1, b: 1, c: "$joined.b"}},
+            {$unwind: "$c"},
+            # Fetching from the cursor more than once is not supported, therefore we aggregate the
+            # result so that only one fetch is needed to exhaust the cursor.
+            {$count: "nDocs"}
+          ]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: LookupOneToMany
       OperationName: RunCommand
       OperationCommand:
         aggregate: Collection0
         pipeline:
-          [{
-            $lookup: {
+          [
+            {$lookup: {
               from: "Collection1",
               let: {b0: "$b"},
-              pipeline: [{
-                $match: {
-                  $expr: {$eq: ["$$b0", "$b"]},
-                }
-              }],
+              pipeline: [{$match: {$expr: {$eq: ["$$b0", "$b"]}}}],
               as: "joined"
-            }
-          }]
+            }},
+            {$project: {a: 1, b: 1, c: "$joined.a"}},
+            {$unwind: "$c"},
+            # Fetching from the cursor more than once is not supported, therefore we aggregate the
+            # result so that only one fetch is needed to exhaust the cursor.
+            {$count: "nDocs"}
+          ]
         cursor: {batchSize: *batchSize}
 
 AutoRun:

--- a/src/workloads/execution/UnshardedLookup.yml
+++ b/src/workloads/execution/UnshardedLookup.yml
@@ -15,9 +15,9 @@ Actors:
     BatchSize: &batchSize 1000
     CollectionCount: 2
     Document:
-      shardKey: {^RandomInt: {min: 1, max: 1000}}
       a: {^RandomInt: {min: 1, max: 1000}}
-      b: &string {^RandomString: {length: 10000}}
+      b: {^RandomInt: {min: 1, max: 100}}
+      c: {^RandomString: {length: 10000}}
   - &Nop {Nop: true}
   - *Nop
 
@@ -43,7 +43,7 @@ Actors:
   - Repeat: 10
     Database: *db
     Operations:
-    - OperationMetricsName: Lookup
+    - OperationMetricsName: LookupOneToOne
       OperationName: RunCommand
       OperationCommand:
         aggregate: Collection0
@@ -54,7 +54,25 @@ Actors:
               let: {a0: "$a"},
               pipeline: [{
                 $match: {
-                  $expr: {$eq: ["$a", "$$a0"]},
+                  $expr: {$eq: ["$$a0", "$a"]},
+                }
+              }],
+              as: "joined"
+            }
+          }]
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: LookupOneToMany
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [{
+            $lookup: {
+              from: "Collection1",
+              let: {b0: "$b"},
+              pipeline: [{
+                $match: {
+                  $expr: {$eq: ["$$b0", "$b"]},
                 }
               }],
               as: "joined"

--- a/src/workloads/execution/UnshardedLookup.yml
+++ b/src/workloads/execution/UnshardedLookup.yml
@@ -11,13 +11,13 @@ Actors:
   - Repeat: 1
     Database: &db test
     Threads: 1
-    DocumentCount: 500
-    BatchSize: &batchSize 500
+    DocumentCount: 1000
+    BatchSize: &batchSize 1000
     CollectionCount: 2
     Document:
-      a: {^RandomInt: {min: 1, max: 500}}
-      b: {^RandomInt: {min: 1, max: 100}}
-      c: {^RandomString: {length: 10000}}
+      a: {^RandomInt: {min: 1, max: 100}}
+      b: {^RandomInt: {min: 1, max: 10}}
+      c: {^RandomInt: {min: 0, max: 999}}
   - &Nop {Nop: true}
   - *Nop
 
@@ -43,7 +43,7 @@ Actors:
   - Repeat: 10
     Database: *db
     Operations:
-    - OperationMetricsName: LookupOneToOne
+    - OperationMetricsName: LookupOneToFew
       OperationName: RunCommand
       OperationCommand:
         aggregate: Collection0
@@ -54,12 +54,7 @@ Actors:
               let: {a0: "$a"},
               pipeline: [{$match: {$expr: {$eq: ["$$a0", "$a"]}}}],
               as: "joined"
-            }},
-            {$project: {a: 1, b: 1, c: "$joined.b"}},
-            {$unwind: "$c"},
-            # Fetching from the cursor more than once is not supported, therefore we aggregate the
-            # result so that only one fetch is needed to exhaust the cursor.
-            {$count: "nDocs"}
+            }}
           ]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: LookupOneToMany
@@ -73,12 +68,7 @@ Actors:
               let: {b0: "$b"},
               pipeline: [{$match: {$expr: {$eq: ["$$b0", "$b"]}}}],
               as: "joined"
-            }},
-            {$project: {a: 1, b: 1, c: "$joined.a"}},
-            {$unwind: "$c"},
-            # Fetching from the cursor more than once is not supported, therefore we aggregate the
-            # result so that only one fetch is needed to exhaust the cursor.
-            {$count: "nDocs"}
+            }}
           ]
         cursor: {batchSize: *batchSize}
 


### PR DESCRIPTION
Ran a $lookup against two unsharded collections. One was run in a sharded environment with the sharded lookup feature flag turned on, the other was run with the feature flag turned off. The query was ~33% faster with the feature flag disabled.

Metric | shard-lite | shard-lite-all-feature-flags
-- | -- | --
AverageLatency | 981,263,356 | 1,467,256,868

[Evergreen patch](https://spruce.mongodb.com/version/60f21666d6d80a245ce1599a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)