### PR TITLE
PERF-2818 Productionalize the ConnectionBuildup workload for non-sharded configurations

### DIFF
--- a/src/phases/issues/ConnectionsBuildup.yml
+++ b/src/phases/issues/ConnectionsBuildup.yml
@@ -11,7 +11,7 @@ EnableSharding:
     - OperationMetricsName: EnableSharding
       OperationName: AdminCommand
       OperationCommand:
-        enableSharding: &db test
+        enableSharding: *db
 
 ShardCollection:
   Repeat: 1
@@ -41,7 +41,8 @@ InsertData:
   
 ConnectionsBuildup:
   Repeat: 30000
-  Collection: Collection0
+  Database: *db
+  Collection: *coll
   Operations:
     - OperationName: find
       OperationCommand:

--- a/src/phases/issues/ConnectionsBuildup.yml
+++ b/src/phases/issues/ConnectionsBuildup.yml
@@ -11,7 +11,7 @@ EnableSharding:
     - OperationMetricsName: EnableSharding
       OperationName: AdminCommand
       OperationCommand:
-        enableSharding: *db
+        enableSharding: &db test
 
 ShardCollection:
   Repeat: 1
@@ -42,7 +42,7 @@ InsertData:
 ConnectionsBuildup:
   Repeat: 30000
   Database: *db
-  Collection: *coll
+  Collection: &coll Collection0
   Operations:
     - OperationName: find
       OperationCommand:

--- a/src/phases/issues/ConnectionsBuildup.yml
+++ b/src/phases/issues/ConnectionsBuildup.yml
@@ -41,8 +41,7 @@ InsertData:
   
 ConnectionsBuildup:
   Repeat: 30000
-  Database: *db
-  Collection: &coll Collection0
+  Collection: Collection0
   Operations:
     - OperationName: find
       OperationCommand:

--- a/src/phases/issues/ConnectionsBuildup.yml
+++ b/src/phases/issues/ConnectionsBuildup.yml
@@ -1,0 +1,51 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  These are the phases used to reproduce SERVER-53853: Large buildup of mongos to mongod connections and
+  low performance with secondaryPreferred reads
+
+EnableSharding:
+  Repeat: 1
+  Database: admin
+  Operations:
+    - OperationMetricsName: EnableSharding
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: &db test
+
+ShardCollection:
+  Repeat: 1
+  Database: admin
+  Operations:
+    - OperationMetricsName: ShardCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: test.Collection0  # Collection0 is the default collection populated by the Loader.
+        key:
+          _id: 1
+
+InsertData:
+  Repeat: 1
+  Threads: 1
+  Database: *db
+  CollectionCount: 1
+  DocumentCount: 50000
+  BatchSize: 10000
+  Document:
+      _id: {^Inc: {start: 1000}}
+      date: &date {^RandomDate: {min: "2019-01-01", max: "2020-01-01"}}
+      ticker: &ticker {^RandomString: {length: 3}}
+      price: &price {^RandomInt: {min: 1, max: 1000}}
+      quantity: &quantity {^RandomInt: {min: 1, max: 1000}}
+      fee: &fee {^RandomInt: {min: 0, max: 1000}}
+  
+ConnectionsBuildup:
+  Repeat: 30000
+  Collection: Collection0
+  Operations:
+    - OperationName: find
+      OperationCommand:
+        Filter: {_id: {^RandomInt: {min: 1000, max: 50000}}}
+        Options:
+          ReadPreference:
+            ReadMode: secondaryPreferred

--- a/src/phases/issues/ConnectionsBuildup.yml
+++ b/src/phases/issues/ConnectionsBuildup.yml
@@ -8,21 +8,21 @@ EnableSharding:
   Repeat: 1
   Database: admin
   Operations:
-    - OperationMetricsName: EnableSharding
-      OperationName: AdminCommand
-      OperationCommand:
-        enableSharding: &db test
+  - OperationMetricsName: EnableSharding
+    OperationName: AdminCommand
+    OperationCommand:
+      enableSharding: &db test
 
 ShardCollection:
   Repeat: 1
   Database: admin
   Operations:
