### PR TITLE
Use BOOST_THROW_EXCEPTION more pervasively

### DIFF
--- a/src/canaries/src/main.cpp
+++ b/src/canaries/src/main.cpp
@@ -173,7 +173,7 @@ int main(int argc, char** argv) {
     else {
         std::ostringstream stm;
         stm << "Unknown task name: " << opts._task;
-        throw InvalidConfigurationException(stm.str());
+        BOOST_THROW_EXCEPTION(InvalidConfigurationException(stm.str()));
     }
 
     std::cout << "Total duration for " << opts._task << ":" << std::endl;

--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -543,7 +543,8 @@ std::vector<std::string> distributeCollectionNames(size_t collectionCount,
     std::vector<std::string> collectionNames{};
     if ((threadCount > collectionCount && threadCount % collectionCount != 0) ||
         collectionCount % threadCount != 0) {
-        BOOST_THROW_EXCEPTION(std::invalid_argument("Thread count must be mutliple of database collection count"));
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("Thread count must be mutliple of database collection count"));
     }
     int collectionsPerActor = threadCount > collectionCount ? 1 : collectionCount / threadCount;
     int collectionIndexStart = (actorId % collectionCount) * collectionsPerActor;

--- a/src/cast_core/src/CollectionScanner.cpp
+++ b/src/cast_core/src/CollectionScanner.cpp
@@ -543,7 +543,7 @@ std::vector<std::string> distributeCollectionNames(size_t collectionCount,
     std::vector<std::string> collectionNames{};
     if ((threadCount > collectionCount && threadCount % collectionCount != 0) ||
         collectionCount % threadCount != 0) {
-        throw std::invalid_argument("Thread count must be mutliple of database collection count");
+        BOOST_THROW_EXCEPTION(std::invalid_argument("Thread count must be mutliple of database collection count"));
     }
     int collectionsPerActor = threadCount > collectionCount ? 1 : collectionCount / threadCount;
     int collectionIndexStart = (actorId % collectionCount) * collectionsPerActor;

--- a/src/cast_core/src/LoggingActor.cpp
+++ b/src/cast_core/src/LoggingActor.cpp
@@ -50,8 +50,9 @@ struct LoggingActor::PhaseConfig {
         const auto now = metrics::clock::now();
         const auto duration = now - last;
         if (duration >= logEvery.value) {
-            BOOST_LOG_TRIVIAL(info) << "Phase still progressing (" <<
-                std::chrono::duration_cast<std::chrono::seconds>(now - started).count() << "s)";
+            BOOST_LOG_TRIVIAL(info)
+                << "Phase still progressing ("
+                << std::chrono::duration_cast<std::chrono::seconds>(now - started).count() << "s)";
             last = now;
         }
     }

--- a/src/cast_core/src/MoveRandomChunkToRandomShard.cpp
+++ b/src/cast_core/src/MoveRandomChunkToRandomShard.cpp
@@ -70,7 +70,8 @@ void MoveRandomChunkToRandomShard::run() {
                     << bsoncxx::builder::stream::finalize;
                 auto numChunks = configDatabase["chunks"].count_documents(chunksFilter.view());
                 // The collection must have been sharded and must have at least one chunk;
-                boost::random::uniform_int_distribution<int64_t> chunkUniformDistribution(0, (int)numChunks - 1);
+                boost::random::uniform_int_distribution<int64_t> chunkUniformDistribution(
+                    0, (int)numChunks - 1);
                 mongocxx::options::find chunkFindOptions;
                 auto chunkSort = bsoncxx::builder::stream::document()
                     << "lastmod" << 1 << bsoncxx::builder::stream::finalize;
@@ -91,7 +92,8 @@ void MoveRandomChunkToRandomShard::run() {
                 bsoncxx::document::value shardFilter = bsoncxx::builder::stream::document()
                     << "_id" << notEqualDoc.view() << bsoncxx::builder::stream::finalize;
                 auto numShards = configDatabase["shards"].count_documents(shardFilter.view());
-                boost::random::uniform_int_distribution<int64_t> shardUniformDistribution(0, (int)numShards - 1);
+                boost::random::uniform_int_distribution<int64_t> shardUniformDistribution(
+                    0, (int)numShards - 1);
                 mongocxx::options::find shardFindOptions;
                 auto shardSort = bsoncxx::builder::stream::document()
                     << "_id" << 1 << bsoncxx::builder::stream::finalize;

--- a/src/cast_core/src/RunCommand.cpp
+++ b/src/cast_core/src/RunCommand.cpp
@@ -70,7 +70,7 @@ bsoncxx::document::value commandRequiringStepdownCompleted = []() {
 void runThenAwaitStepdown(mongocxx::database& database, bsoncxx::document::view& command) {
     try {
         database.run_command(command);
-        throw std::logic_error("Stepdown should throw operation exception");
+        BOOST_THROW_EXCEPTION(std::logic_error("Stepdown should throw operation exception"));
     } catch (mongocxx::operation_exception& exception) {
         if (!isNetworkError(exception)) {
             throw;
@@ -218,8 +218,8 @@ struct actor::RunCommand::PhaseConfig {
         auto actorType = actorContext["Type"].to<std::string>();
         auto database = context["Database"].maybe<std::string>().value_or("admin");
         if (actorType == "AdminCommand" && database != "admin") {
-            throw InvalidConfigurationException(
-                "AdminCommands can only be run on the 'admin' database.");
+            BOOST_THROW_EXCEPTION(InvalidConfigurationException(
+                "AdminCommands can only be run on the 'admin' database."));
         }
 
         auto createOperation = [&](const Node& node) {

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -267,8 +267,9 @@ boost::log::trivial::severity_level parseVerbosity(const std::string& level) {
         return boost::log::trivial::fatal;
     }
 
-    BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid verbosity level '" + level +
-                                "'. Need one of trace/debug/info/warning/error/fatal"));
+    BOOST_THROW_EXCEPTION(
+        std::invalid_argument("Invalid verbosity level '" + level +
+                              "'. Need one of trace/debug/info/warning/error/fatal"));
 }
 
 }  // namespace

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -129,7 +129,7 @@ DefaultDriver::OutcomeCode doRunLogic(const DefaultDriver::ProgramOptions& optio
     } else if (options.workloadSourceType == DefaultDriver::ProgramOptions::YamlSource::kString) {
         yaml = YAML::Load(options.workloadSource);
     } else {
-        throw std::invalid_argument("Unrecognized workload source type.");
+        BOOST_THROW_EXCEPTION(std::invalid_argument("Unrecognized workload source type."));
     }
 
     auto orchestrator = Orchestrator{};
@@ -267,8 +267,8 @@ boost::log::trivial::severity_level parseVerbosity(const std::string& level) {
         return boost::log::trivial::fatal;
     }
 
-    throw std::invalid_argument("Invalid verbosity level '" + level +
-                                "'. Need one of trace/debug/info/warning/error/fatal");
+    BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid verbosity level '" + level +
+                                "'. Need one of trace/debug/info/warning/error/fatal"));
 }
 
 }  // namespace

--- a/src/driver/test/Driver_test.cpp
+++ b/src/driver/test/Driver_test.cpp
@@ -108,7 +108,7 @@ struct Fails : public genny::Actor {
                     auto x = SomeException{};
                     BOOST_THROW_EXCEPTION(x);
                 } else if (config->mode == "StdException") {
-                    throw std::exception{};
+                    BOOST_THROW_EXCEPTION(std::exception{});
                 } else {
                     BOOST_LOG_TRIVIAL(error) << "Bad Mode " << config->mode;
                     std::terminate();

--- a/src/gennylib/include/gennylib/conventions.hpp
+++ b/src/gennylib/include/gennylib/conventions.hpp
@@ -203,13 +203,13 @@ struct PhaseRangeSpec {
             std::stringstream msg;
             msg << "Invalid start value for genny::PhaseRangeSpec: '" << s.value << "'."
                 << " The value must be of type 'u_int32_t";
-            throw genny::InvalidConfigurationException(msg.str());
+            BOOST_THROW_EXCEPTION(genny::InvalidConfigurationException(msg.str()));
         }
         if (!(e.value >= 0 && e.value <= UINT_MAX)) {
             std::stringstream msg;
             msg << "Invalid end value for genny::PhaseRangeSpec: '" << e.value << "'."
                 << " The value must be of type 'u_int32_t";
-            throw genny::InvalidConfigurationException(msg.str());
+            BOOST_THROW_EXCEPTION(genny::InvalidConfigurationException(msg.str()));
         }
     }
     PhaseRangeSpec(genny::IntegerSpec s) : PhaseRangeSpec(s, s) {}

--- a/src/gennylib/src/Cast.cpp
+++ b/src/gennylib/src/Cast.cpp
@@ -16,6 +16,8 @@
 
 #include <sstream>
 
+#include <boost/throw_exception.hpp>
+
 namespace genny {
 
 Cast::Cast(Cast::List init) {
@@ -39,7 +41,7 @@ void Cast::add(const std::string_view& castName, std::shared_ptr<ActorProducer> 
         stream << "Failed to add '" << entry->name() << "' as '" << castName
                << "', a producer named '" << previousActorProducer->name()
                << "' was already added instead.";
-        throw std::domain_error(stream.str());
+        BOOST_THROW_EXCEPTION(std::domain_error(stream.str()));
     }
 }
 

--- a/src/gennylib/src/Node.cpp
+++ b/src/gennylib/src/Node.cpp
@@ -40,7 +40,7 @@ Node::Type determineType(const YAML::Node node) {
         case YAML::NodeType::Map:
             return Node::Type::Map;
     }
-    throw std::logic_error("impossible");
+    BOOST_THROW_EXCEPTION(std::logic_error("impossible"));
 }
 
 // Like YAML::Load but throw more useful exception

--- a/src/gennylib/src/PoolFactory.cpp
+++ b/src/gennylib/src/PoolFactory.cpp
@@ -135,7 +135,8 @@ struct PoolFactory::Config {
             }
         }
 
-        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Did not recognize OptionType in setter"));
+        BOOST_THROW_EXCEPTION(
+            InvalidConfigurationException("Did not recognize OptionType in setter"));
     }
 
     std::optional<std::string_view> get(OptionType type, const std::string& key) {
@@ -159,7 +160,8 @@ struct PoolFactory::Config {
             }
         }
 
