### PR TITLE
PERF-2883 Temporarily disable the SBE lookup testing

### DIFF
--- a/src/workloads/execution/LookupSBEPushdown.yml
+++ b/src/workloads/execution/LookupSBEPushdown.yml
@@ -437,4 +437,4 @@ AutoRun:
       - standalone
 # Reenable this setup if you want to enable the SBE $lookup perf testing on all-feature-flags
 # build variant on Evergreen patch build
-      # - standalone-all-feature-flags
+# - standalone-all-feature-flags

--- a/src/workloads/execution/LookupSBEPushdown.yml
+++ b/src/workloads/execution/LookupSBEPushdown.yml
@@ -435,4 +435,6 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone
-      - standalone-all-feature-flags
+# Reenable this setup if you want to enable the SBE $lookup perf testing on all-feature-flags
+# build variant on Evergreen patch build
+      # - standalone-all-feature-flags

--- a/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
@@ -386,4 +386,4 @@ AutoRun:
       - standalone
 # Reenable this setup if you want to enable the SBE $lookup perf testing on all-feature-flags
 # build variant on Evergreen patch build
-      # - standalone-all-feature-flags
+# - standalone-all-feature-flags

--- a/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
@@ -384,4 +384,6 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone
-      - standalone-all-feature-flags
+# Reenable this setup if you want to enable the SBE $lookup perf testing on all-feature-flags
+# build variant on Evergreen patch build
+      # - standalone-all-feature-flags


### PR DESCRIPTION
Given that the SBE lookup algorithms have not been yet fully implemented and we're enabling the feature on all-feature-flags build variant for correctness testing coverage, I'm temporarily disabling the SBE lookup perf testing.

As soon as we have enough confidence in feature's correctness, will re-enable the perf testing. Until then, we can run manually the SBE lookup perf testing by re-enabling the following part.

```
# Reenable this setup if you want to enable the SBE $lookup perf testing on all-feature-flags
# build variant on Evergreen patch build
      # - standalone-all-feature-flags
```