### PR TITLE
TIG-3937 bulkWrite should not ignore OnSession

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -492,6 +492,8 @@ struct BulkWriteOperation : public BaseOperation {
                 "WriteCommand '" + writeCommand + "' not supported in bulkWrite operations."));
         }
         auto createWriteOp = writeOpConstructor->second;
+        auto& yamlCommand = writeOp["OperationCommand"];
+        bool onSession = yamlCommand["OnSession"].maybe<bool>().value_or(_onSession);
         _writeOps.push_back(
             createWriteOp(writeOp, _onSession, _collection, _operation, context, id));
     }

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -597,6 +597,25 @@ Tests:
         Count: 1
     AssertNumTransactionsCommitted: 0
 
+  - Description: simple findOneAndReplace in a withTransaction without OnSession
+    Operations:
+      - OperationName: withTransaction
+        OperationCommand:
+          OperationsInTransaction:
+            - OperationName: insertOne
+              OperationCommand:
+                Document: {a: 100}
+            - OperationName: findOneAndReplace
+              OperationCommand:
+                Filter: {a: 100}
+                Replacement: {a: 30}
+    OutcomeCounts:
+      - Filter: {a: 100}
+        Count: 0
+      - Filter: {a: 30}
+        Count: 1
+    AssertNumTransactionsCommitted: 0
+
   - Description: WithTransaction, BulkWrite insert, delete, then re-insert with OnSession on bulkWrite
     Operations:
       - OperationName: withTransaction

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -616,6 +616,44 @@ Tests:
         Count: 1
     AssertNumTransactionsCommitted: 0
 
+  - Description: simple findOneAndReplace in a withTransaction with OnSession
+    Operations:
+      - OperationName: withTransaction
+        OperationCommand:
+          OnSession: true
+          OperationsInTransaction:
+            - OperationName: insertOne
+              OperationCommand:
+                Document: {a: 100}
+            - OperationName: findOneAndReplace
+              OperationCommand:
+                Filter: {a: 100}
+                Replacement: {a: 30}
+    OutcomeCounts:
+      - Filter: {a: 100}
+        Count: 0
+      - Filter: {a: 30}
+        Count: 1
+    AssertNumTransactionsCommitted: 1
+
+  - Description: WithTransaction, BulkWrite insert, delete, then re-insert without OnSession on bulkWrite
+    Operations:
+      - OperationName: withTransaction
+        OperationCommand:
+          OperationsInTransaction:
+          - OperationName: bulkWrite
+            OperationCommand:
+              WriteOperations:
+                - WriteCommand: insertOne
+                  Document: { a: 1 }
+                - WriteCommand: deleteOne
+                  Filter: { a: 1 }
+                - WriteCommand: insertOne
+                  Document: { a: 2 }
+    OutcomeData:
+      - {a: 2}
+    AssertNumTransactionsCommitted: 0
+
   - Description: WithTransaction, BulkWrite insert, delete, then re-insert with OnSession on bulkWrite
     Operations:
       - OperationName: withTransaction

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -597,21 +597,21 @@ Tests:
         Count: 1
     AssertNumTransactionsCommitted: 0
 
-  - Description: simple findOneAndReplace in a withTransaction without OnSession
+  - Description: WithTransaction, BulkWrite insert, delete, then re-insert with OnSession on bulkWrite
     Operations:
       - OperationName: withTransaction
         OperationCommand:
           OperationsInTransaction:
-            - OperationName: insertOne
-              OperationCommand:
-                Document: {a: 100}
-            - OperationName: findOneAndReplace
-              OperationCommand:
-                Filter: {a: 100}
-                Replacement: {a: 30}
-    OutcomeCounts:
-      - Filter: {a: 100}
-        Count: 0
-      - Filter: {a: 30}
-        Count: 1
-    AssertNumTransactionsCommitted: 0
+          - OperationName: bulkWrite
+            OperationCommand:
+              OnSession: true
+              WriteOperations:
+                - WriteCommand: insertOne
+                  Document: { a: 1 }
+                - WriteCommand: deleteOne
+                  Filter: { a: 1 }
+                - WriteCommand: insertOne
+                  Document: { a: 2 }
+    OutcomeData:
+      - {a: 2}
+    AssertNumTransactionsCommitted: 1


### PR DESCRIPTION
In a similar vein to [this PR](https://github.com/mongodb/genny/pull/620), we need to respect OnSession when it's on bulkWrite. [Example affected workload](https://github.com/mongodb/genny/blob/master/src/workloads/scale/UpdateMillionDocsInTxn.yml#L78).