### PR TITLE
Fix BF-23993

### DIFF
--- a/src/workloads/execution/DensifyNumeric.yml
+++ b/src/workloads/execution/DensifyNumeric.yml
@@ -127,6 +127,36 @@ Actors:
           }
         }]
         cursor: {batchSize: *batchSize}
+    - OperationMetricsName: FullByPartitionSmallStep
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline: [{
+          $densify: {
+            field: *field,
+            partitionByFields: ["partitionKey"],
+            range: {
+              bounds: "full",
+              step: *smallStep
+            }
+          }
+        }]
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: FullByPartitionLargeStep
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline: [{
+          $densify: {
+            field: *field,
+            partitionByFields: ["partitionKey"],
+            range: {
+              bounds: "full",
+              step: *largeStep
+            }
+          }
+        }]
+        cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
       OperationName: RunCommand
       OperationCommand:


### PR DESCRIPTION
A stark improvement was observed after removing some tasks from DensifyNumeric. After reviewing densify behavior, we realized we need to add back those tasks for fill with full bounds. 

This is the BF: https://jira.mongodb.org/browse/BF-23993

This is this PR's patch:  https://spruce.mongodb.com/version/620297e99ccd4e4171723f35/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC