### PR TITLE
PERF-2571: Add genny tests for $graphLookup with maxDepth 0

### DIFF
--- a/src/workloads/execution/UnshardedGraphLookup.yml
+++ b/src/workloads/execution/UnshardedGraphLookup.yml
@@ -225,6 +225,7 @@ Actors:
         aggregate: Collection0
         pipeline:
           [
+            {$match: {a: {$lte: 30}}},
             {$graphLookup: {
               from: "Collection1",
               startWith: "$c",

--- a/src/workloads/execution/UnshardedGraphLookup.yml
+++ b/src/workloads/execution/UnshardedGraphLookup.yml
@@ -54,6 +54,7 @@ Actors:
       d: {^RandomInt: {min: 1, max: 600}}
       e: {^RandomInt: {min: 1, max: 600}}
       f: {^RandomInt: {min: 1, max: 30}}
+      g: {^RandomInt: {min: 1, max: 1500}}
       s: {^RandomString: {length: 3000}}
   - *Nop
   - *Nop
@@ -167,6 +168,23 @@ Actors:
             {$project: {s: 0, "matches.s": 0}}
           ]
         cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupShardedToUnshardedMaxDepthZeroOneToTwo
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$g",
+              connectFromField: "g",
+              connectToField: "g",
+              as: "matches",
+              maxDepth: 0
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
     - OperationMetricsName: GraphLookupShardedToUnshardedMaxDepthZeroOneToFive
       OperationName: RunCommand
       OperationCommand:
@@ -201,12 +219,30 @@ Actors:
             {$project: {s: 0, "matches.s": 0}}
           ]
         cursor: {batchSize: *NumDocs}
-    - OperationMetricsName: GraphLookupShardedToUnshardedMaxDepthZeroMatchOneToTenTargeted
+    - OperationMetricsName: GraphLookupShardedToUnshardedMaxDepthZeroMatchAllShards
       OperationName: RunCommand
       OperationCommand:
         aggregate: Collection0
         pipeline:
           [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$c",
+              connectFromField: "c",
+              connectToField: "c",
+              as: "matches",
+              maxDepth: 0
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupShardedToUnshardedMaxDepthZeroMatchSomeShards
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$match: {c: {$in: [1, 2, 3]}}},
             {$graphLookup: {
               from: "Collection1",
               startWith: "$c",

--- a/src/workloads/execution/UnshardedGraphLookup.yml
+++ b/src/workloads/execution/UnshardedGraphLookup.yml
@@ -53,6 +53,7 @@ Actors:
       c: {^RandomInt: {min: 1, max: 300}}
       d: {^RandomInt: {min: 1, max: 600}}
       e: {^RandomInt: {min: 1, max: 600}}
+      f: {^RandomInt: {min: 1, max: 30}}
       s: {^RandomString: {length: 3000}}
   - *Nop
   - *Nop
@@ -145,6 +146,74 @@ Actors:
               connectToField: "e",
               as: "matches",
               maxDepth: 1
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupShardedToUnshardedMaxDepthZeroOneToOne
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$a",
+              connectFromField: "a",
+              connectToField: "b",
+              as: "matches",
+              maxDepth: 0
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupShardedToUnshardedMaxDepthZeroOneToFive
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$d",
+              connectFromField: "d",
+              connectToField: "e",
+              as: "matches",
+              maxDepth: 0
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupShardedToUnshardedMaxDepthZeroOneToOneHundred
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$f",
+              connectFromField: "f",
+              connectToField: "f",
+              as: "matches",
+              maxDepth: 0
+            }},
+            {$project: {s: 0, "matches.s": 0}}
+          ]
+        cursor: {batchSize: *NumDocs}
+    - OperationMetricsName: GraphLookupShardedToUnshardedMaxDepthZeroMatchOneToTenTargeted
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [
+            {$graphLookup: {
+              from: "Collection1",
+              startWith: "$c",
+              connectFromField: "c",
+              connectToField: "c",
+              as: "matches",
+              maxDepth: 0
             }},
             {$project: {s: 0, "matches.s": 0}}
           ]


### PR DESCRIPTION
From [this](https://spruce.mongodb.com/version/6148dfd20305b97273016779/tasks) evergreen patch, we see the following results.

Feature flag off:

| Benchmark | Avg latency (sec)  |
|---|---|
| GraphLookupShardedToUnshardedMaxDepthZeroOneToOne  | 5.0487785019 |
| GraphLookupShardedToUnshardedMaxDepthZeroOneToFive | 1.5662687845 |
| GraphLookupShardedToUnshardedMaxDepthZeroOneToOneHundred | 1.3148955413 |
| GraphLookupShardedToUnshardedMaxDepthZeroMatchOneToTenTargeted | .8854111305 |

Feature flag on:
| Benchmark | Avg latency (sec)  |
|---|---|
| GraphLookupShardedToUnshardedMaxDepthZeroOneToOne | 3.660342830 |
| GraphLookupShardedToUnshardedMaxDepthZeroOneToFive | 1.6935450762 |
| GraphLookupShardedToUnshardedMaxDepthZeroOneToOneHundred | 1.178930092 |
| GraphLookupShardedToUnshardedMaxDepthZeroMatchOneToTenTargeted | .5505447558 |

In most cases except OneToFive, we're seeing improvements of 25%+. For OneToFive, there is a regression of about 6%.
These results are interesting! `$graphLookup` with `maxDepth: 0` is much more similar to `$lookup`, yet we still see better performance when parallelizing in the `ShardedToUnsharded` case than we do with `$lookup`! It must be that the cache is somehow helping us out here. Would welcome any other ideas!