### PR TITLE
PERF-2939 Exclude the lookup pushdown workloads from running on v4 branches

### DIFF
--- a/src/workloads/execution/LookupSBEPushdown.yml
+++ b/src/workloads/execution/LookupSBEPushdown.yml
@@ -436,3 +436,8 @@ AutoRun:
       $eq:
       - standalone
       - standalone-all-feature-flags
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4

--- a/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
@@ -385,3 +385,8 @@ AutoRun:
       $eq:
       - standalone
       - standalone-all-feature-flags
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4


### PR DESCRIPTION
Given that we onboarded LookupSBEPushdown.yml and LookupSBEPushdownINLMisc.yml to compare the SBE lookup perf to the classic lookup perf, It's not necessary to run two workloads on v4 branches.

It looks like that the Quiesce actor won't work on v4.0 branch, looking at this patch build. The patch in the run disabled Quiesce actor in lookup_sbe_pushdown workloads which is successful but lookup_sbe_pushdown_inlj_misc workload failed.
https://spruce.mongodb.com/version/625487fa1e2d1770ebbec3f9/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Scheduled another patch build with this patch:
https://spruce.mongodb.com/version/6254975657e85a4a74752e74/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC