### PR TITLE
Update toolchain to 10gen/vcpkg#12

### DIFF
--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -161,7 +161,6 @@ class ToolchainDownloader(Downloader):
     # =>                                cf1c50fab5291cd583a5036dc9ade265bca165a3_21_10_20_20_05_26
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
     #
-    
 
     TOOLCHAIN_BUILD_ID = "cf1c50fab5291cd583a5036dc9ade265bca165a3_21_10_20_20_05_26"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]


### PR DESCRIPTION
Update to [the latest version of the toolchain](https://evergreen.mongodb.com/version/genny_toolchain_cf1c50fab5291cd583a5036dc9ade265bca165a3). Includes boost-beast for upcoming work to add a streamlined HTTP library wrapper for Actors to use.