### PR TITLE
TIG-3517 Add workload for normalized scale 1 TPC-H Benchmark

### DIFF
--- a/src/phases/tpch/normalized/Q1.yml
+++ b/src/phases/tpch/normalized/Q1.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 1 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query1Delta: &query1Delta -90
 
 TPCHNormalizedQuery1:
@@ -18,9 +18,7 @@ TPCHNormalizedQuery1:
         aggregate: lineitem
         pipeline:
           [
-            {$match: {$expr: {$lte:
-              ["$l_shipdate", {$dateAdd: {startDate:
-                {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: {^Parameter: {Name: "Query1Delta", Default: *query1Delta}}}}]}}},
+            {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: {^Parameter: {Name: "Query1Delta", Default: *query1Delta}}}}]}}},
             {$group: {
               _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
               sum_qty: {$sum: "$l_quantity"},
@@ -37,20 +35,20 @@ TPCHNormalizedQuery1:
               avg_price: {$avg: "$l_extendedprice"},
               avg_disc: {$avg: "$l_discount"},
               count_order: {$count: {}}}},
-          {$project: {
-            _id: 0,
-            l_returnflag: "$_id.l_returnflag",
-            l_linestatus: "$_id.l_linestatus",
-            sum_qty: 1,
-            sum_base_price: 1,
-            sum_disc_price: 1,
-            sum_charge: 1,
-            avg_qty: 1,
-            avg_price: 1,
-            avg_disc: 1,
-            count_order: 1}},
-          {$sort: {l_returnflag: 1, l_linestatus: 1}},
-        ]
+            {$project: {
+              _id: 0,
+              l_returnflag: "$_id.l_returnflag",
+              l_linestatus: "$_id.l_linestatus",
+              sum_qty: 1,
+              sum_base_price: 1,
+              sum_disc_price: 1,
+              sum_charge: 1,
+              avg_qty: 1,
+              avg_price: 1,
+              avg_disc: 1,
+              count_order: 1}},
+            {$sort: {l_returnflag: 1, l_linestatus: 1}},
+          ]
         cursor: {batchSize: *batchSize}
         allowDiskUse: true
       verbosity:

--- a/src/phases/tpch/normalized/Q1.yml
+++ b/src/phases/tpch/normalized/Q1.yml
@@ -1,11 +1,11 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 1 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 1 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query1Delta: &query1Delta -90
+query1Delta: &query1Delta {^Parameter: {Name: "Query1Delta", Default: -90}}
 
 TPCHNormalizedQuery1:
   Repeat: 1