-        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Did not recognize OptionType in getter"));
+        BOOST_THROW_EXCEPTION(
+            InvalidConfigurationException("Did not recognize OptionType in getter"));
     }
 
     bool getFlag(OptionType type, const std::string& key, bool defaultValue = false) {

--- a/src/gennylib/src/PoolFactory.cpp
+++ b/src/gennylib/src/PoolFactory.cpp
@@ -128,14 +128,14 @@ struct PoolFactory::Config {
                 if (it == accessOptions.end()) {
                     std::ostringstream ss;
                     ss << "Attempted to set unknown access option '" << key << "'";
-                    throw InvalidConfigurationException(ss.str());
+                    BOOST_THROW_EXCEPTION(InvalidConfigurationException(ss.str()));
                 }
                 it->second = value;
                 return;
             }
         }
 
-        throw InvalidConfigurationException("Did not recognize OptionType in setter");
+        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Did not recognize OptionType in setter"));
     }
 
     std::optional<std::string_view> get(OptionType type, const std::string& key) {
@@ -153,13 +153,13 @@ struct PoolFactory::Config {
                 if (it == accessOptions.end()) {
                     std::ostringstream ss;
                     ss << "Attempted to get unknown access option '" << key << "'";
-                    throw InvalidConfigurationException(ss.str());
+                    BOOST_THROW_EXCEPTION(InvalidConfigurationException(ss.str()));
                 }
                 return std::make_optional<std::string_view>(it->second);
             }
         }
 
