### PR TITLE
PERF-2429 Add Stress Tests to Production (mixed stress and Load Test)

### DIFF
--- a/src/cast_core/src/Loader.cpp
+++ b/src/cast_core/src/Loader.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <locale>
 
 #include <bsoncxx/json.hpp>
 
@@ -118,9 +117,9 @@ void genny::actor::Loader::run() {
                 auto collectionName = "Collection" + std::to_string(i);
                 auto collection = config->database[collectionName];
                 // Insert the documents
-                BOOST_LOG_TRIVIAL(info) << "Starting to insert: "
-                                        << config->numDocuments << " docs "
-                                        << "into " << collectionName;
+                BOOST_LOG_TRIVIAL(info)
+                    << "Starting to insert: " << config->numDocuments << " docs "
+                    << "into " << collectionName;
                 uint remainingInserts = config->numDocuments;
                 {
                     auto totalOpCtx = _totalBulkLoad.start();
@@ -162,8 +161,8 @@ void genny::actor::Loader::run() {
                         indexOpCtx.success();
                     }
                 }
-                BOOST_LOG_TRIVIAL(info) << "Done with load phase. All " <<
-                  config->numDocuments << " documents loaded into " << collectionName;
+                BOOST_LOG_TRIVIAL(info) << "Done with load phase. All " << config->numDocuments
+                                        << " documents loaded into " << collectionName;
             }
         }
     }

--- a/src/cast_core/src/Loader.cpp
+++ b/src/cast_core/src/Loader.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <locale>
 
 #include <bsoncxx/json.hpp>
 
@@ -117,6 +118,9 @@ void genny::actor::Loader::run() {
                 auto collectionName = "Collection" + std::to_string(i);
                 auto collection = config->database[collectionName];
                 // Insert the documents
+                BOOST_LOG_TRIVIAL(info) << "Starting to insert: "
+                                        << config->numDocuments << " docs "
+                                        << "into " << collectionName;
                 uint remainingInserts = config->numDocuments;
                 {
                     auto totalOpCtx = _totalBulkLoad.start();
@@ -158,8 +162,9 @@ void genny::actor::Loader::run() {
                         indexOpCtx.success();
                     }
                 }
+                BOOST_LOG_TRIVIAL(info) << "Done with load phase. All " <<
+                  config->numDocuments << " documents loaded into " << collectionName;
             }
-            BOOST_LOG_TRIVIAL(info) << "Done with load phase. All documents loaded";
         }
     }
 }

