### PR TITLE
PERF-2547 Increase sleep time for balancer to finish balancing chunks in WouldChangeOwningShard workload

### DIFF
--- a/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+++ b/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
@@ -19,7 +19,7 @@ GlobalDefaults:
   Namespace: &Namespace test.Collection0
 
   DocumentCount: &DocumentCount 10000  # Number of documents to insert and modify.
-  BalancerWait: &BalancerWait "10 seconds"  # Wait out the 10 second delay between balancing rounds
+  BalancerWait: &BalancerWait "20 seconds"  # Wait out the 20 second delay between balancing rounds
   # with a little extra leeway for balancing to finish.
 
 Actors:


### PR DESCRIPTION
Increasing the timeout to avoid overlapping range deletion task.