@@ -18,7 +18,7 @@ TPCHNormalizedQuery1:
         aggregate: lineitem
         pipeline:
           [
-            {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: {^Parameter: {Name: "Query1Delta", Default: *query1Delta}}}}]}}},
+            {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
             {$group: {
               _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
               sum_qty: {$sum: "$l_quantity"},

--- a/src/phases/tpch/normalized/Q1.yml
+++ b/src/phases/tpch/normalized/Q1.yml
@@ -1,0 +1,57 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 1 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query1Delta: &query1Delta -90
+
+TPCHNormalizedQuery1:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query1
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: lineitem
+        pipeline:
+          [
+            {$match: {$expr: {$lte:
+              ["$l_shipdate", {$dateAdd: {startDate:
+                {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: {^Parameter: {Name: "Query1Delta", Default: *query1Delta}}}}]}}},
+            {$group: {
+              _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
+              sum_qty: {$sum: "$l_quantity"},
+              sum_base_price: {$sum: "$l_extendedprice"},
+              sum_disc_price:
+                {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}},
+              sum_charge: {
+                $sum: {
+                  $multiply: [
+                    "$l_extendedprice",
+                    {$subtract: [1, "$l_discount"]},
+                    {$add: [1, "$l_tax"]}]}},
+              avg_qty: {$avg: "$l_quantity"},
+              avg_price: {$avg: "$l_extendedprice"},
+              avg_disc: {$avg: "$l_discount"},
+              count_order: {$count: {}}}},
+          {$project: {
+            _id: 0,
+            l_returnflag: "$_id.l_returnflag",
+            l_linestatus: "$_id.l_linestatus",
+            sum_qty: 1,
+            sum_base_price: 1,
+            sum_disc_price: 1,
+            sum_charge: 1,
+            avg_qty: 1,
+            avg_price: 1,
+            avg_disc: 1,
+            count_order: 1}},
+          {$sort: {l_returnflag: 1, l_linestatus: 1}},
+        ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q10.yml
+++ b/src/phases/tpch/normalized/Q10.yml
@@ -1,11 +1,11 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 10 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 10 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query10Date: &query10Date "1993-10-01"
+query10Date: &query10Date {^Parameter: {Name: "Query10Date", Default: "1993-10-01"}}
 
 TPCHNormalizedQuery10:
   Repeat: 1
@@ -19,8 +19,8 @@ TPCHNormalizedQuery10:
         pipeline:
           [
             {$match: {$and: [
-              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query10Date", Default: *query10Date}}}}]}},
-              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query10Date", Default: *query10Date}}}}, unit: "month", amount: 3}}]}}]}},
+              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
+              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
             {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
               {$match: {l_returnflag: "R"}}]}},
             {$unwind: "$lineitem"},

--- a/src/phases/tpch/normalized/Q10.yml
+++ b/src/phases/tpch/normalized/Q10.yml
@@ -1,0 +1,39 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 10 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query10Date: &query10Date "1993-10-01"
+
+TPCHNormalizedQuery10:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query10
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: orders
+        pipeline:
+          [
+            {$match: {$and:[
+            {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query10Date", Default: *query10Date}}}}]}},
+            {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query10Date", Default: *query10Date}}}}, unit: "month", amount: 3}}]}}]}},
+            {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+              {$match: {l_returnflag: "R"}}]}},
+            {$unwind: "$lineitem"},
+            {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer", pipeline: [
+                {$lookup: { from: "nation", localField: "c_nationkey", foreignField: "n_nationkey", as: "nation"}},
+                {$unwind: "$nation"}]}},
+            {$unwind: "$customer"},
+            {$group: {_id: {c_custkey: "$customer.c_custkey", c_name: "$customer.c_name", c_acctbal: "$customer.c_acctbal", n_name: "$customer.nation.n_name", c_address: "$customer.c_address", c_phone: "$customer.c_phone", c_comment: "$customer.c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+            {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
+            {$sort: {revenue: -1}},
+            {$limit: 20}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q10.yml
+++ b/src/phases/tpch/normalized/Q10.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 10 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query10Date: &query10Date "1993-10-01"
 
 TPCHNormalizedQuery10:
@@ -18,15 +18,15 @@ TPCHNormalizedQuery10:
         aggregate: orders
         pipeline:
           [
-            {$match: {$and:[
-            {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query10Date", Default: *query10Date}}}}]}},
-            {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query10Date", Default: *query10Date}}}}, unit: "month", amount: 3}}]}}]}},
+            {$match: {$and: [
+              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query10Date", Default: *query10Date}}}}]}},
+              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query10Date", Default: *query10Date}}}}, unit: "month", amount: 3}}]}}]}},
             {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
               {$match: {l_returnflag: "R"}}]}},
             {$unwind: "$lineitem"},
             {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer", pipeline: [
-                {$lookup: { from: "nation", localField: "c_nationkey", foreignField: "n_nationkey", as: "nation"}},
-                {$unwind: "$nation"}]}},
+              {$lookup: { from: "nation", localField: "c_nationkey", foreignField: "n_nationkey", as: "nation"}},
+              {$unwind: "$nation"}]}},
             {$unwind: "$customer"},
             {$group: {_id: {c_custkey: "$customer.c_custkey", c_name: "$customer.c_name", c_acctbal: "$customer.c_acctbal", n_name: "$customer.nation.n_name", c_address: "$customer.c_address", c_phone: "$customer.c_phone", c_comment: "$customer.c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
             {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},

--- a/src/phases/tpch/normalized/Q11.yml
+++ b/src/phases/tpch/normalized/Q11.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 11 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 11 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query11Nation: &query11Nation "GERMANY"
-query11Fraction: &query11Fraction 0.0001
+query11Nation: &query11Nation {^Parameter: {Name: "Query11Nation", Default: "GERMANY"}}
+query11Fraction: &query11Fraction {^Parameter: {Name: "Query11Fraction", Default: 0.0001}}
 
 TPCHNormalizedQuery11:
   Repeat: 1
@@ -29,7 +29,7 @@ TPCHNormalizedQuery11:
               from: "nation",
               localField: "supplier.s_nationkey",
               foreignField: "n_nationkey",
-              pipeline: [{$match: {n_name: {^Parameter: {Name: "Query11Nation", Default: *query11Nation}}}}],
+              pipeline: [{$match: {n_name: *query11Nation}}],
               as: "nation"}},
             {$unwind: "$nation"},
             {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
@@ -41,7 +41,7 @@ TPCHNormalizedQuery11:
               groups: {$push: {ps_partkey: "$_id", value: "$value"}},
               total_cost: {$sum: "$value"}}},
             {$addFields: {
-              threshold: {$multiply: ["$total_cost", {^Parameter: {Name: "Query11Fraction", Default: *query11Fraction}}]}}},
+              threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
             {$unwind: "$groups"},
             {$project: {
               ps_partkey: "$groups.ps_partkey",

--- a/src/phases/tpch/normalized/Q11.yml
+++ b/src/phases/tpch/normalized/Q11.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 11 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query11Nation: &query11Nation "GERMANY"
 query11Fraction: &query11Fraction 0.0001
 

--- a/src/phases/tpch/normalized/Q11.yml
+++ b/src/phases/tpch/normalized/Q11.yml
@@ -1,0 +1,57 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 11 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query11Nation: &query11Nation "GERMANY"
+query11Fraction: &query11Fraction 0.0001
+
+TPCHNormalizedQuery11:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query11
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: partsupp
+        pipeline:
+          [
+            {$lookup: {
+              from: "supplier",
+              localField: "ps_suppkey",
+              foreignField: "s_suppkey",
+              as: "supplier"}},
+            {$unwind: "$supplier"},
+            {$lookup: {
+              from: "nation",
+              localField: "supplier.s_nationkey",
+              foreignField: "n_nationkey",
+              pipeline: [{$match: {n_name: {^Parameter: {Name: "Query11Nation", Default: *query11Nation}}}}],
+              as: "nation"}},
+            {$unwind: "$nation"},
+            {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
+            {$group: {
+              _id: "$ps_partkey",
+              value: {$sum: "$total_cost"}}},
+            {$group: {
+              _id: 0,
+              groups: {$push: {ps_partkey: "$_id", value: "$value"}},
+              total_cost: {$sum: "$value"}}},
+            {$addFields: {
+              threshold: {$multiply: ["$total_cost", {^Parameter: {Name: "Query11Fraction", Default: *query11Fraction}}]}}},
+            {$unwind: "$groups"},
+            {$project: {
+              ps_partkey: "$groups.ps_partkey",
+              value: "$groups.value",
+              threshold: 1}},
+            {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
+            {$project: {_id: 0, ps_partkey: 1, value: 1}},
+            {$sort: {value: -1}},
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q12.yml
+++ b/src/phases/tpch/normalized/Q12.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 12 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 
 query12ShipMode1: &query12ShipMode1 "MAIL"
 query12ShipMode2: &query12ShipMode2 "SHIP"
@@ -30,8 +30,7 @@ TPCHNormalizedQuery12:
                 {$expr: {$lt: [
                   "$l_receiptdate",
                   {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query12Date", Default: *query12Date}}}}, unit: "year", amount: 1}}]}}]}},
-            {$lookup:
-              {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+            {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
             {$unwind: "$orders"},
             {$group: {
               _id: "$l_shipmode",
@@ -63,4 +62,4 @@ TPCHNormalizedQuery12:
         cursor: {batchSize: *batchSize}
         allowDiskUse: true
       verbosity:
-          executionStats
+        executionStats

--- a/src/phases/tpch/normalized/Q12.yml
+++ b/src/phases/tpch/normalized/Q12.yml
@@ -1,14 +1,14 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 12 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 12 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
 
-query12ShipMode1: &query12ShipMode1 "MAIL"
-query12ShipMode2: &query12ShipMode2 "SHIP"
-query12Date: &query12Date "1994-01-01"
+query12ShipMode1: &query12ShipMode1 {^Parameter: {Name: "Query12ShipMode1", Default: "MAIL"}}
+query12ShipMode2: &query12ShipMode2 {^Parameter: {Name: "Query12ShipMode2", Default: "SHIP"}}
+query12Date: &query12Date {^Parameter: {Name: "Query12Date", Default: "1994-01-01"}}
 
 TPCHNormalizedQuery12:
   Repeat: 1
@@ -23,13 +23,13 @@ TPCHNormalizedQuery12:
           [
             {$match: {
               $and: [
-                {$or: [{l_shipmode: {^Parameter: {Name: "Query12ShipMode1", Default: *query12ShipMode1}}}, {l_shipmode: {^Parameter: {Name: "Query12ShipMode2", Default: *query12ShipMode2}}}]},
+                {$or: [{l_shipmode: *query12ShipMode1}, {l_shipmode: *query12ShipMode2}]},
                 {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
                 {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
-                {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query12Date", Default: *query12Date}}}}]}},
+                {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
                 {$expr: {$lt: [
                   "$l_receiptdate",
-                  {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query12Date", Default: *query12Date}}}}, unit: "year", amount: 1}}]}}]}},
+                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
             {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
             {$unwind: "$orders"},
             {$group: {

--- a/src/phases/tpch/normalized/Q12.yml
+++ b/src/phases/tpch/normalized/Q12.yml
@@ -1,0 +1,66 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 12 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+
+query12ShipMode1: &query12ShipMode1 "MAIL"
+query12ShipMode2: &query12ShipMode2 "SHIP"
+query12Date: &query12Date "1994-01-01"
+
+TPCHNormalizedQuery12:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query12
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: lineitem
+        pipeline:
+          [
+            {$match: {
+              $and: [
+                {$or: [{l_shipmode: {^Parameter: {Name: "Query12ShipMode1", Default: *query12ShipMode1}}}, {l_shipmode: {^Parameter: {Name: "Query12ShipMode2", Default: *query12ShipMode2}}}]},
+                {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
+                {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
+                {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query12Date", Default: *query12Date}}}}]}},
+                {$expr: {$lt: [
+                  "$l_receiptdate",
+                  {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query12Date", Default: *query12Date}}}}, unit: "year", amount: 1}}]}}]}},
+            {$lookup:
+              {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+            {$unwind: "$orders"},
+            {$group: {
+              _id: "$l_shipmode",
+              high_line_count: {
+                $sum: {
+                  $cond: {
+                    if: {
+                      $or: [
+                        {$eq: ["$orders.o_orderpriority", "1-URGENT"]},
+                        {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]},
+                    then: 1,
+                    else: 0}}},
+              low_line_count: {
+                $sum: {
+                  $cond: {
+                    if: {
+                      $and: [
+                        {$ne: ["$orders.o_orderpriority", "1-URGENT"]},
+                        {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]},
+                    then: 1,
+                    else: 0}}}}},
+            {$project: {
+              _id: 0,
+              l_shipmode: "$_id",
+              high_line_count: 1,
+              low_line_count: 1}},
+            {$sort: {l_shipmode: 1}},
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+          executionStats

--- a/src/phases/tpch/normalized/Q13.yml
+++ b/src/phases/tpch/normalized/Q13.yml
@@ -1,11 +1,11 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 13 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 13 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query13Regex: &query13Regex "^.*special.*requests.*$"  # `^.*${query13Word1}.*${query13Word2}.*$`
+query13Regex: &query13Regex {^Parameter: {Name: "Query13Regex", Default: "^.*special.*requests.*$"}}  # `^.*${query13Word1}.*${query13Word2}.*$`
 
 TPCHNormalizedQuery13:
   Repeat: 1
@@ -19,7 +19,7 @@ TPCHNormalizedQuery13:
         pipeline:
           [
             {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-              {$match: {$expr: {$cond: {if: {$regexMatch: {input: "$o_comment", regex: {^Parameter: {Name: "Query13Regex", Default: *query13Regex}}, options: "si"}}, then: 0, else: 1}}}}]}},
+              {$match: {$expr: {$cond: {if: {$regexMatch: {input: "$o_comment", regex: *query13Regex, options: "si"}}, then: 0, else: 1}}}}]}},
             {$project: {c_custkey: 1, c_count: {$size: "$orders"}}},
             {$group: {_id: "$c_count", custdist: {$count: {}}}},
             {$project: {_id: 0, c_count: "$_id", custdist: 1}},

--- a/src/phases/tpch/normalized/Q13.yml
+++ b/src/phases/tpch/normalized/Q13.yml
@@ -4,8 +4,8 @@ Description: |
   Run TPC-H query 13 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
-query13Regex: &query13Regex "^.*special.*requests.*$" # `^.*${query13Word1}.*${query13Word2}.*$`
+batchSize: &batchSize 101  # The default batch size.
+query13Regex: &query13Regex "^.*special.*requests.*$"  # `^.*${query13Word1}.*${query13Word2}.*$`
 
 TPCHNormalizedQuery13:
   Repeat: 1

--- a/src/phases/tpch/normalized/Q13.yml
+++ b/src/phases/tpch/normalized/Q13.yml
@@ -1,0 +1,31 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 13 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query13Regex: &query13Regex "^.*special.*requests.*$" # `^.*${query13Word1}.*${query13Word2}.*$`
+
+TPCHNormalizedQuery13:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query13
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
+              {$match: {$expr: {$cond: {if: {$regexMatch: {input: "$o_comment", regex: {^Parameter: {Name: "Query13Regex", Default: *query13Regex}}, options: "si"}}, then: 0, else: 1}}}}]}},
+            {$project: {c_custkey: 1, c_count: {$size: "$orders"}}},
+            {$group: {_id: "$c_count", custdist: {$count: {}}}},
+            {$project: {_id: 0, c_count: "$_id", custdist: 1}},
+            {$sort: {custdist: -1, c_count: -1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q14.yml
+++ b/src/phases/tpch/normalized/Q14.yml
@@ -1,0 +1,56 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 14 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query14Date: &query14Date "1995-09-01"
+
+TPCHNormalizedQuery14:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query14
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: lineitem
+        pipeline:
+          [
+            {$match: {
+              $and: [
+                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query14Date", Default: *query14Date}}}}]}},
+                {$expr: {
+                  $lt: [
+                    "$l_shipdate",
+                    {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query14Date", Default: *query14Date}}}}, unit: "month", amount: 1}}]}}]}},
+            {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
+            {$unwind: "$part"},
+            {$group: {
+              _id: {},
+              promo_price_total: {
+                  $sum: {
+                    $cond: {
+                      if: {
+                        $cond: {
+                            if: {
+                                $regexMatch: {
+                                    input: "$part.p_type",
+                                    regex: "^PROMO.*$",
+                                    options: "si"}},
+                            then: 1,
+                            else: 0}},
+                      then: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]},
+                      else: 0}}},
+              price_total:
+                {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+            {$project: {
+              _id: 0,
+              promo_revenue:
+                {$multiply: [100.00, {$divide: ["$promo_price_total", "$price_total"]}]}}},
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q14.yml
+++ b/src/phases/tpch/normalized/Q14.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 14 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query14Date: &query14Date "1995-09-01"
 
 TPCHNormalizedQuery14:
@@ -30,25 +30,21 @@ TPCHNormalizedQuery14:
             {$group: {
               _id: {},
               promo_price_total: {
-                  $sum: {
-                    $cond: {
-                      if: {
-                        $cond: {
-                            if: {
-                                $regexMatch: {
-                                    input: "$part.p_type",
-                                    regex: "^PROMO.*$",
-                                    options: "si"}},
-                            then: 1,
-                            else: 0}},
-                      then: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]},
-                      else: 0}}},
-              price_total:
-                {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-            {$project: {
-              _id: 0,
-              promo_revenue:
-                {$multiply: [100.00, {$divide: ["$promo_price_total", "$price_total"]}]}}},
+                $sum: {
+                  $cond: {
+                    if: {
+                      $cond: {
+                        if: {
+                          $regexMatch: {
+                            input: "$part.p_type",
+                            regex: "^PROMO.*$",
+                            options: "si"}},
+                        then: 1,
+                        else: 0}},
+                    then: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]},
+                    else: 0}}},
+              price_total: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+            {$project: {_id: 0, promo_revenue: {$multiply: [100.00, {$divide: ["$promo_price_total", "$price_total"]}]}}},
           ]
         cursor: {batchSize: *batchSize}
         allowDiskUse: true

--- a/src/phases/tpch/normalized/Q14.yml
+++ b/src/phases/tpch/normalized/Q14.yml
@@ -1,11 +1,11 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 14 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 14 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query14Date: &query14Date "1995-09-01"
+query14Date: &query14Date {^Parameter: {Name: "Query14Date", Default: "1995-09-01"}}
 
 TPCHNormalizedQuery14:
   Repeat: 1
@@ -20,11 +20,11 @@ TPCHNormalizedQuery14:
           [
             {$match: {
               $and: [
-                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query14Date", Default: *query14Date}}}}]}},
+                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
                 {$expr: {
                   $lt: [
                     "$l_shipdate",
-                    {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query14Date", Default: *query14Date}}}}, unit: "month", amount: 1}}]}}]}},
+                    {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
             {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
             {$unwind: "$part"},
             {$group: {

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -1,0 +1,72 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 15 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query15Date: &query15Date "1996-01-01"
+
+TPCHNormalizedQuery15:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query15CreateView
+    OperationName: RunCommand
+    OperationCommand:
+      create: revenue
+      viewOn: lineitem
+      pipeline:
+        [
+          {$match: {
+            $and: [
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query15Date", Default: *query15Date}}}}]}},
+              {$expr: {
+                $lt: [
+                    "$l_shipdate",
+                    {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query15Date", Default: *query15Date}}}}, unit: "month", amount: 3}}
+                ]}}]}},
+          {$group: {
+            _id: "$l_suppkey",
+            total_revenue:
+                {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+          {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
+      ]
+  - OperationMetricsName: Query15
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: revenue
+        pipeline:
+          [
+            {$group: {
+                _id: "$total_revenue",
+                supplier_no: {$push: "$supplier_no"},
+            }},
+            {$sort: {_id: -1}},
+            {$limit: 1},
+            {$unwind: "$supplier_no"},
+            {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
+            {$lookup: {
+                from: "supplier",
+                localField: "supplier_no",
+                foreignField: "s_suppkey",
+                as: "supplier"
+            }},
+            {$unwind: "$supplier"},
+            {$project: {
+                s_suppkey: "$supplier.s_suppkey",
+                s_name: "$supplier.s_name",
+                s_address: "$supplier.s_address",
+                s_phone: "$supplier.s_phone",
+                total_revenue: 1
+            }},
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats
+  - OperationMetricsName: Query15DropView
+    OperationName: RunCommand
+    OperationCommand:
+      drop: revenue

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -1,11 +1,11 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 15 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 15 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query15Date: &query15Date "1996-01-01"
+query15Date: &query15Date {^Parameter: {Name: "Query15Date", Default: "1996-01-01"}}
 
 TPCHNormalizedQuery15:
   Repeat: 1
@@ -20,11 +20,11 @@ TPCHNormalizedQuery15:
         [
           {$match: {
             $and: [
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query15Date", Default: *query15Date}}}}]}},
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
               {$expr: {
                 $lt: [
                   "$l_shipdate",
-                  {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query15Date", Default: *query15Date}}}}, unit: "month", amount: 3}}
+                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}
                 ]}}]}},
           {$group: {
             _id: "$l_suppkey",

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 15 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query15Date: &query15Date "1996-01-01"
 
 TPCHNormalizedQuery15:
@@ -23,15 +23,15 @@ TPCHNormalizedQuery15:
               {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query15Date", Default: *query15Date}}}}]}},
               {$expr: {
                 $lt: [
-                    "$l_shipdate",
-                    {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query15Date", Default: *query15Date}}}}, unit: "month", amount: 3}}
+                  "$l_shipdate",
+                  {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query15Date", Default: *query15Date}}}}, unit: "month", amount: 3}}
                 ]}}]}},
           {$group: {
             _id: "$l_suppkey",
             total_revenue:
-                {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+              {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
           {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
-      ]
+        ]
   - OperationMetricsName: Query15
     OperationName: RunCommand
     OperationCommand:
@@ -39,27 +39,19 @@ TPCHNormalizedQuery15:
         aggregate: revenue
         pipeline:
           [
-            {$group: {
-                _id: "$total_revenue",
-                supplier_no: {$push: "$supplier_no"},
-            }},
+            {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
             {$sort: {_id: -1}},
             {$limit: 1},
             {$unwind: "$supplier_no"},
             {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
-            {$lookup: {
-                from: "supplier",
-                localField: "supplier_no",
-                foreignField: "s_suppkey",
-                as: "supplier"
-            }},
+            {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
             {$unwind: "$supplier"},
             {$project: {
-                s_suppkey: "$supplier.s_suppkey",
-                s_name: "$supplier.s_name",
-                s_address: "$supplier.s_address",
-                s_phone: "$supplier.s_phone",
-                total_revenue: 1
+              s_suppkey: "$supplier.s_suppkey",
+              s_name: "$supplier.s_name",
+              s_address: "$supplier.s_address",
+              s_phone: "$supplier.s_phone",
+              total_revenue: 1
             }},
           ]
         cursor: {batchSize: *batchSize}

--- a/src/phases/tpch/normalized/Q16.yml
+++ b/src/phases/tpch/normalized/Q16.yml
@@ -4,10 +4,10 @@ Description: |
   Run TPC-H query 16 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 
 query16Brand: &query16Brand "Brand#45"
-query16Type: &query16Type "^MEDIUM POLISHED.*" # ^${type}.*$"
+query16Type: &query16Type "^MEDIUM POLISHED.*"  # ^${type}.*$"
 query16Sizes: &query16Sizes [49, 14, 23, 45, 19, 3, 36, 9]
 
 TPCHNormalizedQuery16:
@@ -35,10 +35,7 @@ TPCHNormalizedQuery16:
               from: "supplier",
               localField: "partsupp.ps_suppkey",
               foreignField: "s_suppkey",
-              pipeline: [
-                {$match: {$expr: 
-                    {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}
-                }}],
+              pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}],
               as: "supplier"}},
             {$match: {supplier: {$eq: []}}},
             {$group: {
@@ -62,4 +59,4 @@ TPCHNormalizedQuery16:
         cursor: {batchSize: *batchSize}
         allowDiskUse: true
       verbosity:
-          executionStats
+        executionStats

--- a/src/phases/tpch/normalized/Q16.yml
+++ b/src/phases/tpch/normalized/Q16.yml
@@ -1,14 +1,14 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 16 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 16 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
 
-query16Brand: &query16Brand "Brand#45"
-query16Type: &query16Type "^MEDIUM POLISHED.*"  # ^${type}.*$"
-query16Sizes: &query16Sizes [49, 14, 23, 45, 19, 3, 36, 9]
+query16Brand: &query16Brand {^Parameter: {Name: "Query16Brand", Default: "Brand#45"}}
+query16Type: &query16Type {^Parameter: {Name: "Query16Type", Default: "^MEDIUM POLISHED.*"}}  # ^${type}.*$"
+query16Sizes: &query16Sizes {^Parameter: {Name: "Query16Sizes", Default: [49, 14, 23, 45, 19, 3, 36, 9]}}
 
 TPCHNormalizedQuery16:
   Repeat: 1
@@ -22,9 +22,9 @@ TPCHNormalizedQuery16:
         pipeline:
           [
             {$match: {$and: [
-              {p_brand: {$ne: {^Parameter: {Name: "Query16Brand", Default: *query16Brand}}}},
-              {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: {^Parameter: {Name: "Query16Type", Default: *query16Type}}, options: "si"}}, then: 0, else: 1}}},
-              {p_size: {$in: {^Parameter: {Name: "Query16Sizes", Default: *query16Sizes}}}}]}},
+              {p_brand: {$ne: *query16Brand}},
+              {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}},
+              {p_size: {$in: *query16Sizes}}]}},
             {$lookup: {
               from: "partsupp",
               localField: "p_partkey",

--- a/src/phases/tpch/normalized/Q16.yml
+++ b/src/phases/tpch/normalized/Q16.yml
@@ -1,0 +1,65 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 16 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+
+query16Brand: &query16Brand "Brand#45"
+query16Type: &query16Type "^MEDIUM POLISHED.*" # ^${type}.*$"
+query16Sizes: &query16Sizes [49, 14, 23, 45, 19, 3, 36, 9]
+
+TPCHNormalizedQuery16:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query16
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: part
+        pipeline:
+          [
+            {$match: {$and: [
+              {p_brand: {$ne: {^Parameter: {Name: "Query16Brand", Default: *query16Brand}}}},
+              {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: {^Parameter: {Name: "Query16Type", Default: *query16Type}}, options: "si"}}, then: 0, else: 1}}},
+              {p_size: {$in: {^Parameter: {Name: "Query16Sizes", Default: *query16Sizes}}}}]}},
+            {$lookup: {
+              from: "partsupp",
+              localField: "p_partkey",
+              foreignField: "ps_partkey",
+              as: "partsupp"}},
+            {$unwind: "$partsupp"},
+            {$lookup: {
+              from: "supplier",
+              localField: "partsupp.ps_suppkey",
+              foreignField: "s_suppkey",
+              pipeline: [
+                {$match: {$expr: 
+                    {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}
+                }}],
+              as: "supplier"}},
+            {$match: {supplier: {$eq: []}}},
+            {$group: {
+              _id: {
+                p_brand: "$p_brand",
+                p_type: "$p_type",
+                p_size: "$p_size"},
+              ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
+            {$project: {
+              _id: 0,
+              p_brand: "$_id.p_brand",
+              p_type: "$_id.p_type",
+              p_size: "$_id.p_size",
+              supplier_cnt: {$size: "$ps_suppkey"}}},
+            {$sort: {
+              supplier_cnt: -1,
+              p_brand: 1,
+              p_type: 1,
+              p_size: 1}},
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+          executionStats

--- a/src/phases/tpch/normalized/Q18.yml
+++ b/src/phases/tpch/normalized/Q18.yml
@@ -1,0 +1,38 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 18 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query18Quantity: &query18Quantity 300
+
+TPCHNormalizedQuery18:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query18
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: orders
+        pipeline:
+          [
+            {$lookup: {from: "lineitem", let: {o_orderkey: "$o_orderkey"}, as: "lineitem", pipeline: [
+              {$match: {$expr: {$eq: ["$$o_orderkey", "$l_orderkey"]}}},
+              {$group: {_id: "$l_orderkey", "sum(l_quantity)": {$sum: "$l_quantity"}}},
+              {$match: {$expr: {$gt: ["$sum(l_quantity)", {^Parameter: {Name: "Query18Quantity", Default: *query18Quantity}}]}}},
+              {$project: {_id: 0, o_orderkey: "$_id", "sum(l_quantity)": 1}}]}},
+            {$unwind: "$lineitem"},
+            {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer"}},
+            {$unwind: "$customer"},
+            {$group: {_id: {c_name: "$customer.c_name", c_custkey: "$customer.c_custkey", o_orderkey: "$o_orderkey", o_orderdate: "$o_orderdate", o_totalprice: "$o_totalprice"}, "sum(l_quantity)": {$push: "$lineitem.sum(l_quantity)"}}},
+            {$unwind: "$sum(l_quantity)"},
+            {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
+            {$sort: {o_totalprice: -1, o_orderdate: 1}},
+            {$limit: 100}
+        ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+          executionStats

--- a/src/phases/tpch/normalized/Q18.yml
+++ b/src/phases/tpch/normalized/Q18.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 18 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query18Quantity: &query18Quantity 300
 
 TPCHNormalizedQuery18:
@@ -31,8 +31,8 @@ TPCHNormalizedQuery18:
             {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
             {$sort: {o_totalprice: -1, o_orderdate: 1}},
             {$limit: 100}
-        ]
+          ]
         cursor: {batchSize: *batchSize}
         allowDiskUse: true
       verbosity:
-          executionStats
+        executionStats

--- a/src/phases/tpch/normalized/Q18.yml
+++ b/src/phases/tpch/normalized/Q18.yml
@@ -1,11 +1,11 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 18 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 18 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query18Quantity: &query18Quantity 300
+query18Quantity: &query18Quantity {^Parameter: {Name: "Query18Quantity", Default: 300}}
 
 TPCHNormalizedQuery18:
   Repeat: 1
@@ -21,7 +21,7 @@ TPCHNormalizedQuery18:
             {$lookup: {from: "lineitem", let: {o_orderkey: "$o_orderkey"}, as: "lineitem", pipeline: [
               {$match: {$expr: {$eq: ["$$o_orderkey", "$l_orderkey"]}}},
               {$group: {_id: "$l_orderkey", "sum(l_quantity)": {$sum: "$l_quantity"}}},
-              {$match: {$expr: {$gt: ["$sum(l_quantity)", {^Parameter: {Name: "Query18Quantity", Default: *query18Quantity}}]}}},
+              {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
               {$project: {_id: 0, o_orderkey: "$_id", "sum(l_quantity)": 1}}]}},
             {$unwind: "$lineitem"},
             {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer"}},

--- a/src/phases/tpch/normalized/Q19.yml
+++ b/src/phases/tpch/normalized/Q19.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 19 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 
 query19Brand1: &query19Brand1 "Brand#12"
 query19Quantity1: &query19Quantity1 1
@@ -24,21 +24,26 @@ TPCHNormalizedQuery19:
         aggregate: lineitem
         pipeline:
           [
-            {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode",  l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-            {$match: {$or: [{$and: [{p_brand: {^Parameter: {Name: "Query19Brand1", Default: *query19Brand1}}}, {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
+            {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+              {$match: {$or: [
+                {$and: [
+                  {p_brand: {^Parameter: {Name: "Query19Brand1", Default: *query19Brand1}}},
+                  {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
                   {$expr: {$gte: ["$$l_quantity", {^Parameter: {Name: "Query19Quantity1", Default: *query19Quantity1}}]}},
                   {$expr: {$lte: ["$$l_quantity", {$add: [{^Parameter: {Name: "Query19Quantity1", Default: *query19Quantity1}}, 10]}]}},
                   {p_size: {$gte: 1}}, {p_size: {$lte: 5}},
                   {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
                   {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-                {$and: [{p_brand: {^Parameter: {Name: "Query19Brand2", Default: *query19Brand2}}},
+                {$and: [
+                  {p_brand: {^Parameter: {Name: "Query19Brand2", Default: *query19Brand2}}},
                   {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
                   {$expr: {$gte: ["$$l_quantity", {^Parameter: {Name: "Query19Quantity2", Default: *query19Quantity2}}]}},
                   {$expr: {$lte: ["$$l_quantity", {$add: [{^Parameter: {Name: "Query19Quantity2", Default: *query19Quantity2}}, 10]}]}},
                   {p_size: {$gte: 1}}, {p_size: {$lte: 10}},
                   {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
                   {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-                {$and: [{p_brand: {^Parameter: {Name: "Query19Brand3", Default: *query19Brand3}}},
+                {$and: [
+                  {p_brand: {^Parameter: {Name: "Query19Brand3", Default: *query19Brand3}}},
                   {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
                   {$expr: {$gte: ["$$l_quantity", {^Parameter: {Name: "Query19Quantity3", Default: *query19Quantity3}}]}},
                   {$expr: {$lte: ["$$l_quantity", {$add: [{^Parameter: {Name: "Query19Quantity3", Default: *query19Quantity3}}, 10]}]}},

--- a/src/phases/tpch/normalized/Q19.yml
+++ b/src/phases/tpch/normalized/Q19.yml
@@ -1,0 +1,55 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 19 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+
+query19Brand1: &query19Brand1 "Brand#12"
+query19Quantity1: &query19Quantity1 1
+query19Brand2: &query19Brand2 "Brand#23"
+query19Quantity2: &query19Quantity2 10
+query19Brand3: &query19Brand3 "Brand#34"
+query19Quantity3: &query19Quantity3 20
+
+TPCHNormalizedQuery19:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query19
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: lineitem
+        pipeline:
+          [
+            {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode",  l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+            {$match: {$or: [{$and: [{p_brand: {^Parameter: {Name: "Query19Brand1", Default: *query19Brand1}}}, {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
+                  {$expr: {$gte: ["$$l_quantity", {^Parameter: {Name: "Query19Quantity1", Default: *query19Quantity1}}]}},
+                  {$expr: {$lte: ["$$l_quantity", {$add: [{^Parameter: {Name: "Query19Quantity1", Default: *query19Quantity1}}, 10]}]}},
+                  {p_size: {$gte: 1}}, {p_size: {$lte: 5}},
+                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+                {$and: [{p_brand: {^Parameter: {Name: "Query19Brand2", Default: *query19Brand2}}},
+                  {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
+                  {$expr: {$gte: ["$$l_quantity", {^Parameter: {Name: "Query19Quantity2", Default: *query19Quantity2}}]}},
+                  {$expr: {$lte: ["$$l_quantity", {$add: [{^Parameter: {Name: "Query19Quantity2", Default: *query19Quantity2}}, 10]}]}},
+                  {p_size: {$gte: 1}}, {p_size: {$lte: 10}},
+                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+                {$and: [{p_brand: {^Parameter: {Name: "Query19Brand3", Default: *query19Brand3}}},
+                  {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
+                  {$expr: {$gte: ["$$l_quantity", {^Parameter: {Name: "Query19Quantity3", Default: *query19Quantity3}}]}},
+                  {$expr: {$lte: ["$$l_quantity", {$add: [{^Parameter: {Name: "Query19Quantity3", Default: *query19Quantity3}}, 10]}]}},
+                  {p_size: {$gte: 1}}, {p_size: {$lte: 15}},
+                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
+            {$unwind: "$part"},
+            {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+            {$project: {_id: 0, revenue: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q19.yml
+++ b/src/phases/tpch/normalized/Q19.yml
@@ -1,17 +1,17 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 19 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 19 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
 
-query19Brand1: &query19Brand1 "Brand#12"
-query19Quantity1: &query19Quantity1 1
-query19Brand2: &query19Brand2 "Brand#23"
-query19Quantity2: &query19Quantity2 10
-query19Brand3: &query19Brand3 "Brand#34"
-query19Quantity3: &query19Quantity3 20
+query19Brand1: &query19Brand1 {^Parameter: {Name: "Query19Brand1", Default: "Brand#12"}}
+query19Quantity1: &query19Quantity1 {^Parameter: {Name: "Query19Quantity1", Default: 1}}
+query19Brand2: &query19Brand2 {^Parameter: {Name: "Query19Brand2", Default: "Brand#23"}}
+query19Quantity2: &query19Quantity2 {^Parameter: {Name: "Query19Quantity2", Default: 10}}
+query19Brand3: &query19Brand3 {^Parameter: {Name: "Query19Brand3", Default: "Brand#34"}}
+query19Quantity3: &query19Quantity3 {^Parameter: {Name: "Query19Quantity3", Default: 20}}
 
 TPCHNormalizedQuery19:
   Repeat: 1
@@ -27,26 +27,26 @@ TPCHNormalizedQuery19:
             {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
               {$match: {$or: [
                 {$and: [
-                  {p_brand: {^Parameter: {Name: "Query19Brand1", Default: *query19Brand1}}},
+                  {p_brand: *query19Brand1},
                   {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
-                  {$expr: {$gte: ["$$l_quantity", {^Parameter: {Name: "Query19Quantity1", Default: *query19Quantity1}}]}},
-                  {$expr: {$lte: ["$$l_quantity", {$add: [{^Parameter: {Name: "Query19Quantity1", Default: *query19Quantity1}}, 10]}]}},
+                  {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
+                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
                   {p_size: {$gte: 1}}, {p_size: {$lte: 5}},
                   {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
                   {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
                 {$and: [
-                  {p_brand: {^Parameter: {Name: "Query19Brand2", Default: *query19Brand2}}},
+                  {p_brand: *query19Brand2},
                   {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
-                  {$expr: {$gte: ["$$l_quantity", {^Parameter: {Name: "Query19Quantity2", Default: *query19Quantity2}}]}},
-                  {$expr: {$lte: ["$$l_quantity", {$add: [{^Parameter: {Name: "Query19Quantity2", Default: *query19Quantity2}}, 10]}]}},
+                  {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
+                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
                   {p_size: {$gte: 1}}, {p_size: {$lte: 10}},
                   {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
                   {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
                 {$and: [
-                  {p_brand: {^Parameter: {Name: "Query19Brand3", Default: *query19Brand3}}},
+                  {p_brand: *query19Brand3},
                   {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
-                  {$expr: {$gte: ["$$l_quantity", {^Parameter: {Name: "Query19Quantity3", Default: *query19Quantity3}}]}},
-                  {$expr: {$lte: ["$$l_quantity", {$add: [{^Parameter: {Name: "Query19Quantity3", Default: *query19Quantity3}}, 10]}]}},
+                  {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
+                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
                   {p_size: {$gte: 1}}, {p_size: {$lte: 15}},
                   {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
                   {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},

--- a/src/phases/tpch/normalized/Q2.yml
+++ b/src/phases/tpch/normalized/Q2.yml
@@ -1,13 +1,14 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 2 against the normalized schema.
+  Run TPC-H query 2 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
 
-query2Size: &query2Size 15
-query2Type: &query2Type "^.*BRASS$"  # ^.*{type}$"
-query2Region: &query2Region "EUROPE"
+query2Size: &query2Size {^Parameter: {Name: "Query2Size", Default: 15}}
+query2Type: &query2Type {^Parameter: {Name: "Query2Type", Default: "^.*BRASS$"}}  # ^.*{type}$"
+query2Region: &query2Region {^Parameter: {Name: "Query2Region", Default: "EUROPE"}}
 
 TPCHNormalizedQuery2:
   Repeat: 1
@@ -21,8 +22,8 @@ TPCHNormalizedQuery2:
         pipeline:
           [
             {$match: {$and: [
-              {p_type: {$regex: {^Parameter: {Name: "Query2Type", Default: *query2Type}}, $options: "si"}},
-              {p_size: {$eq: {^Parameter: {Name: "Query2Size", Default: *query2Size}}}}]}},
+              {p_type: {$regex: *query2Type, $options: "si"}},
+              {p_size: {$eq: *query2Size}}]}},
             {$lookup: {
               from: "partsupp",
               localField: "p_partkey",
@@ -47,7 +48,7 @@ TPCHNormalizedQuery2:
               foreignField: "r_regionkey",
               as: "region"}},
             {$unwind: "$region"},
-            {$match: {"region.r_name": {^Parameter: {Name: "Query2Region", Default: *query2Region}}}},
+            {$match: {"region.r_name": *query2Region}},
             {$sort: {"partsupp.ps_supplycost": 1}},
             {$group: {
               _id: {

--- a/src/phases/tpch/normalized/Q2.yml
+++ b/src/phases/tpch/normalized/Q2.yml
@@ -3,10 +3,10 @@ Owner: "@mongodb/product-query"
 Description: |
   Run TPC-H query 2 against the normalized schema.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 
 query2Size: &query2Size 15
-query2Type: &query2Type "^.*BRASS$" # ^.*{type}$"
+query2Type: &query2Type "^.*BRASS$"  # ^.*{type}$"
 query2Region: &query2Region "EUROPE"
 
 TPCHNormalizedQuery2:

--- a/src/phases/tpch/normalized/Q2.yml
+++ b/src/phases/tpch/normalized/Q2.yml
@@ -1,0 +1,80 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 2 against the normalized schema.
+
+batchSize: &batchSize 101 # The default batch size.
+
+query2Size: &query2Size 15
+query2Type: &query2Type "^.*BRASS$" # ^.*{type}$"
+query2Region: &query2Region "EUROPE"
+
+TPCHNormalizedQuery2:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query2
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: part
+        pipeline:
+          [
+            {$match: {$and: [
+              {p_type: {$regex: {^Parameter: {Name: "Query2Type", Default: *query2Type}}, $options: "si"}},
+              {p_size: {$eq: {^Parameter: {Name: "Query2Size", Default: *query2Size}}}}]}},
+            {$lookup: {
+              from: "partsupp",
+              localField: "p_partkey",
+              foreignField: "ps_partkey",
+              as: "partsupp"}},
+            {$unwind: "$partsupp"},
+            {$lookup: {
+              from: "supplier",
+              localField: "partsupp.ps_suppkey",
+              foreignField: "s_suppkey",
+              as: "supplier"}},
+            {$unwind: "$supplier"},
+            {$lookup: {
+              from: "nation",
+              localField: "supplier.s_nationkey",
+              foreignField: "n_nationkey",
+              as: "nation"}},
+            {$unwind: "$nation"},
+            {$lookup: {
+              from: "region",
+              localField: "nation.n_regionkey",
+              foreignField: "r_regionkey",
+              as: "region"}},
+            {$unwind: "$region"},
+            {$match: {"region.r_name": {^Parameter: {Name: "Query2Region", Default: *query2Region}}}},
+            {$sort: {"partsupp.ps_supplycost": 1}},
+            {$group: {
+              _id: {
+                p_partkey: "$p_partkey",
+                p_mfgr: "$p_mfgr"},
+              supplier: {$first: {
+                s_acctbal: "$supplier.s_acctbal",
+                s_name: "$supplier.s_name",
+                s_address: "$supplier.s_address",
+                s_phone: "$supplier.s_phone",
+                s_comment: "$supplier.s_comment",
+                ps_supplycost: "$partsupp.ps_supplycost",
+                n_name: "$nation.n_name"}}}},
+            {$project: {
+              _id: 0,
+              s_acctbal: "$supplier.s_acctbal",
+              s_name: "$supplier.s_name",
+              n_name: "$supplier.n_name",
+              p_partkey: "$_id.p_partkey",
+              p_mfgr: "$_id.p_mfgr",
+              s_address: "$supplier.s_address",
+              s_phone: "$supplier.s_phone",
+              s_comment: "$supplier.s_comment"}},
+            {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
+            {$limit: 100}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q20.yml
+++ b/src/phases/tpch/normalized/Q20.yml
@@ -1,14 +1,14 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 20 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 20 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
 
-query20Nation: &query20Nation "CANADA"
-query20Color: &query20Color "^forest.*$"  # "^${color}.*$"
-query20Date: &query20Date "1994-01-01"
+query20Nation: &query20Nation {^Parameter: {Name: "Query20Nation", Default: "CANADA"}}
+query20Color: &query20Color {^Parameter: {Name: "Query20Color", Default: "^forest.*$"}}  # "^${color}.*$"
+query20Date: &query20Date {^Parameter: {Name: "Query20Date", Default: "1994-01-01"}}
 
 TPCHNormalizedQuery20:
   Repeat: 1
@@ -23,17 +23,17 @@ TPCHNormalizedQuery20:
           [
             {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
             {$unwind: "$nation"},
-            {$match: {"nation.n_name": {^Parameter: {Name: "Query20Nation", Default: *query20Nation}}}},
+            {$match: {"nation.n_name": *query20Nation}},
             {$lookup: {from: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", as: "partsupp"}},
             {$unwind: "$partsupp"},
             {$lookup: {from: "part", localField: "partsupp.ps_partkey", foreignField: "p_partkey", as: "part"}},
             {$unwind: "$part"},
-            {$match: {"part.p_name": {$regex: {^Parameter: {Name: "Query20Color", Default: *query20Color}}, $options: "si"}}},
+            {$match: {"part.p_name": {$regex: *query20Color, $options: "si"}}},
             {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
               {$match: {$and: [
                 {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
-                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query20Date", Default: *query20Date}}}}]}},
-                {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query20Date", Default: *query20Date}}}}, unit: "year", amount: 1}}]}}]}},
+                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
+                {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
               {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
               {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
             {$unwind: "$lineitem"},

--- a/src/phases/tpch/normalized/Q20.yml
+++ b/src/phases/tpch/normalized/Q20.yml
@@ -4,10 +4,10 @@ Description: |
   Run TPC-H query 20 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 
 query20Nation: &query20Nation "CANADA"
-query20Color: &query20Color "^forest.*$" # "^${color}.*$"
+query20Color: &query20Color "^forest.*$"  # "^${color}.*$"
 query20Date: &query20Date "1994-01-01"
 
 TPCHNormalizedQuery20:
@@ -30,9 +30,10 @@ TPCHNormalizedQuery20:
             {$unwind: "$part"},
             {$match: {"part.p_name": {$regex: {^Parameter: {Name: "Query20Color", Default: *query20Color}}, $options: "si"}}},
             {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
-              {$match: {$and: [{$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
+              {$match: {$and: [
+                {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
                 {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query20Date", Default: *query20Date}}}}]}},
-                {$expr: {$lt: ["$l_shipdate",  {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query20Date", Default: *query20Date}}}}, unit: "year", amount: 1}}]}}]}},
+                {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query20Date", Default: *query20Date}}}}, unit: "year", amount: 1}}]}}]}},
               {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
               {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
             {$unwind: "$lineitem"},

--- a/src/phases/tpch/normalized/Q20.yml
+++ b/src/phases/tpch/normalized/Q20.yml
@@ -1,0 +1,47 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 20 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+
+query20Nation: &query20Nation "CANADA"
+query20Color: &query20Color "^forest.*$" # "^${color}.*$"
+query20Date: &query20Date "1994-01-01"
+
+TPCHNormalizedQuery20:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query20
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: supplier
+        pipeline:
+          [
+            {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
+            {$unwind: "$nation"},
+            {$match: {"nation.n_name": {^Parameter: {Name: "Query20Nation", Default: *query20Nation}}}},
+            {$lookup: {from: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", as: "partsupp"}},
+            {$unwind: "$partsupp"},
+            {$lookup: {from: "part", localField: "partsupp.ps_partkey", foreignField: "p_partkey", as: "part"}},
+            {$unwind: "$part"},
+            {$match: {"part.p_name": {$regex: {^Parameter: {Name: "Query20Color", Default: *query20Color}}, $options: "si"}}},
+            {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
+              {$match: {$and: [{$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
+                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query20Date", Default: *query20Date}}}}]}},
+                {$expr: {$lt: ["$l_shipdate",  {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query20Date", Default: *query20Date}}}}, unit: "year", amount: 1}}]}}]}},
+              {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
+              {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
+            {$unwind: "$lineitem"},
+            {$match: {$expr: {$gt: ["$partsupp.ps_availqty", "$lineitem.quantity"]}}},
+            {$group: {_id: {s_name: "$s_name", s_address: "$s_address"}}},
+            {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
+            {$sort: {s_name: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q21.yml
+++ b/src/phases/tpch/normalized/Q21.yml
@@ -1,0 +1,42 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 21 against the normalized schema.
+
+batchSize: &batchSize 101 # The default batch size.
+query21Nation: &query21Nation "SAUDI ARABIA"
+
+TPCHNormalizedQuery21:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query21
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: supplier
+        pipeline:
+          [
+            {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
+            {$unwind: "$nation"},
+            {$match: {"nation.n_name": {^Parameter: {Name: "Query1Delta", Default: *query21Nation}}}},
+            {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "l1", pipeline: [{$match: {$expr: {$gt: ["$l_receiptdate", "$l_commitdate"]}}}]}},
+            {$unwind: "$l1"},
+            {$lookup: {from: "orders", localField: "l1.l_orderkey", foreignField: "o_orderkey", as: "orders", pipeline: [{$match: {o_orderstatus: "F"}}]}},
+            {$unwind: "$orders"},
+            {$lookup: {from: "lineitem", let: {l1: "$l1"}, localField: "l1.l_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+              {$match: {$expr: {$ne: ["$$l1.l_suppkey", "$l_suppkey"]}}},
+              {$group: {_id: {}, l2_count: {$count: {}}, l3_count: {$sum: {$cond: {if: {$gt: ["$l_receiptdate", "$l_commitdate"]}, then: 1, else: 0}}}}}]}},
+            {$unwind: "$lineitem"},
+            {$match: {$and: [
+              {$expr: {$gt: ["$lineitem.l2_count", 0]}},
+              {$expr: {$eq: ["$lineitem.l3_count", 0]}}]}},
+            {$group: {_id: "$s_name", numwait: {$count: {}}}},
+            {$project: {_id: 0, s_name: "$_id", numwait: 1}},
+            {$sort: {numwait: -1, s_name: 1}},
+            {$limit: 100}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q21.yml
+++ b/src/phases/tpch/normalized/Q21.yml
@@ -3,7 +3,7 @@ Owner: "@mongodb/product-query"
 Description: |
   Run TPC-H query 21 against the normalized schema.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query21Nation: &query21Nation "SAUDI ARABIA"
 
 TPCHNormalizedQuery21:

--- a/src/phases/tpch/normalized/Q21.yml
+++ b/src/phases/tpch/normalized/Q21.yml
@@ -1,10 +1,11 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 21 against the normalized schema.
+  Run TPC-H query 21 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query21Nation: &query21Nation "SAUDI ARABIA"
+query21Nation: &query21Nation {^Parameter: {Name: "Query1Delta", Default: "SAUDI ARABIA"}}
 
 TPCHNormalizedQuery21:
   Repeat: 1
@@ -19,7 +20,7 @@ TPCHNormalizedQuery21:
           [
             {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
             {$unwind: "$nation"},
-            {$match: {"nation.n_name": {^Parameter: {Name: "Query1Delta", Default: *query21Nation}}}},
+            {$match: {"nation.n_name": *query21Nation}},
             {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "l1", pipeline: [{$match: {$expr: {$gt: ["$l_receiptdate", "$l_commitdate"]}}}]}},
             {$unwind: "$l1"},
             {$lookup: {from: "orders", localField: "l1.l_orderkey", foreignField: "o_orderkey", as: "orders", pipeline: [{$match: {o_orderstatus: "F"}}]}},

--- a/src/phases/tpch/normalized/Q22.yml
+++ b/src/phases/tpch/normalized/Q22.yml
@@ -1,0 +1,57 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 22 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+# Sadly, using an array here parses as an array of numbers instead of as an array of strings.
+# To work around this, use separate parameters for each entry in the array.
+query22CountryCode1: &query22CountryCode1 "13"
+query22CountryCode2: &query22CountryCode2 "31"
+query22CountryCode3: &query22CountryCode3 "23"
+query22CountryCode4: &query22CountryCode4 "29"
+query22CountryCode5: &query22CountryCode5 "30"
+query22CountryCode6: &query22CountryCode6 "18"
+query22CountryCode7: &query22CountryCode7 "17"
+
+TPCHNormalizedQuery22:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query22
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "custsale"}},
+            {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
+            {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}}},
+            {$match: {$and: [{$expr: {$in: ["$cntrycode", [
+              {^Parameter: {Name: "Query22CountryCode1", Default: *query22CountryCode1}},
+              {^Parameter: {Name: "Query22CountryCode2", Default: *query22CountryCode2}},
+              {^Parameter: {Name: "Query22CountryCode3", Default: *query22CountryCode3}},
+              {^Parameter: {Name: "Query22CountryCode4", Default: *query22CountryCode4}},
+              {^Parameter: {Name: "Query22CountryCode5", Default: *query22CountryCode5}},
+              {^Parameter: {Name: "Query22CountryCode6", Default: *query22CountryCode6}},
+              {^Parameter: {Name: "Query22CountryCode7", Default: *query22CountryCode7}},
+              ]]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
+            {$facet: {
+              customer: [
+                {$project: {cntrycode: 1, c_acctbal: 1}}],
+              "avg(c_acctbal)": [
+                {$group: {_id: {}, value: {$avg: "$c_acctbal"}}},
+                {$project: {_id: 0}}]}},
+            {$unwind: "$avg(c_acctbal)"},
+            {$unwind: "$customer"},
+            {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
+            {$group: {_id: "$customer.cntrycode", numcust: {$count: {}},  totacctbal: {$sum: "$customer.c_acctbal"}}},
+            {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
+            {$sort: {cntrycode: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q22.yml
+++ b/src/phases/tpch/normalized/Q22.yml
@@ -1,19 +1,19 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 22 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 22 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
 # Sadly, using an array here parses as an array of numbers instead of as an array of strings.
 # To work around this, use separate parameters for each entry in the array.
-query22CountryCode1: &query22CountryCode1 "13"
-query22CountryCode2: &query22CountryCode2 "31"
-query22CountryCode3: &query22CountryCode3 "23"
-query22CountryCode4: &query22CountryCode4 "29"
-query22CountryCode5: &query22CountryCode5 "30"
-query22CountryCode6: &query22CountryCode6 "18"
-query22CountryCode7: &query22CountryCode7 "17"
+query22CountryCode1: &query22CountryCode1 {^Parameter: {Name: "Query22CountryCode1", Default: "13"}}
+query22CountryCode2: &query22CountryCode2 {^Parameter: {Name: "Query22CountryCode2", Default: "31"}}
+query22CountryCode3: &query22CountryCode3 {^Parameter: {Name: "Query22CountryCode3", Default: "23"}}
+query22CountryCode4: &query22CountryCode4 {^Parameter: {Name: "Query22CountryCode4", Default: "29"}}
+query22CountryCode5: &query22CountryCode5 {^Parameter: {Name: "Query22CountryCode5", Default: "30"}}
+query22CountryCode6: &query22CountryCode6 {^Parameter: {Name: "Query22CountryCode6", Default: "18"}}
+query22CountryCode7: &query22CountryCode7 {^Parameter: {Name: "Query22CountryCode7", Default: "17"}}
 
 TPCHNormalizedQuery22:
   Repeat: 1
@@ -31,13 +31,13 @@ TPCHNormalizedQuery22:
             {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}}},
             {$match: {$and: [
               {$expr: {$in: ["$cntrycode", [
-                {^Parameter: {Name: "Query22CountryCode1", Default: *query22CountryCode1}},
-                {^Parameter: {Name: "Query22CountryCode2", Default: *query22CountryCode2}},
-                {^Parameter: {Name: "Query22CountryCode3", Default: *query22CountryCode3}},
-                {^Parameter: {Name: "Query22CountryCode4", Default: *query22CountryCode4}},
-                {^Parameter: {Name: "Query22CountryCode5", Default: *query22CountryCode5}},
-                {^Parameter: {Name: "Query22CountryCode6", Default: *query22CountryCode6}},
-                {^Parameter: {Name: "Query22CountryCode7", Default: *query22CountryCode7}}]]}},
+                *query22CountryCode1,
+                *query22CountryCode2,
+                *query22CountryCode3,
+                *query22CountryCode4,
+                *query22CountryCode5,
+                *query22CountryCode6,
+                *query22CountryCode7]]}},
               {custsale: null},
               {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
             {$facet: {

--- a/src/phases/tpch/normalized/Q22.yml
+++ b/src/phases/tpch/normalized/Q22.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 22 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 # Sadly, using an array here parses as an array of numbers instead of as an array of strings.
 # To work around this, use separate parameters for each entry in the array.
 query22CountryCode1: &query22CountryCode1 "13"
@@ -29,15 +29,17 @@ TPCHNormalizedQuery22:
             {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "custsale"}},
             {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
             {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}}},
-            {$match: {$and: [{$expr: {$in: ["$cntrycode", [
-              {^Parameter: {Name: "Query22CountryCode1", Default: *query22CountryCode1}},
-              {^Parameter: {Name: "Query22CountryCode2", Default: *query22CountryCode2}},
-              {^Parameter: {Name: "Query22CountryCode3", Default: *query22CountryCode3}},
-              {^Parameter: {Name: "Query22CountryCode4", Default: *query22CountryCode4}},
-              {^Parameter: {Name: "Query22CountryCode5", Default: *query22CountryCode5}},
-              {^Parameter: {Name: "Query22CountryCode6", Default: *query22CountryCode6}},
-              {^Parameter: {Name: "Query22CountryCode7", Default: *query22CountryCode7}},
-              ]]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
+            {$match: {$and: [
+              {$expr: {$in: ["$cntrycode", [
+                {^Parameter: {Name: "Query22CountryCode1", Default: *query22CountryCode1}},
+                {^Parameter: {Name: "Query22CountryCode2", Default: *query22CountryCode2}},
+                {^Parameter: {Name: "Query22CountryCode3", Default: *query22CountryCode3}},
+                {^Parameter: {Name: "Query22CountryCode4", Default: *query22CountryCode4}},
+                {^Parameter: {Name: "Query22CountryCode5", Default: *query22CountryCode5}},
+                {^Parameter: {Name: "Query22CountryCode6", Default: *query22CountryCode6}},
+                {^Parameter: {Name: "Query22CountryCode7", Default: *query22CountryCode7}}]]}},
+              {custsale: null},
+              {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
             {$facet: {
               customer: [
                 {$project: {cntrycode: 1, c_acctbal: 1}}],
@@ -47,7 +49,7 @@ TPCHNormalizedQuery22:
             {$unwind: "$avg(c_acctbal)"},
             {$unwind: "$customer"},
             {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
-            {$group: {_id: "$customer.cntrycode", numcust: {$count: {}},  totacctbal: {$sum: "$customer.c_acctbal"}}},
+            {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
             {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
             {$sort: {cntrycode: 1}}
           ]

--- a/src/phases/tpch/normalized/Q3.yml
+++ b/src/phases/tpch/normalized/Q3.yml
@@ -3,7 +3,7 @@ Owner: "@mongodb/product-query"
 Description: |
   Run TPC-H query 3 against the normalized schema.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 
 query3Segment: &query3Segment "BUILDING"
 query3Date: &query3Date "1995-03-15"
@@ -20,14 +20,14 @@ TPCHNormalizedQuery3:
         pipeline:
           [
             {$match: {$expr: {$eq: ["$c_mktsegment", {^Parameter: {Name: "Query3Segment", Default: *query3Segment}}]}}},
-            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", pipeline: [
+            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
               {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query3Date", Default: *query3Date}}}}]}}},
-              {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}], as: "orders"}},
-              {$unwind: "$orders"},
-              {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", pipeline: [
-                {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query3Date", Default: *query3Date}}}}]}}}], as: "lineitem"}},
-                {$unwind: "$lineitem"},
-                {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+              {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
+            {$unwind: "$orders"},
+            {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+              {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query3Date", Default: *query3Date}}}}]}}}]}},
+            {$unwind: "$lineitem"},
+            {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
             {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
             {$sort: {revenue: -1, o_orderdate: 1}},
             {$limit: 10}

--- a/src/phases/tpch/normalized/Q3.yml
+++ b/src/phases/tpch/normalized/Q3.yml
@@ -1,0 +1,38 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 3 against the normalized schema.
+
+batchSize: &batchSize 101 # The default batch size.
+
+query3Segment: &query3Segment "BUILDING"
+query3Date: &query3Date "1995-03-15"
+
+TPCHNormalizedQuery3:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query3
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$match: {$expr: {$eq: ["$c_mktsegment", {^Parameter: {Name: "Query3Segment", Default: *query3Segment}}]}}},
+            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", pipeline: [
+              {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query3Date", Default: *query3Date}}}}]}}},
+              {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}], as: "orders"}},
+              {$unwind: "$orders"},
+              {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", pipeline: [
+                {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query3Date", Default: *query3Date}}}}]}}}], as: "lineitem"}},
+                {$unwind: "$lineitem"},
+                {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+            {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
+            {$sort: {revenue: -1, o_orderdate: 1}},
+            {$limit: 10}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q3.yml
+++ b/src/phases/tpch/normalized/Q3.yml
@@ -1,12 +1,13 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 3 against the normalized schema.
+  Run TPC-H query 3 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
 
-query3Segment: &query3Segment "BUILDING"
-query3Date: &query3Date "1995-03-15"
+query3Segment: &query3Segment {^Parameter: {Name: "Query3Segment", Default: "BUILDING"}}
+query3Date: &query3Date {^Parameter: {Name: "Query3Date", Default: "1995-03-15"}}
 
 TPCHNormalizedQuery3:
   Repeat: 1
@@ -19,13 +20,13 @@ TPCHNormalizedQuery3:
         aggregate: customer
         pipeline:
           [
-            {$match: {$expr: {$eq: ["$c_mktsegment", {^Parameter: {Name: "Query3Segment", Default: *query3Segment}}]}}},
+            {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
             {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-              {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query3Date", Default: *query3Date}}}}]}}},
+              {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
               {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
             {$unwind: "$orders"},
             {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-              {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query3Date", Default: *query3Date}}}}]}}}]}},
+              {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}}]}},
             {$unwind: "$lineitem"},
             {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
             {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},

--- a/src/phases/tpch/normalized/Q4.yml
+++ b/src/phases/tpch/normalized/Q4.yml
@@ -1,11 +1,11 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 4 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 4 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query4Date: &query4Date "1993-07-01"
+query4Date: &query4Date {^Parameter: {Name: "Query4Date", Default: "1993-07-01"}}
 
 TPCHNormalizedQuery4:
   Repeat: 1
@@ -20,8 +20,8 @@ TPCHNormalizedQuery4:
           [
             {$match: {
               $and: [
-                {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query4Date", Default: *query4Date}}}}]}},
-                {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query4Date", Default: *query4Date}}}}, unit: "month", amount: 3}}]}}]}},
+                {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
+                {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}}]}},
             {$lookup: {
               from: "lineitem",
               localField: "o_orderkey",

--- a/src/phases/tpch/normalized/Q4.yml
+++ b/src/phases/tpch/normalized/Q4.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 4 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query4Date: &query4Date "1993-07-01"
 
 TPCHNormalizedQuery4:

--- a/src/phases/tpch/normalized/Q4.yml
+++ b/src/phases/tpch/normalized/Q4.yml
@@ -1,0 +1,42 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 4 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query4Date: &query4Date "1993-07-01"
+
+TPCHNormalizedQuery4:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query4
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: orders
+        pipeline:
+          [
+            {$match: {
+              $and: [
+                {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query4Date", Default: *query4Date}}}}]}},
+                {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query4Date", Default: *query4Date}}}}, unit: "month", amount: 3}}]}}]}},
+            {$lookup: {
+              from: "lineitem",
+              localField: "o_orderkey",
+              foreignField: "l_orderkey",
+              pipeline: [{$match: {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}}}, {$count: "count"}],
+              as: "lineitem"}},
+            {$unwind: "$lineitem"},
+            {$match: {$expr: {$gt: ["$lineitem.count", 0]}}},
+            {$group: {
+              _id: "$o_orderpriority",
+              order_count: {$count: {}}}},
+            {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
+            {$sort: {o_orderpriority: 1}},
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q5.yml
+++ b/src/phases/tpch/normalized/Q5.yml
@@ -1,0 +1,44 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 5 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query5Region: &query5Region "ASIA"
+query5Date: &query5Date "1994-01-01"
+
+TPCHNormalizedQuery5:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query5
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$lookup: { from: "orders",  localField: "c_custkey", foreignField: "o_custkey",  as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
+            {$match: {$and: [
+              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query5Date", Default: *query5Date}}}}]}},
+              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query5Date", Default: *query5Date}}}}, unit: "year", amount: 1}}]}}]}},
+            {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
+              {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+                {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
+                {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
+                  {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
+                    {$match: {r_name: {^Parameter: {Name: "Query5Region", Default: *query5Region}}}}]}},
+                  {$unwind: "$region"}]}},
+                {$unwind: "$nation"}]}},
+              {$unwind: "$supplier"}]}},
+            {$unwind: "$lineitem"}]}},
+            {$unwind: "$orders"},
+            {$group: {_id: "$orders.lineitem.supplier.nation.n_name", revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+            {$project: {_id: 0, n_name: "$_id", revenue: 1}},
+            {$sort: {revenue: -1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q5.yml
+++ b/src/phases/tpch/normalized/Q5.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 5 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 5 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query5Region: &query5Region "ASIA"
-query5Date: &query5Date "1994-01-01"
+query5Region: &query5Region {^Parameter: {Name: "Query5Region", Default: "ASIA"}}
+query5Date: &query5Date {^Parameter: {Name: "Query5Date", Default: "1994-01-01"}}
 
 TPCHNormalizedQuery5:
   Repeat: 1
@@ -21,14 +21,14 @@ TPCHNormalizedQuery5:
           [
             {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
               {$match: {$and: [
-                {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query5Date", Default: *query5Date}}}}]}},
-                {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query5Date", Default: *query5Date}}}}, unit: "year", amount: 1}}]}}]}},
+                {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
+                {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
               {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
                 {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
                   {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
                   {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
                     {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
-                      {$match: {r_name: {^Parameter: {Name: "Query5Region", Default: *query5Region}}}}]}},
+                      {$match: {r_name: *query5Region}}]}},
                     {$unwind: "$region"}]}},
                   {$unwind: "$nation"}]}},
                 {$unwind: "$supplier"}]}},

--- a/src/phases/tpch/normalized/Q5.yml
+++ b/src/phases/tpch/normalized/Q5.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 5 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query5Region: &query5Region "ASIA"
 query5Date: &query5Date "1994-01-01"
 
@@ -19,20 +19,20 @@ TPCHNormalizedQuery5:
         aggregate: customer
         pipeline:
           [
-            {$lookup: { from: "orders",  localField: "c_custkey", foreignField: "o_custkey",  as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
-            {$match: {$and: [
-              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query5Date", Default: *query5Date}}}}]}},
-              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query5Date", Default: *query5Date}}}}, unit: "year", amount: 1}}]}}]}},
-            {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
-              {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-                {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
-                {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
-                  {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
-                    {$match: {r_name: {^Parameter: {Name: "Query5Region", Default: *query5Region}}}}]}},
-                  {$unwind: "$region"}]}},
-                {$unwind: "$nation"}]}},
-              {$unwind: "$supplier"}]}},
-            {$unwind: "$lineitem"}]}},
+            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
+              {$match: {$and: [
+                {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query5Date", Default: *query5Date}}}}]}},
+                {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query5Date", Default: *query5Date}}}}, unit: "year", amount: 1}}]}}]}},
+              {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
+                {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+                  {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
+                  {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
+                    {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
+                      {$match: {r_name: {^Parameter: {Name: "Query5Region", Default: *query5Region}}}}]}},
+                    {$unwind: "$region"}]}},
+                  {$unwind: "$nation"}]}},
+                {$unwind: "$supplier"}]}},
+              {$unwind: "$lineitem"}]}},
             {$unwind: "$orders"},
             {$group: {_id: "$orders.lineitem.supplier.nation.n_name", revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
             {$project: {_id: 0, n_name: "$_id", revenue: 1}},

--- a/src/phases/tpch/normalized/Q6.yml
+++ b/src/phases/tpch/normalized/Q6.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 6 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 
 query6Date: &query6Date "1994-01-01"
 query6Discount: &query6Discount 0.06

--- a/src/phases/tpch/normalized/Q6.yml
+++ b/src/phases/tpch/normalized/Q6.yml
@@ -1,14 +1,14 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 6 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 6 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
 
-query6Date: &query6Date "1994-01-01"
-query6Discount: &query6Discount 0.06
-query6Quantity: &query6Quantity 24
+query6Date: &query6Date {^Parameter: {Name: "Query6Date", Default: "1994-01-01"}}
+query6Discount: &query6Discount {^Parameter: {Name: "Query6Discount", Default: 0.06}}
+query6Quantity: &query6Quantity {^Parameter: {Name: "Query6Quantity", Default: 24}}
 
 TPCHNormalizedQuery6:
   Repeat: 1
@@ -22,11 +22,11 @@ TPCHNormalizedQuery6:
         pipeline:
           [
             {$match: {$and: [
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query6Date", Default: *query6Date}}}}]}},
-              {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query6Date", Default: *query6Date}}}}, unit: "year", amount: 1}}]}},
-              {$expr: {$gte: ["$l_discount", {$subtract: [{^Parameter: {Name: "Query6Discount", Default: *query6Discount}}, 0.01]}]}},
-              {$expr: {$lte: ["$l_discount", {$add: [{^Parameter: {Name: "Query6Discount", Default: *query6Discount}}, 0.011]}]}},
-              {$expr: {$lt: ["$l_quantity", {^Parameter: {Name: "Query6Quantity", Default: *query6Quantity}}]}}]}},
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
+              {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+              {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
+              {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
+              {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
             {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
             {$project: {_id: 0, revenue: 1}},
           ]

--- a/src/phases/tpch/normalized/Q6.yml
+++ b/src/phases/tpch/normalized/Q6.yml
@@ -1,0 +1,36 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 6 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+
+query6Date: &query6Date "1994-01-01"
+query6Discount: &query6Discount 0.06
+query6Quantity: &query6Quantity 24
+
+TPCHNormalizedQuery6:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query6
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: lineitem
+        pipeline:
+          [
+            {$match: {$and: [
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: {^Parameter: {Name: "Query6Date", Default: *query6Date}}}}]}},
+              {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: {^Parameter: {Name: "Query6Date", Default: *query6Date}}}}, unit: "year", amount: 1}}]}},
+              {$expr: {$gte: ["$l_discount", {$subtract: [{^Parameter: {Name: "Query6Discount", Default: *query6Discount}}, 0.01]}]}},
+              {$expr: {$lte: ["$l_discount", {$add: [{^Parameter: {Name: "Query6Discount", Default: *query6Discount}}, 0.011]}]}},
+              {$expr: {$lt: ["$l_quantity", {^Parameter: {Name: "Query6Quantity", Default: *query6Quantity}}]}}]}},
+            {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
+            {$project: {_id: 0, revenue: 1}},
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q7.yml
+++ b/src/phases/tpch/normalized/Q7.yml
@@ -1,12 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 7 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 7 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query7Nation1: &query7Nation1 "FRANCE"
-query7Nation2: &query7Nation2 "GERMANY"
+query7Nation1: &query7Nation1 {^Parameter: {Name: "Query7Nation1", Default: "FRANCE"}}
+query7Nation2: &query7Nation2 {^Parameter: {Name: "Query7Nation2", Default: "GERMANY"}}
 
 TPCHNormalizedQuery7:
   Repeat: 1
@@ -34,8 +34,8 @@ TPCHNormalizedQuery7:
             {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n2"}},
             {$unwind: "$n2"},
             {$match: {$or: [
-              {$and: [{"n1.n_name": {^Parameter: {Name: "Query7Nation1", Default: *query7Nation1}}}, {"n2.n_name": {^Parameter: {Name: "Query7Nation2", Default: *query7Nation2}}}]},
-              {$and: [{"n1.n_name": {^Parameter: {Name: "Query7Nation2", Default: *query7Nation2}}}, {"n2.n_name": {^Parameter: {Name: "Query7Nation1", Default: *query7Nation1}}}]}]}},
+              {$and: [{"n1.n_name": *query7Nation1}, {"n2.n_name": *query7Nation2}]},
+              {$and: [{"n1.n_name": *query7Nation2}, {"n2.n_name": *query7Nation1}]}]}},
             {$project: {supp_nation: "$n1.n_name", cust_nation: "$n2.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
             {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
             {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},

--- a/src/phases/tpch/normalized/Q7.yml
+++ b/src/phases/tpch/normalized/Q7.yml
@@ -1,0 +1,47 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 7 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+query7Nation1: &query7Nation1 "FRANCE"
+query7Nation2: &query7Nation2 "GERMANY"
+
+TPCHNormalizedQuery7:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query7
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: supplier
+        pipeline:
+          [
+            {$project: {s_nationkey: 1, s_suppkey: 1}},
+            {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "n1"}},
+            {$unwind: "$n1"},
+            {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
+              {$match: {$and: [
+                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
+                {$expr: {$lt: ["$l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}}]}},
+            {$unwind: "$lineitem"},
+            {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+            {$unwind: "$orders"},
+            {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
+            {$unwind: "$customer"},
+            {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n2"}},
+            {$unwind: "$n2"},
+            {$match: {$or: [
+              {$and: [{"n1.n_name": {^Parameter: {Name: "Query7Nation1", Default: *query7Nation1}}}, {"n2.n_name": {^Parameter: {Name: "Query7Nation2", Default: *query7Nation2}}}]},
+              {$and: [{"n1.n_name": {^Parameter: {Name: "Query7Nation2", Default: *query7Nation2}}}, {"n2.n_name": {^Parameter: {Name: "Query7Nation1", Default: *query7Nation1}}}]}]}},
+            {$project: {supp_nation: "$n1.n_name", cust_nation: "$n2.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
+            {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year",}, revenue: {$sum: "$volume"}}},
+            {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
+            {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q7.yml
+++ b/src/phases/tpch/normalized/Q7.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 7 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 query7Nation1: &query7Nation1 "FRANCE"
 query7Nation2: &query7Nation2 "GERMANY"
 
@@ -37,7 +37,7 @@ TPCHNormalizedQuery7:
               {$and: [{"n1.n_name": {^Parameter: {Name: "Query7Nation1", Default: *query7Nation1}}}, {"n2.n_name": {^Parameter: {Name: "Query7Nation2", Default: *query7Nation2}}}]},
               {$and: [{"n1.n_name": {^Parameter: {Name: "Query7Nation2", Default: *query7Nation2}}}, {"n2.n_name": {^Parameter: {Name: "Query7Nation1", Default: *query7Nation1}}}]}]}},
             {$project: {supp_nation: "$n1.n_name", cust_nation: "$n2.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
-            {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year",}, revenue: {$sum: "$volume"}}},
+            {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
             {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
             {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
           ]

--- a/src/phases/tpch/normalized/Q8.yml
+++ b/src/phases/tpch/normalized/Q8.yml
@@ -1,14 +1,14 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 8 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  Run TPC-H query 8 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
 
-query8Type: &query8Type "ECONOMY ANODIZED STEEL"
-query8Region: &query8Region "AMERICA"
-query8Nation: &query8Nation "BRAZIL"
+query8Type: &query8Type {^Parameter: {Name: "Query8Type", Default: "ECONOMY ANODIZED STEEL"}}
+query8Region: &query8Region {^Parameter: {Name: "Query8Region", Default: "AMERICA"}}
+query8Nation: &query8Nation {^Parameter: {Name: "Query8Nation", Default: "BRAZIL"}}
 
 TPCHNormalizedQuery8:
   Repeat: 1
@@ -21,7 +21,7 @@ TPCHNormalizedQuery8:
         aggregate: part
         pipeline:
           [
-            {$match: {p_type: {$eq: {^Parameter: {Name: "Query8Type", Default: *query8Type}}}}},
+            {$match: {p_type: {$eq: *query8Type}}},
             {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem"}},
             {$unwind: "$lineitem"},
             {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
@@ -39,14 +39,14 @@ TPCHNormalizedQuery8:
             {$unwind: "$n1"},
             {$lookup: {from: "region", localField: "n1.n_regionkey", foreignField: "r_regionkey", as: "region"}},
             {$unwind: "$region"},
-            {$match: {"region.r_name": {$eq: {^Parameter: {Name: "Query8Region", Default: *query8Region}}}}},
+            {$match: {"region.r_name": {$eq: *query8Region}}},
             {$project: {
               o_year: {$year: "$orders.o_orderdate"},
               volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]},
               nation: "$n2.n_name"}},
             {$group: {
               _id: "$o_year", total_volume: {$sum: "$volume"},
-              nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", {^Parameter: {Name: "Query8Nation", Default: *query8Nation}}]}, then: "$volume", else: 0}}}}},
+              nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
             {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
             {$sort: {o_year: 1}}
           ]

--- a/src/phases/tpch/normalized/Q8.yml
+++ b/src/phases/tpch/normalized/Q8.yml
@@ -1,0 +1,53 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 8 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101 # The default batch size.
+
+query8Type: &query8Type "ECONOMY ANODIZED STEEL"
+query8Region: &query8Region "AMERICA"
+query8Nation: &query8Nation "BRAZIL"
+
+TPCHNormalizedQuery8:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query8
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: part
+        pipeline:
+          [
+            {$match: {p_type: {$eq: {^Parameter: {Name: "Query8Type", Default: *query8Type}}}}},
+            {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem"}},
+            {$unwind: "$lineitem"},
+            {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+            {$unwind: "$supplier"},
+            {$lookup: {from: "nation", localField: "supplier.s_nationkey", foreignField: "n_nationkey", as: "n2"}},
+            {$unwind: "$n2"},
+            {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+            {$unwind: "$orders"},
+            {$match: {$and: [
+              {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
+              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+            {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
+            {$unwind: "$customer"},
+            {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n1"}},
+            {$unwind: "$n1"},
+            {$lookup: {from: "region", localField: "n1.n_regionkey", foreignField: "r_regionkey", as: "region"}},
+            {$unwind: "$region"},
+            {$match: {"region.r_name": {$eq: {^Parameter: {Name: "Query8Region", Default: *query8Region}}}}},
+            {$project: {o_year: {$year: "$orders.o_orderdate"},
+              volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]}, nation: "$n2.n_name", }},
+            {$group: {_id: "$o_year", total_volume: {$sum: "$volume"},
+              nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", {^Parameter: {Name: "Query8Nation", Default: *query8Nation}}]}, then: "$volume", else: 0}}}}},
+            {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
+            {$sort: {o_year: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q8.yml
+++ b/src/phases/tpch/normalized/Q8.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 8 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101 # The default batch size.
+batchSize: &batchSize 101  # The default batch size.
 
 query8Type: &query8Type "ECONOMY ANODIZED STEEL"
 query8Region: &query8Region "AMERICA"
@@ -40,9 +40,12 @@ TPCHNormalizedQuery8:
             {$lookup: {from: "region", localField: "n1.n_regionkey", foreignField: "r_regionkey", as: "region"}},
             {$unwind: "$region"},
             {$match: {"region.r_name": {$eq: {^Parameter: {Name: "Query8Region", Default: *query8Region}}}}},
-            {$project: {o_year: {$year: "$orders.o_orderdate"},
-              volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]}, nation: "$n2.n_name", }},
-            {$group: {_id: "$o_year", total_volume: {$sum: "$volume"},
+            {$project: {
+              o_year: {$year: "$orders.o_orderdate"},
+              volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]},
+              nation: "$n2.n_name"}},
+            {$group: {
+              _id: "$o_year", total_volume: {$sum: "$volume"},
               nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", {^Parameter: {Name: "Query8Nation", Default: *query8Nation}}]}, then: "$volume", else: 0}}}}},
             {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
             {$sort: {o_year: 1}}

--- a/src/workloads/tpch/normalized/1/Q1.yml
+++ b/src/workloads/tpch/normalized/1/Q1.yml
@@ -1,0 +1,28 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 1 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery1
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q1.yml
+      Key: TPCHNormalizedQuery1
+      Parameters:
+        Query1Delta: -90
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q1.yml
+++ b/src/workloads/tpch/normalized/1/Q1.yml
@@ -18,11 +18,3 @@ Actors:
       Key: TPCHNormalizedQuery1
       Parameters:
         Query1Delta: -90
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q1.yml
+++ b/src/workloads/tpch/normalized/1/Q1.yml
@@ -25,4 +25,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q10.yml
+++ b/src/workloads/tpch/normalized/1/Q10.yml
@@ -1,0 +1,28 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 10 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery10
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q10.yml
+      Key: TPCHNormalizedQuery10
+      Parameters:
+        Query10Date: "1993-10-01"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q10.yml
+++ b/src/workloads/tpch/normalized/1/Q10.yml
@@ -18,11 +18,3 @@ Actors:
       Key: TPCHNormalizedQuery10
       Parameters:
         Query10Date: "1993-10-01"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q10.yml
+++ b/src/workloads/tpch/normalized/1/Q10.yml
@@ -25,4 +25,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q11.yml
+++ b/src/workloads/tpch/normalized/1/Q11.yml
@@ -20,11 +20,3 @@ Actors:
       Parameters:
         Query11Nation: "GERMANY"
         Query11Fraction: 0.0001
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q11.yml
+++ b/src/workloads/tpch/normalized/1/Q11.yml
@@ -1,0 +1,30 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 11 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery11
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q11.yml
+      Key: TPCHNormalizedQuery11
+      Parameters:
+        Query11Nation: "GERMANY"
+        Query11Fraction: 0.0001
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q11.yml
+++ b/src/workloads/tpch/normalized/1/Q11.yml
@@ -27,4 +27,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q12.yml
+++ b/src/workloads/tpch/normalized/1/Q12.yml
@@ -1,0 +1,30 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 12 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery12
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q12.yml
+      Key: TPCHNormalizedQuery12
+      Parameters:
+        Query12ShipMode1: "MAIL"
+        Query12ShipMode2: "SHIP"
+        Query12Date: "1994-01-01"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q12.yml
+++ b/src/workloads/tpch/normalized/1/Q12.yml
@@ -20,11 +20,3 @@ Actors:
         Query12ShipMode1: "MAIL"
         Query12ShipMode2: "SHIP"
         Query12Date: "1994-01-01"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q12.yml
+++ b/src/workloads/tpch/normalized/1/Q12.yml
@@ -27,4 +27,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q13.yml
+++ b/src/workloads/tpch/normalized/1/Q13.yml
@@ -1,0 +1,28 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 13 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery13
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q13.yml
+      Key: TPCHNormalizedQuery13
+      Parameters:
+        Query13Regex: "^.*special.*requests.*$"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q13.yml
+++ b/src/workloads/tpch/normalized/1/Q13.yml
@@ -18,11 +18,3 @@ Actors:
       Key: TPCHNormalizedQuery13
       Parameters:
         Query13Regex: "^.*special.*requests.*$"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q13.yml
+++ b/src/workloads/tpch/normalized/1/Q13.yml
@@ -25,4 +25,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q14.yml
+++ b/src/workloads/tpch/normalized/1/Q14.yml
@@ -17,11 +17,3 @@ Actors:
       Key: TPCHNormalizedQuery14
       Parameters:
         Query4Date: "1995-09-01"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q14.yml
+++ b/src/workloads/tpch/normalized/1/Q14.yml
@@ -24,4 +24,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q14.yml
+++ b/src/workloads/tpch/normalized/1/Q14.yml
@@ -1,0 +1,27 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 14 against the normalized schema for scale 1.
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery14
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q14.yml
+      Key: TPCHNormalizedQuery14
+      Parameters:
+        Query4Date: "1995-09-01"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q15.yml
+++ b/src/workloads/tpch/normalized/1/Q15.yml
@@ -18,11 +18,3 @@ Actors:
       Key: TPCHNormalizedQuery15
       Parameters:
         Query15Date: "1996-01-01"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q15.yml
+++ b/src/workloads/tpch/normalized/1/Q15.yml
@@ -1,0 +1,28 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 15 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery15
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q15.yml
+      Key: TPCHNormalizedQuery15
+      Parameters:
+        Query15Date: "1996-01-01"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q15.yml
+++ b/src/workloads/tpch/normalized/1/Q15.yml
@@ -25,4 +25,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q16.yml
+++ b/src/workloads/tpch/normalized/1/Q16.yml
@@ -1,0 +1,30 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 16 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery16
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q16.yml
+      Key: TPCHNormalizedQuery16
+      Parameters:
+        Query16Brand: "Brand#45"
+        Query16Type: "^MEDIUM POLISHED.*"
+        Query16Sizes: [49, 14, 23, 45, 19, 3, 36, 9]
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q16.yml
+++ b/src/workloads/tpch/normalized/1/Q16.yml
@@ -27,4 +27,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q16.yml
+++ b/src/workloads/tpch/normalized/1/Q16.yml
@@ -20,11 +20,3 @@ Actors:
         Query16Brand: "Brand#45"
         Query16Type: "^MEDIUM POLISHED.*"
         Query16Sizes: [49, 14, 23, 45, 19, 3, 36, 9]
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q18.yml
+++ b/src/workloads/tpch/normalized/1/Q18.yml
@@ -1,0 +1,28 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 18 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery18
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q18.yml
+      Key: TPCHNormalizedQuery18
+      Parameters:
+        Query18Quantity: 300
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q18.yml
+++ b/src/workloads/tpch/normalized/1/Q18.yml
@@ -18,11 +18,3 @@ Actors:
       Key: TPCHNormalizedQuery18
       Parameters:
         Query18Quantity: 300
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q18.yml
+++ b/src/workloads/tpch/normalized/1/Q18.yml
@@ -25,4 +25,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q19.yml
+++ b/src/workloads/tpch/normalized/1/Q19.yml
@@ -1,0 +1,33 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 19 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery19
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q19.yml
+      Key: TPCHNormalizedQuery19
+      Parameters:
+        Query19Brand1: "Brand#12"
+        Query19Quantity1: 1
+        Query19Brand2: "Brand#23"
+        Query19Quantity2: 10
+        Query19Brand3: "Brand#34"
+        Query19Quantity3: 20
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q19.yml
+++ b/src/workloads/tpch/normalized/1/Q19.yml
@@ -30,4 +30,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q19.yml
+++ b/src/workloads/tpch/normalized/1/Q19.yml
@@ -23,11 +23,3 @@ Actors:
         Query19Quantity2: 10
         Query19Brand3: "Brand#34"
         Query19Quantity3: 20
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q2.yml
+++ b/src/workloads/tpch/normalized/1/Q2.yml
@@ -1,0 +1,30 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 2 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery2
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q2.yml
+      Key: TPCHNormalizedQuery2
+      Parameters:
+        Query2Size: 15
+        Query2Type: "^.*BRASS$"
+        Query2Region: "EUROPE"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q2.yml
+++ b/src/workloads/tpch/normalized/1/Q2.yml
@@ -20,11 +20,3 @@ Actors:
         Query2Size: 15
         Query2Type: "^.*BRASS$"
         Query2Region: "EUROPE"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q2.yml
+++ b/src/workloads/tpch/normalized/1/Q2.yml
@@ -27,4 +27,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q20.yml
+++ b/src/workloads/tpch/normalized/1/Q20.yml
@@ -20,11 +20,3 @@ Actors:
         Query20Nation: "CANADA"
         Query20Color: "^forest.*$"
         Query20Date: "1994-01-01"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q20.yml
+++ b/src/workloads/tpch/normalized/1/Q20.yml
@@ -1,0 +1,30 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 20 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery20
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q20.yml
+      Key: TPCHNormalizedQuery20
+      Parameters:
+        Query20Nation: "CANADA"
+        Query20Color: "^forest.*$"
+        Query20Date: "1994-01-01"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q20.yml
+++ b/src/workloads/tpch/normalized/1/Q20.yml
@@ -27,4 +27,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q21.yml
+++ b/src/workloads/tpch/normalized/1/Q21.yml
@@ -18,11 +18,3 @@ Actors:
       Key: TPCHNormalizedQuery21
       Parameters:
         Query21Nation: "SAUDI ARABIA"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q21.yml
+++ b/src/workloads/tpch/normalized/1/Q21.yml
@@ -25,4 +25,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q21.yml
+++ b/src/workloads/tpch/normalized/1/Q21.yml
@@ -1,0 +1,28 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 21 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery21
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q21.yml
+      Key: TPCHNormalizedQuery21
+      Parameters:
+        Query21Nation: "SAUDI ARABIA"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q22.yml
+++ b/src/workloads/tpch/normalized/1/Q22.yml
@@ -24,11 +24,3 @@ Actors:
         Query22CountryCode5: {$toString: "30"}
         Query22CountryCode6: {$toString: "18"}
         Query22CountryCode7: {$toString: "17"}
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q22.yml
+++ b/src/workloads/tpch/normalized/1/Q22.yml
@@ -16,7 +16,7 @@ Actors:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q22.yml
       Key: TPCHNormalizedQuery22
-      Parameters: # This is a hack, because yml parses these strings into ints before outputting the pipeline.
+      Parameters:  # This is a hack, because yml parses these strings into ints before outputting the pipeline.
         Query22CountryCode1: {$toString: "13"}
         Query22CountryCode2: {$toString: "31"}
         Query22CountryCode3: {$toString: "23"}
@@ -31,4 +31,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q22.yml
+++ b/src/workloads/tpch/normalized/1/Q22.yml
@@ -1,0 +1,34 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 22 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery22
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q22.yml
+      Key: TPCHNormalizedQuery22
+      Parameters: # This is a hack, because yml parses these strings into ints before outputting the pipeline.
+        Query22CountryCode1: {$toString: "13"}
+        Query22CountryCode2: {$toString: "31"}
+        Query22CountryCode3: {$toString: "23"}
+        Query22CountryCode4: {$toString: "29"}
+        Query22CountryCode5: {$toString: "30"}
+        Query22CountryCode6: {$toString: "18"}
+        Query22CountryCode7: {$toString: "17"}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q3.yml
+++ b/src/workloads/tpch/normalized/1/Q3.yml
@@ -19,11 +19,3 @@ Actors:
       Parameters:
         Query3Segment: "BUILDING"
         Query3Date: "1995-03-15"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q3.yml
+++ b/src/workloads/tpch/normalized/1/Q3.yml
@@ -1,0 +1,29 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 3 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery3
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q3.yml
+      Key: TPCHNormalizedQuery3
+      Parameters:
+        Query3Segment: "BUILDING"
+        Query3Date: "1995-03-15"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q3.yml
+++ b/src/workloads/tpch/normalized/1/Q3.yml
@@ -26,4 +26,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q4.yml
+++ b/src/workloads/tpch/normalized/1/Q4.yml
@@ -18,11 +18,3 @@ Actors:
       Key: TPCHNormalizedQuery4
       Parameters:
         Query4Date: "1993-07-01"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q4.yml
+++ b/src/workloads/tpch/normalized/1/Q4.yml
@@ -1,0 +1,28 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 4 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery4
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q4.yml
+      Key: TPCHNormalizedQuery4
+      Parameters:
+        Query4Date: "1993-07-01"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q4.yml
+++ b/src/workloads/tpch/normalized/1/Q4.yml
@@ -25,4 +25,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q5.yml
+++ b/src/workloads/tpch/normalized/1/Q5.yml
@@ -19,11 +19,3 @@ Actors:
       Parameters:
         Query5Date: "1994-01-01"
         Query5Region: "ASIA"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q5.yml
+++ b/src/workloads/tpch/normalized/1/Q5.yml
@@ -26,4 +26,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q5.yml
+++ b/src/workloads/tpch/normalized/1/Q5.yml
@@ -1,0 +1,29 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 5 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery5
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q5.yml
+      Key: TPCHNormalizedQuery5
+      Parameters:
+        Query5Date: "1994-01-01"
+        Query5Region: "ASIA"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q6.yml
+++ b/src/workloads/tpch/normalized/1/Q6.yml
@@ -20,11 +20,3 @@ Actors:
         Query6Date: "1994-01-01"
         Query6Discount: 0.06
         Query6Quantity: 24
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q6.yml
+++ b/src/workloads/tpch/normalized/1/Q6.yml
@@ -27,4 +27,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q6.yml
+++ b/src/workloads/tpch/normalized/1/Q6.yml
@@ -1,0 +1,30 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 6 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery6
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q6.yml
+      Key: TPCHNormalizedQuery6
+      Parameters:
+        Query6Date: "1994-01-01"
+        Query6Discount: 0.06
+        Query6Quantity: 24
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q7.yml
+++ b/src/workloads/tpch/normalized/1/Q7.yml
@@ -1,0 +1,29 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 7 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery7
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q7.yml
+      Key: TPCHNormalizedQuery7
+      Parameters:
+        Query7Nation1: "FRANCE"
+        Query7Nation2: "GERMANY"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q7.yml
+++ b/src/workloads/tpch/normalized/1/Q7.yml
@@ -26,4 +26,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q7.yml
+++ b/src/workloads/tpch/normalized/1/Q7.yml
@@ -19,11 +19,3 @@ Actors:
       Parameters:
         Query7Nation1: "FRANCE"
         Query7Nation2: "GERMANY"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q8.yml
+++ b/src/workloads/tpch/normalized/1/Q8.yml
@@ -1,0 +1,30 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 8 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery8
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q8.yml
+      Key: TPCHNormalizedQuery8
+      Parameters:
+        Query8Type: "ECONOMY ANODIZED STEEL"
+        Query8Region: "AMERICA"
+        Query8Nation: "BRAZIL"
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+  ThenRun:
+      - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q8.yml
+++ b/src/workloads/tpch/normalized/1/Q8.yml
@@ -20,11 +20,3 @@ Actors:
         Query8Type: "ECONOMY ANODIZED STEEL"
         Query8Region: "AMERICA"
         Query8Nation: "BRAZIL"
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-  ThenRun:
-  - test_control: tpch

--- a/src/workloads/tpch/normalized/1/Q8.yml
+++ b/src/workloads/tpch/normalized/1/Q8.yml
@@ -27,4 +27,4 @@ AutoRun:
       $eq:
       - standalone
   ThenRun:
-      - test_control: tpch
+  - test_control: tpch


### PR DESCRIPTION
Link to 🌲 patch containing changes to Genny, DSI, and the evergreen task itself can be found [here](https://spruce.mongodb.com/task/sys_perf_linux_standalone_tpch_1_normalized_patch_fcd93d3668831df603399b2132260635cfe89ec7_61bc6079d1fe07301bb14132_21_12_17_10_05_35/logs?execution=0&sortBy=STATUS&sortDir=ASC).

Current structure:
- `src/phases/tpch/normalized/` contains the query definitions, each in its own file (this could easily be refactored to combine all queries into one file, but each query is quite complex, so I leave this question up to review). The queries must exist separately as phases so that scales 1 and 10 can reuse the same pipelines with different timeouts and possibly query parameters.
- `src/workloads/tpch/normalized/1` contains the workload definitions for scale 1. Because the corresponding test control in dsi needs to do some preparation before each individual query, each workload definition must live in its own file. Scale 10 will have its own directory (~1), and the denormalized schema will have a sibling directory to the normalized schema.

Note:
- This included 20/22 queries, which were validated against the scale 1 validation parameters.
- The queries use the validation parameters defined in the TPC-H benchmark for scale 1; however, this is configurable, as scale 10 may need to use different parameters.
- For now, the workloads are only configured to run on the standalone variant because sharding scenarios need to be handled in a different way in the DSI test control.
- The timeout for each query will be updated based on the timing results obtained from evergreen.