-    - OperationMetricsName: ShardCollection
-      OperationName: AdminCommand
-      OperationCommand:
-        shardCollection: test.Collection0  # Collection0 is the default collection populated by the Loader.
-        key:
-          _id: 1
+  - OperationMetricsName: ShardCollection
+    OperationName: AdminCommand
+    OperationCommand:
+      shardCollection: test.Collection0  # Collection0 is the default collection populated by the Loader.
+      key:
+        _id: 1
 
 InsertData:
   Repeat: 1
@@ -32,20 +32,20 @@ InsertData:
   DocumentCount: 50000
   BatchSize: 10000
   Document:
-      _id: {^Inc: {start: 1000}}
-      date: &date {^RandomDate: {min: "2019-01-01", max: "2020-01-01"}}
-      ticker: &ticker {^RandomString: {length: 3}}
-      price: &price {^RandomInt: {min: 1, max: 1000}}
-      quantity: &quantity {^RandomInt: {min: 1, max: 1000}}
-      fee: &fee {^RandomInt: {min: 0, max: 1000}}
-  
+    _id: {^Inc: {start: 1000}}
+    date: &date {^RandomDate: {min: "2019-01-01", max: "2020-01-01"}}
+    ticker: &ticker {^RandomString: {length: 3}}
+    price: &price {^RandomInt: {min: 1, max: 1000}}
+    quantity: &quantity {^RandomInt: {min: 1, max: 1000}}
+    fee: &fee {^RandomInt: {min: 0, max: 1000}}
+
 ConnectionsBuildup:
   Repeat: 30000
   Collection: Collection0
   Operations:
-    - OperationName: find
-      OperationCommand:
-        Filter: {_id: {^RandomInt: {min: 1000, max: 50000}}}
-        Options:
-          ReadPreference:
-            ReadMode: secondaryPreferred
+  - OperationName: find
+    OperationCommand:
+      Filter: {_id: {^RandomInt: {min: 1000, max: 50000}}}
+      Options:
+        ReadPreference:
+          ReadMode: secondaryPreferred

--- a/src/workloads/issues/ConnectionsBuildup.yml
+++ b/src/workloads/issues/ConnectionsBuildup.yml
@@ -42,7 +42,7 @@ InsertData: &InsertData
     Parameters:
       db: *db
       coll: *coll
-ConnectionsBuildup: &LConnectionsBuildup
+ConnectionsBuildup: &ConnectionsBuildup
   LoadConfig:
     Path: *phasePath
     Key: ConnectionsBuildup

--- a/src/workloads/issues/ConnectionsBuildup.yml
+++ b/src/workloads/issues/ConnectionsBuildup.yml
@@ -16,7 +16,6 @@ Clients:
 
 # Parameters reused in multiple Actors.
 db: &db test
-coll: &coll Collection0
 phasePath: &phasePath ../../phases/issues/ConnectionsBuildup.yml
 
 # Operations reused in multiple Phases.
@@ -25,30 +24,18 @@ EnableSharding: &EnableSharding
   LoadConfig:
     Key: EnableSharding
     Path: *phasePath
-    Parameters:
-      db: *db
-      call: *coll
 ShardCollection: &ShardCollection
   LoadConfig:
     Path: *phasePath
     Key: ShardCollection
-    Parameters:
-      db: *db
-      coll: *coll
 InsertData: &InsertData
   LoadConfig:
     Path: *phasePath
     Key: InsertData
-    Parameters:
-      db: *db
-      coll: *coll
 ConnectionsBuildup: &ConnectionsBuildup
   LoadConfig:
     Path: *phasePath
     Key: ConnectionsBuildup
-    Parameters:
-      db: *db
-      coll: *coll
 
 Actors:
 - Name: EnableSharding

--- a/src/workloads/issues/ConnectionsBuildup.yml
+++ b/src/workloads/issues/ConnectionsBuildup.yml
@@ -14,19 +14,18 @@ Clients:
     QueryOptions:
       maxPoolSize: 1000
 
+# Parameters reused in multiple Actors.
+db: &db test
+&Nop {Nop: true}
+phasePath: &phasePath ../../phases/issues/ConnectionsBuildup.yml
+
 Actors:
 - Name: EnableSharding
   Type: AdminCommand
   Threads: 1
   Phases:
