### PR TITLE
TIG-3236 t_benchmark_test is flaky

### DIFF
--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -219,7 +219,7 @@ Actors:
         // We may run the GlobalRate ops more or fewer, based on the randomness of thread
         // wakeup times coinciding with phase endings for non-blocking operations.
         // This is expected, so we can account for it by allowing more or fewer recurrence
-        // around the "expected" value of 158.
+        // around the "expected" value of 168.
         // (Including both actors and phases able to have timings off by an entire cycle.)
         const auto expected = 168;
         const auto maxCount = expected + 8 * 4;

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -215,7 +215,6 @@ Actors:
         t.join();
 
         const auto state = getCurState();
-        BOOST_LOG_TRIVIAL(error) << "state: " << state;
         
         // We may run the GlobalRate ops more or fewer, based on the randomness of thread
         // wakeup times coinciding with phase endings for non-blocking operations.

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -219,9 +219,9 @@ Actors:
         // We may run the GlobalRate ops more or fewer, based on the randomness of thread
         // wakeup times coinciding with phase endings for non-blocking operations.
         // This is expected, so we can account for it by allowing more or fewer recurrence
-        // around the "expected" value of 168.
+        // around the "expected" value of 156.
         // (Including both actors and phases able to have timings off by an entire cycle.)
-        const auto expected = 168;
+        const auto expected = 156;
         const auto maxCount = expected + 8 * 4;
         const auto minCount = expected - 8 * 4;
         REQUIRE(state <= maxCount);

--- a/src/gennylib/test/GlobalRateLimiter_test.cpp
+++ b/src/gennylib/test/GlobalRateLimiter_test.cpp
@@ -174,7 +174,7 @@ auto resetState() {
 
 auto incProducer = std::make_shared<DefaultActorProducer<IncActor>>("IncActor");
 
-TEST_CASE("Global rate limiter can be used by phase loop", "[benchmark]") {
+TEST_CASE("Global rate limiter can be used by phase loop", "[slow][benchmark]") {
     using namespace std::chrono_literals;
 
     SECTION("Works with no Repeat or Duration") {
@@ -185,35 +185,48 @@ Actors:
   Type: IncActor
   Threads: 1
   Phases:
-    - Duration: 50 milliseconds 
-      GlobalRate: 7 per 20 milliseconds
-    - Duration: 50 milliseconds 
-      GlobalRate: 8 per 100 milliseconds
+    - Duration: 520 milliseconds 
+      GlobalRate: 7 per 50 milliseconds
+    - Duration: 520 milliseconds 
+      GlobalRate: 8 per 10000 milliseconds
 
 - Name: Two
   Type: IncActor
   Threads: 1
   Phases:
     - Blocking: None
-      GlobalRate: 8 per 100 milliseconds
+      GlobalRate: 7 per 50 milliseconds
 
       # When the phase ends the rate limit is reset and all threads
       # are immediately woken up.
     - Blocking: None
-      GlobalRate: 7 per 20 milliseconds
+      GlobalRate: 8 per 1000 milliseconds
 )",
                       "");
         auto& config = ns.root();
         int num_threads = 2;
 
+        resetState();
+        REQUIRE(getCurState() == 0);
+
         genny::ActorHelper ah{config, num_threads, {{"IncActor", incProducer}}};
         auto runInBg = [&ah]() { ah.run(); };
         std::thread t(runInBg);
-        std::this_thread::sleep_for(110ms);
         t.join();
 
         const auto state = getCurState();
-        REQUIRE(state == 72);
+        BOOST_LOG_TRIVIAL(error) << "state: " << state;
+        
+        // We may run the GlobalRate ops more or fewer, based on the randomness of thread
+        // wakeup times coinciding with phase endings for non-blocking operations.
+        // This is expected, so we can account for it by allowing more or fewer recurrence
+        // around the "expected" value of 158.
+        // (Including both actors and phases able to have timings off by an entire cycle.)
+        const auto expected = 168;
+        const auto maxCount = expected + 8 * 4;
+        const auto minCount = expected - 8 * 4;
+        REQUIRE(state <= maxCount);
+        REQUIRE(state >= minCount);
     }
 
     // The rate interval needs to be large enough to avoid sporadic failures, which makes


### PR DESCRIPTION
Templatizing phaseloop on a ClockSource would be a bit too invasive of a change to be worth it in the near-term, when this is red for basically every PR (affecting workload authors too). And even that wouldn't remove the thread-based nondeterminism. Arguably the thread jumble like this is expected and mocking it out would be a worse test of behavior anyway. (Plus we have separate unit tests for rate limiters anyway; the benchmark test I believe is happier with a more "real-world" situation.)

We could consider doing some stats about this, but the exact distribution would probably vary from machine to machine, and this is in line with how the other benchmark tests measure behavior.

Tested by removing the "benchmark" tag and running with `--repeat=500`, seemed good.