### PR TITLE
TIG-3613 Add Genny workload for denormalized scale 1 TPC-H benchmark

### DIFF
--- a/src/phases/tpch/denormalized/Q1.yml
+++ b/src/phases/tpch/denormalized/Q1.yml
@@ -1,0 +1,33 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 1 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query1Delta: &query1Delta {^Parameter: {Name: "Query1Delta", Default: -90}}
+
+TPCHDenormalizedQuery1:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query1
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: "customer"
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+            {$unwind: "$lineitem"},
+            {$replaceWith: "$lineitem"},
+            {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
+            {$group: {_id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"}, sum_qty: {$sum: "$l_quantity"}, sum_base_price: {$sum: "$l_extendedprice"}, sum_disc_price: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}, sum_charge: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}, {$add: [1, "$l_tax"]}]}}, avg_qty: {$avg: "$l_quantity"}, avg_price: {$avg: "$l_extendedprice"}, avg_disc: {$avg: "$l_discount"}, count_order: {$count: {}}}},
+            {$project: {_id: 0, l_returnflag: "$_id.l_returnflag", l_linestatus: "$_id.l_linestatus", sum_qty: 1, sum_base_price: 1, sum_disc_price: 1, sum_charge: 1, avg_qty: 1, avg_price: 1, avg_disc: 1, count_order: 1}},
+            {$sort: {l_returnflag: 1, l_linestatus: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q10.yml
+++ b/src/phases/tpch/denormalized/Q10.yml
@@ -1,0 +1,36 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 10 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query10Date: &query10Date {^Parameter: {Name: "Query10Date", Default: "1993-10-01"}}
+
+TPCHDenormalizedQuery10:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query10
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$match: {$and: [
+              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
+              {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
+            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+            {$unwind: "$lineitem"},
+            {$match: {"lineitem.l_returnflag": "R"}},
+            {$group: {_id: {c_custkey: "$c_custkey", c_name: "$c_name", c_acctbal: "$c_acctbal", n_name: "$nation.n_name", c_address: "$c_address", c_phone: "$c_phone", c_comment: "$c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+            {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
+            {$sort: {revenue: -1}},
+            {$limit: 20}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q11.yml
+++ b/src/phases/tpch/denormalized/Q11.yml
@@ -1,0 +1,37 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 11 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query11Nation: &query11Nation {^Parameter: {Name: "Query11Nation", Default: "GERMANY"}}
+query11Fraction: &query11Fraction {^Parameter: {Name: "Query11Fraction", Default: 0.0001}}
+
+TPCHDenormalizedQuery11:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query11
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: partsupp
+        pipeline:
+          [
+            {$lookup: {from: "supplier", localField: "ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query11Nation}}]}},
+            {$unwind: "$supplier"},
+            {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
+            {$group: {_id: "$ps_partkey", value: {$sum: "$total_cost"}}},
+            {$group: {_id: 0, groups: {$push: {ps_partkey: "$_id", value: "$value"}}, total_cost: {$sum: "$value"}}},
+            {$addFields: {threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
+            {$unwind: "$groups"},
+            {$project: {ps_partkey: "$groups.ps_partkey", value: "$groups.value", threshold: 1}},
+            {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
+            {$project: {_id: 0, ps_partkey: 1, value: 1}},
+            {$sort: {value: -1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q12.yml
+++ b/src/phases/tpch/denormalized/Q12.yml
@@ -1,0 +1,40 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 12 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query12ShipMode1: &query12ShipMode1 {^Parameter: {Name: "Query12ShipMode1", Default: "MAIL"}}
+query12ShipMode2: &query12ShipMode2 {^Parameter: {Name: "Query12ShipMode2", Default: "SHIP"}}
+query12Date: &query12Date {^Parameter: {Name: "Query12Date", Default: "1994-01-01"}}
+
+TPCHDenormalizedQuery12:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query12
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+            {$unwind: "$lineitem"},
+            {$match: {$and: [
+              {$or: [{"lineitem.l_shipmode": *query12ShipMode1}, {"lineitem.l_shipmode": *query12ShipMode2}]},
+              {$expr: {$lt: ["$lineitem.l_commitdate", "$lineitem.l_receiptdate"]}},
+              {$expr: {$lt: ["$lineitem.l_shipdate", "$lineitem.l_commitdate"]}},
+              {$expr: {$gte: ["$lineitem.l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
+              {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
+            {$group: {_id: "$lineitem.l_shipmode", high_line_count: {$sum: {$cond: {if: {$or: [{$eq: ["$orders.o_orderpriority", "1-URGENT"]}, {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}, low_line_count: {$sum: {$cond: {if: {$and: [{$ne: ["$orders.o_orderpriority", "1-URGENT"]}, {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}}},
+            {$project: {_id: 0, l_shipmode: "$_id", high_line_count: 1, low_line_count: 1}},
+            {$sort: {l_shipmode: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q13.yml
+++ b/src/phases/tpch/denormalized/Q13.yml
@@ -1,0 +1,29 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 13 gainst the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query13Regex: &query13Regex {^Parameter: {Name: "Query13Regex", Default: "^.*special.*requests.*$"}}  # `^.*${query13Word1}.*${query13Word2}.*$`
+
+TPCHDenormalizedQuery13:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query13
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$project: {c_custkey: 1, c_count: {$size: {$filter: {input: "$orders", cond: {$not: {$regexMatch: {input: "$$this.o_comment", regex: *query13Regex, options: "si"}}}}}}}},
+            {$group: {_id: "$c_count", custdist: {$count: {}}}},
+            {$project: {_id: 0, c_count: "$_id", custdist: 1}},
+            {$sort: {custdist: -1, c_count: -1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q14.yml
+++ b/src/phases/tpch/denormalized/Q14.yml
@@ -1,0 +1,34 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 14 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query14Date: &query14Date {^Parameter: {Name: "Query14Date", Default: "1995-09-01"}}
+
+TPCHDenormalizedQuery14:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query14
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+            {$unwind: "$lineitem"},
+            {$match: {$and: [
+              {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
+              {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
+            {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part"}},
+            {$unwind: "$part"},
+            {$group: {_id: {}, promo_price_total: {$sum: {$cond: {if: {$cond: {if: {$regexMatch: {input: "$part.p_type", regex: "^PROMO.*$", options: "si"}}, then: 1, else: 0}}, then: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}, else: 0}}}, price_total: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}}, {$project: {_id: 0, promo_revenue: {$multiply: [100.0, {$divide: ["$promo_price_total", "$price_total"]}]}}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -1,0 +1,60 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 15 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query15Date: &query15Date {^Parameter: {Name: "Query15Date", Default: "1996-01-01"}}
+
+TPCHDenormalizedQuery15:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query15CreateView
+    OperationName: RunCommand
+    OperationCommand:
+      create: revenue
+      viewOn: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+          {$unwind: "$lineitem"},
+          {$replaceWith: "$lineitem"},
+          {$match: {$and: [
+            {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
+            {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}]}}]}},
+          {$group: {_id: "$l_suppkey", total_revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+          {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}}
+        ]
+  - OperationMetricsName: Query15
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: revenue
+        pipeline:
+          [
+            {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
+            {$sort: {_id: -1}},
+            {$limit: 1},
+            {$unwind: "$supplier_no"},
+            {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
+            {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
+            {$unwind: "$supplier"},
+            {$project: {
+              s_suppkey: "$supplier.s_suppkey",
+              s_name: "$supplier.s_name",
+              s_address: "$supplier.s_address",
+              s_phone: "$supplier.s_phone",
+              total_revenue: 1
+            }},
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats
+  - OperationMetricsName: Query15DropView
+    OperationName: RunCommand
+    OperationCommand:
+      drop: revenue

--- a/src/phases/tpch/denormalized/Q16.yml
+++ b/src/phases/tpch/denormalized/Q16.yml
@@ -1,0 +1,36 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 16 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query16Brand: &query16Brand {^Parameter: {Name: "Query16Brand", Default: "Brand#45"}}
+query16Type: &query16Type {^Parameter: {Name: "Query16Type", Default: "^MEDIUM POLISHED.*"}}  # ^${type}.*$"
+query16Sizes: &query16Sizes {^Parameter: {Name: "Query16Sizes", Default: [49, 14, 23, 45, 19, 3, 36, 9]}}
+
+TPCHDenormalizedQuery16:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query16
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: part
+        pipeline:
+          [
+            {$match: {$and: [{p_brand: {$ne: *query16Brand}}, {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}}, {p_size: {$in: *query16Sizes}}]}},
+            {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
+            {$unwind: "$partsupp"},
+            {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}], as: "supplier"}},
+            {$match: {supplier: {$eq: []}}},
+            {$group: {_id: {p_brand: "$p_brand", p_type: "$p_type", p_size: "$p_size"}, ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
+            {$project: {_id: 0, p_brand: "$_id.p_brand", p_type: "$_id.p_type", p_size: "$_id.p_size", supplier_cnt: {$size: "$ps_suppkey"}}},
+            {$sort: {supplier_cnt: -1, p_brand: 1, p_type: 1, p_size: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q18.yml
+++ b/src/phases/tpch/denormalized/Q18.yml
@@ -1,0 +1,33 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 18 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query18Quantity: &query18Quantity {^Parameter: {Name: "Query18Quantity", Default: 300}}
+
+TPCHDenormalizedQuery18:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query18
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$addFields: {"sum(l_quantity)": {$reduce: {input: "$orders.lineitem", initialValue: 0, in: {$add: ["$$value", "$$this.l_quantity"]}}}}},
+            {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
+            {$group: {_id: {c_name: "$c_name", c_custkey: "$c_custkey", o_orderkey: "$orders.o_orderkey", o_orderdate: "$orders.o_orderdate", o_totalprice: "$orders.o_totalprice"}, "sum(l_quantity)": {$push: "$sum(l_quantity)"}}},
+            {$unwind: "$sum(l_quantity)"},
+            {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
+            {$sort: {o_totalprice: -1, o_orderdate: 1}},
+            {$limit: 100}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q19.yml
+++ b/src/phases/tpch/denormalized/Q19.yml
@@ -1,0 +1,67 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 19 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query19Brand1: &query19Brand1 {^Parameter: {Name: "Query19Brand1", Default: "Brand#12"}}
+query19Quantity1: &query19Quantity1 {^Parameter: {Name: "Query19Quantity1", Default: 1}}
+query19Brand2: &query19Brand2 {^Parameter: {Name: "Query19Brand2", Default: "Brand#23"}}
+query19Quantity2: &query19Quantity2 {^Parameter: {Name: "Query19Quantity2", Default: 10}}
+query19Brand3: &query19Brand3 {^Parameter: {Name: "Query19Brand3", Default: "Brand#34"}}
+query19Quantity3: &query19Quantity3 {^Parameter: {Name: "Query19Quantity3", Default: 20}}
+
+TPCHDenormalizedQuery19:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query19
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+            {$unwind: "$lineitem"},
+            {$replaceWith: "$lineitem"},
+            {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+              {$match: {$or: [
+                {$and: [
+                  {p_brand: *query19Brand1},
+                  {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
+                  {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
+                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
+                  {p_size: {$gte: 1}},
+                  {p_size: {$lte: 5}},
+                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+                {$and: [
+                  {p_brand: *query19Brand2},
+                  {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
+                  {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
+                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
+                  {p_size: {$gte: 1}},
+                  {p_size: {$lte: 10}},
+                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+                {$and: [
+                  {p_brand: *query19Brand3},
+                  {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
+                  {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
+                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
+                  {p_size: {$gte: 1}},
+                  {p_size: {$lte: 15}},
+                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
+            {$unwind: "$part"},
+            {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+            {$project: {_id: 0, revenue: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q2.yml
+++ b/src/phases/tpch/denormalized/Q2.yml
@@ -1,0 +1,41 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 2 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query2Size: &query2Size {^Parameter: {Name: "Query2Size", Default: 15}}
+query2Type: &query2Type {^Parameter: {Name: "Query2Type", Default: "^.*BRASS$"}}  # ^.*{type}$"
+query2Region: &query2Region {^Parameter: {Name: "Query2Region", Default: "EUROPE"}}
+
+TPCHDenormalizedQuery2:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query2
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: partsupp
+        pipeline:
+          [
+            {$lookup: {from: "part", as: "part", localField: "ps_partkey", foreignField: "p_partkey", pipeline: [
+              {$match: {$and: [{p_type: {$regex: *query2Type, "$options": "si"}}, {p_size: {$eq: *query2Size}}]}}]}},
+            {$unwind: "$part"},
+            {$lookup: {from: "supplier", localField: "ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+              {$match: {"nation.region.r_name": *query2Region}}]}},
+            {$unwind: "$supplier"},
+            {$sort: {ps_supplycost: 1}},
+            {$group: {
+              _id: {p_partkey: "$part.p_partkey", p_mfgr: "$part.p_mfgr"},
+              supplier: {$first: {s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment", ps_supplycost: "$ps_supplycost", n_name: "$supplier.nation.n_name"}}}},
+            {$project: {_id: 0, s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", n_name: "$supplier.n_name", p_partkey: "$_id.p_partkey", p_mfgr: "$_id.p_mfgr", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment"}},
+            {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
+            {$limit: 100}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q20.yml
+++ b/src/phases/tpch/denormalized/Q20.yml
@@ -1,0 +1,45 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 20 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query20Nation: &query20Nation {^Parameter: {Name: "Query20Nation", Default: "CANADA"}}
+query20Color: &query20Color {^Parameter: {Name: "Query20Color", Default: "^forest.*$"}}  # "^${color}.*$"
+query20Date: &query20Date {^Parameter: {Name: "Query20Date", Default: "1994-01-01"}}
+
+TPCHDenormalizedQuery20:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query20
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE", quantity: {$sum: "$orders.lineitem.l_quantity"}}},
+            {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
+            {$unwind: "$lineitem"},
+            {$match: {$and: [
+              {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
+              {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
+            {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
+              {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},
+            {$unwind: "$partsupp"},
+            {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query20Nation}}]}},
+            {$unwind: "$supplier"},
+            {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [{$match: {p_name: {$regex: *query20Color, "$options": "si"}}}]}},
+            {$unwind: "$part"},
+            {$group: {_id: {s_name: "$supplier.s_name", s_address: "$supplier.s_address"}}},
+            {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
+            {$sort: {s_name: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q21.yml
+++ b/src/phases/tpch/denormalized/Q21.yml
@@ -1,0 +1,40 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 21 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query21Nation: &query21Nation {^Parameter: {Name: "Query1Delta", Default: "SAUDI ARABIA"}}
+
+TPCHDenormalizedQuery21:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query21
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$match: {$and: [
+              {"orders.o_orderstatus": "F"},
+              {$expr: {$gt: [{$size: {$reduce: {input: "$orders.lineitem", initialValue: [], in: {$setUnion: [["$$this.l_suppkey"], "$$value"]}}}}, 1]}}]}},
+            {$addFields: {"orders.lineitem": {$filter: {input: "$orders.lineitem", cond: {$gt: ["$$this.l_receiptdate", "$$this.l_commitdate"]}}}}},
+            {$match: {$expr: {$eq: [{$size: "$orders.lineitem"}, 1]}}},
+            {$unwind: "$orders.lineitem"},
+            {$match: {$expr: {$gt: ["$orders.lineitem.l_receiptdate", "$lineitem.l_commitdate"]}}},
+            {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+              {$match: {"nation.n_name": *query21Nation}}]}},
+            {$unwind: "$supplier"},
+            {$group: {_id: "$supplier.s_name", numwait: {$count: {}}}},
+            {$project: {_id: 0, s_name: "$_id", numwait: 1}},
+            {$sort: {numwait: -1, s_name: 1}},
+            {$limit: 100}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q21.yml
+++ b/src/phases/tpch/denormalized/Q21.yml
@@ -5,7 +5,7 @@ Description: |
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize 101  # The default batch size.
-query21Nation: &query21Nation {^Parameter: {Name: "Query1Delta", Default: "SAUDI ARABIA"}}
+query21Nation: &query21Nation {^Parameter: {Name: "Query21Nation", Default: "SAUDI ARABIA"}}
 
 TPCHDenormalizedQuery21:
   Repeat: 1

--- a/src/phases/tpch/denormalized/Q22.yml
+++ b/src/phases/tpch/denormalized/Q22.yml
@@ -1,0 +1,53 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 22 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+# Sadly, using an array here parses as an array of numbers instead of as an array of strings.
+# To work around this, use separate parameters for each entry in the array.
+query22CountryCode1: &query22CountryCode1 {^Parameter: {Name: "Query22CountryCode1", Default: "13"}}
+query22CountryCode2: &query22CountryCode2 {^Parameter: {Name: "Query22CountryCode2", Default: "31"}}
+query22CountryCode3: &query22CountryCode3 {^Parameter: {Name: "Query22CountryCode3", Default: "23"}}
+query22CountryCode4: &query22CountryCode4 {^Parameter: {Name: "Query22CountryCode4", Default: "29"}}
+query22CountryCode5: &query22CountryCode5 {^Parameter: {Name: "Query22CountryCode5", Default: "30"}}
+query22CountryCode6: &query22CountryCode6 {^Parameter: {Name: "Query22CountryCode6", Default: "18"}}
+query22CountryCode7: &query22CountryCode7 {^Parameter: {Name: "Query22CountryCode7", Default: "17"}}
+
+TPCHDenormalizedQuery22:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query22
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$addFields: {custsale: "$orders", orders: "$$REMOVE"}},
+            {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
+            {$addFields: {cntrycode: {$substr: ["$c_phone", 0, 2]}}},
+            {$match: {$and: [{$expr: {$in: ["$cntrycode", [
+              *query22CountryCode1,
+              *query22CountryCode2,
+              *query22CountryCode3,
+              *query22CountryCode4,
+              *query22CountryCode5,
+              *query22CountryCode6,
+              *query22CountryCode7]]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.0]}}]}},
+            {$facet: {
+              customer: [{$project: {cntrycode: 1, c_acctbal: 1}}],
+              "avg(c_acctbal)": [{$group: {_id: {}, value: {$avg: "$c_acctbal"}}}, {$project: {_id: 0}}]}},
+            {$unwind: "$avg(c_acctbal)"},
+            {$unwind: "$customer"},
+            {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
+            {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
+            {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
+            {$sort: {cntrycode: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q3.yml
+++ b/src/phases/tpch/denormalized/Q3.yml
@@ -1,0 +1,38 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 3 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query3Segment: &query3Segment {^Parameter: {Name: "Query3Segment", Default: "BUILDING"}}
+query3Date: &query3Date {^Parameter: {Name: "Query3Date", Default: "1995-03-15"}}
+
+TPCHDenormalizedQuery3:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query3
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
+            {$unwind: "$orders"},
+            {$match: {$expr: {$lt: ["$orders.o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
+            {$unwind: "$orders.lineitem"},
+            {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}},
+            {$group: {
+              _id: {l_orderkey: "$orders.lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"},
+              revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+            {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
+            {$sort: {revenue: -1, o_orderdate: 1}},
+            {$limit: 10}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q4.yml
+++ b/src/phases/tpch/denormalized/Q4.yml
@@ -1,0 +1,33 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 4 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query4Date: &query4Date {^Parameter: {Name: "Query4Date", Default: "1993-07-01"}}
+
+TPCHDenormalizedQuery4:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query4
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$match: {$and: [
+              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
+              {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}},
+              {$expr: {$gt: [{$size: {$filter: {input: "$orders.lineitem", cond: {$lt: ["$$this.l_commitdate", "$$this.l_receiptdate"]}}}}, 0]}}]}},
+            {$group: {_id: "$orders.o_orderpriority", order_count: {$count: {}}}},
+            {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
+            {$sort: {o_orderpriority: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q5.yml
+++ b/src/phases/tpch/denormalized/Q5.yml
@@ -1,0 +1,40 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 5 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query5Region: &query5Region {^Parameter: {Name: "Query5Region", Default: "ASIA"}}
+query5Date: &query5Date {^Parameter: {Name: "Query5Date", Default: "1994-01-01"}}
+
+TPCHDenormalizedQuery5:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query5
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$match: {"nation.region.r_name": *query5Region}},
+            {$unwind: "$orders"},
+            {$match: {$and: [
+              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
+              {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
+            {$unwind: "$orders.lineitem"},
+            {$lookup: {from: "supplier", as: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", let: {c_nationkey: "$nation.n_nationkey"}, pipeline: [
+              {$match: {$expr: {$eq: ["$nation.n_nationkey", "$$c_nationkey"]}}}]}},
+            {$unwind: "$supplier"},
+            {$group: {
+              _id: "$supplier.nation.n_name",
+              revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+            {$project: {_id: 0, n_name: "$_id", revenue: 1}},
+            {$sort: {revenue: -1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q6.yml
+++ b/src/phases/tpch/denormalized/Q6.yml
@@ -1,0 +1,40 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 6 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query6Date: &query6Date {^Parameter: {Name: "Query6Date", Default: "1994-01-01"}}
+query6Discount: &query6Discount {^Parameter: {Name: "Query6Discount", Default: 0.06}}
+query6Quantity: &query6Quantity {^Parameter: {Name: "Query6Quantity", Default: 24}}
+
+TPCHDenormalizedQuery6:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query6
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+            {$unwind: "$lineitem"},
+            {$replaceWith: "$lineitem"},
+            {$match: {$and: [
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
+              {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+              {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
+              {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
+              {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
+            {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
+            {$project: {_id: 0, revenue: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q7.yml
+++ b/src/phases/tpch/denormalized/Q7.yml
@@ -1,0 +1,41 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 7 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+query7Nation1: &query7Nation1 {^Parameter: {Name: "Query7Nation1", Default: "FRANCE"}}
+query7Nation2: &query7Nation2 {^Parameter: {Name: "Query7Nation2", Default: "GERMANY"}}
+
+TPCHDenormalizedQuery7:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query7
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+            {$unwind: "$lineitem"},
+            {$match: {$and: [
+              {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
+              {$expr: {$lt: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}},
+            {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+            {$unwind: "$supplier"},
+            {$match: {$or: [
+              {$and: [{"supplier.nation.n_name": *query7Nation1}, {"nation.n_name": *query7Nation2}]},
+              {$and: [{"supplier.nation.n_name": *query7Nation2}, {"nation.n_name": *query7Nation1}]}]}},
+            {$project: {supp_nation: "$supplier.nation.n_name", cust_nation: "$nation.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
+            {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
+            {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
+            {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q8.yml
+++ b/src/phases/tpch/denormalized/Q8.yml
@@ -1,0 +1,43 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 8 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query8Type: &query8Type {^Parameter: {Name: "Query8Type", Default: "ECONOMY ANODIZED STEEL"}}
+query8Region: &query8Region {^Parameter: {Name: "Query8Region", Default: "AMERICA"}}
+query8Nation: &query8Nation {^Parameter: {Name: "Query8Nation", Default: "BRAZIL"}}
+
+TPCHDenormalizedQuery8:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query8
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$match: {"nation.region.r_name": {$eq: *query8Region}}},
+            {$unwind: "$orders"},
+            {$match: {$and: [
+              {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
+              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+            {$unwind: "$orders.lineitem"},
+            {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+            {$unwind: "$supplier"},
+            {$lookup: {from: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+              {$match: {p_type: {$eq: *query8Type}}}]}},
+            {$unwind: "$part"},
+            {$project: {o_year: {$year: "$orders.o_orderdate"}, volume: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$orders.lineitem.l_discount"]}]}, nation: "$supplier.nation.n_name"}},
+            {$group: { _id: "$o_year", total_volume: {$sum: "$volume"}, nation_volume: {$sum: {$cond: {if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
+            {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
+            {$sort: {o_year: 1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/workloads/tpch/denormalized/1/Q1.yml
+++ b/src/workloads/tpch/denormalized/1/Q1.yml
@@ -1,0 +1,20 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 1 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery1
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q1.yml
+      Key: TPCHDenormalizedQuery1
+      Parameters:
+        Query1Delta: -90

--- a/src/workloads/tpch/denormalized/1/Q10.yml
+++ b/src/workloads/tpch/denormalized/1/Q10.yml
@@ -1,0 +1,20 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 10 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery10
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q10.yml
+      Key: TPCHDenormalizedQuery10
+      Parameters:
+        Query10Date: "1993-10-01"

--- a/src/workloads/tpch/denormalized/1/Q11.yml
+++ b/src/workloads/tpch/denormalized/1/Q11.yml
@@ -1,0 +1,22 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 11 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery11
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q11.yml
+      Key: TPCHDenormalizedQuery11
+      Parameters:
+        Query11Nation: "GERMANY"
+        Query11Fraction: 0.0001

--- a/src/workloads/tpch/denormalized/1/Q12.yml
+++ b/src/workloads/tpch/denormalized/1/Q12.yml
@@ -1,0 +1,22 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 12 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery12
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q12.yml
+      Key: TPCHDenormalizedQuery12
+      Parameters:
+        Query12ShipMode1: "MAIL"
+        Query12ShipMode2: "SHIP"
+        Query12Date: "1994-01-01"

--- a/src/workloads/tpch/denormalized/1/Q13.yml
+++ b/src/workloads/tpch/denormalized/1/Q13.yml
@@ -1,0 +1,20 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 13 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery13
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q13.yml
+      Key: TPCHDenormalizedQuery13
+      Parameters:
+        Query13Regex: "^.*special.*requests.*$"

--- a/src/workloads/tpch/denormalized/1/Q14.yml
+++ b/src/workloads/tpch/denormalized/1/Q14.yml
@@ -1,0 +1,19 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 14 against the denormalized schema for scale 1.
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery14
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q14.yml
+      Key: TPCHDenormalizedQuery14
+      Parameters:
+        Query4Date: "1995-09-01"

--- a/src/workloads/tpch/denormalized/1/Q15.yml
+++ b/src/workloads/tpch/denormalized/1/Q15.yml
@@ -1,0 +1,20 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 15 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery15
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q15.yml
+      Key: TPCHDenormalizedQuery15
+      Parameters:
+        Query15Date: "1996-01-01"

--- a/src/workloads/tpch/denormalized/1/Q16.yml
+++ b/src/workloads/tpch/denormalized/1/Q16.yml
@@ -1,0 +1,22 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 16 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery16
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q16.yml
+      Key: TPCHDenormalizedQuery16
+      Parameters:
+        Query16Brand: "Brand#45"
+        Query16Type: "^MEDIUM POLISHED.*"
+        Query16Sizes: [49, 14, 23, 45, 19, 3, 36, 9]

--- a/src/workloads/tpch/denormalized/1/Q18.yml
+++ b/src/workloads/tpch/denormalized/1/Q18.yml
@@ -1,0 +1,20 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 18 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery18
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q18.yml
+      Key: TPCHDenormalizedQuery18
+      Parameters:
+        Query18Quantity: 300

--- a/src/workloads/tpch/denormalized/1/Q19.yml
+++ b/src/workloads/tpch/denormalized/1/Q19.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 19 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery19
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q19.yml
+      Key: TPCHDenormalizedQuery19
+      Parameters:
+        Query19Brand1: "Brand#12"
+        Query19Quantity1: 1
+        Query19Brand2: "Brand#23"
+        Query19Quantity2: 10
+        Query19Brand3: "Brand#34"
+        Query19Quantity3: 20

--- a/src/workloads/tpch/denormalized/1/Q2.yml
+++ b/src/workloads/tpch/denormalized/1/Q2.yml
@@ -1,0 +1,22 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 2 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery2
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q2.yml
+      Key: TPCHDenormalizedQuery2
+      Parameters:
+        Query2Size: 15
+        Query2Type: "^.*BRASS$"
+        Query2Region: "EUROPE"

--- a/src/workloads/tpch/denormalized/1/Q20.yml
+++ b/src/workloads/tpch/denormalized/1/Q20.yml
@@ -1,0 +1,22 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 20 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery20
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q20.yml
+      Key: TPCHDenormalizedQuery20
+      Parameters:
+        Query20Nation: "CANADA"
+        Query20Color: "^forest.*$"
+        Query20Date: "1994-01-01"

--- a/src/workloads/tpch/denormalized/1/Q21.yml
+++ b/src/workloads/tpch/denormalized/1/Q21.yml
@@ -1,0 +1,20 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 21 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery21
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q21.yml
+      Key: TPCHDenormalizedQuery21
+      Parameters:
+        Query21Nation: "SAUDI ARABIA"

--- a/src/workloads/tpch/denormalized/1/Q22.yml
+++ b/src/workloads/tpch/denormalized/1/Q22.yml
@@ -1,0 +1,26 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 22 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery22
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q22.yml
+      Key: TPCHDenormalizedQuery22
+      Parameters:  # This is a hack, because yml parses these strings into ints before outputting the pipeline.
+        Query22CountryCode1: {$toString: "13"}
+        Query22CountryCode2: {$toString: "31"}
+        Query22CountryCode3: {$toString: "23"}
+        Query22CountryCode4: {$toString: "29"}
+        Query22CountryCode5: {$toString: "30"}
+        Query22CountryCode6: {$toString: "18"}
+        Query22CountryCode7: {$toString: "17"}

--- a/src/workloads/tpch/denormalized/1/Q3.yml
+++ b/src/workloads/tpch/denormalized/1/Q3.yml
@@ -1,0 +1,21 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 3 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery3
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q3.yml
+      Key: TPCHDenormalizedQuery3
+      Parameters:
+        Query3Segment: "BUILDING"
+        Query3Date: "1995-03-15"

--- a/src/workloads/tpch/denormalized/1/Q4.yml
+++ b/src/workloads/tpch/denormalized/1/Q4.yml
@@ -1,0 +1,20 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 4 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery4
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q4.yml
+      Key: TPCHDenormalizedQuery4
+      Parameters:
+        Query4Date: "1993-07-01"

--- a/src/workloads/tpch/denormalized/1/Q5.yml
+++ b/src/workloads/tpch/denormalized/1/Q5.yml
@@ -1,0 +1,21 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 5 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery5
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q5.yml
+      Key: TPCHDenormalizedQuery5
+      Parameters:
+        Query5Date: "1994-01-01"
+        Query5Region: "ASIA"

--- a/src/workloads/tpch/denormalized/1/Q6.yml
+++ b/src/workloads/tpch/denormalized/1/Q6.yml
@@ -1,0 +1,22 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 6 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery6
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q6.yml
+      Key: TPCHDenormalizedQuery6
+      Parameters:
+        Query6Date: "1994-01-01"
+        Query6Discount: 0.06
+        Query6Quantity: 24

--- a/src/workloads/tpch/denormalized/1/Q7.yml
+++ b/src/workloads/tpch/denormalized/1/Q7.yml
@@ -1,0 +1,21 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 7 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery7
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q7.yml
+      Key: TPCHDenormalizedQuery7
+      Parameters:
+        Query7Nation1: "FRANCE"
+        Query7Nation2: "GERMANY"

--- a/src/workloads/tpch/denormalized/1/Q8.yml
+++ b/src/workloads/tpch/denormalized/1/Q8.yml
@@ -1,0 +1,22 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 8 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery8
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q8.yml
+      Key: TPCHDenormalizedQuery8
+      Parameters:
+        Query8Type: "ECONOMY ANODIZED STEEL"
+        Query8Region: "AMERICA"
+        Query8Nation: "BRAZIL"


### PR DESCRIPTION
The query definitions (20/22 queries) are in `src/phases/tpch/denormalized/*`.
The actual workloads for scale 1 are in `src/workloads/tpch/denormalized/1`.

🌲 Evergreen [patch](https://spruce.mongodb.com/version/61eadeb60ae606612be82e86/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (includes some normalized tasks as well because I accidentally selected them too).

Evergreen task definitions PR is [here](https://github.com/10gen/mongo/pull/2888).