### PR TITLE
TIG-3501 change LLT workload to use the expected index names

### DIFF
--- a/src/workloads/transactions/LLTAnalytics.yml
+++ b/src/workloads/transactions/LLTAnalytics.yml
@@ -37,8 +37,14 @@ GlobalDefaults:
 
   LLTIndexes: &LLTIndexes
   - keys: {price: 1, ts: 1, cuid: 1}     # Ptc
+    options:
+      name: price_1_ts_1_cuid_1
   - keys: {price: 1, cuid: 1}            # Pc
+    options:
+      name: price_1_cuid_1
   - keys: {caid: 1, price: 1, cuid: 1}   # Cpc
+    options:
+      name: caid_1_price_1_cuid_1
 
   # Loader Config.
   LoadThreads: &LoadThreads 4

--- a/src/workloads/transactions/LLTMixed.yml
+++ b/src/workloads/transactions/LLTMixed.yml
@@ -27,8 +27,14 @@ GlobalDefaults:
 
   LLTIndexes: &LLTIndexes
   - keys: {price: 1, ts: 1, cuid: 1}     # Ptc
+    options:
+      name: price_1_ts_1_cuid_1
   - keys: {price: 1, cuid: 1}            # Pc
+    options:
+      name: price_1_cuid_1
   - keys: {caid: 1, price: 1, cuid: 1}   # Cpc
+    options:
+      name: caid_1_price_1_cuid_1
 
   # Loader Config.
   LoadThreads: &LoadThreads 4


### PR DESCRIPTION
The simplest way forward is just to change the workload to use the expected index names.

[patch](https://spruce.mongodb.com/version/618a9a4457e85a1960f7de88/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) with the new code.