### PR TITLE
Clarify install dir for genny

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -34,6 +34,9 @@ Here're the steps to get Genny up and running locally:
     On a Mac, run `brew install python3` (assuming you have [homebrew installed](https://brew.sh/))
     and then restart your shell.
     
+    This command expects that the /data/mci directory exists, and that you have write access
+    to it. It will error otherwise.
+    
 ### Errors Mentioning zstd and libmongocrypt
 There is currently a leak in Genny's toolchain requiring zstd and libmongocrypt to be installed.
 If the `./run-genny install` phase above errors mentioning these, you may need to install them separately.


### PR DESCRIPTION
I was installing genny on my workstation, and I got an error that the install dir didn't exist. /data/mci isn't a standard directory available on the workstation, so I got confused. I've added a note to our setup docs to clarify.