### PR TITLE
PERF-2767: Adding rate limited version of MixedWorkloadsGenny

### DIFF
--- a/src/phases/scale/MixPhasesRateLimited.yml
+++ b/src/phases/scale/MixPhasesRateLimited.yml
@@ -1,0 +1,79 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  Phase defintions for the MixedWorkloadsGenny, which is a port of the mixed_workloads in the
+  workloads repo. https://github.com/10gen/workloads/blob/master/workloads/mix.js. It runs 4 sets of
+  operations, each with dedicated actors/threads. The 4 operations are insertOne, findOne,
+  updateOne, and deleteOne. Since each type of operation runs in a dedicated thread it enables
+  interesting behavior, such as reads getting faster because of a write regression, or reads being
+  starved by writes. The origin of the test was as a reproduction for BF-2385 in which reads were
+  starved out by writes.
+
+Keywords:
+- scale
+- insertOne
+- insert
+- findOne
+- find
+- updateOne
+- update
+- deleteOne
+- delete
+
+dbname: &dbname mix
+runtime: &runtime 7 minutes
+DocumentCount: &NumDocs 100000
+CollectionCount: &NumColls 1
+
+Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
+string: &string {^FastRandomString: {length: 50}}
+Document: &doc
+  id: {^RandomInt: {min: 0, max: *NumDocs}}
+  a: {^RandomInt: {min: 0, max: *NumDocs}}
+  # Note that in the original workload the string c was perfectly compressable.
+  # We can put a constant there if needed.
+  c: *string
+
+UpdatePhase:
+  Duration: *runtime
+  GlobalRate: 500 per 250 milliseconds
+  RecordFailure: true
+  CollectionCount: *NumColls
+  Operations:
+  - OperationName: updateOne
+    OperationCommand:
+      Filter: *filter
+      Update:
+        $inc: {a: 1}
+        $set: {c: *string}
+
+RemovePhase:
+  Duration: *runtime
+  GlobalRate: 500 per 125 milliseconds
+  RecordFailure: true
+  CollectionCount: *NumColls
+  Operations:
+  - OperationName: deleteOne
+    OperationCommand:
+      Filter: *filter
+
+InsertPhase:
+  Duration: *runtime
+  GlobalRate: 500 per 125 milliseconds
+  RecordFailure: true
+  CollectionCount: *NumColls
+  Operations:
+  - OperationName: insertOne
+    OperationCommand:
+      Document: *doc
+
+FindPhase:
+  Duration: *runtime
+  GlobalRate: 500 per 125 milliseconds
+  RecordFailure: true
+  CollectionCount: *NumColls
+  Operations:
+  - OperationName: findOne
+    OperationCommand:
+      Filter: *filter
+

--- a/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
@@ -1,0 +1,201 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  This workload is a port of the mixed_workloads in the workloads
+  repo. https://github.com/10gen/workloads/blob/master/workloads/mix.js. It runs 4 sets of
+  operations, each with dedicated actors/threads. The 4 operations are insertOne, findOne,
+  updateOne, and deleteOne. Since each type of operation runs in a dedicated thread it enables
+  interesting behavior, such as reads getting faster because of a write regression, or reads being
+  starved by writes. The origin of the test was as a reproduction for BF-2385 in which reads were
+  starved out by writes.
+
+# This workload does not support sharding yet.
+Keywords:
+- scale
+- insertOne
+- insert
+- findOne
+- find
+- updateOne
+- update
+- deleteOne
+- delete
+
+# These two values should match those are the top of MixPhases.yml
+dbname: &dbname mix
+DocumentCount: &NumDocs 100000
+CollectionCount: &NumColls 1
+
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 500
+  Insert:
+    QueryOptions:
+      maxPoolSize: 500
+  Query:
+    QueryOptions:
+      maxPoolSize: 500
+  Remove:
+    QueryOptions:
+      maxPoolSize: 500
+  Update:
+    QueryOptions:
+      maxPoolSize: 500
+
+ActorTemplates:
+- TemplateName: UpdateTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Update"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Update
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 2
+        PhaseConfig:
+          LoadConfig:
+            Path: ../../phases/scale/MixPhasesRateLimited.yml
+            Key: UpdatePhase
+
+- TemplateName: RemoveTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Remove"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Remove
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 2
+        PhaseConfig:
+          LoadConfig:
+            Path: ../../phases/scale/MixPhasesRateLimited.yml
+            Key: RemovePhase
+
+- TemplateName: InsertTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Insert"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Insert
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 2
+        PhaseConfig:
+          LoadConfig:
+            Path: ../../phases/scale/MixPhasesRateLimited.yml
+            Key: InsertPhase
+
+- TemplateName: FindTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Find"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Query
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 2
+        PhaseConfig:
+          LoadConfig:
+            Path: ../../phases/scale/MixPhasesRateLimited.yml
+            Key: FindPhase
+
+Actors:
+- Name: Setup
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    BatchSize: 100
+    Threads: 1
+    DocumentCount: *NumDocs
+    Database: *dbname
+    CollectionCount: *NumColls
+    Document: &doc
+      id: {^RandomInt: {min: 0, max: *NumDocs}}
+      a: {^RandomInt: {min: 0, max: *NumDocs}}
+      # Note that in the original workload the string c was perfectly compressable. We can put a
+      # constant there if needed.
+      c: &string {^RandomString: {length: 50}}  # Adjust this so the doc comes out as 100 B.
+    Indexes:
+    - keys: {id: 1}
+    - keys: {a: 1}
+  - Phase: 1..2
+    Nop: true
+
+- Name: QuiesceBetweenLevels
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - &nop {Nop: true}
+  - &quiesce
+    Repeat: 1
+    Database: admin
+    Operations:
+    # Fsync to force a checkpoint and quiesce the system.
+    - OperationMetricsName: FsyncCommand
+      OperationName: AdminCommand
+      OperationCommand:
+        fsync: 1
+  - *nop
+
+
+# Update Actors
+
+- ActorFromTemplate:
+    TemplateName: UpdateTemplate
+    TemplateParameters:
+      Name: Update_250
+      Threads: 250
+      OnlyActiveInPhase: 2
+
+#
+## Remove Actors
+#
+
+- ActorFromTemplate:
+    TemplateName: RemoveTemplate
+    TemplateParameters:
+      Name: Remove_250
+      Threads: 250
+      OnlyActiveInPhase: 2
+
+## Insert Actors
+#
+
+- ActorFromTemplate:
+    TemplateName: InsertTemplate
+    TemplateParameters:
+      Name: Insert_250
+      Threads: 250
+      OnlyActiveInPhase: 2
+
+## Find Actors
+
+- ActorFromTemplate:
+    TemplateName: FindTemplate
+    TemplateParameters:
+      Name: Find_250
+      Threads: 250
+      OnlyActiveInPhase: 2
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - replica
+      - single-replica
+      - standalone
+      - replica-noflowcontrol
+      - replica-1dayhistory-15gbwtcache
+      - replica-maintenance-events
+      - replica-all-feature-flags


### PR DESCRIPTION
Removed first 3 phases to MixedWorkloadsGenny and renamed new file MixedWorkloadsGennyRateLimited. MixPhases was used to add the limits to achieve a 30-40% cpu usage throughout and renamed MixPhasesRateLimited.

Link to Evergreen Patch results: 
https://spruce.mongodb.com/version/622f71807742ae1b8ce80c52/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC 