### PR TITLE
TIG-3935 Wrong path to uri option in genny_canaries

### DIFF
--- a/src/canaries/src/tasks.cpp
+++ b/src/canaries/src/tasks.cpp
@@ -14,7 +14,7 @@ Singleton* Singleton::getInstance(const std::string& mongoUri) {
 
 Singleton::Singleton(std::string mongoUri)
     : _poolManager{{}},
-      ns{"Clients: {Default: {URI: " + mongoUri + "}}", ""},
+      ns{"Clients: {PingTask: {URI: " + mongoUri + "}}", ""},
       client{_poolManager.client("PingTask", 1, ns.root())},
       pingCmd{make_document(kvp("ping", 1))} {};
 }  // namespace genny::canaries::ping_task

--- a/src/canaries/src/tasks.cpp
+++ b/src/canaries/src/tasks.cpp
@@ -14,7 +14,12 @@ Singleton* Singleton::getInstance(const std::string& mongoUri) {
 
 Singleton::Singleton(std::string mongoUri)
     : _poolManager{{}},
-      ns{"Clients: {PingTask: {URI: " + mongoUri + "}}", ""},
+      ns{
+        R"(
+          Clients:
+            PingTask:
+              URI: )" + mongoUri, ""
+      },
       client{_poolManager.client("PingTask", 1, ns.root())},
       pingCmd{make_document(kvp("ping", 1))} {};
 }  // namespace genny::canaries::ping_task


### PR DESCRIPTION
Worked locally with the fix but here's a [patch as well](https://spruce.mongodb.com/version/62263fd41e2d1747bf097442/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)