-        throw InvalidConfigurationException("Did not recognize OptionType in getter");
+        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Did not recognize OptionType in getter"));
     }
 
     bool getFlag(OptionType type, const std::string& key, bool defaultValue = false) {

--- a/src/gennylib/src/PoolManager.cpp
+++ b/src/gennylib/src/PoolManager.cpp
@@ -76,7 +76,8 @@ mongocxx::pool::entry genny::v1::PoolManager::client(const std::string& name,
     auto entry = pool->try_acquire();
     if (!entry) {
         // TODO: better error handling
-        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Failed to acquire an entry from the client pool."));
+        BOOST_THROW_EXCEPTION(
+            InvalidConfigurationException("Failed to acquire an entry from the client pool."));
     }
     return std::move(*entry);
 }

--- a/src/gennylib/src/PoolManager.cpp
+++ b/src/gennylib/src/PoolManager.cpp
@@ -76,7 +76,7 @@ mongocxx::pool::entry genny::v1::PoolManager::client(const std::string& name,
     auto entry = pool->try_acquire();
     if (!entry) {
         // TODO: better error handling
-        throw InvalidConfigurationException("Failed to acquire an entry from the client pool.");
+        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Failed to acquire an entry from the client pool."));
     }
     return std::move(*entry);
 }

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -62,8 +62,9 @@ WorkloadContext::WorkloadContext(const Node& node,
                                 << " is deprecated in favor of ftdc.";
     }
 
-    auto metricsPath =
-        ((*this)["Metrics"]["Path"]).maybe<std::string>().value_or("build/WorkloadOutput/CedarMetrics");
+    auto metricsPath = ((*this)["Metrics"]["Path"])
+                           .maybe<std::string>()
+                           .value_or("build/WorkloadOutput/CedarMetrics");
 
     _registry = genny::metrics::Registry(std::move(format), std::move(metricsPath));
 
@@ -139,8 +140,7 @@ DefaultRandom& WorkloadContext::getRNGForThread(ActorId id) {
             // This should be impossible.
             // But invariants don't hurt we only call this during setup
             BOOST_THROW_EXCEPTION(
-                std::logic_error("Already have DefaultRandom for Actor " + std::to_string(id))
-            );
+                std::logic_error("Already have DefaultRandom for Actor " + std::to_string(id)));
         }
     }
     return _rngRegistry[id];

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -46,7 +46,7 @@ WorkloadContext::WorkloadContext(const Node& node,
         validSchemaVersions.count(schemaVersion) != 1) {
         std::ostringstream errMsg;
         errMsg << "Invalid Schema Version: " << schemaVersion;
-        throw InvalidConfigurationException(errMsg.str());
+        BOOST_THROW_EXCEPTION(InvalidConfigurationException(errMsg.str()));
     }
 
     // Make sure we have a valid mongocxx instance happening here
@@ -98,7 +98,7 @@ ActorVector WorkloadContext::_constructActors(const Cast& cast,
         std::ostringstream stream;
         stream << "Unable to construct actors: No producer for '" << name << "'." << std::endl;
         cast.streamProducersTo(stream);
-        throw InvalidConfigurationException(stream.str());
+        BOOST_THROW_EXCEPTION(InvalidConfigurationException(stream.str()));
     }
 
     for (auto&& actor : producer->produce(*actorContext)) {
@@ -138,7 +138,9 @@ DefaultRandom& WorkloadContext::getRNGForThread(ActorId id) {
         if (!success) {
             // This should be impossible.
             // But invariants don't hurt we only call this during setup
-            throw std::logic_error("Already have DefaultRandom for Actor " + std::to_string(id));
+            BOOST_THROW_EXCEPTION(
+                std::logic_error("Already have DefaultRandom for Actor " + std::to_string(id))
+            );
         }
     }
     return _rngRegistry[id];
@@ -159,7 +161,7 @@ std::unordered_map<PhaseNumber, std::unique_ptr<PhaseContext>> ActorContext::con
             std::ostringstream ss;
             ss << "Encountered a null/empty phase. "
                   "Every phase should have at least be an empty map.";
-            throw InvalidConfigurationException(ss.str());
+            BOOST_THROW_EXCEPTION(InvalidConfigurationException(ss.str()));
         }
         PhaseRangeSpec configuredRange = phase["Phase"].maybe<PhaseRangeSpec>().value_or(
             PhaseRangeSpec{IntegerSpec{lastPhaseNumber}});
