### PR TITLE
PERF-2475: Add tests for $graphLookup to explore trade off of paralle…

### DIFF
--- a/src/workloads/execution/UnshardedGraphLookup.yml
+++ b/src/workloads/execution/UnshardedGraphLookup.yml
@@ -1,0 +1,123 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test exercises the behavior of $graphLookup against an unsharded foreign collection.
+  The workload consists of the following phases:
+    1. Creating an empty sharded collection distributed across all shards in the cluster.
+    2. Populating collections with data.
+    3. Fsync.
+    4. Running $graphLookup's.
+
+Actors:
+- Name: CreateShardedCollections
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: admin
+    Operations:
+    # Shard Collection0 using hashed sharding to ensure even distribution of chunks across shards.
+    - OperationMetricsName: EnableSharding
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: &Database test
+    - OperationMetricsName: ShardLocalCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: test.Collection0
+        key: {c: hashed}
+        numInitialChunks: &NumChunks 6
+    # Disable the balancer so that it can't skew results while the $lookups are running.
+    - OperationMetricsName: DisableBalancer
+      OperationName: AdminCommand
+      OperationCommand:
+        balancerStop: 1
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+
+- Name: LoadGraphLookupData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    BatchSize: 1000
+    Threads: 1
+    DocumentCount: &NumDocs 3000
+    Database: *Database
+    CollectionCount: 3 # Loader will populate 'Collection0', 'Collection1', and 'Collection2'.
+    Document:
+      a: {^RandomInt: {min: 1, max: 3000}}
+      b: {^RandomInt: {min: 1, max: 3000}}
+      c: {^RandomInt: {min: 1, max: 3000}}
+      s: {^RandomString: {length: 3000}}
+  - *Nop
+  - *Nop
+
+- Name: Quiesce
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        fsync: 1
+  - *Nop
+
+- Name: RunGraphLookups
+  Type: RunCommand
+  Database: *Database
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 10
+    Database: *Database
+    Operations:
+    - OperationMetricsName: GraphLookupShardedToUnsharded
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$a",
+              connectFromField: "a",
+              connectToField: "b",
+              as: "matches",
+              maxDepth: 1
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupUnshardedToUnsharded
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection2
+        pipeline:
+          [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$a",
+              connectFromField: "a",
+              connectToField: "b",
+              as: "matches",
+              maxDepth: 1
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - shard-lite
+          - shard-lite-all-feature-flags
+        


### PR DESCRIPTION
…lization and shared cache

Timing results here: https://spruce.mongodb.com/version/6123a66ba4cf4718ca4703a6/tasks

Feature flag off:
| Benchmark | Avg latency (sec)  |
|---|---|
| RunGraphLookups.GraphLookupUnshardedToUnsharded | 6.5536703637 |
| RunGraphLookups.GraphLookupShardedToUnsharded | 6.4973098341 |

Feature flag on:
| Benchmark | Avg latency (sec)  |
|---|---|
| RunGraphLookups.GraphLookupUnshardedToUnsharded | 6.8557203083 |
| RunGraphLookups.GraphLookupShardedToUnsharded | 4.4047303946 |

When the feature flag is turned on, we see a slight slowdown in the unsharded case (<5%) possibly because we end up targetting shards instead of reading locally. Also, we see a speed up in the sharded local case (~32%) even though the cache is not shared between the nodes, since the $graphLookup execution can be parallelized.