### PR TITLE
PERF-2378: Add tests for caching behavior of sharded $lookup

### DIFF
--- a/src/workloads/execution/ShardedLookup.yml
+++ b/src/workloads/execution/ShardedLookup.yml
@@ -142,6 +142,40 @@ Actors:
             }}
           ]
         cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: LookupWithCachedPrefixShardedToSharded
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [{
+            $lookup: {
+              from: Collection1,
+              let: {localInt: "$int"},
+              pipeline: [
+                {$group: {_id: {$sum: ["$int", 1]}}},
+                {$match: {$expr: {$eq: ["$_id", "$$localInt"]}}}
+              ],
+              as: matches
+            }
+          }]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: LookupWithCachedPrefixUnshardedToSharded
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection2
+        pipeline:
+          [{
+            $lookup: {
+              from: Collection1,
+              let: {localInt: "$int"},
+              pipeline: [
+                {$group: {_id: {$sum: ["$int", 1]}}},
+                {$match: {$expr: {$eq: ["$_id", "$$localInt"]}}}
+              ],
+              as: matches
+            }
+          }]
+        cursor: {batchSize: *NumDocs}
 
 AutoRun:
   - When:


### PR DESCRIPTION
From [this patch build](https://spruce.mongodb.com/version/610d3c9d1e2d173508a875db/tasks), we get the following results.

| Benchmark | Avg latency (sec)  |
|---|---|
| LookupWithCachedPrefixUnshardedToSharded | 17.1584018563 |
| LookupWithCachedPrefixShardedToSharded | 9.4955312718 |

The queries with sharded local collections are faster because the $lookup can be parallelized.

It's interesting to see how these results relate to #512. Compared to the UnshardedToUnsharded (~9.2 sec) and ShardedToUnsharded (~5.5 sec) feature-flag-enabled benchmarks, we see a slow down when the foreign collection becomes sharded. A slow down is expected, since when the foreign collection is sharded we have to scatter-gather results instead of targeting just the primary. However, it's much slower than I expected-- the results for ShardedToSharded are even slower than ShardedToUnsharded  with the feature flag turned off. That is, it seems that the effect of having a sharded foreign collection is worse than the benefits of parallel execution, at least in the case of these queries.