### PR TITLE
PERF-2771 Add workloads for TPC-H queries 9 and 17

### DIFF
--- a/src/phases/tpch/denormalized/Q17.yml
+++ b/src/phases/tpch/denormalized/Q17.yml
@@ -1,0 +1,40 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 17 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
+query17Type: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
+
+TPCHDenormalizedQuery17:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query17
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: part
+        pipeline:
+          [
+            {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
+            {$lookup: {from: "customer", localField: "p_partkey", foreignField: "orders.lineitem.l_partkey", as: "lineitem", let: {p_partkey: "$p_partkey"}, pipeline: [
+              {$unwind: "$orders"},
+              {$unwind: "$orders.lineitem"},
+              {$replaceWith: "$orders.lineitem"},
+              {$match: {$expr: {$eq: ["$l_partkey", "$$p_partkey"]}}},
+              {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
+              {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
+              {$unwind: "$lineitem"},
+              {$replaceWith: "$lineitem"}]}},
+            {$unwind: "$lineitem"},
+            {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
+            {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q17.yml
+++ b/src/phases/tpch/denormalized/Q17.yml
@@ -7,7 +7,7 @@ Description: |
 batchSize: &batchSize 101  # The default batch size.
 
 query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
-query17Type: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
+query17Container: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
 
 TPCHDenormalizedQuery17:
   Repeat: 1

--- a/src/phases/tpch/denormalized/Q2.yml
+++ b/src/phases/tpch/denormalized/Q2.yml
@@ -18,19 +18,17 @@ TPCHDenormalizedQuery2:
     OperationName: RunCommand
     OperationCommand:
       explain:
-        aggregate: partsupp
+        aggregate: part
         pipeline:
           [
-            {$lookup: {from: "part", as: "part", localField: "ps_partkey", foreignField: "p_partkey", pipeline: [
-              {$match: {$and: [{p_type: {$regex: *query2Type, "$options": "si"}}, {p_size: {$eq: *query2Size}}]}}]}},
-            {$unwind: "$part"},
-            {$lookup: {from: "supplier", localField: "ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-              {$match: {"nation.region.r_name": *query2Region}}]}},
+            {$match: {$and: [{p_type: {$regex: *query2Type, $options: "si"}}, {p_size: {$eq: *query2Size}}]}},
+            {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
+            {$unwind: "$partsupp"},
+            {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+              {$match: {"nation.region.r_name": {$eq: *query2Region}}}]}},
             {$unwind: "$supplier"},
-            {$sort: {ps_supplycost: 1}},
-            {$group: {
-              _id: {p_partkey: "$part.p_partkey", p_mfgr: "$part.p_mfgr"},
-              supplier: {$first: {s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment", ps_supplycost: "$ps_supplycost", n_name: "$supplier.nation.n_name"}}}},
+            {$sort: {"partsupp.ps_supplycost": 1}},
+            {$group: {_id: {p_partkey: "$p_partkey", p_mfgr: "$p_mfgr"}, supplier: {$first: {s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment", ps_supplycost: "$partsupp.ps_supplycost", n_name: "$supplier.nation.n_name"}}}},
             {$project: {_id: 0, s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", n_name: "$supplier.n_name", p_partkey: "$_id.p_partkey", p_mfgr: "$_id.p_mfgr", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment"}},
             {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
             {$limit: 100}

--- a/src/phases/tpch/denormalized/Q9.yml
+++ b/src/phases/tpch/denormalized/Q9.yml
@@ -1,0 +1,48 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 9 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${query9Color}.*$
+
+TPCHDenormalizedQuery9:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query9
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: customer
+        pipeline:
+          [
+            {$unwind: "$orders"},
+            {$lookup: {from: "part", as: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", pipeline: [
+              {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}}]}},
+            {$project: {
+              o_year: {$year: "$orders.o_orderdate"},
+              part: {$map: {input: "$part", as: "part", in: {
+                $mergeObjects: ["$$part", {lineitem: {$filter: {input: "$orders.lineitem", as: "lineitem", cond: {$eq: ["$$part.p_partkey", "$$lineitem.l_partkey"]}}}}]}}}}},
+            {$unwind: "$part"},
+            {$unwind: "$part.lineitem"},
+            {$lookup: {from: "supplier", as: "partsupp", localField: "part.lineitem.l_suppkey", foreignField: "s_suppkey", let: {p_partkey: "$part.p_partkey"}, pipeline: [
+              {$lookup: {from: "partsupp", as: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", pipeline: [
+                {$match: {$expr: {$eq: ["$$p_partkey", "$ps_partkey"]}}}]}},
+              {$unwind: "$partsupp"},
+              {$replaceWith: {$mergeObjects: ["$partsupp", {nation: "$nation.n_name"}]}}]}},
+            {$unwind: "$partsupp"},
+            {$group: {
+              _id: {nation: "$partsupp.nation", o_year: "$o_year"},
+              sum_profit: {$sum: {$subtract: [
+                {$multiply: ["$part.lineitem.l_extendedprice", {$subtract: [1, "$part.lineitem.l_discount"]}]},
+                {$multiply: ["$partsupp.ps_supplycost", "$part.lineitem.l_quantity"]}]}}}},
+            {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
+            {$sort: {nation: 1, o_year: -1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/denormalized/Q9.yml
+++ b/src/phases/tpch/denormalized/Q9.yml
@@ -6,7 +6,7 @@ Description: |
 
 batchSize: &batchSize 101  # The default batch size.
 
-query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${query9Color}.*$
+query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${color}.*$
 
 TPCHDenormalizedQuery9:
   Repeat: 1

--- a/src/phases/tpch/normalized/Q17.yml
+++ b/src/phases/tpch/normalized/Q17.yml
@@ -1,0 +1,36 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 17 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
+query17Type: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
+
+TPCHNormalizedQuery17:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query17
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: part
+        pipeline:
+          [
+            {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
+            {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem", pipeline: [
+              {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
+              {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
+              {$unwind: "$lineitem"},
+              {$replaceWith: "$lineitem"}]}},
+            {$unwind: "$lineitem"},
+            {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
+            {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q17.yml
+++ b/src/phases/tpch/normalized/Q17.yml
@@ -7,7 +7,7 @@ Description: |
 batchSize: &batchSize 101  # The default batch size.
 
 query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
-query17Type: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
+query17Container: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
 
 TPCHNormalizedQuery17:
   Repeat: 1

--- a/src/phases/tpch/normalized/Q9.yml
+++ b/src/phases/tpch/normalized/Q9.yml
@@ -1,0 +1,44 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 9 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+batchSize: &batchSize 101  # The default batch size.
+
+query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${query9Color}.*$
+
+TPCHNormalizedQuery9:
+  Repeat: 1
+  Database: tpch
+  Operations:
+  - OperationMetricsName: Query9
+    OperationName: RunCommand
+    OperationCommand:
+      explain:
+        aggregate: part
+        pipeline:
+          [
+            {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}},
+            {$lookup: {from: "partsupp", as: "partsupp", localField: "p_partkey", foreignField: "ps_partkey"}},
+            {$unwind: "$partsupp"},
+            {$lookup: {from: "supplier", as: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [
+              {$lookup: {from: "nation", as: "nation", localField: "s_nationkey", foreignField: "n_nationkey"}},
+              {$unwind: "$nation"}]}},
+            {$unwind: "$supplier"},
+            {$project: {p_partkey: 1, s_suppkey: "$supplier.s_suppkey", nation: "$supplier.nation.n_name", partsupp: 1}},
+            {$lookup: {from: "lineitem", as: "lineitem", localField: "p_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, pipeline: [
+              {$match: {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}}},
+              {$lookup: {from: "orders", as: "orders", localField: "l_orderkey", foreignField: "o_orderkey"}},
+              {$unwind: "$orders"}]}},
+            {$unwind: "$lineitem"},
+            {$group: {_id: {nation: "$nation", o_year: {$year: "$lineitem.orders.o_orderdate"}}, sum_profit: {$sum: {$subtract: [
+              {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]},
+              {$multiply: ["$partsupp.ps_supplycost", "$lineitem.l_quantity"]}]}}}},
+            {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
+            {$sort: {nation: 1, o_year: -1}}
+          ]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+      verbosity:
+        executionStats

--- a/src/phases/tpch/normalized/Q9.yml
+++ b/src/phases/tpch/normalized/Q9.yml
@@ -6,7 +6,7 @@ Description: |
 
 batchSize: &batchSize 101  # The default batch size.
 
-query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${query9Color}.*$
+query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${color}.*$
 
 TPCHNormalizedQuery9:
   Repeat: 1

--- a/src/workloads/tpch/denormalized/1/Q17.yml
+++ b/src/workloads/tpch/denormalized/1/Q17.yml
@@ -1,0 +1,21 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 17 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery17
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q17.yml
+      Key: TPCHDenormalizedQuery17
+      Parameters:
+        Query17Brand: "Brand#23"
+        Query17Container: "MED BOX"

--- a/src/workloads/tpch/denormalized/1/Q9.yml
+++ b/src/workloads/tpch/denormalized/1/Q9.yml
@@ -1,0 +1,20 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 9 against the denormalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery9
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q9.yml
+      Key: TPCHDenormalizedQuery9
+      Parameters:
+        Query9Color: "^.*green.*$"

--- a/src/workloads/tpch/normalized/1/Q17.yml
+++ b/src/workloads/tpch/normalized/1/Q17.yml
@@ -1,0 +1,21 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 17 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery17
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q17.yml
+      Key: TPCHNormalizedQuery17
+      Parameters:
+        Query17Brand: "Brand#23"
+        Query17Container: "MED BOX"

--- a/src/workloads/tpch/normalized/1/Q9.yml
+++ b/src/workloads/tpch/normalized/1/Q9.yml
@@ -1,0 +1,20 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 9 against the normalized schema for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery9
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q9.yml
+      Key: TPCHNormalizedQuery9
+      Parameters:
+        Query9Color: "^.*green.*$"


### PR DESCRIPTION
Evergreen patch: https://spruce.mongodb.com/version/61fa8f6930661521f06d4635/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

This patch includes a fly-by fix to update query 2 on the denormalized schema to us a faster join order (similar to what the normalized schema does).