-  - Repeat: 1
-    Database: admin
-    Operations:
-    - OperationMetricsName: EnableSharding
-      OperationName: AdminCommand
-      OperationCommand:
-        enableSharding: &db test
-  - &Nop {Nop: true}
+  - *EnableSharding
+  - *Nop
   - *Nop
   - *Nop
 
@@ -35,15 +34,7 @@ Actors:
   Threads: 1
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: admin
-    Operations:
-    - OperationMetricsName: ShardCollection
-      OperationName: AdminCommand
-      OperationCommand:
-        shardCollection: test.Collection0  # Collection0 is the default collection populated by the Loader.
-        key:
-          _id: 1
+  - *ShardCollection
   - *Nop
   - *Nop
 
@@ -53,19 +44,7 @@ Actors:
   Phases:
   - *Nop
   - *Nop
-  - Repeat: 1
-    Threads: 1
-    Database: *db
-    CollectionCount: 1
-    DocumentCount: 50000
-    BatchSize: 10000
-    Document:
-      _id: {^Inc: {start: 1000}}
-      date: &date {^RandomDate: {min: "2019-01-01", max: "2020-01-01"}}
-      ticker: &ticker {^RandomString: {length: 3}}
-      price: &price {^RandomInt: {min: 1, max: 1000}}
-      quantity: &quantity {^RandomInt: {min: 1, max: 1000}}
-      fee: &fee {^RandomInt: {min: 0, max: 1000}}
+  - *InsertData
   - *Nop
 
 - Name: ConnectionsBuildup
@@ -77,15 +56,7 @@ Actors:
   - *Nop
   - *Nop
   - *Nop
-  - Repeat: 30000
-    Collection: Collection0
-    Operations:
-    - OperationName: find
-      OperationCommand:
-        Filter: {_id: {^RandomInt: {min: 1000, max: 50000}}}
-        Options:
-          ReadPreference:
-            ReadMode: secondaryPreferred
+  - *ConnectionsBuildup
 
 # to avoid connection closing
 - Name: LoggingActor

--- a/src/workloads/issues/ConnectionsBuildup.yml
+++ b/src/workloads/issues/ConnectionsBuildup.yml
@@ -16,8 +16,39 @@ Clients:
 
 # Parameters reused in multiple Actors.
 db: &db test
-&Nop {Nop: true}
+coll: &coll Collection0
 phasePath: &phasePath ../../phases/issues/ConnectionsBuildup.yml
+
+# Operations reused in multiple Phases.
+Nop: &Nop {Nop: true}
+EnableSharding: &EnableSharding
+  LoadConfig:
+    Key: EnableSharding
+    Path: *phasePath
+    Parameters:
+      db: *db
+      call: *coll
+ShardCollection: &ShardCollection
+  LoadConfig:
+    Path: *phasePath
+    Key: ShardCollection
+    Parameters:
+      db: *db
+      coll: *coll
+InsertData: &InsertData
+  LoadConfig:
+    Path: *phasePath
+    Key: InsertData
+    Parameters:
+      db: *db
+      coll: *coll
+ConnectionsBuildup: &LConnectionsBuildup
+  LoadConfig:
+    Path: *phasePath
+    Key: ConnectionsBuildup
+    Parameters:
+      db: *db
+      coll: *coll
 
 Actors:
 - Name: EnableSharding

--- a/src/workloads/issues/ConnectionsBuildupNoSharding.yml
+++ b/src/workloads/issues/ConnectionsBuildupNoSharding.yml
@@ -1,0 +1,56 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  This workload created to reproduce SERVER-53853: Large buildup of mongos to mongod connections and
+  low performance with secondaryPreferred reads
+
+Keywords:
+- reproducer
+- connections
+- secondaryPreferred
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 1000
+
+# Parameters reused in multiple Actors.
+db: &db test
+&Nop {Nop: true}
+phasePath: &phasePath ../../phases/issues/ConnectionsBuildup.yml
+
+Actors:
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - *InsertData
+  - *Nop
+
+- Name: ConnectionsBuildup
+  Type: CrudActor
+  ClientName: Default
+  Database: *db
+  Threads: 500
+  Phases:
+  - *Nop
+  - *ConnectionsBuildup
+
+# to avoid connection closing
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1  # must be 1
+  Phases:
+  - LogEvery: 10 second  # TimeSpec
+    Blocking: None  # must be Blocking:None
+  - LogEvery: 1 minute  # TimeSpec
+    Blocking: None  # must be Blocking:None
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq: 
+      - atlas-like-replica
+      - replica
+      - replica-all-feature-flags
+      - single-replica

