### PR TITLE
Updated a few failing steps

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -5,7 +5,7 @@ to add actors and workloads. For details on the development process, see [Develo
 
 ## Running Genny Workloads
 
-First install mongodb and start a mongod process:
+Start a mongod process. Use locally-built mongod if available. Otherwise, first install mongodb:
 
 ```sh
 brew install mongodb
@@ -17,9 +17,7 @@ Then build Genny (see [above](#build-and-install) for details):
 And then run a workload:
 
 ```sh
-./run-genny workload -- run                                         \
-    --workload-file       ./src/workloads/scale/InsertRemove.yml    \
-    --mongo-uri           'mongodb://localhost:27017'
+./run-genny workload ./src/workloads/scale/InsertRemove.yml
 ```
 If you see errors like the following, try reducing the number of threads and duration in ./src/workloads/scale/InsertRemove.yml
 ```E0218 17:46:13.640106000 123145604628480 wakeup_fd_pipe.cc:40]         pipe creation failed (24): Too many open files```


### PR DESCRIPTION
I’m following steps here. Is this guide up to date?
I noticed that following steps fail:

```
brew install mongodb
$ brew install mongodb
Warning: No available formula with the name "mongodb". Did you mean mongosh or monetdb?
==> Searching for similarly named formulae...
These similarly named formulae were found:
mongosh                                                                       monetdb
To install one of them, run (for example):
  brew install mongosh
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
==> Searching taps on GitHub...
Error: No formulae found in taps.
```
I’m not sure why this step is necessary. I guess one can use locally-built mongod.

```
$ ./run-genny workload -- run --workload-file ./src/workloads/scale/InsertRemove.yml --mongo-uri 'mongodb://localhost:27017'
[info ] [genny.curator       ] Starting poplar grpc in the background. command=['/home/ubuntu/genny/build/curator/curator', 'poplar', 'grpc'] cwd=/home/ubuntu/genny timestamp=2022-01-29T00:23:51Z
[curator] 2022/01/29 00:23:51 [p=info]: starting poplar gRPC service at 'localhost:2288'
[curator] 2022/01/29 00:23:51 [p=info]: poplar rpc service terminated
Traceback (most recent call last):
  File "/home/ubuntu/genny/src/lamplib/src/genny/cli.py", line 548, in <module>
    cli()
  File "/home/ubuntu/genny/genny_venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/genny/genny_venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/genny/genny_venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/genny/genny_venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/genny/genny_venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/ubuntu/genny/genny_venv/lib/python3.9/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/ubuntu/genny/src/lamplib/src/genny/cli.py", line 348, in workload
    genny_runner.main_genny_runner(
  File "/home/ubuntu/genny/src/lamplib/src/genny/tasks/genny_runner.py", line 54, in main_genny_runner
    preprocess.preprocess(
  File "/home/ubuntu/genny/src/lamplib/src/genny/tasks/preprocess.py", line 66, in preprocess
    conf = OmegaConf.load(workload_path)
  File "/home/ubuntu/genny/genny_venv/lib/python3.9/site-packages/omegaconf/omegaconf.py", line 183, in load
    with io.open(os.path.abspath(file_), "r", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/genny/run'
```
I found the following command works instead.
```
./run-genny ./src/workloads/scale/InsertRemove.yml
```