### PR TITLE
PERF-2789 Add $lookup pushdown workloads

### DIFF
--- a/src/phases/execution/LookupCommands.yml
+++ b/src/phases/execution/LookupCommands.yml
@@ -9,7 +9,7 @@ Description: |
 RandIntUpToTemplate: &RandIntUpTo {^RandomInt: {min: 1, max: {^Parameter: {Name: "card", Default: 9500}}}}
 # Generates a monotonically increasing integer value from 1 to 'card' parameter of which the default
 # is 9500.
-IncIntUpToTemplate: &IncIntUpTo {^Inc: {start: 1, end: {^Parameter: {Name: "card", Default: 9500}}}}
+IncIntUpToTemplate: &IncIntUpTo {^Inc: {start: 1}}
 # Generates a random 32bit integer value.
 Rand32BitIntGen: &Rand32BitInt {^RandomInt: {min: 0, max: 2147483647}}
 # Generates a random string of which the length is 10 - 80.
@@ -55,7 +55,7 @@ ForeignSmallDocTemplate:
     ^FormatString:
       format: "%010d"
       withArgs: [*IncIntUpTo]
-  doc_key: {int: *IncIntUpTo}
+  doc_key: {int: *IncIntUpTo, arr: {^Array: {of: *RandIntUpTo, number: 5}}}
   arr_key: {^Array: {of: *RandIntUpTo, number: 5}}
   data1: *Rand32BitInt
 
@@ -74,8 +74,8 @@ HJLookupCmdTemplate:
   allowDiskUse: true
   cursor: {batchSize: 2000}
 
-# The command template for double HJ lookups. Note that 'allowDiskUse' is true.
-HJDoubleLookupCmdTemplate:
+# The command template for double NLJ lookups. Note that 'allowDiskUse' is true.
+NLJDoubleLookupCmdTemplate:
   aggregate: {^Parameter: {Name: "l", Default: "local"}}
   pipeline:
     [
@@ -92,11 +92,11 @@ HJDoubleLookupCmdTemplate:
         as: "joined2"
       }},
     ]
-  allowDiskUse: true
+  allowDiskUse: false
   cursor: {batchSize: 2000}
 
-# The command template for triple HJ lookups. Note that 'allowDiskUse' is true.
-HJTripleLookupCmdTemplate:
+# The command template for triple NLJ lookups. Note that 'allowDiskUse' is true.
+NLJTripleLookupCmdTemplate:
   aggregate: {^Parameter: {Name: "l", Default: "local"}}
   pipeline:
     [
@@ -119,7 +119,7 @@ HJTripleLookupCmdTemplate:
         as: "joined3"
       }},
     ]
-  allowDiskUse: true
+  allowDiskUse: false
   cursor: {batchSize: 2000}
 
 # The command template for NLJ lookups. Note that 'allowDiskUse' is false. This command template

--- a/src/phases/execution/LookupCommands.yml
+++ b/src/phases/execution/LookupCommands.yml
@@ -9,13 +9,13 @@ Description: |
 RandIntUpToTemplate: &RandIntUpTo {^RandomInt: {min: 1, max: {^Parameter: {Name: "card", Default: 9500}}}}
 # Generates a monotonically increasing integer value from 1 to 'card' parameter of which the default
 # is 9500.
-IncIntUpToTemplate: &IncIntUpTo {^Inc: {start: 1}}
+IncIntTemplate: &IncInt {^Inc: {start: 1}}
 # Generates a random 32bit integer value.
 Rand32BitIntGen: &Rand32BitInt {^RandomInt: {min: 0, max: 2147483647}}
 # Generates a random string of which the length is 10 - 80.
-RandomShortStringGen: &RandShortStr {^RandomString: {length: {^RandomInt: {min: 10, max: 80}}}}
+RandomShortStringGen: &RandShortStr {^FastRandomString: {length: {^RandomInt: {min: 10, max: 80}}}}
 # Generates a random string of which the length is 480 - 960.
-RandMediumStrGen: &RandMediumStr {^RandomString: {length: {^RandomInt: {min: 480, max: 960}}}}
+RandMediumStrGen: &RandMediumStr {^FastRandomString: {length: {^RandomInt: {min: 480, max: 960}}}}
 
 # The small document template for a local collection. Random values are generated for 'int_key' and
 # 'str_key' fields since local collections would have much more documents than foreign collections
@@ -50,12 +50,12 @@ LocalLargeDocTemplate:
 # guaranteed to be generated. But random values are generated for 'arr_key' since the array will
 # 5 elements which is likely to make it possible to generate all possible values.
 ForeignSmallDocTemplate:
-  int_key: *IncIntUpTo
+  int_key: *IncInt
   str_key:
     ^FormatString:
       format: "%010d"
-      withArgs: [*IncIntUpTo]
-  doc_key: {int: *IncIntUpTo, arr: {^Array: {of: *RandIntUpTo, number: 5}}}
+      withArgs: [*IncInt]
+  doc_key: {int: *IncInt, arr: {^Array: {of: *RandIntUpTo, number: 5}}}
   arr_key: {^Array: {of: *RandIntUpTo, number: 5}}
   data1: *Rand32BitInt
 