--- a/src/workloads/issues/ConnectionsBuildupNoSharding.yml
+++ b/src/workloads/issues/ConnectionsBuildupNoSharding.yml
@@ -16,39 +16,18 @@ Clients:
 
 # Parameters reused in multiple Actors.
 db: &db test
-coll: &coll Collection0
 phasePath: &phasePath ../../phases/issues/ConnectionsBuildup.yml
 
 # Operations reused in multiple Phases.
 Nop: &Nop {Nop: true}
-EnableSharding: &EnableSharding
-  LoadConfig:
-    Key: EnableSharding
-    Path: *phasePath
-    Parameters:
-      db: *db
-      call: *coll
-ShardCollection: &ShardCollection
-  LoadConfig:
-    Path: *phasePath
-    Key: ShardCollection
-    Parameters:
-      db: *db
-      coll: *coll
 InsertData: &InsertData
   LoadConfig:
     Path: *phasePath
     Key: InsertData
-    Parameters:
-      db: *db
-      coll: *coll
 ConnectionsBuildup: &ConnectionsBuildup
   LoadConfig:
     Path: *phasePath
     Key: ConnectionsBuildup
-    Parameters:
-      db: *db
-      coll: *coll
 
 Actors:
 - Name: InsertData

--- a/src/workloads/issues/ConnectionsBuildupNoSharding.yml
+++ b/src/workloads/issues/ConnectionsBuildupNoSharding.yml
@@ -2,7 +2,7 @@ SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
   This workload created to reproduce SERVER-53853: Large buildup of mongos to mongod connections and
-  low performance with secondaryPreferred reads
+  low performance with secondaryPreferred reads - for running without sharding
 
 Keywords:
 - reproducer
@@ -16,8 +16,39 @@ Clients:
 
 # Parameters reused in multiple Actors.
 db: &db test
-&Nop {Nop: true}
+coll: &coll Collection0
 phasePath: &phasePath ../../phases/issues/ConnectionsBuildup.yml
+
+# Operations reused in multiple Phases.
+Nop: &Nop {Nop: true}
+EnableSharding: &EnableSharding
+  LoadConfig:
+    Key: EnableSharding
+    Path: *phasePath
+    Parameters:
+      db: *db
+      call: *coll
+ShardCollection: &ShardCollection
+  LoadConfig:
+    Path: *phasePath
+    Key: ShardCollection
+    Parameters:
+      db: *db
+      coll: *coll
+InsertData: &InsertData
+  LoadConfig:
+    Path: *phasePath
+    Key: InsertData
+    Parameters:
+      db: *db
+      coll: *coll
+ConnectionsBuildup: &LConnectionsBuildup
+  LoadConfig:
+    Path: *phasePath
+    Key: ConnectionsBuildup
+    Parameters:
+      db: *db
+      coll: *coll
 
 Actors:
 - Name: InsertData

--- a/src/workloads/issues/ConnectionsBuildupNoSharding.yml
+++ b/src/workloads/issues/ConnectionsBuildupNoSharding.yml
@@ -59,7 +59,7 @@ Actors:
 AutoRun:
 - When:
     mongodb_setup:
-      $eq: 
+      $eq:
       - atlas-like-replica
       - replica
       - replica-all-feature-flags

--- a/src/workloads/issues/ConnectionsBuildupNoSharding.yml
+++ b/src/workloads/issues/ConnectionsBuildupNoSharding.yml
@@ -42,7 +42,7 @@ InsertData: &InsertData
     Parameters:
       db: *db
       coll: *coll
-ConnectionsBuildup: &LConnectionsBuildup
+ConnectionsBuildup: &ConnectionsBuildup
   LoadConfig:
     Path: *phasePath
     Key: ConnectionsBuildup


### PR DESCRIPTION
Moving common parts into phases and adding a separate ConnectionsBuildupNoSharding to run the workload on non-sharded  environments.

Here is [the patch](https://spruce.mongodb.com/version/622bc7d19ccd4e4a1a9b5d45/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)