### PR TITLE
TIG-3503 Auto-task workload yamls can be in any repo in src not just genny

### DIFF
--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -70,13 +70,14 @@ class WorkloadLister:
     Separate from the Repo class for easier testing.
     """
 
-    def __init__(self, genny_repo_root: str, reader: YamlReader):
+    def __init__(self, workspace_root: str, genny_repo_root: str, reader: YamlReader):
+        self.workspace_root = workspace_root
         self.genny_repo_root = genny_repo_root
         self._expansions = None
         self.reader = reader
 
     def all_workload_files(self) -> Set[str]:
-        pattern = os.path.join(self.genny_repo_root, "src", "workloads", "**", "*.yml")
+        pattern = os.path.join(self.workspace_root, "src", "*", "workloads", "**", "*.yml")
         return {*glob.glob(pattern)}
 
     def modified_workload_files(self) -> Set[str]:
@@ -485,7 +486,9 @@ def main(mode_name: str, genny_repo_root: str, workspace_root: str) -> None:
         genny_repo_root=genny_repo_root,
         workspace_root=workspace_root,
     )
-    lister = WorkloadLister(genny_repo_root=genny_repo_root, reader=reader)
+    lister = WorkloadLister(
+        workspace_root=workspace_root, genny_repo_root=genny_repo_root, reader=reader
+    )
     repo = Repo(lister=lister, reader=reader, workspace_root=workspace_root)
     tasks = repo.tasks(op=op, build=build)
 

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -77,7 +77,7 @@ class WorkloadLister:
         self.reader = reader
 
     def all_workload_files(self) -> Set[str]:
-        pattern = os.path.join(self.workspace_root, "src", "*", "workloads", "**", "*.yml")
+        pattern = os.path.join(self.workspace_root, "src", "*", "src", "workloads", "**", "*.yml")
         return {*glob.glob(pattern)}
 
     def modified_workload_files(self) -> Set[str]:
@@ -178,6 +178,7 @@ class Workload:
     """The list of `When/ThenRun` blocks, if present"""
 
     def __init__(self, workspace_root: str, file_path: str, is_modified: bool, reader: YamlReader):
+        self.workspace_root = workspace_root
         self.file_path = file_path
         self.is_modified = is_modified
 
@@ -211,7 +212,7 @@ class Workload:
 
     @property
     def relative_path(self) -> str:
-        return self.file_path.split("src/workloads/")[1]
+        return self.file_path.replace(self.workspace_root, ".")
 
     def generate_requested_tasks(self, then_run) -> List[GeneratedTask]:
         """

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -455,7 +455,9 @@ def test_dry_run_all_tasks():
                 genny_repo_root=genny_repo_root,
                 workspace_root=workspace_root,
             )
-            lister = WorkloadLister(genny_repo_root=genny_repo_root, reader=reader)
+            lister = WorkloadLister(
+                workspace_root=workspace_root, genny_repo_root=genny_repo_root, reader=reader
+            )
             repo = Repo(lister=lister, reader=reader, workspace_root=workspace_root)
             tasks = repo.tasks(op=op, build=build)
 


### PR DESCRIPTION
Does what it says on the tin. I created [a new public repo](https://github.com/rtimmons/has-genny-workloads) that has a HelloWorld workload in it and we should see that task get scheduled.

Patch-build:
https://spruce.mongodb.com/version/6180343d0305b960c8728b99/

Depends on a related change in DSI to not assume the repo path is within genny.