--- a/src/phases/execution/LookupCommands.yml
+++ b/src/phases/execution/LookupCommands.yml
@@ -1,0 +1,140 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query-execution"
+Description: |
+  Defines common configurations for 'LookupSBEPushdown' and 'LookupSBEPushdownMisc' workloads.
+
+# Defines value generators.
+
+# Generates a random integer value from 1 to 'card' parameter of which the default is 9500.
+RandIntUpToTemplate: &RandIntUpTo {^RandomInt: {min: 1, max: {^Parameter: {Name: "card", Default: 9500}}}}
+# Generates a monotonically increasing integer value from 1 to 'card' parameter of which the default
+# is 9500.
+IncIntUpToTemplate: &IncIntUpTo {^Inc: {start: 1, end: {^Parameter: {Name: "card", Default: 9500}}}}
+# Generates a random 32bit integer value.
+Rand32BitIntGen: &Rand32BitInt {^RandomInt: {min: 0, max: 2147483647}}
+# Generates a random string of which the length is 10 - 80.
+RandomShortStringGen: &RandShortStr {^RandomString: {length: {^RandomInt: {min: 10, max: 80}}}}
+# Generates a random string of which the length is 480 - 960.
+RandMediumStrGen: &RandMediumStr {^RandomString: {length: {^RandomInt: {min: 480, max: 960}}}}
+
+# The small document template for a local collection. Random values are generated for 'int_key' and
+# 'str_key' fields since local collections would have much more documents than foreign collections
+# and it's highly probable that all possible values are generated for the join key.
+LocalSmallDocTemplate:
+  int_key: *RandIntUpTo
+  str_key:
+    ^FormatString:
+      format: "%010d"
+      withArgs: [*RandIntUpTo]
+  data1: *Rand32BitInt
+  data2: *Rand32BitInt
+  payload: *RandShortStr
+
+# The large document template for a local collection. The same comment applies to 'int_key' and
+# 'str_key' fields as 'LocalSmallDocTemplate'.
+LocalLargeDocTemplate:
+  int_key: *RandIntUpTo
+  str_key:
+    ^FormatString:
+      format: "%010d"
+      withArgs: [*RandIntUpTo]
+  data1: *Rand32BitInt
+  data2: *Rand32BitInt
+  data3: *Rand32BitInt
+  data4: *Rand32BitInt
+  payload1: *RandShortStr
+  payload2: *RandMediumStr
+
+# The document template for a foreign collections. Monotonically increasing values are generated
+# for 'int_key' / 'str_key' / 'doc_key.int' fields so that every possible values for the range are
+# guaranteed to be generated. But random values are generated for 'arr_key' since the array will
+# 5 elements which is likely to make it possible to generate all possible values.
+ForeignSmallDocTemplate:
+  int_key: *IncIntUpTo
+  str_key:
+    ^FormatString:
+      format: "%010d"
+      withArgs: [*IncIntUpTo]
+  doc_key: {int: *IncIntUpTo}
+  arr_key: {^Array: {of: *RandIntUpTo, number: 5}}
+  data1: *Rand32BitInt
+
+# The command template for HJ lookups. Note that 'allowDiskUse' is true.
+HJLookupCmdTemplate:
+  aggregate: {^Parameter: {Name: "l", Default: "local"}}
+  pipeline:
+    [
+      {$lookup: {
+        from: {^Parameter: {Name: "f", Default: "foreign"}},
+        localField: {^Parameter: {Name: "lk", Default: "int_key"}},
+        foreignField: {^Parameter: {Name: "k", Default: "int_key"}},
+        as: "joined"
+      }},
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+# The command template for double HJ lookups. Note that 'allowDiskUse' is true.
+HJDoubleLookupCmdTemplate:
+  aggregate: {^Parameter: {Name: "l", Default: "local"}}
+  pipeline:
+    [
+      {$lookup: {
+        from: {^Parameter: {Name: "f", Default: "foreign"}},
+        localField: {^Parameter: {Name: "lk1", Default: "int_key"}},
+        foreignField: {^Parameter: {Name: "k1", Default: "int_key"}},
+        as: "joined1"
+      }},
+      {$lookup: {
+        from: {^Parameter: {Name: "f", Default: "foreign"}},
+        localField: {^Parameter: {Name: "lk2", Default: "str_key"}},
+        foreignField: {^Parameter: {Name: "k2", Default: "str_key"}},
+        as: "joined2"
+      }},
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+# The command template for triple HJ lookups. Note that 'allowDiskUse' is true.
+HJTripleLookupCmdTemplate:
+  aggregate: {^Parameter: {Name: "l", Default: "local"}}
+  pipeline:
+    [
+      {$lookup: {
+        from: {^Parameter: {Name: "f1", Default: "foreign"}},
+        localField: {^Parameter: {Name: "lk1", Default: "int_key"}},
+        foreignField: {^Parameter: {Name: "k1", Default: "int_key"}},
+        as: "joined1"
+      }},
+      {$lookup: {
+        from: {^Parameter: {Name: "f2", Default: "foreign"}},
+        localField: {^Parameter: {Name: "lk2", Default: "str_key"}},
+        foreignField: {^Parameter: {Name: "k2", Default: "str_key"}},
+        as: "joined2"
+      }},
+      {$lookup: {
+        from: {^Parameter: {Name: "f3", Default: "foreign"}},
+        localField: {^Parameter: {Name: "lk3", Default: "int_key"}},
+        foreignField: {^Parameter: {Name: "k3", Default: "arr_key"}},
+        as: "joined3"
+      }},
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+# The command template for NLJ lookups. Note that 'allowDiskUse' is false. This command template
+# can be used for INLJ lookups too since INLJ lookups depend on the existence of index on the join
+# field.
+NLJLookupCmdTemplate:
+  aggregate: {^Parameter: {Name: "l", Default: "local"}}
+  pipeline:
+    [
+      {$lookup: {
+        from: {^Parameter: {Name: "f", Default: "foreign"}},
+        localField: {^Parameter: {Name: "lk", Default: "int_key"}},
+        foreignField: {^Parameter: {Name: "k", Default: "int_key"}},
+        as: "joined"
+      }},
+    ]
+  allowDiskUse: false
+  cursor: {batchSize: 2000}

--- a/src/workloads/execution/LookupSBEPushdown.yml
+++ b/src/workloads/execution/LookupSBEPushdown.yml
@@ -11,35 +11,26 @@ Description: |
   the SBE HJ / NLJ implementations to the classic engine NLJ implementation and the SBE INLJ
   implementation to the classic engine INLJ implementation.
 
+  Numbers on the 'standalone-all-feature-flags' environment are for the SBE $lookup and numbers on
+  the 'standalone' environment for the classic $lookup.
+
   In summary, this workload conducts testing for the following test matrix:
   - JoinType: HJ / NLJ / INLJ
   - ForeignCollectionCardinality: 1500 / 3500 / 5500 / 7500 / 9500
-
-  This workload assumes that the SBE and SBE $lookup pushdown features are turned on.
 
   The workload consists of the following phases and actors:
     0. Cleans up database
        - 'Setup' actor
     1. Loads data into the local and foreign collections.
        - 'LoadXXX' actors.
-    2. Runs and measures the SBE HJ lookups
-       - 'SBE_HJ' actor
-    3. Runs and measures the SBE NLJ lookups
-       - 'SBE_NLJ' actor
-    4. Turns off the SBE
-       - 'TurnOffSBE1st' actor
-    5. Runs and measures the classic NLJ lookups
-       - 'Classic' actor
-    6. Turns back on the SBE
-       - 'TurnOnSBE' actor
-    7. Build indexes on foreign collections
+    2. Runs and measures the SBE HJ lookups and the classic NLJ lookups
+       - 'HJLookup' actor
+    3. Runs and measures the SBE NLJ lookups and the classic NLJ lookups
+       - 'NLJLookup' actor
+    4. Builds indexes on foreign collections
        - 'BuildIndexes' actor
-    8. Runs and measures the SBE INLJ lookups
-       - 'SBE_INLJ' actor
-    9. Turns off the SBE
-       - 'TurnOffSBE2nd' actor
-    10. Runs and measures the classic INLJ lookups
-       - 'Classic_Indexed' actor
+    5. Runs and measures the SBE INLJ lookups and the classic INLJ lookups
+       - 'INLJLookup' actor
 
 # Defines the database name.
 Database: &db lookup_sbe_pushdown
@@ -99,9 +90,9 @@ ForeignSmallDoc9500: &ForeignSmallDoc9500
     Parameters:
       card: 9500
 
-# Defines HJ lookup commands which are used by 'SBE_HJ' actor. See 'HJLookupCmdTemplate' for
+# Defines HJ lookup commands which are used by 'HJLookup' actor. See 'HJLookupCmdTemplate' for
 # details. To enable the SBE HJ lookup, the template has 'allowDiskUse: true' argument and all
-# foreign collections has the cardinality < 10000 and 'SBE_HJ' actor runs before creating any
+# foreign collections has the cardinality < 10000 and 'HJLookup' actor runs before creating any
 # indexes on any join fields.
 HJLookupForeign1500Cmd: &HJLookupForeign1500Cmd
   LoadConfig:
@@ -143,9 +134,9 @@ HJLookupForeign9500Cmd: &HJLookupForeign9500Cmd
       l: *LocalSmallDoc100k
       f: *Foreign9500
 
-# Defines NLJ lookup commands which are used by 'SBE_NLJ' / 'Classic' / 'SBE_INLJ' /
-# 'Classic_Indexed' actors. See 'NLJLookupCmdTemplate' for details. The command template can be
-# used for INLJ too because INLJ can be enabled when the foreign join field is indexed.
+# Defines NLJ lookup commands which are used by 'NLJLookup' / 'INLJLookup' actors. See
+# 'NLJLookupCmdTemplate' for details. The command template can be used for INLJ too because INLJ
+# will be enabled when the foreign join field is indexed.
 NLJLookupForeign1500Cmd: &NLJLookupForeign1500Cmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
@@ -186,7 +177,7 @@ NLJLookupForeign9500Cmd: &NLJLookupForeign9500Cmd
       l: *LocalSmallDoc100k
       f: *Foreign9500
 
-# Defines test operations for 'SBE_HJ' actor.
+# Defines test operations for 'HJLookup' actor.
 HJTestOperations: &HJTestOperations
 - OperationMetricsName: Foreign1500_IntTopField
   OperationName: RunCommand
@@ -204,7 +195,7 @@ HJTestOperations: &HJTestOperations
   OperationName: RunCommand
   OperationCommand: *HJLookupForeign9500Cmd
 
-# Defines test operations for 'SBE_NLJ'/ 'Classic' / 'SBE_INLJ' / 'Classic_Indexed' actors.
+# Defines test operations for 'NLJLookup'/ 'INLJLookup' actors.
 NLJTestOperations: &NLJTestOperations
 - OperationMetricsName: Foreign1500_IntTopField
   OperationName: RunCommand
@@ -225,15 +216,6 @@ NLJTestOperations: &NLJTestOperations
 # Defines how many times each test operation is executed.
 TestRepeatCount: &TestRepeatCount 10
 
-TurnOffSBECmd: &TurnOffSBECmd
-  Repeat: 1
-  Database: admin
-  Operations:
-  - OperationName: AdminCommand
-    OperationCommand:
-      setParameter: 1
-      internalQueryForceClassicEngine: true
-
 Actors:
 # The 'Setup' actor drops the database and runs in the 0th phase.
 - Name: Setup
@@ -247,7 +229,7 @@ Actors:
     Operations:
     - OperationName: RunCommand
       OperationCommand: {dropDatabase: 1}
-  - Phase: 1..10
+  - Phase: 1..5
     Nop: true
 
 # The 'LoadForeign1500' / 'LoadForeign3500' / 'LoadForeign5500' / 'LoadForeign7500' /
@@ -265,7 +247,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc1500
-  - Phase: 2..10
+  - Phase: 2..5
     Nop: true
 
 - Name: LoadForeign3500
@@ -281,7 +263,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc3500
-  - Phase: 2..10
+  - Phase: 2..5
     Nop: true
 
 - Name: LoadForeign5500
@@ -297,7 +279,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc5500
-  - Phase: 2..10
+  - Phase: 2..5
     Nop: true
 
 - Name: LoadForeign7500
@@ -313,7 +295,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc7500
-  - Phase: 2..10
+  - Phase: 2..5
     Nop: true
 
 - Name: LoadForeign9500
@@ -329,7 +311,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc9500
-  - Phase: 2..10
+  - Phase: 2..5
     Nop: true
 
 - Name: LoadLocalSmallDoc100k
@@ -345,11 +327,12 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - Phase: 2..10
+  - Phase: 2..5
     Nop: true
 
-# The 'SBE_HJ' actor measures the SBE HJ lookup performances and runs in the 2nd phase.
-- Name: SBE_HJ
+# The 'HJLookup' actor measures the SBE HJ lookup performances on an all-feature-flags build and
+# runs in the 2nd phase. HJLookup becomes a NLJLookup on a normal build.
+- Name: HJLookup
   Type: RunCommand
   Database: *db
   Phases:
@@ -358,11 +341,11 @@ Actors:
   - Repeat: *TestRepeatCount
     Database: *db
     Operations: *HJTestOperations
-  - Phase: 3..10
+  - Phase: 3..5
     Nop: true
 
-# The 'SBE_NLJ' actor measures the SBE NLJ lookup performances and runs in the 3rd phase.
-- Name: SBE_NLJ
+# The 'NLJLookup' actor measures the NLJ lookup performances and runs in the 3rd phase.
+- Name: NLJLookup
   Type: RunCommand
   Database: *db
   Phases:
@@ -371,55 +354,15 @@ Actors:
   - Repeat: *TestRepeatCount
     Database: *db
     Operations: *NLJTestOperations
-  - Phase: 4..10
-    Nop: true
-
-# The 'TurnOffSBE1st' actor turns off the SBE engine so that the classic engine's NLJ performances
-# can be measures and runs in the 4th phase.
-- Name: TurnOffSBE1st
-  Type: AdminCommand
-  Phases:
-  - Phase: 0..3
-    Nop: true
-  - *TurnOffSBECmd
-  - Phase: 5..10
-    Nop: true
-
-# The 'Classic' actor measures the classic engine's NLJ performances and runs in the 5th phase.
-- Name: Classic
-  Type: RunCommand
-  Database: *db
-  Phases:
-  - Phase: 0..4
-    Nop: true
-  - Repeat: *TestRepeatCount
-    Database: *db
-    Operations: *NLJTestOperations
-  - Phase: 6..10
-    Nop: true
-
-# The 'TurnOnSBE' actor turns back on the SBE and runs in 6th phase.
-- Name: TurnOnSBE
-  Type: AdminCommand
-  Phases:
-  - Phase: 0..5
-    Nop: true
-  - Repeat: 1
-    Database: admin
-    Operations:
-    - OperationName: AdminCommand
-      OperationCommand:
-        setParameter: 1
-        internalQueryForceClassicEngine: false
-  - Phase: 7..10
-    Nop: true
+  - *Nop
+  - *Nop
 
 # The 'BuildIndexes' actor builds indexes on 'int_key' join field of foreign collections so that
-# INLJ lookup performances can be measured and runs in the 7th phase.
+# INLJ lookup performances can be measured and runs in the 4th phase.
 - Name: BuildIndexes
   Type: RunCommand
   Phases:
-  - Phase: 0..6
+  - Phase: 0..3
     Nop: true
   - Repeat: 1
     Database: *db
@@ -444,39 +387,14 @@ Actors:
       OperationCommand:
         createIndexes: *Foreign9500
         indexes: *IndexSpec
-  - Phase: 8..10
-    Nop: true
+  - *Nop
 
-# The 'SBE_INLJ' actor measures the SBE INLJ lookup performances and  runs in the 8th phase.
-- Name: SBE_INLJ
+# The 'INLJLookup' actor measures the INLJ lookup performances and  runs in the 5th phase.
+- Name: INLJLookup
   Type: RunCommand
   Database: *db
   Phases:
-  - Phase: 0..7
-    Nop: true
-  - Repeat: *TestRepeatCount
-    Database: *db
-    Operations: *NLJTestOperations
-  - *Nop
-  - *Nop
-
-# The 'TurnOffSBE2nd' actor turns off the SBE so that the classic INLJ lookup performances can be
-# measured and runs in the 9th phase.
-- Name: TurnOffSBE2nd
-  Type: AdminCommand
-  Phases:
-  - Phase: 0..8
-    Nop: true
-  - *TurnOffSBECmd
-  - *Nop
-
-# The 'Classic_Indexed' actor measures the classic INLJ lookup performances and runs in the 10th
-# phase.
-- Name: Classic_Indexed
-  Type: RunCommand
-  Database: *db
-  Phases:
-  - Phase: 0..9
+  - Phase: 0..4
     Nop: true
   - Repeat: *TestRepeatCount
     Database: *db
@@ -486,4 +404,5 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
+      - standalone
       - standalone-all-feature-flags

--- a/src/workloads/execution/LookupSBEPushdown.yml
+++ b/src/workloads/execution/LookupSBEPushdown.yml
@@ -5,11 +5,12 @@ Description: |
   foreign collection's integer key, when the foreign collections have multiple collection
   cardinalities such as 1500 / 3500 / 5500 / 7500 / 9500.
 
-  While measuring performances, this workload collects numbers for both the SBE and the classic
-  engine $lookup implementations. The SBE $lookup implements the hash join and the (index) nested
-  loop join but the classic $lookup implements only (index) nested loop join. So we can compare
-  the SBE HJ / NLJ implementations to the classic engine NLJ implementation and the SBE INLJ
-  implementation to the classic engine INLJ implementation.
+  While measuring performances, this workload collects numbers for either the SBE or the classic
+  engine $lookup implementations, depending on environments that it runs on. The SBE $lookup
+  implements the hash join and the (index) nested loop join but the classic $lookup implements
+  only (index) nested loop join. So we can compare the SBE HJ / NLJ implementations to the classic
+  engine NLJ implementation and the SBE INLJ implementation to the classic engine INLJ
+  implementation.
 
   Numbers on the 'standalone-all-feature-flags' environment are for the SBE $lookup and numbers on
   the 'standalone' environment for the classic $lookup.
@@ -21,16 +22,25 @@ Description: |
   The workload consists of the following phases and actors:
     0. Cleans up database
        - 'Setup' actor
-    1. Loads data into the local and foreign collections.
-       - 'LoadXXX' actors.
-    2. Runs and measures the SBE HJ lookups and the classic NLJ lookups
+    1. Loads data into the local and foreign collections
+       - 'LoadXXX' actors
+    2. Calms down to isolate any trailing impacts from the load phase
+       - 'Quiesce' actor
+    3. Runs and measures the SBE HJ lookups and the classic NLJ lookups
        - 'HJLookup' actor
-    3. Runs and measures the SBE NLJ lookups and the classic NLJ lookups
+    4. Runs and measures the SBE NLJ lookups and the classic NLJ lookups
        - 'NLJLookup' actor
-    4. Builds indexes on foreign collections
+    5. Builds indexes on foreign collections
        - 'BuildIndexes' actor
-    5. Runs and measures the SBE INLJ lookups and the classic INLJ lookups
+    6. Calms down to isolate any trailing impacts from the previous phase
+       - 'Quiesce' actor
+    7. Runs and measures the SBE INLJ lookups and the classic INLJ lookups
        - 'INLJLookup' actor
+
+Keywords:
+- lookup
+- aggregate
+- sbe
 
 # Defines the database name.
 Database: &db lookup_sbe_pushdown
@@ -229,11 +239,11 @@ Actors:
     Operations:
     - OperationName: RunCommand
       OperationCommand: {dropDatabase: 1}
-  - Phase: 1..5
+  - Phase: 1..7
     Nop: true
 
 # The 'LoadForeign1500' / 'LoadForeign3500' / 'LoadForeign5500' / 'LoadForeign7500' /
-# 'LoadForeign9500' / 'LoadLocalSmallDoc100k' actors runs in the 1st phase.
+# 'LoadForeign9500' / 'LoadLocalSmallDoc100k' actors run in the 1st phase.
 - Name: LoadForeign1500
   Type: CrudActor
   Database: *db
@@ -247,7 +257,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc1500
-  - Phase: 2..5
+  - Phase: 2..7
     Nop: true
 
 - Name: LoadForeign3500
@@ -263,7 +273,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc3500
-  - Phase: 2..5
+  - Phase: 2..7
     Nop: true
 
 - Name: LoadForeign5500
@@ -279,7 +289,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc5500
-  - Phase: 2..5
+  - Phase: 2..7
     Nop: true
 
 - Name: LoadForeign7500
@@ -295,7 +305,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc7500
-  - Phase: 2..5
+  - Phase: 2..7
     Nop: true
 
 - Name: LoadForeign9500
@@ -311,7 +321,7 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc9500
-  - Phase: 2..5
+  - Phase: 2..7
     Nop: true
 
 - Name: LoadLocalSmallDoc100k
@@ -327,25 +337,27 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - Phase: 2..5
+  - Phase: 2..7
     Nop: true
 
-# The 'HJLookup' actor measures the SBE HJ lookup performances on an all-feature-flags build and
-# runs in the 2nd phase. HJLookup becomes a NLJLookup on a normal build.
-- Name: HJLookup
-  Type: RunCommand
+# The 'Quiesce' actor calms down to avoid any trailing impacts from the previous phase and runs
+# in the 2nd and 6th phases.
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
   Database: *db
   Phases:
   - *Nop
   - *Nop
-  - Repeat: *TestRepeatCount
-    Database: *db
-    Operations: *HJTestOperations
+  - Repeat: 1
   - Phase: 3..5
     Nop: true
+  - Repeat: 1
+  - *Nop
 
-# The 'NLJLookup' actor measures the NLJ lookup performances and runs in the 3rd phase.
-- Name: NLJLookup
+# The 'HJLookup' actor measures the SBE HJ lookup performances on an all-feature-flags build and
+# runs in the 3rd phase. HJLookup becomes a NLJLookup on a normal build.
+- Name: HJLookup
   Type: RunCommand
   Database: *db
   Phases:
@@ -353,16 +365,29 @@ Actors:
     Nop: true
   - Repeat: *TestRepeatCount
     Database: *db
+    Operations: *HJTestOperations
+  - Phase: 4..7
+    Nop: true
+
+# The 'NLJLookup' actor measures the NLJ lookup performances and runs in the 4th phase.
+- Name: NLJLookup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - Phase: 0..3
+    Nop: true
+  - Repeat: *TestRepeatCount
+    Database: *db
     Operations: *NLJTestOperations
-  - *Nop
-  - *Nop
+  - Phase: 5..7
+    Nop: true
 
 # The 'BuildIndexes' actor builds indexes on 'int_key' join field of foreign collections so that
-# INLJ lookup performances can be measured and runs in the 4th phase.
+# INLJ lookup performances can be measured and runs in the 5th phase.
 - Name: BuildIndexes
   Type: RunCommand
   Phases:
-  - Phase: 0..3
+  - Phase: 0..4
     Nop: true
   - Repeat: 1
     Database: *db
@@ -388,13 +413,14 @@ Actors:
         createIndexes: *Foreign9500
         indexes: *IndexSpec
   - *Nop
+  - *Nop
 
-# The 'INLJLookup' actor measures the INLJ lookup performances and  runs in the 5th phase.
+# The 'INLJLookup' actor measures the INLJ lookup performances and  runs in the 7th phase.
 - Name: INLJLookup
   Type: RunCommand
   Database: *db
   Phases:
-  - Phase: 0..4
+  - Phase: 0..6
     Nop: true
   - Repeat: *TestRepeatCount
     Database: *db

--- a/src/workloads/execution/LookupSBEPushdown.yml
+++ b/src/workloads/execution/LookupSBEPushdown.yml
@@ -1,7 +1,7 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query-execution"
 Description: |
-  This workload measures $lookup performance for scenarios that looks up local integer key against
+  This workload measures $lookup performance for scenarios that look up local integer key against
   foreign collection's integer key, when the foreign collections have multiple collection
   cardinalities such as 1500 / 3500 / 5500 / 7500 / 9500.
 
@@ -18,6 +18,7 @@ Description: |
   In summary, this workload conducts testing for the following test matrix:
   - JoinType: HJ / NLJ / INLJ
   - ForeignCollectionCardinality: 1500 / 3500 / 5500 / 7500 / 9500
+  - The local collection has 100k documents and its documents are small ones
 
   The workload consists of the following phases and actors:
     0. Cleans up database
@@ -26,9 +27,11 @@ Description: |
        - 'LoadXXX' actors
     2. Calms down to isolate any trailing impacts from the load phase
        - 'Quiesce' actor
-    3. Runs and measures the SBE HJ lookups and the classic NLJ lookups
+    3. Runs and measures either the SBE HJ lookups or the classic NLJ lookups, depending on the
+       environment
        - 'HJLookup' actor
-    4. Runs and measures the SBE NLJ lookups and the classic NLJ lookups
+    4. Runs and measures either the SBE NLJ lookups or the classic NLJ lookups, depending on the
+       environment
        - 'NLJLookup' actor
     5. Builds indexes on foreign collections
        - 'BuildIndexes' actor

--- a/src/workloads/execution/LookupSBEPushdown.yml
+++ b/src/workloads/execution/LookupSBEPushdown.yml
@@ -13,7 +13,8 @@ Description: |
   implementation.
 
   Numbers on the 'standalone-all-feature-flags' environment are for the SBE $lookup and numbers on
-  the 'standalone' environment for the classic $lookup.
+  the 'standalone' environment for the classic $lookup until the SBE $lookup pushdown feature will
+  be turned on by default.
 
   In summary, this workload conducts testing for the following test matrix:
   - JoinType: HJ / NLJ / INLJ
@@ -418,7 +419,7 @@ Actors:
   - *Nop
   - *Nop
 
-# The 'INLJLookup' actor measures the INLJ lookup performances and  runs in the 7th phase.
+# The 'INLJLookup' actor measures the INLJ lookup performances and runs in the 7th phase.
 - Name: INLJLookup
   Type: RunCommand
   Database: *db

--- a/src/workloads/execution/LookupSBEPushdown.yml
+++ b/src/workloads/execution/LookupSBEPushdown.yml
@@ -1,0 +1,489 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query-execution"
+Description: |
+  This workload measures $lookup performance for scenarios that looks up local integer key against
+  foreign collection's integer key, when the foreign collections have multiple collection
+  cardinalities such as 1500 / 3500 / 5500 / 7500 / 9500.
+
+  While measuring performances, this workload collects numbers for both the SBE and the classic
+  engine $lookup implementations. The SBE $lookup implements the hash join and the (index) nested
+  loop join but the classic $lookup implements only (index) nested loop join. So we can compare
+  the SBE HJ / NLJ implementations to the classic engine NLJ implementation and the SBE INLJ
+  implementation to the classic engine INLJ implementation.
+
+  In summary, this workload conducts testing for the following test matrix:
+  - JoinType: HJ / NLJ / INLJ
+  - ForeignCollectionCardinality: 1500 / 3500 / 5500 / 7500 / 9500
+
+  This workload assumes that the SBE and SBE $lookup pushdown features are turned on.
+
+  The workload consists of the following phases and actors:
+    0. Cleans up database
+       - 'Setup' actor
+    1. Loads data into the local and foreign collections.
+       - 'LoadXXX' actors.
+    2. Runs and measures the SBE HJ lookups
+       - 'SBE_HJ' actor
+    3. Runs and measures the SBE NLJ lookups
+       - 'SBE_NLJ' actor
+    4. Turns off the SBE
+       - 'TurnOffSBE1st' actor
+    5. Runs and measures the classic NLJ lookups
+       - 'Classic' actor
+    6. Turns back on the SBE
+       - 'TurnOnSBE' actor
+    7. Build indexes on foreign collections
+       - 'BuildIndexes' actor
+    8. Runs and measures the SBE INLJ lookups
+       - 'SBE_INLJ' actor
+    9. Turns off the SBE
+       - 'TurnOffSBE2nd' actor
+    10. Runs and measures the classic INLJ lookups
+       - 'Classic_Indexed' actor
+
+# Defines the database name.
+Database: &db lookup_sbe_pushdown
+
+# Defines foreign collection names.
+Foreign1500: &Foreign1500 foreign_1500
+Foreign3500: &Foreign3500 foreign_3500
+Foreign5500: &Foreign5500 foreign_5500
+Foreign7500: &Foreign7500 foreign_7500
+Foreign9500: &Foreign9500 foreign_9500
+
+# Defines the local collection name.
+LocalSmallDoc100k: &LocalSmallDoc100k local_smalldoc_100k
+
+# Defines the local collection document type which is used by 'LoadLocalSmallDoc100k' actor. See
+# 'LocalSmallDocTemplate' to understand how each doc is filled.
+LocalSmallDoc: &LocalSmallDoc
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: LocalSmallDocTemplate
+
+# Defines foreign collections with 1500 / 3500 / 5500 / 7500 / 9500 documents which is used by
+# 'LoadForeign[1500|3500|5500|7500|9500]' actor. See 'ForeignSmallDocTemplate' to understand how
+# each doc is filled.
+ForeignSmallDoc1500: &ForeignSmallDoc1500
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: ForeignSmallDocTemplate
+    Parameters:
+      card: 1500
+
+ForeignSmallDoc3500: &ForeignSmallDoc3500
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: ForeignSmallDocTemplate
+    Parameters:
+      card: 3500
+
+ForeignSmallDoc5500: &ForeignSmallDoc5500
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: ForeignSmallDocTemplate
+    Parameters:
+      card: 5500
+
+ForeignSmallDoc7500: &ForeignSmallDoc7500
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: ForeignSmallDocTemplate
+    Parameters:
+      card: 7500
+
+ForeignSmallDoc9500: &ForeignSmallDoc9500
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: ForeignSmallDocTemplate
+    Parameters:
+      card: 9500
+
+# Defines HJ lookup commands which are used by 'SBE_HJ' actor. See 'HJLookupCmdTemplate' for
+# details. To enable the SBE HJ lookup, the template has 'allowDiskUse: true' argument and all
+# foreign collections has the cardinality < 10000 and 'SBE_HJ' actor runs before creating any
+# indexes on any join fields.
+HJLookupForeign1500Cmd: &HJLookupForeign1500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign1500
+
+HJLookupForeign3500Cmd: &HJLookupForeign3500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign3500
+
+HJLookupForeign5500Cmd: &HJLookupForeign5500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign5500
+
+HJLookupForeign7500Cmd: &HJLookupForeign7500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign7500
+
+HJLookupForeign9500Cmd: &HJLookupForeign9500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign9500
+
+# Defines NLJ lookup commands which are used by 'SBE_NLJ' / 'Classic' / 'SBE_INLJ' /
+# 'Classic_Indexed' actors. See 'NLJLookupCmdTemplate' for details. The command template can be
+# used for INLJ too because INLJ can be enabled when the foreign join field is indexed.
+NLJLookupForeign1500Cmd: &NLJLookupForeign1500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: NLJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign1500
+
+NLJLookupForeign3500Cmd: &NLJLookupForeign3500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: NLJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign3500
+
+NLJLookupForeign5500Cmd: &NLJLookupForeign5500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: NLJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign5500
+
+NLJLookupForeign7500Cmd: &NLJLookupForeign7500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: NLJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign7500
+
+NLJLookupForeign9500Cmd: &NLJLookupForeign9500Cmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: NLJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign9500
+
+# Defines test operations for 'SBE_HJ' actor.
+HJTestOperations: &HJTestOperations
+- OperationMetricsName: Foreign1500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupForeign1500Cmd
+- OperationMetricsName: Foreign3500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupForeign3500Cmd
+- OperationMetricsName: Foreign5500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupForeign5500Cmd
+- OperationMetricsName: Foreign7500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupForeign7500Cmd
+- OperationMetricsName: Foreign9500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupForeign9500Cmd
+
+# Defines test operations for 'SBE_NLJ'/ 'Classic' / 'SBE_INLJ' / 'Classic_Indexed' actors.
+NLJTestOperations: &NLJTestOperations
+- OperationMetricsName: Foreign1500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *NLJLookupForeign1500Cmd
+- OperationMetricsName: Foreign3500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *NLJLookupForeign3500Cmd
+- OperationMetricsName: Foreign5500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *NLJLookupForeign5500Cmd
+- OperationMetricsName: Foreign7500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *NLJLookupForeign7500Cmd
+- OperationMetricsName: Foreign9500_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *NLJLookupForeign9500Cmd
+
+# Defines how many times each test operation is executed.
+TestRepeatCount: &TestRepeatCount 10
+
+TurnOffSBECmd: &TurnOffSBECmd
+  Repeat: 1
+  Database: admin
+  Operations:
+  - OperationName: AdminCommand
+    OperationCommand:
+      setParameter: 1
+      internalQueryForceClassicEngine: true
+
+Actors:
+# The 'Setup' actor drops the database and runs in the 0th phase.
+- Name: Setup
+  Type: RunCommand
+  Database: *db
+  Thread: 1
+  Phases:
+  - Repeat: 1
+    Threads: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+  - Phase: 1..10
+    Nop: true
+
+# The 'LoadForeign1500' / 'LoadForeign3500' / 'LoadForeign5500' / 'LoadForeign7500' /
+# 'LoadForeign9500' / 'LoadLocalSmallDoc100k' actors runs in the 1st phase.
+- Name: LoadForeign1500
+  Type: CrudActor
+  Database: *db
+  Threads: 1
+  Phases:
+  - &Nop {Nop: true}
+  - Repeat: 1500
+    Threads: 1
+    Collection: *Foreign1500
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *ForeignSmallDoc1500
+  - Phase: 2..10
+    Nop: true
+
+- Name: LoadForeign3500
+  Type: CrudActor
+  Database: *db
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 3500
+    Threads: 1
+    Collection: *Foreign3500
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *ForeignSmallDoc3500
+  - Phase: 2..10
+    Nop: true
+
+- Name: LoadForeign5500
+  Type: CrudActor
+  Database: *db
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 5500
+    Threads: 1
+    Collection: *Foreign5500
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *ForeignSmallDoc5500
+  - Phase: 2..10
+    Nop: true
+
+- Name: LoadForeign7500
+  Type: CrudActor
+  Database: *db
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 7500
+    Threads: 1
+    Collection: *Foreign7500
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *ForeignSmallDoc7500
+  - Phase: 2..10
+    Nop: true
+
+- Name: LoadForeign9500
+  Type: CrudActor
+  Database: *db
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 9500
+    Threads: 1
+    Collection: *Foreign9500
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *ForeignSmallDoc9500
+  - Phase: 2..10
+    Nop: true
+
+- Name: LoadLocalSmallDoc100k
+  Type: CrudActor
+  Database: *db
+  Threads: 10
+  Phases:
+  - *Nop
+  - Repeat: 10000
+    Threads: 1
+    Collection: *LocalSmallDoc100k
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *LocalSmallDoc
+  - Phase: 2..10
+    Nop: true
+
+# The 'SBE_HJ' actor measures the SBE HJ lookup performances and runs in the 2nd phase.
+- Name: SBE_HJ
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: *TestRepeatCount
+    Database: *db
+    Operations: *HJTestOperations
+  - Phase: 3..10
+    Nop: true
+
+# The 'SBE_NLJ' actor measures the SBE NLJ lookup performances and runs in the 3rd phase.
+- Name: SBE_NLJ
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - Phase: 0..2
+    Nop: true
+  - Repeat: *TestRepeatCount
+    Database: *db
+    Operations: *NLJTestOperations
+  - Phase: 4..10
+    Nop: true
+
+# The 'TurnOffSBE1st' actor turns off the SBE engine so that the classic engine's NLJ performances
+# can be measures and runs in the 4th phase.
+- Name: TurnOffSBE1st
+  Type: AdminCommand
+  Phases:
+  - Phase: 0..3
+    Nop: true
+  - *TurnOffSBECmd
+  - Phase: 5..10
+    Nop: true
+
+# The 'Classic' actor measures the classic engine's NLJ performances and runs in the 5th phase.
+- Name: Classic
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - Phase: 0..4
+    Nop: true
+  - Repeat: *TestRepeatCount
+    Database: *db
+    Operations: *NLJTestOperations
+  - Phase: 6..10
+    Nop: true
+
+# The 'TurnOnSBE' actor turns back on the SBE and runs in 6th phase.
+- Name: TurnOnSBE
+  Type: AdminCommand
+  Phases:
+  - Phase: 0..5
+    Nop: true
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationName: AdminCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryForceClassicEngine: false
+  - Phase: 7..10
+    Nop: true
+
+# The 'BuildIndexes' actor builds indexes on 'int_key' join field of foreign collections so that
+# INLJ lookup performances can be measured and runs in the 7th phase.
+- Name: BuildIndexes
+  Type: RunCommand
+  Phases:
+  - Phase: 0..6
+    Nop: true
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *Foreign1500
+        indexes: &IndexSpec [{key: {"int_key": 1}, name: "idx"}]
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *Foreign3500
+        indexes: *IndexSpec
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *Foreign5500
+        indexes: *IndexSpec
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *Foreign7500
+        indexes: *IndexSpec
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *Foreign9500
+        indexes: *IndexSpec
+  - Phase: 8..10
+    Nop: true
+
+# The 'SBE_INLJ' actor measures the SBE INLJ lookup performances and  runs in the 8th phase.
+- Name: SBE_INLJ
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - Phase: 0..7
+    Nop: true
+  - Repeat: *TestRepeatCount
+    Database: *db
+    Operations: *NLJTestOperations
+  - *Nop
+  - *Nop
+
+# The 'TurnOffSBE2nd' actor turns off the SBE so that the classic INLJ lookup performances can be
+# measured and runs in the 9th phase.
+- Name: TurnOffSBE2nd
+  Type: AdminCommand
+  Phases:
+  - Phase: 0..8
+    Nop: true
+  - *TurnOffSBECmd
+  - *Nop
+
+# The 'Classic_Indexed' actor measures the classic INLJ lookup performances and runs in the 10th
+# phase.
+- Name: Classic_Indexed
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - Phase: 0..9
+    Nop: true
+  - Repeat: *TestRepeatCount
+    Database: *db
+    Operations: *NLJTestOperations
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone-all-feature-flags

--- a/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
@@ -18,7 +18,8 @@ Description: |
   since the INLJ lookup is supposed to be very fast on both the SBE and the classic egnine.
 
   Numbers on the 'standalone-all-feature-flags' environment are for the SBE INLJ lookup and numbers
-  on the 'standalone' environment for the classic INLJ lookup.
+  on the 'standalone' environment for the classic INLJ lookup until the SBE $lookup feature will be
+  turned on by default.
 
   The workload consists of the following phases and actors:
     0. Cleans up database

--- a/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
@@ -6,6 +6,7 @@ Description: |
   - DocumentSize: Small document size vs Large document size
   - JoinFieldType: string type / sub-field type / array type / sub-field array type
   - NumberOfLookups: 1 / 2 / 3
+  - The foreign collection has 1500 documents each of which has a unique key value
 
   But this workload does not try to measure performances for full combination of the above test
   dimensions to avoid too lengthy test execution.
@@ -29,7 +30,7 @@ Description: |
     3. Calms down to isolate any trailing impacts from the previous phase
        - 'QuiesceActor'
     4. Runs and measures the miscellaneous lookups.
-       - 'MiscLookup' actor
+       - 'INLJLookupMisc' actor
 
 Keywords:
 - lookup
@@ -37,7 +38,7 @@ Keywords:
 - sbe
 
 # Defines the database name.
-Database: &db lookup_sbe_pushdown_misc
+Database: &db lookup_sbe_pushdown_inlj_misc
 
 # Defines foreign collection names.
 Foreign: &Foreign foreign
@@ -215,7 +216,7 @@ TestOperations: &TestOperations
   OperationCommand: *INLJTripleLookupCmd
 
 # Defines how many times each test operation is executed.
-TestRepeatCount: &TestRepeatCount 10
+TestRepeatCount: &TestRepeatCount 1
 
 Actors:
 # The 'Setup' actor drops the database and runs in the 0th phase.
@@ -365,9 +366,9 @@ Actors:
   - Repeat: 1
   - *Nop
 
-# The 'MiscLookup' actor measures the SBE INLJ lookup performances on an all-feature-flags build and
-# the classic INLJ lookup performances on a normal build and runs in the 4th phase.
-- Name: MiscLookup
+# The 'INLJLookupMisc' actor measures the SBE INLJ lookup performances on an all-feature-flags build
+# and the classic INLJ lookup performances on a normal build and runs in the 4th phase.
+- Name: INLJLookupMisc
   Type: RunCommand
   Database: *db
   Phases:

--- a/src/workloads/execution/LookupSBEPushdownMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownMisc.yml
@@ -10,11 +10,11 @@ Description: |
   But this workload does not try to measure performances for full combination of the above test
   dimensions to avoid too lengthy test execution.
 
-  While measuring performances, this workload collects numbers for both the SBE INLJ and the classic
-  engine INLJ $lookup implementations. The reason why it collects numbers for the INLJ lookup
-  implementation is to compare both implementations on the same algorithmic complexity for fairer
-  comparison and yet to minimize the test execution time since the INLJ lookup is supposed to be
-  very fast on both the SBE and the classic egnine.
+  While measuring performances, this workload collects numbers for either the SBE INLJ or the
+  classic engine INLJ $lookup implementations, depending on environments that it runs on. The reason
+  why it collects numbers for the INLJ lookup implementation is to compare both implementations on
+  the same algorithmic complexity for fairer comparison and yet to minimize the test execution time
+  since the INLJ lookup is supposed to be very fast on both the SBE and the classic egnine.
 
   Numbers on the 'standalone-all-feature-flags' environment are for the SBE INLJ lookup and numbers
   on the 'standalone' environment for the classic INLJ lookup.
@@ -26,8 +26,15 @@ Description: |
        - 'LoadXXX' actors.
     2. Builds indexes on the foreign collection.
        - 'BuildIndexes' actor.
-    3. Runs and measures the miscellaneous lookups.
+    3. Calms down to isolate any trailing impacts from the previous phase
+       - 'QuiesceActor'
+    4. Runs and measures the miscellaneous lookups.
        - 'MiscLookup' actor
+
+Keywords:
+- lookup
+- aggregate
+- sbe
 
 # Defines the database name.
 Database: &db lookup_sbe_pushdown_misc
@@ -223,7 +230,7 @@ Actors:
     Operations:
     - OperationName: RunCommand
       OperationCommand: {dropDatabase: 1}
-  - Phase: 1..3
+  - Phase: 1..4
     Nop: true
 
 # The 'LoadForeign' / 'LoadLocalSmallDoc100k' / 'LocalSmallDoc300k' / 'LocalSmallDoc500k' /
@@ -241,8 +248,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc
-  - *Nop
-  - *Nop
+  - Phase: 2..4
+    Nop: true
 
 - Name: LoadLocalSmallDoc100k
   Type: CrudActor
@@ -257,8 +264,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - *Nop
-  - *Nop
+  - Phase: 2..4
+    Nop: true
 
 - Name: LoadLocalSmallDoc300k
   Type: CrudActor
@@ -273,8 +280,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - *Nop
-  - *Nop
+  - Phase: 2..4
+    Nop: true
 
 - Name: LoadLocalSmallDoc500k
   Type: CrudActor
@@ -289,8 +296,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - *Nop
-  - *Nop
+  - Phase: 2..4
+    Nop: true
 
 - Name: LoadLocalSmallDoc700k
   Type: CrudActor
@@ -305,8 +312,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - *Nop
-  - *Nop
+  - Phase: 2..4
+    Nop: true
 
 - Name: LoadLocalLargeDoc100k
   Type: CrudActor
@@ -321,8 +328,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalLargeDoc
-  - *Nop
-  - *Nop
+  - Phase: 2..4
+    Nop: true
 
 # The 'BuildIndexes' actor builds indexes on all foreign join fields so that INLJ lookup
 # performances can be measured and runs in the 2nd phase.
@@ -344,14 +351,27 @@ Actors:
         - {key: {"doc_key.arr": 1}, name: "idx4"}
         - {key: {"arr_key": 1}, name: "idx5"}
   - *Nop
+  - *Nop
+
+# The 'Quiesce' actor calms down to avoid any trailing impacts from the previous phase and runs
+# in the 4th phase.
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *db
+  Phases:
+  - Phase: 0..2
+    Nop: true
+  - Repeat: 1
+  - *Nop
 
 # The 'MiscLookup' actor measures the SBE INLJ lookup performances on an all-feature-flags build and
-# the classic INLJ lookup performances on a normal build and runs in the 3rd phase.
+# the classic INLJ lookup performances on a normal build and runs in the 4th phase.
 - Name: MiscLookup
   Type: RunCommand
   Database: *db
   Phases:
-  - Phase: 0..2
+  - Phase: 0..3
     Nop: true
   - Repeat: *TestRepeatCount
     Database: *db

--- a/src/workloads/execution/LookupSBEPushdownMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownMisc.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: "@mongodb/query-execution"
 Description: |
   This workload conducts testing for the following test matrix:
   - LocalCollectionCardinality: 100k / 300k / 500k / 700k

--- a/src/workloads/execution/LookupSBEPushdownMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownMisc.yml
@@ -4,30 +4,30 @@ Description: |
   This workload conducts testing for the following test matrix:
   - LocalCollectionCardinality: 100k / 300k / 500k / 700k
   - DocumentSize: Small document size vs Large document size
-  - JoinFieldType: string type / sub-field type / array type
+  - JoinFieldType: string type / sub-field type / array type / sub-field array type
   - NumberOfLookups: 1 / 2 / 3
 
   But this workload does not try to measure performances for full combination of the above test
   dimensions to avoid too lengthy test execution.
 
-  While measuring performances, this workload collects numbers for both the SBE HJ and the classic
-  engine NLJ $lookup implementations. The reason why it collects numbers for the SBE HJ lookup
-  implementation is to minimize the test execution time since the SBE HJ is supposed to be very fast
-  compared to the classic engine's NLJ.
+  While measuring performances, this workload collects numbers for both the SBE INLJ and the classic
+  engine INLJ $lookup implementations. The reason why it collects numbers for the INLJ lookup
+  implementation is to compare both implementations on the same algorithmic complexity for fairer
+  comparison and yet to minimize the test execution time since the INLJ lookup is supposed to be
+  very fast on both the SBE and the classic egnine.
 
-  This workload assumes that the SBE and SBE $lookup pushdown features are turned on.
+  Numbers on the 'standalone-all-feature-flags' environment are for the SBE INLJ lookup and numbers
+  on the 'standalone' environment for the classic INLJ lookup.
 
   The workload consists of the following phases and actors:
     0. Cleans up database
        - 'Setup' actor
     1. Loads data into the local and foreign collections.
        - 'LoadXXX' actors.
-    2. Runs and measures the SBE HJ lookups.
-       - 'SBE_Misc' actor
-    3. Turns off the SBE
-       - 'TurnOffSBE' actor
-    4. Runs and measures the classic NLJ lookups
-       - 'Classic_Misc' actor
+    2. Builds indexes on the foreign collection.
+       - 'BuildIndexes' actor.
+    3. Runs and measures the miscellaneous lookups.
+       - 'MiscLookup' actor
 
 # Defines the database name.
 Database: &db lookup_sbe_pushdown_misc
@@ -67,10 +67,10 @@ ForeignSmallDoc: &ForeignSmallDoc
     Parameters: {card: 1500}
 
 # The lookup command for local_smalldoc_100k.str_key == foreign.str_key.
-HJLookupOnStrKeyCmd: &HJLookupOnStrKeyCmd
+INLJLookupOnStrKeyCmd: &INLJLookupOnStrKeyCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJLookupCmdTemplate
+    Key: NLJLookupCmdTemplate
     Parameters:
       l: *LocalSmallDoc100k
       f: *Foreign
@@ -78,86 +78,96 @@ HJLookupOnStrKeyCmd: &HJLookupOnStrKeyCmd
       k: "str_key"
 
 # The lookup command for local_smalldoc_100k.int_key == foreign.arr_key.
-HJLookupOnArrKeyCmd: &HJLookupOnArrKeyCmd
+INLJLookupOnArrKeyCmd: &INLJLookupOnArrKeyCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJLookupCmdTemplate
+    Key: NLJLookupCmdTemplate
     Parameters:
       l: *LocalSmallDoc100k
       f: *Foreign
       k: "arr_key"
 
 # The lookup command for local_smalldoc_100k.int_key == foreign.doc_key.int.
-HJLookupOnSubFieldKeyCmd: &HJLookupOnSubFieldKeyCmd
+INLJLookupOnSubFieldKeyCmd: &INLJLookupOnSubFieldKeyCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJLookupCmdTemplate
+    Key: NLJLookupCmdTemplate
     Parameters:
       l: *LocalSmallDoc100k
       f: *Foreign
       k: "doc_key.int"
 
-# The lookup command for local_largedoc_100k.int_key == foreign.int_key.
-HJLookupLargeDocCmd: &HJLookupLargeDocCmd
+# The lookup command for local_smalldoc_100k.int_key == foreign.doc_key.arr.
+INLJLookupOnSubArrFieldKeyCmd: &INLJLookupOnSubArrFieldKeyCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJLookupCmdTemplate
+    Key: NLJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign
+      k: "doc_key.arr"
+
+# The lookup command for local_largedoc_100k.int_key == foreign.int_key.
+INLJLookupLargeDocCmd: &INLJLookupLargeDocCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: NLJLookupCmdTemplate
     Parameters:
       l: *LocalLargeDoc100k
       f: *Foreign
 
 # The lookup command for local_smalldoc_300k.int_key == foreign.int_key.
-HJLookupLocal100kCmd: &HJLookupLocal100kCmd
+INLJLookupLocal100kCmd: &INLJLookupLocal100kCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJLookupCmdTemplate
+    Key: NLJLookupCmdTemplate
     Parameters:
       l: *LocalSmallDoc100k
       f: *Foreign
 
 # The lookup command for local_smalldoc_300k.int_key == foreign.int_key.
-HJLookupLocal300kCmd: &HJLookupLocal300kCmd
+INLJLookupLocal300kCmd: &INLJLookupLocal300kCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJLookupCmdTemplate
+    Key: NLJLookupCmdTemplate
     Parameters:
       l: *LocalSmallDoc300k
       f: *Foreign
 
 # The lookup command for local_smalldoc_500k.int_key == foreign.int_key.
-HJLookupLocal500kCmd: &HJLookupLocal500kCmd
+INLJLookupLocal500kCmd: &INLJLookupLocal500kCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJLookupCmdTemplate
+    Key: NLJLookupCmdTemplate
     Parameters:
       l: *LocalSmallDoc500k
       f: *Foreign
 
 # The lookup command for local_smalldoc_700k.int_key == foreign.int_key.
-HJLookupLocal700kCmd: &HJLookupLocal700kCmd
+INLJLookupLocal700kCmd: &INLJLookupLocal700kCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJLookupCmdTemplate
+    Key: NLJLookupCmdTemplate
     Parameters:
       l: *LocalSmallDoc700k
       f: *Foreign
 
 # The lookup command for local_smalldoc_100k.int_key == foreign.int_key
 # | local_smalldoc_100k.str_key == foreign.str_key.
-HJDoubleLookupCmd: &HJDoubleLookupCmd
+INLJDoubleLookupCmd: &INLJDoubleLookupCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJDoubleLookupCmdTemplate
+    Key: NLJDoubleLookupCmdTemplate
     Parameters:
       l: *LocalSmallDoc100k
 
 # The lookup command for local_smalldoc_100k.int_key == foreign.int_key
 # | local_smalldoc_100k.str_key == foreign.str_key
 # | local_smalldoc_100k.int_key == foreign.arr_key.
-HJTripleLookupCmd: &HJTripleLookupCmd
+INLJTripleLookupCmd: &INLJTripleLookupCmd
   LoadConfig:
     Path: "../../phases/execution/LookupCommands.yml"
-    Key: HJTripleLookupCmdTemplate
+    Key: NLJTripleLookupCmdTemplate
     Parameters:
       l: *LocalSmallDoc100k
 
@@ -165,34 +175,37 @@ HJTripleLookupCmd: &HJTripleLookupCmd
 TestOperations: &TestOperations
 - OperationMetricsName: LocalSmallDoc100k_StrTopField
   OperationName: RunCommand
-  OperationCommand: *HJLookupOnStrKeyCmd
+  OperationCommand: *INLJLookupOnStrKeyCmd
 - OperationMetricsName: LocalSmallDoc100k_ArrTopField
   OperationName: RunCommand
-  OperationCommand: *HJLookupOnArrKeyCmd
+  OperationCommand: *INLJLookupOnArrKeyCmd
 - OperationMetricsName: LocalSmallDoc100k_SubField
   OperationName: RunCommand
-  OperationCommand: *HJLookupOnSubFieldKeyCmd
+  OperationCommand: *INLJLookupOnSubFieldKeyCmd
+- OperationMetricsName: LocalSmallDoc100k_SubArrField
+  OperationName: RunCommand
+  OperationCommand: *INLJLookupOnSubArrFieldKeyCmd
 - OperationMetricsName: LocalLargeDoc100k_IntTopField
   OperationName: RunCommand
-  OperationCommand: *HJLookupLargeDocCmd
+  OperationCommand: *INLJLookupLargeDocCmd
 - OperationMetricsName: LocalSmallDoc100k_IntTopField
   OperationName: RunCommand
-  OperationCommand: *HJLookupLocal100kCmd
+  OperationCommand: *INLJLookupLocal100kCmd
 - OperationMetricsName: LocalSmallDoc300k_IntTopField
   OperationName: RunCommand
-  OperationCommand: *HJLookupLocal300kCmd
+  OperationCommand: *INLJLookupLocal300kCmd
 - OperationMetricsName: LocalSmallDoc500k_IntTopField
   OperationName: RunCommand
-  OperationCommand: *HJLookupLocal500kCmd
+  OperationCommand: *INLJLookupLocal500kCmd
 - OperationMetricsName: LocalSmallDoc700k_IntTopField
   OperationName: RunCommand
-  OperationCommand: *HJLookupLocal700kCmd
+  OperationCommand: *INLJLookupLocal700kCmd
 - OperationMetricsName: LocalSmallDoc100k_DoubleLookups
   OperationName: RunCommand
-  OperationCommand: *HJDoubleLookupCmd
+  OperationCommand: *INLJDoubleLookupCmd
 - OperationMetricsName: LocalSmallDoc100k_TripleLookups
   OperationName: RunCommand
-  OperationCommand: *HJTripleLookupCmd
+  OperationCommand: *INLJTripleLookupCmd
 
 # Defines how many times each test operation is executed.
 TestRepeatCount: &TestRepeatCount 10
@@ -210,7 +223,7 @@ Actors:
     Operations:
     - OperationName: RunCommand
       OperationCommand: {dropDatabase: 1}
-  - Phase: 1..4
+  - Phase: 1..3
     Nop: true
 
 # The 'LoadForeign' / 'LoadLocalSmallDoc100k' / 'LocalSmallDoc300k' / 'LocalSmallDoc500k' /
@@ -228,8 +241,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *ForeignSmallDoc
-  - Phase: 2..4
-    Nop: true
+  - *Nop
+  - *Nop
 
 - Name: LoadLocalSmallDoc100k
   Type: CrudActor
@@ -244,8 +257,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - Phase: 2..4
-    Nop: true
+  - *Nop
+  - *Nop
 
 - Name: LoadLocalSmallDoc300k
   Type: CrudActor
@@ -260,8 +273,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - Phase: 2..4
-    Nop: true
+  - *Nop
+  - *Nop
 
 - Name: LoadLocalSmallDoc500k
   Type: CrudActor
@@ -276,8 +289,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - Phase: 2..4
-    Nop: true
+  - *Nop
+  - *Nop
 
 - Name: LoadLocalSmallDoc700k
   Type: CrudActor
@@ -292,8 +305,8 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalSmallDoc
-  - Phase: 2..4
-    Nop: true
+  - *Nop
+  - *Nop
 
 - Name: LoadLocalLargeDoc100k
   Type: CrudActor
@@ -308,44 +321,37 @@ Actors:
     - OperationName: insertOne
       OperationCommand:
         Document: *LocalLargeDoc
-  - Phase: 2..4
-    Nop: true
+  - *Nop
+  - *Nop
 
-# The 'SBE_Misc' actor measures the SBE HJ lookup performances and runs in the 2nd phase.
-- Name: SBE_Misc
+# The 'BuildIndexes' actor builds indexes on all foreign join fields so that INLJ lookup
+# performances can be measured and runs in the 2nd phase.
+- Name: BuildIndexes
   Type: RunCommand
-  Database: *db
   Phases:
   - *Nop
   - *Nop
-  - Repeat: *TestRepeatCount
+  - Repeat: 1
     Database: *db
-    Operations: *TestOperations
-  - *Nop
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *Foreign
+        indexes:
+          - {key: {"int_key": 1}, name: "idx1"}
+          - {key: {"str_key": 1}, name: "idx2"}
+          - {key: {"doc_key.int": 1}, name: "idx3"}
+          - {key: {"doc_key.arr": 1}, name: "idx4"}
+          - {key: {"arr_key": 1}, name: "idx5"}
   - *Nop
 
-# The 'TurnOffSBE' actor turns off the SBE engine so that the classic engine's NLJ performances can
-# be measures and runs in the 3rd phase.
-- Name: TurnOffSBE
-  Type: AdminCommand
+# The 'MiscLookup' actor measures the SBE INLJ lookup performances on an all-feature-flags build and
+# the classic INLJ lookup performances on a normal build and runs in the 3rd phase.
+- Name: MiscLookup
+  Type: RunCommand
+  Database: *db
   Phases:
   - Phase: 0..2
-    Nop: true
-  - Repeat: 1
-    Database: admin
-    Operations:
-    - OperationName: AdminCommand
-      OperationCommand:
-        setParameter: 1
-        internalQueryForceClassicEngine: true
-  - *Nop
-
-# The 'Classic_Misc' actor measures the classic engine's NLJ performances and runs in the 4th phase.
-- Name: Classic_Misc
-  Type: RunCommand
-  Database: *db
-  Phases:
-  - Phase: 0..3
     Nop: true
   - Repeat: *TestRepeatCount
     Database: *db
@@ -355,4 +361,5 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
+      - standalone
       - standalone-all-feature-flags

--- a/src/workloads/execution/LookupSBEPushdownMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownMisc.yml
@@ -338,11 +338,11 @@ Actors:
       OperationCommand:
         createIndexes: *Foreign
         indexes:
-          - {key: {"int_key": 1}, name: "idx1"}
-          - {key: {"str_key": 1}, name: "idx2"}
-          - {key: {"doc_key.int": 1}, name: "idx3"}
-          - {key: {"doc_key.arr": 1}, name: "idx4"}
-          - {key: {"arr_key": 1}, name: "idx5"}
+        - {key: {"int_key": 1}, name: "idx1"}
+        - {key: {"str_key": 1}, name: "idx2"}
+        - {key: {"doc_key.int": 1}, name: "idx3"}
+        - {key: {"doc_key.arr": 1}, name: "idx4"}
+        - {key: {"arr_key": 1}, name: "idx5"}
   - *Nop
 
 # The 'MiscLookup' actor measures the SBE INLJ lookup performances on an all-feature-flags build and

--- a/src/workloads/execution/LookupSBEPushdownMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownMisc.yml
@@ -1,0 +1,358 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload conducts testing for the following test matrix:
+  - LocalCollectionCardinality: 100k / 300k / 500k / 700k
+  - DocumentSize: Small document size vs Large document size
+  - JoinFieldType: string type / sub-field type / array type
+  - NumberOfLookups: 1 / 2 / 3
+
+  But this workload does not try to measure performances for full combination of the above test
+  dimensions to avoid too lengthy test execution.
+
+  While measuring performances, this workload collects numbers for both the SBE HJ and the classic
+  engine NLJ $lookup implementations. The reason why it collects numbers for the SBE HJ lookup
+  implementation is to minimize the test execution time since the SBE HJ is supposed to be very fast
+  compared to the classic engine's NLJ.
+
+  This workload assumes that the SBE and SBE $lookup pushdown features are turned on.
+
+  The workload consists of the following phases and actors:
+    0. Cleans up database
+       - 'Setup' actor
+    1. Loads data into the local and foreign collections.
+       - 'LoadXXX' actors.
+    2. Runs and measures the SBE HJ lookups.
+       - 'SBE_Misc' actor
+    3. Turns off the SBE
+       - 'TurnOffSBE' actor
+    4. Runs and measures the classic NLJ lookups
+       - 'Classic_Misc' actor
+
+# Defines the database name.
+Database: &db lookup_sbe_pushdown_misc
+
+# Defines foreign collection names.
+Foreign: &Foreign foreign
+
+# Defines the local collection names.
+LocalSmallDoc100k: &LocalSmallDoc100k local_smalldoc_100k
+LocalSmallDoc300k: &LocalSmallDoc300k local_smalldoc_300k
+LocalSmallDoc500k: &LocalSmallDoc500k local_smalldoc_500k
+LocalSmallDoc700k: &LocalSmallDoc700k local_smalldoc_700k
+LocalLargeDoc100k: &LocalLargeDoc100k local_largedoc_100k
+
+# Defines the small local collection document type which is used by 'LoadLocalSmallDocXXX' actors.
+# See 'LocalSmallDocTemplate' to understand how each doc is filled.
+LocalSmallDoc: &LocalSmallDoc
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: LocalSmallDocTemplate
+    Parameters: {card: 1500}
+
+# Defines the large local collection document type which is used by 'LoadLocalLargeDoc100k' actor.
+# See 'LocalLargeDocTemplate' to understand how each doc is filled.
+LocalLargeDoc: &LocalLargeDoc
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: LocalLargeDocTemplate
+    Parameters: {card: 1500}
+
+# Defines the foreign collection document type which is used by 'LoadForeign' See
+# 'ForeignSmallDocTemplate' to understand how each doc is filled.
+ForeignSmallDoc: &ForeignSmallDoc
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: ForeignSmallDocTemplate
+    Parameters: {card: 1500}
+
+# The lookup command for local_smalldoc_100k.str_key == foreign.str_key.
+HJLookupOnStrKeyCmd: &HJLookupOnStrKeyCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign
+      lk: "str_key"
+      k: "str_key"
+
+# The lookup command for local_smalldoc_100k.int_key == foreign.arr_key.
+HJLookupOnArrKeyCmd: &HJLookupOnArrKeyCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign
+      k: "arr_key"
+
+# The lookup command for local_smalldoc_100k.int_key == foreign.doc_key.int.
+HJLookupOnSubFieldKeyCmd: &HJLookupOnSubFieldKeyCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign
+      k: "doc_key.int"
+
+# The lookup command for local_largedoc_100k.int_key == foreign.int_key.
+HJLookupLargeDocCmd: &HJLookupLargeDocCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalLargeDoc100k
+      f: *Foreign
+
+# The lookup command for local_smalldoc_300k.int_key == foreign.int_key.
+HJLookupLocal100kCmd: &HJLookupLocal100kCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+      f: *Foreign
+
+# The lookup command for local_smalldoc_300k.int_key == foreign.int_key.
+HJLookupLocal300kCmd: &HJLookupLocal300kCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc300k
+      f: *Foreign
+
+# The lookup command for local_smalldoc_500k.int_key == foreign.int_key.
+HJLookupLocal500kCmd: &HJLookupLocal500kCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc500k
+      f: *Foreign
+
+# The lookup command for local_smalldoc_700k.int_key == foreign.int_key.
+HJLookupLocal700kCmd: &HJLookupLocal700kCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc700k
+      f: *Foreign
+
+# The lookup command for local_smalldoc_100k.int_key == foreign.int_key
+# | local_smalldoc_100k.str_key == foreign.str_key.
+HJDoubleLookupCmd: &HJDoubleLookupCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJDoubleLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+
+# The lookup command for local_smalldoc_100k.int_key == foreign.int_key
+# | local_smalldoc_100k.str_key == foreign.str_key
+# | local_smalldoc_100k.int_key == foreign.arr_key.
+HJTripleLookupCmd: &HJTripleLookupCmd
+  LoadConfig:
+    Path: "../../phases/execution/LookupCommands.yml"
+    Key: HJTripleLookupCmdTemplate
+    Parameters:
+      l: *LocalSmallDoc100k
+
+# Defines test operations for both 'SBE_Misc' and 'Classic_Misc' actors.
+TestOperations: &TestOperations
+- OperationMetricsName: LocalSmallDoc100k_StrTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupOnStrKeyCmd
+- OperationMetricsName: LocalSmallDoc100k_ArrTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupOnArrKeyCmd
+- OperationMetricsName: LocalSmallDoc100k_SubField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupOnSubFieldKeyCmd
+- OperationMetricsName: LocalLargeDoc100k_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupLargeDocCmd
+- OperationMetricsName: LocalSmallDoc100k_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupLocal100kCmd
+- OperationMetricsName: LocalSmallDoc300k_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupLocal300kCmd
+- OperationMetricsName: LocalSmallDoc500k_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupLocal500kCmd
+- OperationMetricsName: LocalSmallDoc700k_IntTopField
+  OperationName: RunCommand
+  OperationCommand: *HJLookupLocal700kCmd
+- OperationMetricsName: LocalSmallDoc100k_DoubleLookups
+  OperationName: RunCommand
+  OperationCommand: *HJDoubleLookupCmd
+- OperationMetricsName: LocalSmallDoc100k_TripleLookups
+  OperationName: RunCommand
+  OperationCommand: *HJTripleLookupCmd
+
+# Defines how many times each test operation is executed.
+TestRepeatCount: &TestRepeatCount 10
+
+Actors:
+# The 'Setup' actor drops the database and runs in the 0th phase.
+- Name: Setup
+  Type: RunCommand
+  Database: *db
+  Thread: 1
+  Phases:
+  - Repeat: 1
+    Threads: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+  - Phase: 1..4
+    Nop: true
+
+# The 'LoadForeign' / 'LoadLocalSmallDoc100k' / 'LocalSmallDoc300k' / 'LocalSmallDoc500k' /
+# 'LocalSmallDoc700k' / 'LoadLocalLargeDoc100k' actors runs in the 1st phase.
+- Name: LoadForeign
+  Type: CrudActor
+  Database: *db
+  Threads: 1
+  Phases:
+  - &Nop {Nop: true}
+  - Repeat: 1500
+    Threads: 1
+    Collection: *Foreign
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *ForeignSmallDoc
+  - Phase: 2..4
+    Nop: true
+
+- Name: LoadLocalSmallDoc100k
+  Type: CrudActor
+  Database: *db
+  Threads: 10
+  Phases:
+  - *Nop
+  - Repeat: 10000
+    Threads: 1
+    Collection: *LocalSmallDoc100k
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *LocalSmallDoc
+  - Phase: 2..4
+    Nop: true
+
+- Name: LoadLocalSmallDoc300k
+  Type: CrudActor
+  Database: *db
+  Threads: 10
+  Phases:
+  - *Nop
+  - Repeat: 30000
+    Threads: 1
+    Collection: *LocalSmallDoc300k
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *LocalSmallDoc
+  - Phase: 2..4
+    Nop: true
+
+- Name: LoadLocalSmallDoc500k
+  Type: CrudActor
+  Database: *db
+  Threads: 10
+  Phases:
+  - *Nop
+  - Repeat: 50000
+    Threads: 1
+    Collection: *LocalSmallDoc500k
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *LocalSmallDoc
+  - Phase: 2..4
+    Nop: true
+
+- Name: LoadLocalSmallDoc700k
+  Type: CrudActor
+  Database: *db
+  Threads: 10
+  Phases:
+  - *Nop
+  - Repeat: 70000
+    Threads: 1
+    Collection: *LocalSmallDoc700k
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *LocalSmallDoc
+  - Phase: 2..4
+    Nop: true
+
+- Name: LoadLocalLargeDoc100k
+  Type: CrudActor
+  Database: *db
+  Threads: 10
+  Phases:
+  - *Nop
+  - Repeat: 10000
+    Threads: 1
+    Collection: *LocalLargeDoc100k
+    Operations:
+    - OperationName: insertOne
+      OperationCommand:
+        Document: *LocalLargeDoc
+  - Phase: 2..4
+    Nop: true
+
+# The 'SBE_Misc' actor measures the SBE HJ lookup performances and runs in the 2nd phase.
+- Name: SBE_Misc
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: *TestRepeatCount
+    Database: *db
+    Operations: *TestOperations
+  - *Nop
+  - *Nop
+
+# The 'TurnOffSBE' actor turns off the SBE engine so that the classic engine's NLJ performances can
+# be measures and runs in the 3rd phase.
+- Name: TurnOffSBE
+  Type: AdminCommand
+  Phases:
+  - Phase: 0..2
+    Nop: true
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationName: AdminCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryForceClassicEngine: true
+  - *Nop
+
+# The 'Classic_Misc' actor measures the classic engine's NLJ performances and runs in the 4th phase.
+- Name: Classic_Misc
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - Phase: 0..3
+    Nop: true
+  - Repeat: *TestRepeatCount
+    Database: *db
+    Operations: *TestOperations
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone-all-feature-flags


### PR DESCRIPTION
This is a draft PR to add workloads for $lookup pushdown feature.

Given that $lookup pushdown feature is a reimplementation of $lookup pipeline stage using the SBE, the proposed workloads have metrics for the SBE $lookup implementation and the classic $lookup implementation so that the team can compare the SBE results to the classic engine's results.

A related PR to add a build variant: 10gen/mongo#3201

See the document for details: 
https://docs.google.com/document/d/1KijhnCvbfhfWtZJXUSrreNK-vcke7xofdkuUrVrnjDo/edit#