### PR TITLE
PERF-2378: Add tests for caching behavior of sharded $lookup

### DIFF
--- a/src/workloads/execution/ShardedLookup.yml
+++ b/src/workloads/execution/ShardedLookup.yml
@@ -7,7 +7,7 @@ Description: |
     1. Creating empty sharded collections distributed across all shards in the cluster.
     2. Populating collections with data.
     3. Fsync.
-    4. Running untargeted $lookup from a sharded collection.
+    4. Running $lookup's against a sharded foreign collection.
 
 Actors:
 - Name: CreateShardedCollections
@@ -54,7 +54,7 @@ Actors:
     Threads: 1
     DocumentCount: &NumDocs 3000
     Database: *Database
-    CollectionCount: 2    # Loader will populate 'Collection0' then 'Collection1'.
+    CollectionCount: 3   # Loader will populate 'Collection0', 'Collection1' and 'Collection2'.
     Document:
       shardKey: {^RandomInt: {min: 1, max: 100}}
       date: &Date {^RandomDate: {min: "2020-01-01", max: "2021-01-01"}}
@@ -83,7 +83,7 @@ Actors:
   - *Nop
   - *Nop
   - *Nop
-  - Repeat: 10    # Untargeted $lookup from sharded collection to sharded collection
+  - Repeat: 10
     Database: *Database
     Operations:
     - OperationMetricsName: UntargetedLookupShardedToSharded
@@ -111,6 +111,41 @@ Actors:
         # To get meaningful results, the entire result set should fit in a single batch. This should
         # be possible since both collections are small.
         cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: LookupWithCachedPrefixShardedToSharded
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [{
+            $lookup: {
+              from: Collection1,
+              let: {localInt: "$int"},
+              pipeline: [
+                {$group: {_id: "$int"}},
+                {$match: {$expr: {$eq: ["$_id", "$$localInt"]}}
+              }],
+              as: matches
+            }
+          }]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: LookupWithCachedPrefixUnshardedToSharded
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection2
+        pipeline:
+          [{
+            $lookup: {
+              from: Collection1,
+              let: {localInt: "$int"},
+              pipeline: [
+                {$group: {_id: "$int"}},
+                {$match: {$expr: {$eq: ["$_id", "$$localInt"]}}
+              }],
+              as: matches
+            }
+          }]
+        cursor: {batchSize: *NumDocs}
+
 
 AutoRun:
   - When:


### PR DESCRIPTION
From [this patch build](https://spruce.mongodb.com/version/6107f34c3e8e8630730b8bb3/tasks), we get the following results.

| Benchmark | Avg latency (sec)  |
|---|---|
| LookupWithCachedPrefixUnshardedToSharded | 7.6230772627 |
| LookupWithCachedPrefixShardedToSharded | 4.100257013 |


The queries with sharded local collections are faster because the $lookup can be parallelized.