### PR TITLE
PERF-2523: Add tests for $graphLookup into unsharded collection in sh…

### DIFF
--- a/src/workloads/execution/UnshardedGraphLookup.yml
+++ b/src/workloads/execution/UnshardedGraphLookup.yml
@@ -27,7 +27,7 @@ Actors:
         shardCollection: test.Collection0
         key: {c: hashed}
         numInitialChunks: &NumChunks 6
-    # Disable the balancer so that it can't skew results while the $lookups are running.
+    # Disable the balancer so that it can't skew results while the $graphLookups are running.
     - OperationMetricsName: DisableBalancer
       OperationName: AdminCommand
       OperationCommand:
@@ -42,7 +42,7 @@ Actors:
   Phases:
   - *Nop
   - Repeat: 1
-    BatchSize: 1000
+    BatchSize: 3000
     Threads: 1
     DocumentCount: &NumDocs 3000
     Database: *Database
@@ -50,7 +50,9 @@ Actors:
     Document:
       a: {^RandomInt: {min: 1, max: 3000}}
       b: {^RandomInt: {min: 1, max: 3000}}
-      c: {^RandomInt: {min: 1, max: 3000}}
+      c: {^RandomInt: {min: 1, max: 300}}
+      d: {^RandomInt: {min: 1, max: 600}}
+      e: {^RandomInt: {min: 1, max: 600}}
       s: {^RandomString: {length: 3000}}
   - *Nop
   - *Nop
@@ -79,7 +81,7 @@ Actors:
   - Repeat: 10
     Database: *Database
     Operations:
-    - OperationMetricsName: GraphLookupShardedToUnsharded
+    - OperationMetricsName: GraphLookupShardedToUnshardedOneToFew
       OperationName: RunCommand
       OperationCommand:
         aggregate: Collection0
@@ -96,7 +98,7 @@ Actors:
             {$project: {s: 0, "matches.s": 0}}
           ]
         cursor: {batchSize: *NumDocs}
-    - OperationMetricsName: GraphLookupUnshardedToUnsharded
+    - OperationMetricsName: GraphLookupUnshardedToUnshardedOneToFew
       OperationName: RunCommand
       OperationCommand:
         aggregate: Collection2
@@ -107,6 +109,76 @@ Actors:
               startWith: "$a",
               connectFromField: "a",
               connectToField: "b",
+              as: "matches",
+              maxDepth: 1
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupShardedToUnshardedOneToMany
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$d",
+              connectFromField: "d",
+              connectToField: "e",
+              as: "matches",
+              maxDepth: 1
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupUnshardedToUnshardedOneToMany
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection2
+        pipeline:
+          [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$d",
+              connectFromField: "d",
+              connectToField: "e",
+              as: "matches",
+              maxDepth: 1
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupShardedToUnshardedMatchAllShards
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$match: {a: {$lte: 30}}},
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$d",
+              connectFromField: "d",
+              connectToField: "e",
+              as: "matches",
+              maxDepth: 1
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupShardedToUnshardedMatchSomeShards
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$match: {c: {$in: [1, 2, 3]}}},
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$d",
+              connectFromField: "d",
+              connectToField: "e",
               as: "matches",
               maxDepth: 1
             }},


### PR DESCRIPTION
…arded cluster

Results can be found [here](https://spruce.mongodb.com/version/61313b3656234307b166d3b0/tasks).

Feature flag off
| Benchmark | Avg latency (sec)  |
|---|---|
| RunGraphLookups.GraphLookupUnshardedToUnshardedOneToMany | 1.6552927594 |
| RunGraphLookups.GraphLookupShardedToUnshardedOneToMany  | 1.6444522419 |
| RunGraphLookups.GraphLookupShardedToUnshardedMatchSomeShards | .1211813272 |
| RunGraphLookups.GraphLookupShardedToUnshardedMatchAllShards | .0906489153 |

Feature flag on
| Benchmark | Avg latency (sec)  |
|---|---|
| RunGraphLookups.GraphLookupUnshardedToUnshardedOneToMany | 1.8329503544 |
| RunGraphLookups.GraphLookupShardedToUnshardedOneToMany | 1.3836131205 |
| RunGraphLookups.GraphLookupShardedToUnshardedMatchSomeShards | .1091266271 |
| RunGraphLookups.GraphLookupShardedToUnshardedMatchAllShards | .0727160483 |

In every case except UnshardedToUnsharded, turning the feature flag on speeds up the queries because of parallelization. Good news!

Another thing to note is that the MatchAllShards case is faster than MatchSomeShards with the feature flag on because we can parallelize across more shards even though we need to get data from every shard. I'm not sure why we see the same thing when the feature flag is off, since I would expect the opposite (MatchSomeShards could be faster because it can use the existing index). I have verified that the execution is as expected locally, so I'm unsure here.