--- a/src/cast_core/src/LoggingActor.cpp
+++ b/src/cast_core/src/LoggingActor.cpp
@@ -29,10 +29,12 @@ namespace genny::actor {
 struct LoggingActor::PhaseConfig {
     TimeSpec logEvery;
     metrics::clock::time_point started;
+    metrics::clock::time_point last;
     unsigned iteration = 0;
 
     explicit PhaseConfig(PhaseContext& phaseContext)
         : logEvery{phaseContext["LogEvery"].to<TimeSpec>()}, started{metrics::clock::now()} {
+        last = started;
         if (phaseContext["Blocking"].to<std::string>() != "None") {
             BOOST_THROW_EXCEPTION(
                 InvalidConfigurationException("LoggingActor must have Blocking:None"));
@@ -46,10 +48,11 @@ struct LoggingActor::PhaseConfig {
         iteration = 0;
 
         const auto now = metrics::clock::now();
-        const auto duration = now - started;
+        const auto duration = now - last;
         if (duration >= logEvery.value) {
-            BOOST_LOG_TRIVIAL(info) << "Phase still progressing.";
-            started = now;
+            BOOST_LOG_TRIVIAL(info) << "Phase still progressing (" <<
+                std::chrono::duration_cast<std::chrono::seconds>(now - started).count() << "s)";
+            last = now;
         }
     }
 };

--- a/src/lamplib/src/genny/tasks/dry_run.py
+++ b/src/lamplib/src/genny/tasks/dry_run.py
@@ -11,6 +11,14 @@ SLOG = structlog.get_logger(__name__)
 def dry_run_workload(
     yaml_file_path: str, is_darwin: bool, genny_repo_root: str, workspace_root: str
 ):
+    if os.path.basename(yaml_file_path) in [
+        "MixedWorkloadsGennyStress.yml",
+    ]:
+        SLOG.info(
+            "TIG-3290 skipping dry run for MixedWorkloadsGennyStress.yml.", file=yaml_file_path
+        )
+        return
+
     if is_darwin and os.path.basename(yaml_file_path) in [
         "AuthNInsert.yml",
         "ParallelInsert.yml",

--- a/src/phases/scale/MixPhases.yml
+++ b/src/phases/scale/MixPhases.yml
@@ -3,19 +3,21 @@ PhaseSchemaVersion: 2018-07-01
 dbname: &dbname mix
 runtime: &runtime 7 minutes
 DocumentCount: &NumDocs 100000
+CollectionCount: &NumColls 1
+
 Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
 string: &string {^FastRandomString: {length: 50}}
 Document: &doc
   id: {^RandomInt: {min: 0, max: *NumDocs}}
-  a: {^RandomInt: {min: 0, max: 1000000}}
-  # Note that in the original workload the string c was perfectly compressable. We can put a
-  # constant there if needed.
+  a: {^RandomInt: {min: 0, max: *NumDocs}}
+  # Note that in the original workload the string c was perfectly compressable.
+  # We can put a constant there if needed.
   c: *string
 
 UpdatePhase:
   Duration: *runtime
   RecordFailure: true
-  Collection: Collection0
+  CollectionCount: *NumColls
   Operations:
   - OperationName: updateOne
     OperationCommand:
@@ -27,7 +29,7 @@ UpdatePhase:
 RemovePhase:
   Duration: *runtime
   RecordFailure: true
-  Collection: Collection0
+  CollectionCount: *NumColls
   Operations:
   - OperationName: deleteOne
     OperationCommand:
@@ -36,7 +38,7 @@ RemovePhase:
 InsertPhase:
   Duration: *runtime
   RecordFailure: true
-  Collection: Collection0
+  CollectionCount: *NumColls
   Operations:
   - OperationName: insertOne
     OperationCommand:
@@ -45,7 +47,7 @@ InsertPhase:
 FindPhase:
   Duration: *runtime
   RecordFailure: true
-  Collection: Collection0
+  CollectionCount: *NumColls
   Operations:
   - OperationName: findOne
     OperationCommand:

--- a/src/workloads/scale/BigUpdate10k.yml
+++ b/src/workloads/scale/BigUpdate10k.yml
@@ -118,6 +118,17 @@ Actors:
     Filter: {y: {^RandomInt: {distribution: poisson, mean: 100}}}
     Limit: 20
 
+# Guard Against timeout for no output.
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0,1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        LogEvery: 10 seconds
+        Blocking: None
 AutoRun:
   - When:
       mongodb_setup:

--- a/src/workloads/scale/BigUpdate10k.yml
+++ b/src/workloads/scale/BigUpdate10k.yml
@@ -1,0 +1,126 @@
+# This workload is developed as a general stress test of the server. The original development of
+# this workload is described here:
+# https://docs.google.com/document/d/1Dz0KyB_Pf94km4cBSpQHTBD7GQ8b3LM4_J350ukWjZ4/edit?usp=sharing
+# It loads data into a large number of collections, with 9 indexes on each collection. After loading
+# the data, a fraction of the collections are queried, and a smaller fraction of collections are
+# updated. This is the larger version of the test, using 10k collections and 10k documents per
+# collection.
+
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 1000
+
+Actors:
+- Name: Loader
+  Type: Loader
+  Threads: 10
+  Phases:
+  - Repeat: 1
+    Database: &DB test
+    CollectionCount: &CollectionCount 1e5
+    Threads: 10
+    DocumentCount: 1e5
+    BatchSize: 1000
+    Document:  # Documents are approximately 1 KiB in size
+      t: {^RandomInt: {min: 0, max: 10}}
+      w: {^RandomInt: {distribution: geometric, p: 0.1}}
+      x: 0
+      y: {^RandomInt: {min: 0, max: 1000}}
+      z: {^RandomInt: {min: 0, max: 2147483647}}  # This is for max int for low probability of conflicts
+      int0: &int {^RandomInt: {distribution: binomial, t: 200, p: 0.5}}
+      int1: *int
+      int2: *int
+      int3: *int
+      int4: *int
+      int5: *int
+      int6: *int
+      int7: *int
+      int8: *int
+      int9: *int
+      # Note -- genny does not support value generation within lists
+      # yet. https://jira.mongodb.org/browse/TIG-1245
+      intArray:
+      - 1000
+      - 2000
+      - 3000
+      - 4000
+      - 5000
+      - 6000
+      - 7000
+      - 8000
+      - 9000
+      string0: &string {^RandomString: {length: {^RandomInt: {min: 5, max: 15}}}}
+      string1: *string
+      string2: *string
+      string3: *string
+      string4: *string
+      string5: *string
+      string6: *string
+      string7: *string
+      string8: *string
+      string9: *string
+      stringShort: {^RandomString: {length: 1}}
+      stringLong: {^RandomString: {length: 100}}
+      compressibleStringArray:
+      - &cstring AAAAAAAAAAAAAAAAAAAA
+      - *cstring
+      - *cstring
+      - *cstring
+      - *cstring
+      - *cstring
+      - *cstring
+      - *cstring
+      - *cstring
+      - *cstring
+      some: {embedded: {document: {with: {some: {depth: *string}}}}}
+    # The Loader needs to be updated to take options to support unique, etc. I will do as a
+    # follow-up. PERF-1758
+    Indexes:
+    - keys: {t: 1, w: 1}
+    - keys: {y: 1}
+    - keys: {t: 1, stringShort: 1}
+    - keys: {string0: 1}
+    - keys: {stringLong: 1}
+      options: {unique: 1}
+    - keys: {stringShort: 1, y: 1}
+    - keys: {int0: 1, int1: 1, int2: 1}
+    - keys: {int3: 1}
+    - keys: {int4: 1}
+    - keys: {int5: 1, int6: 1}
+  - &Nop {Nop: true}
+
+- Name: MultiCollectionUpdate
+  Type: MultiCollectionUpdate
+  Threads: 100
+  Phases:
+  - *Nop
+  - Duration: &phase2_duration 30 minutes
+    MetricsName: Update
+    GlobalRate: 100 per 31 milliseconds
+    Database: *DB
+    CollectionCount: 100  # This is specifically 1% of collections
+    UpdateFilter: {y: {^RandomInt: {distribution: poisson, mean: 100}}}
+    Update: {$inc: {x: 1}}
+
+- Name: MultiCollectionQuery
+  Type: MultiCollectionQuery
+  Threads: 100
+  Phases:
+  - *Nop
+  - Duration: *phase2_duration
+    GlobalRate: 100 per 9 milliseconds
+    Database: *DB
+    CollectionCount: 1000  # This is specifically 10% of collections.
+    Filter: {y: {^RandomInt: {distribution: poisson, mean: 100}}}
+    Limit: 20
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica

--- a/src/workloads/scale/BigUpdate10k.yml
+++ b/src/workloads/scale/BigUpdate10k.yml
@@ -21,9 +21,9 @@ Actors:
   Phases:
   - Repeat: 1
     Database: &DB test
-    CollectionCount: &CollectionCount 1e5
+    CollectionCount: &CollectionCount 10000
     Threads: 10
-    DocumentCount: 1e5
+    DocumentCount: 1e4
     BatchSize: 1000
     Document:  # Documents are approximately 1 KiB in size
       t: {^RandomInt: {min: 0, max: 10}}

--- a/src/workloads/scale/BigUpdate10k.yml
+++ b/src/workloads/scale/BigUpdate10k.yml
@@ -125,7 +125,7 @@ Actors:
   Phases:
     OnlyActiveInPhases:
       Active: [0,1]
-      NopInPhasesUpTo: *MaxPhases
+      NopInPhasesUpTo: 1
       PhaseConfig:
         LogEvery: 10 seconds
         Blocking: None

--- a/src/workloads/scale/BigUpdate10k.yml
+++ b/src/workloads/scale/BigUpdate10k.yml
@@ -124,7 +124,7 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [0,1]
+      Active: [0, 1]
       NopInPhasesUpTo: 1
       PhaseConfig:
         LogEvery: 10 seconds

--- a/src/workloads/scale/BigUpdate10k.yml
+++ b/src/workloads/scale/BigUpdate10k.yml
@@ -129,9 +129,9 @@ Actors:
       PhaseConfig:
         LogEvery: 10 seconds
         Blocking: None
-AutoRun:
-  - When:
-      mongodb_setup:
-        $eq:
-          - atlas
-          - replica
+# AutoRun:
+#   - When:
+#       mongodb_setup:
+#         $eq:
+#           - atlas
+#           - replica

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -29,9 +29,9 @@ GlobalDefaults:
   CollectionCount: &CollectionCount 8
   LoadBatchSize: &LoadBatchSize 1000
 
-  InitialDocumentCount: &InitialNumDocs 20000000
-  SecondDocumentCount: &SecondNumDocs 12000000
-  FinalDocumentCount: &FinalDocumentCount 4000000
+  InitialDocumentCount: &InitialNumDocs 10000000
+  SecondDocumentCount: &SecondNumDocs 6000000
+  FinalDocumentCount: &FinalDocumentCount 2000000
 
 Clients:
   Default:

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -1,0 +1,121 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  Based on LongLivedTransactions Insert workload. Using to experiment with bulk load for PERF-2330
+
+GlobalDefaults:
+  dbname: &dbname perf2330
+  MaxPhases: &MaxPhases 20
+
+  # The Sample Document Shape.
+  Document: &Doc
+    ts: {^Now: {}}
+    caid: {^RandomInt: {min: 0, max: 1000}}
+    cuid: {^RandomInt: {min: 0, max: 100000}}
+    prod: {^RandomInt: {min: 0, max: 10000}}
+    price: {^RandomDouble: {min: 0.0, max: 1000.0}}
+    data: {^Join: {array: ["aaaaaaaaaa", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
+    c: &string {^FastRandomString: {length: 75}}  # Adjust this so the doc comes out as 200 B.
+
+  FirstIndex: &FirstIndex
+    - keys: {price: 1, ts: 1, cuid: 1}     # Ptc
+
+  MoreIndexes: &MoreIndexes
+    - keys: {price: 1, cuid: 1}            # Pc
+    - keys: {caid: 1, price: 1, cuid: 1}   # Cpc
+
+  # Loader Config.
+  LoadThreads: &LoadThreads 8
+  CollectionCount: &CollectionCount 8
+  LoadBatchSize: &LoadBatchSize 1000
+
+  InitialDocumentCount: &InitialNumDocs 5000000
+  SecondDocumentCount: &SecondNumDocs 3000000
+  FinalDocumentCount: &FinalDocumentCount 1000000
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+      maxPoolSize: 400
+
+Actors:
+- Name: InitialNoIndexes
+  Type: Loader
+  Threads: *LoadThreads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Threads: *LoadThreads
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Repeat: 1
+        Document: *Doc
+        DocumentCount: *InitialNumDocs
+        Indexes: *FirstIndex
+        BatchSize: *LoadBatchSize
+
+- Name: LoadWithOneIndex
+  Type: Loader
+  Threads: *LoadThreads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Threads: *LoadThreads
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Repeat: 1
+        Document: *Doc
+        DocumentCount: *SecondNumDocs
+        Indexes: *MoreIndexes
+        BatchSize: *LoadBatchSize
+
+- Name: LoadWithTwoMoreIndexes
+  Type: Loader
+  Threads: *LoadThreads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Threads: *LoadThreads
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Repeat: 1
+        Document: *Doc
+        DocumentCount: *FinalDocumentCount
+        BatchSize: *LoadBatchSize
+
+- Name: QuiescePhase
+  Type: QuiesceActor
+  Threads: 1
+  Database: *dbname
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0, 2, 4]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+
+# Guard Against timeout for no output.
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1, 3, 5]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        LogEvery: 10 seconds
+        Blocking: None
+
+AutoRun:
+  Requires:
+    mongodb_setup:
+      - replica
+      - shard-lite
+      - single-replica

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -114,8 +114,8 @@ Actors:
         Blocking: None
 
 AutoRun:
-  Requires:
-    mongodb_setup:
-      - replica
-      - shard-lite
-      - single-replica
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -18,11 +18,11 @@ GlobalDefaults:
     c: &string {^FastRandomString: {length: 75}}  # Adjust this so the doc comes out as 200 B.
 
   FirstIndex: &FirstIndex
-    - keys: {price: 1, ts: 1, cuid: 1}     # Ptc
+  - keys: {price: 1, ts: 1, cuid: 1}     # Ptc
 
   MoreIndexes: &MoreIndexes
-    - keys: {price: 1, cuid: 1}            # Pc
-    - keys: {caid: 1, price: 1, cuid: 1}   # Cpc
+  - keys: {price: 1, cuid: 1}            # Pc
+  - keys: {caid: 1, price: 1, cuid: 1}   # Cpc
 
   # Loader Config.
   LoadThreads: &LoadThreads 8
@@ -114,8 +114,8 @@ Actors:
         Blocking: None
 
 AutoRun:
-  - When:
-      mongodb_setup:
-        $eq:
-          - atlas
-          - replica
+- When:
+    mongodb_setup:
+      $eq:
+      - atlas
+      - replica

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -29,9 +29,9 @@ GlobalDefaults:
   CollectionCount: &CollectionCount 8
   LoadBatchSize: &LoadBatchSize 1000
 
-  InitialDocumentCount: &InitialNumDocs 5000000
-  SecondDocumentCount: &SecondNumDocs 3000000
-  FinalDocumentCount: &FinalDocumentCount 1000000
+  InitialDocumentCount: &InitialNumDocs 20000000
+  SecondDocumentCount: &SecondNumDocs 12000000
+  FinalDocumentCount: &FinalDocumentCount 4000000
 
 Clients:
   Default:

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -15,6 +15,7 @@ Description: |
 # These two values should match those are the top of MixPhases.yml
 dbname: &dbname mix
 DocumentCount: &NumDocs 100000
+CollectionCount: &NumColls 1
 
 Clients:
   Default:
@@ -108,10 +109,10 @@ Actors:
     Threads: 1
     DocumentCount: *NumDocs
     Database: *dbname
-    CollectionCount: 1
+    CollectionCount: *NumColls
     Document: &doc
       id: {^RandomInt: {min: 0, max: *NumDocs}}
-      a: {^RandomInt: {min: 0, max: 1000000}}
+      a: {^RandomInt: {min: 0, max: *NumDocs}}
       # Note that in the original workload the string c was perfectly compressable. We can put a
       # constant there if needed.
       c: &string {^RandomString: {length: 50}}  # Adjust this so the doc comes out as 100 B.

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -56,7 +56,7 @@ ActorTemplates:
     Phases:
       OnlyActiveInPhases:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-        NopInPhasesUpTo: 10
+        NopInPhasesUpTo: 2
         PhaseConfig:
           Duration: *PhaseDuration
           RecordFailure: true
@@ -80,7 +80,7 @@ ActorTemplates:
     Phases:
       OnlyActiveInPhases:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-        NopInPhasesUpTo: 10
+        NopInPhasesUpTo: 2
         PhaseConfig:
           Duration: *PhaseDuration
           RecordFailure: true
@@ -100,7 +100,7 @@ ActorTemplates:
     Phases:
       OnlyActiveInPhases:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-        NopInPhasesUpTo: 10
+        NopInPhasesUpTo: 2
         PhaseConfig:
           Duration: *PhaseDuration
           RecordFailure: true
@@ -120,7 +120,7 @@ ActorTemplates:
     Phases:
       OnlyActiveInPhases:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-        NopInPhasesUpTo: 10
+        NopInPhasesUpTo: 2
         PhaseConfig:
           Duration: *PhaseDuration
           RecordFailure: true
@@ -162,8 +162,6 @@ Actors:
       OperationName: AdminCommand
       OperationCommand:
         fsync: 1
-  - *nop
-  - *quiesce
   - *nop
 
 # Update Actors

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -207,7 +207,7 @@ Actors:
   Phases:
     OnlyActiveInPhases:
       Active: [0,2]
-      NopInPhasesUpTo: *MaxPhases
+      NopInPhasesUpTo: 2
       PhaseConfig:
         LogEvery: 10 seconds
         Blocking: None

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -206,15 +206,15 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [0,2]
+      Active: [0, 2]
       NopInPhasesUpTo: 2
       PhaseConfig:
         LogEvery: 10 seconds
         Blocking: None
 
 AutoRun:
-  - When:
-      mongodb_setup:
-        $eq:
-          - atlas
-          - replica
+- When:
+    mongodb_setup:
+      $eq:
+      - atlas
+      - replica

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -1,0 +1,210 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  This workload is a more stressful version of MixedWorkloadsGenny.yml, which itself is a port of
+  the mixed_workloads in the workloads,
+  repo. https://github.com/10gen/workloads/blob/master/workloads/mix.js. It runs 4 sets of
+  operations, each with dedicated actors/threads. The 4 operations are insert, findOne, updateOne,
+  and deleteOne. Since each type of operation runs in a dedicated thread it enables interesting
+  behavior, such as reads getting faster because of a write regression, or reads being starved by
+  writes. The origin of the test was as a reproduction for BF-2385 in which reads were starved out
+  by writes.
+
+  This more stressful version of the test only runs one test phase, using 1024 threads per operation
+  for 45 minutes.
+
+# This workload does not support sharding yet.
+
+dbname: &dbname mix
+DocumentCount: &NumDocs 1024
+CollectionCount: &NumColls 512
+PhaseDuration: &PhaseDuration 45 minutes
+StringLength: &StringLength 950
+Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
+Document: &doc
+  id: {^RandomInt: {min: 0, max: *NumDocs}}
+  a: {^RandomInt: {min: 0, max: *NumDocs}}
+  # Note that in the original workload the string c was perfectly compressable. We can put a
+  # constant there if needed.
+  c: &string {^FastRandomString: {length: *StringLength}}  # Adjust StringLength for 1000B docs
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+  Insert:
+    QueryOptions:
+      maxPoolSize: 2500
+  Query:
+    QueryOptions:
+      maxPoolSize: 2500
+  Remove:
+    QueryOptions:
+      maxPoolSize: 2500
+  Update:
+    QueryOptions:
+      maxPoolSize: 2500
+
+ActorTemplates:
+- TemplateName: UpdateTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Update"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Update
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 10
+        PhaseConfig:
+          Duration: *PhaseDuration
+          RecordFailure: true
+          CollectionCount: *NumColls
+          NumDocs: *NumDocs
+          Operations:
+          - OperationName: updateOne
+            OperationCommand:
+              Filter: *filter
+              Update:
+                $inc: {a: 1}
+                $set: {c: *string}
+
+- TemplateName: RemoveTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Remove"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Remove
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 10
+        PhaseConfig:
+          Duration: *PhaseDuration
+          RecordFailure: true
+          CollectionCount: *NumColls
+          Operations:
+          - OperationName: deleteOne
+            OperationCommand:
+              Filter: *filter
+
+- TemplateName: InsertTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Insert"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Insert
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 10
+        PhaseConfig:
+          Duration: *PhaseDuration
+          RecordFailure: true
+          CollectionCount: *NumColls
+          Operations:
+          - OperationName: insertOne
+            OperationCommand:
+              Document: *doc
+
+- TemplateName: FindTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Find"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Query
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 10
+        PhaseConfig:
+          Duration: *PhaseDuration
+          RecordFailure: true
+          CollectionCount: *NumColls
+          Operations:
+          - OperationName: findOne
+            OperationCommand:
+              Filter: *filter
+
+Actors:
+- Name: Setup
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    BatchSize: 100
+    Threads: 8
+    DocumentCount: *NumDocs
+    Database: *dbname
+    CollectionCount: *NumColls
+    Document: *doc
+    Indexes:
+    - keys: {id: 1}
+    - keys: {a: 1}
+  - Phase: 1..2
+    Nop: true
+
+- Name: QuiesceBetweenLevels
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - &nop {Nop: true}
+  - &quiesce
+    Repeat: 1
+    Database: admin
+    Operations:
+    # Fsync to force a checkpoint and quiesce the system.
+    - OperationMetricsName: FsyncCommand
+      OperationName: AdminCommand
+      OperationCommand:
+        fsync: 1
+  - *nop
+  - *quiesce
+  - *nop
+
+# Update Actors
+- ActorFromTemplate:
+    TemplateName: UpdateTemplate
+    TemplateParameters:
+      Name: Update_1024
+      Threads: 1024
+      OnlyActiveInPhase: 2
+
+#
+## Remove Actors
+#
+- ActorFromTemplate:
+    TemplateName: RemoveTemplate
+    TemplateParameters:
+      Name: Remove_1024
+      Threads: 1024
+      OnlyActiveInPhase: 2
+
+## Insert Actors
+#
+- ActorFromTemplate:
+    TemplateName: InsertTemplate
+    TemplateParameters:
+      Name: Insert_1024
+      Threads: 1024
+      OnlyActiveInPhase: 2
+
+## Find Actors
+
+- ActorFromTemplate:
+    TemplateName: FindTemplate
+    TemplateParameters:
+      Name: Find_1024
+      Threads: 1024
+      OnlyActiveInPhase: 2
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - replica

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -200,6 +200,18 @@ Actors:
       Threads: 1024
       OnlyActiveInPhase: 2
 
+# Guard Against timeout for no output.
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0,2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        LogEvery: 10 seconds
+        Blocking: None
+
 AutoRun:
   - When:
       mongodb_setup:


### PR DESCRIPTION
Patch build: https://evergreen.mongodb.com/build/sys_perf_linux_3_node_replSet_patch_01fb3fac6dbf5a6566e0ce6cf5218d4274df19f1_611d2d8b1e2d17098199f36a_21_08_18_15_56_52

The patch build was successful for MixedWorkloadsGennyStress and LoadTest, so I've included those two here. I need to figure out how to get BigUpdate10k to not timeout during validate. I'll split that problem off of this work. 

Note, this PR effectively re-enables PERF-2330 & PERF-2255 miscellaneous changes (#500) (#523) change that was previously reverted. It should also have a working auto run for it. 