@@ -170,7 +172,7 @@ std::unordered_map<PhaseNumber, std::unique_ptr<PhaseContext>> ActorContext::con
             if (!success) {
                 std::stringstream msg;
                 msg << "Duplicate phase " << rangeIndex;
-                throw InvalidConfigurationException(msg.str());
+                BOOST_THROW_EXCEPTION(InvalidConfigurationException(msg.str()));
             }
             lastPhaseNumber++;
         }

--- a/src/gennylib/test/context_test.cpp
+++ b/src/gennylib/test/context_test.cpp
@@ -554,7 +554,7 @@ struct TakesInt {
     int value;
     TakesInt(int x) : value{x} {
         if (x > 7) {
-            throw std::logic_error("Expected");
+            BOOST_THROW_EXCEPTION(std::logic_error("Expected"));
         }
     }
 };

--- a/src/testlib/src/ActorHelper.cpp
+++ b/src/testlib/src/ActorHelper.cpp
@@ -33,7 +33,7 @@ ActorHelper::ActorHelper(const Node& config,
                          const std::string& uri,
                          v1::PoolManager::OnCommandStartCallback apmCallback) {
     if (tokenCount <= 0) {
-        throw InvalidConfigurationException("Must add a positive number of tokens");
+        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Must add a positive number of tokens"));
     }
 
     _orchestrator = std::make_unique<genny::Orchestrator>();
@@ -53,7 +53,7 @@ ActorHelper::ActorHelper(const Node& config,
                          const std::string& uri,
                          v1::PoolManager::OnCommandStartCallback apmCallback) {
     if (tokenCount <= 0) {
-        throw InvalidConfigurationException("Must add a positive number of tokens");
+        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Must add a positive number of tokens"));
     }
 
     _orchestrator = std::make_unique<genny::Orchestrator>();

--- a/src/testlib/src/ActorHelper.cpp
+++ b/src/testlib/src/ActorHelper.cpp
@@ -33,7 +33,8 @@ ActorHelper::ActorHelper(const Node& config,
                          const std::string& uri,
                          v1::PoolManager::OnCommandStartCallback apmCallback) {
     if (tokenCount <= 0) {
-        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Must add a positive number of tokens"));
+        BOOST_THROW_EXCEPTION(
+            InvalidConfigurationException("Must add a positive number of tokens"));
     }
 
     _orchestrator = std::make_unique<genny::Orchestrator>();
@@ -53,7 +54,8 @@ ActorHelper::ActorHelper(const Node& config,
                          const std::string& uri,
                          v1::PoolManager::OnCommandStartCallback apmCallback) {
     if (tokenCount <= 0) {
-        BOOST_THROW_EXCEPTION(InvalidConfigurationException("Must add a positive number of tokens"));
+        BOOST_THROW_EXCEPTION(
+            InvalidConfigurationException("Must add a positive number of tokens"));
     }
 
     _orchestrator = std::make_unique<genny::Orchestrator>();

--- a/src/testlib/src/findRepoRoot.cpp
+++ b/src/testlib/src/findRepoRoot.cpp
@@ -42,7 +42,7 @@ std::string findRepoRoot() {
             std::stringstream msg;
             msg << "Cannot find '" << ROOT_FILE << "' in path from  GENNY_REPO_ROOT env var '"
                 << rootEnvVar << "'";
-            throw std::invalid_argument(msg.str());
+            BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
         }
         return rootEnvVar;
     }
@@ -69,7 +69,7 @@ std::string findRepoRoot() {
         if (curr == fileSystemRoot) {
             std::stringstream msg;
             msg << "Cannot find '" << ROOT_FILE << "' in '" << start << "'";
-            throw std::invalid_argument(msg.str());
+            BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
         }
     }
 

--- a/src/testlib/test/ActorHelper_test.cpp
+++ b/src/testlib/test/ActorHelper_test.cpp
@@ -60,7 +60,7 @@ Actors:
     class CtorThrowingActor : public DummyActor {
     public:
         CtorThrowingActor(genny::ActorContext& ac) : DummyActor(ac) {
-            throw genny::InvalidConfigurationException("CTOR Barf");
+            BOOST_THROW_EXCEPTION(genny::InvalidConfigurationException("CTOR Barf"));
         };
     };
 
@@ -95,7 +95,7 @@ Actors:
         genny::ActorHelper ah(config.root(), 1, {{"DummyActor", dummyProducer}});
         auto runFunc = [](const genny::WorkloadContext& wc) {};
         auto verifyFunc = [](const genny::WorkloadContext& wc) {
-            throw genny::InvalidConfigurationException("RUN Barf");
+            BOOST_THROW_EXCEPTION(genny::InvalidConfigurationException("RUN Barf"));
         };
         REQUIRE_THROWS_WITH(ah.runAndVerify(runFunc, verifyFunc), Matches("RUN Barf"));
     }

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -652,18 +652,17 @@ public:
         : _rng{generatorArgs.rng}, _format{node["format"].maybe<std::string>().value_or("")} {
         std::stringstream msg;
         if (!node["format"]) {
-            msg << "Malformed FormatString: format missing '" << _format << "'" << node
-                << "\n";
+            msg << "Malformed FormatString: format missing '" << _format << "'" << node << "\n";
         } else if (_format.empty()) {
-            msg << "Malformed FormatString: format cannot be empty '" << _format << "'"
-                << node << "\n";
+            msg << "Malformed FormatString: format cannot be empty '" << _format << "'" << node
+                << "\n";
         }
 
         if (!node["withArgs"]) {
             msg << "Malformed FormatString: withArgs missing." << node;
         } else if (!node["withArgs"].isSequence()) {
-            msg << "Malformed FormatString:  withArgs " << node.type()
-                << " not a sequence " << node;
+            msg << "Malformed FormatString:  withArgs " << node.type() << " not a sequence "
+                << node;
         }
 
         if (!msg.str().empty()) {

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -26,22 +26,22 @@ public:
         if (!_givenTemplate) {
             std::stringstream msg;
             msg << "Need GivenTemplate in '" << toString(node) << "'";
-            throw std::invalid_argument(msg.str());
+            BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
         }
         if (_thenReturns && _expectedExceptionMessage) {
             std::stringstream msg;
             msg << "Can't have ThenReturns and ThenThrows in '" << toString(node) << "'";
-            throw std::invalid_argument(msg.str());
+            BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
         }
         if (_thenExecuteAndIgnore && _expectedExceptionMessage) {
             std::stringstream msg;
             msg << "Can't have ThenExecuteAndIgnore and ThenThrows in '" << toString(node) << "'";
-            throw std::invalid_argument(msg.str());
+            BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
         }
         if (_thenReturns && _thenExecuteAndIgnore) {
             std::stringstream msg;
             msg << "Can't have ThenReturns and ThenExecuteAndIgnore in '" << toString(node) << "'";
-            throw std::invalid_argument(msg.str());
+            BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
         }
 
 
@@ -49,7 +49,7 @@ public:
             if (!_thenReturns.IsSequence()) {
                 std::stringstream msg;
                 msg << "ThenReturns must be list in '" << toString(node) << "'";
-                throw std::invalid_argument(msg.str());
+                BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
             }
             _runMode = RunMode::kExpectReturn;
             return;
@@ -66,7 +66,7 @@ public:
         std::stringstream msg;
         msg << "Need one of ThenReturns, ThenExecuteAndIgnore or ThenThrows'" << toString(node)
             << "'";
-        throw std::invalid_argument(msg.str());
+        BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
     }
 
     static NodeSource toNode(YAML::Node node) {


### PR DESCRIPTION
This ensures we always have location and diagnostic information in exception messages.

Idk how feasible it is to lint this, but that's something worth considering in the future.