### PR TITLE
TIG-3678 Genny auto patch test task generation doesn't work with PrivateWorkloads

### DIFF
--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -96,7 +96,9 @@ class WorkloadLister:
             cmd = run_command(cmd=[command], cwd=repo_path, shell=True, check=True)
             if cmd.returncode != 0:
                 SLOG.fatal("Failed to compare workload directory to origin.", *cmd)
-                raise RuntimeError("Failed to compare workload directory to origin: stdout: {cmd.stdout} stderr: {cmd.stderr}")
+                raise RuntimeError(
+                    "Failed to compare workload directory to origin: stdout: {cmd.stdout} stderr: {cmd.stderr}"
+                )
             lines = cmd.stdout
             modified_workloads.update(
                 {os.path.join(repo_path, line) for line in lines if line.endswith(".yml")}


### PR DESCRIPTION
Genny previously assuemed all repo workloads have a master branch. PrivateWorkloads's default branch is named production