### PR TITLE
TIG-3200 Fix ColdScanner's CollectionCount

### DIFF
--- a/src/workloads/scale/OutOfCacheScanner.yml
+++ b/src/workloads/scale/OutOfCacheScanner.yml
@@ -44,7 +44,7 @@ Actors:
   Type: CollectionScanner
   Threads: 6
   Database: cold
-  CollectionCount: 60
+  CollectionCount: 10
   Phases:
   - {Nop: true}
   - {Nop: true}


### PR DESCRIPTION
[Not ready for merge yet just here as reference point.]

Each of the 6 instances wants to iterate over `Collection{0..9}` rather than instance `$i` scanning `Collection$i{0..9}`.