### PR TITLE
PERF-2426: Add tests for caching behavior of unsharded $lookup

### DIFF
--- a/src/workloads/execution/LookupInUnshardedEnvironment.yml
+++ b/src/workloads/execution/LookupInUnshardedEnvironment.yml
@@ -1,0 +1,73 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test exercises $lookup in an unsharded environment.
+
+  The workload consists of the following phases:
+    1. Populating collections with data.
+    2. Fsync.
+    3. Running $lookup's with cacheable subpipeline prefixes.
+
+Actors:
+- Name: LoadInitialData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    BatchSize: 1000
+    Threads: 1
+    DocumentCount: &NumDocs 3000
+    Database: &Database test
+    CollectionCount: 2    # Loader will populate 'Collection0' and 'Collection1'.
+    Document:
+      key: {^RandomInt: {min: 1, max: 100}}
+      int: {^RandomInt: {min: 1, max: 100}}
+      str: {^RandomString: {length: 100}}
+  - &Nop {Nop: true}
+  - *Nop
+
+- Name: Quiesce
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        fsync: 1
+  - *Nop
+
+- Name: RunLookups
+  Type: RunCommand
+  Database: *Database
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 10
+    Database: *Database
+    Operations:
+    - OperationMetricsName: LookupWithCachedPrefixUnshardedEnvironment
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [{
+            $lookup: {
+              from: Collection1,
+              let: {localInt: "$int"},
+              pipeline: [
+                {$group: {_id: {$sum: ["$int", 1]}}},
+                {$match: {$expr: {$eq: ["$_id", "$$localInt"]}}}
+              ],
+              as: matches
+            }
+          }]
+        cursor: {batchSize: *NumDocs}
+    
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - replica

--- a/src/workloads/execution/UnshardedLookupCachedPrefix.yml
+++ b/src/workloads/execution/UnshardedLookupCachedPrefix.yml
@@ -1,0 +1,122 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test exercises $lookup with a uncorrelated prefix against an unsharded collection.
+
+  The workload consists of the following phases:
+    1. Creating an empty sharded collection distributed across all shards in the cluster.
+    2. Populating collections with data.
+    3. Fsync.
+    4. Running $lookup's with cacheable subpipeline prefixes.
+
+Actors:
+- Name: CreateShardedCollections
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: admin
+    Operations:
+    # Shard Collection0 using hashed sharding to ensure even chunk distribution across the shards.
+    - OperationMetricsName: EnableSharding
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: &Database test
+    - OperationMetricsName: ShardLocalCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: test.Collection0
+        key: {key: hashed}
+        numInitialChunks: &NumChunks 6
+    # Disable the balancer so that it can't skew results while the $lookups are running.
+    - OperationMetricsName: DisableBalancer
+      OperationName: AdminCommand
+      OperationCommand:
+        balancerStop: 1
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+
+- Name: LoadInitialData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    BatchSize: 1000
+    Threads: 1
+    DocumentCount: &NumDocs 3000
+    Database: *Database
+    CollectionCount: 3    # Loader will populate 'Collection0', 'Collection1', and 'Collection2'.
+    Document:
+      key: {^RandomInt: {min: 1, max: 100}}
+      int: {^RandomInt: {min: 1, max: 100}}
+      str: {^RandomString: {length: 100}}
+  - *Nop
+  - *Nop
+
+- Name: Quiesce
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        fsync: 1
+  - *Nop
+
+- Name: RunLookups
+  Type: RunCommand
+  Database: *Database
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 10
+    Database: *Database
+    Operations:
+    - OperationMetricsName: LookupWithCachedPrefixShardedToUnsharded
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [{
+            $lookup: {
+              from: Collection2,
+              let: {localInt: "$int"},
+              pipeline: [
+                {$group: {_id: {$sum: ["$int", 1]}}},
+                {$match: {$expr: {$eq: ["$_id", "$$localInt"]}}}
+              ],
+              as: matches
+            }
+          }]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: LookupWithCachedPrefixUnshardedToUnsharded
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection1
+        pipeline:
+          [{
+            $lookup: {
+              from: Collection2,
+              let: {localInt: "$int"},
+              pipeline: [
+                {$group: {_id: {$sum: ["$int", 1]}}},
+                {$match: {$expr: {$eq: ["$_id", "$$localInt"]}}}
+              ],
+              as: matches
+            }
+          }]
+        cursor: {batchSize: *NumDocs}
+    
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - shard-lite
+          - shard-lite-all-feature-flags


### PR DESCRIPTION
From [this patch build](https://spruce.mongodb.com/version/610d3c9d1e2d173508a875db/tasks), we get the following results.

With feature flag disabled, in an unsharded environment:
| Benchmark | Avg latency (sec)  |
|---|---|
| LookupWithCachedPrefixUnshardedToUnsharded | .1554993457 |

This is by far the fastest result. 

With feature flag disabled:
| Benchmark | Avg latency (sec)  |
|---|---|
| LookupWithCachedPrefixUnshardedToUnsharded | 7.6843960346 |
| LookupWithCachedPrefixShardedToUnsharded | 7.6966880165|

With feature flag enabled:
| Benchmark | Avg latency (sec)  |
|---|---|
| LookupWithCachedPrefixUnshardedToUnsharded | 9.1613125435 |
| LookupWithCachedPrefixShardedToUnsharded | 5.5058569847 |

When the feature flag is turned on, we see a slow down in the unsharded local case because we end up targetting shards instead of reading locally when we execute the $lookup subpipeline. Also, we see a speed up in the sharded local case because the $lookup can be parallelized.

We hoped that this testing might have revealed the bug where the $lookup cache is lost in a sharded environment, related to [SERVER-57168](https://jira.mongodb.org/browse/SERVER-57168). It turns out it's a bit hard to do that because there are other confounding factors that can lead to huge performance boosts in an unsharded environment.