### PR TITLE
TIG-3849: Change AutoRun to mongodb_setup = replica

### DIFF
--- a/src/workloads/scale/MixedWrites.yml
+++ b/src/workloads/scale/MixedWrites.yml
@@ -37,7 +37,7 @@ Actors:
 
 AutoRun:
 - When:
-    infrastructure_provisioning:
+    mongodb_setup:
       $eq: replica
   ThenRun:
   - mongodb_setup: replica-delay-mixed


### PR DESCRIPTION
MixedWrites was being used by `AutoRun` on those variants where `infrastructure_provisioning` was `replica`. The issue is that `ThenRun` overwrites the `mongod_setup` of the variant, duplicating the work and running the variants with a different `mongodb_setup` from the ones configured in `system_perf`. This caused situations like `Linux 3-Node ReplSet Initial Sync` running with `replica` instead of the configured `replica-2node` and `linux-3-node-replSet-ssl` without SSL.

With this change the workload will only run on `linux-3-node-replSet` with `replica-delay-mixed` and `replica` MongoDB setups.