### PR TITLE
Add ^NumExpr preprocessing directive to perform arithmetic operations on YAML configuration files

### DIFF
--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -12,3 +12,4 @@ shrub.py==1.1.0
 black==19.10b0
 setuptools==51.0.0
 pytest==6.0.2
+numexpr==2.7.2

--- a/src/lamplib/src/genny/tasks/preprocess.py
+++ b/src/lamplib/src/genny/tasks/preprocess.py
@@ -291,20 +291,20 @@ class _WorkloadParser(object):
             msg = "Invalid value for 'Expr', which must be a string," f" in following node: {input}"
             raise ParseException(msg)
 
-        parsedDict = {}  # Pass empty dict to avoid yaml to access context of this function
+        parsed_values = {}  # Pass empty dict to avoid yaml to access context of this function
         if "Dict" in input:
-            inputDict = input["Dict"]
-            parsedDict = self._recursive_parse(inputDict)
-            if not all(type(value) == int or type(value) == float for value in parsedDict.values()):
+            input_values = input["Dict"]
+            parsed_values = self._recursive_parse(input_values)
+            if not all(type(value) == int or type(value) == float for value in parsed_values.values()):
                 msg = (
                     "Invalid values for 'Dict' in '^NumExpr', only numerical values are allowed.\n"
-                    f"Node source: {inputDict}\n"
-                    f"Node eval: {parsedDict}\n"
+                    f"Node source: {input_values}\n"
+                    f"Node eval: {parsed_values}\n"
                 )
                 raise ParseException(msg)
 
         try:
-            return numexpr.evaluate(input["Expr"], parsedDict).tolist()
+            return numexpr.evaluate(input["Expr"], parsed_values).tolist()
         except KeyError as e:
             msg = (
                 "Key used in 'Expr' not found in 'Dict'\n"

--- a/src/lamplib/src/genny/tasks/preprocess.py
+++ b/src/lamplib/src/genny/tasks/preprocess.py
@@ -312,6 +312,13 @@ class _WorkloadParser(object):
                 f"Faulting key: {e}\n"
             )
             raise ParseException(msg)
+        except Exception as e:
+            msg = (
+                "Failure trying to parse ^NumExpr node.\n"
+                f"Node source: {input}\n"
+                f"Exception: {e}\n"
+            )
+            raise ParseException(msg)
 
     def _parse_templates(self, templates):
         for template_node in templates:

--- a/src/lamplib/src/genny/tasks/preprocess.py
+++ b/src/lamplib/src/genny/tasks/preprocess.py
@@ -283,38 +283,44 @@ class _WorkloadParser(object):
             return self._recursive_parse(defaultVal)
 
     def _replace_numexpr(self, input):
-        if "Expr" not in input:
-            msg = "Invalid keys for '^NumExpr', please set 'Expr'" f" in following node: {input}"
+        OP_KEY = "^NumExpr"
+        EXPR_KEY = "withExpression"
+        VALUE_KEY = "andValues"
+
+        if EXPR_KEY not in input:
+            msg = f"Invalid keys for '{OP_KEY}', please set '{EXPR_KEY}' in following node: {input}"
             raise ParseException(msg)
 
-        if type(input["Expr"]) != str:
-            msg = "Invalid value for 'Expr', which must be a string," f" in following node: {input}"
+        if type(input[EXPR_KEY]) != str:
+            msg = f"Invalid value for '{EXPR_KEY}', which must be a string, in following node: {input}"
             raise ParseException(msg)
 
         parsed_values = {}  # Pass empty dict to avoid yaml to access context of this function
-        if "Dict" in input:
-            input_values = input["Dict"]
+        if VALUE_KEY in input:
+            input_values = input[VALUE_KEY]
             parsed_values = self._recursive_parse(input_values)
-            if not all(type(value) == int or type(value) == float for value in parsed_values.values()):
+            if not all(
+                type(value) == int or type(value) == float for value in parsed_values.values()
+            ):
                 msg = (
-                    "Invalid values for 'Dict' in '^NumExpr', only numerical values are allowed.\n"
+                    f"Invalid values for '{VALUE_KEY}' in '{OP_KEY}', only numerical values are allowed.\n"
                     f"Node source: {input_values}\n"
                     f"Node eval: {parsed_values}\n"
                 )
                 raise ParseException(msg)
 
         try:
-            return numexpr.evaluate(input["Expr"], parsed_values).tolist()
+            return numexpr.evaluate(input[EXPR_KEY], parsed_values).tolist()
         except KeyError as e:
             msg = (
-                "Key used in 'Expr' not found in 'Dict'\n"
+                f"Key used in '{EXPR_KEY}' not found in '{VALUE_KEY}'\n"
                 f"Node source: {input}\n"
                 f"Faulting key: {e}\n"
             )
             raise ParseException(msg)
         except Exception as e:
             msg = (
-                "Failure trying to parse ^NumExpr node.\n"
+                "Failure trying to parse '{OP_KEY}' node.\n"
                 f"Node source: {input}\n"
                 f"Exception: {e}\n"
             )

--- a/src/lamplib/src/tests/test_preprocess.py
+++ b/src/lamplib/src/tests/test_preprocess.py
@@ -570,3 +570,47 @@ HighLevelKey:
 """
         output.seek(0)
         self.assertEqual(output.read(), expected)
+
+    def test_numexpr_no_dict(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Test: {^NumExpr: {Expr: "10 - 50"}}
+"""
+        expected = """SchemaVersion: '2018-07-01'
+Test: -40
+"""
+        self._assertYaml(yaml_input, expected)
+
+    def test_numexpr_with_dict(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Test: {^NumExpr: {Expr: "a - b", Dict: {a: 100, b: 25}}}
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Test: 75
+"""
+        self._assertYaml(yaml_input, expected)
+
+    def test_numexpr_with_dict_parameter(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Param1: &Param1 {^Parameter: {Name: "Name1", Default: 100}}
+Test: {^NumExpr: {Expr: "a - b", Dict: {a: *Param1, b: 25}}}
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Param1: 100
+Test: 75
+"""
+        self._assertYaml(yaml_input, expected)
+
+    def test_numexpr_non_string_expr_throws(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Test: {^NumExpr: {Expr: 1}}
+"""
+        self._assertParseException(yaml_input)
+
+    def test_numexpr_with_dict_string_value_throws(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Param1: &Param1 {^Parameter: {Name: "Name1", Default: 100}}
+Test: {^NumExpr: {Expr: "a - b", Dict: {a: *Param1, b: "25"}}}
+"""
+        self._assertParseException(yaml_input)

--- a/src/lamplib/src/tests/test_preprocess.py
+++ b/src/lamplib/src/tests/test_preprocess.py
@@ -573,7 +573,7 @@ HighLevelKey:
 
     def test_numexpr_no_dict(self):
         yaml_input = """SchemaVersion: 2018-07-01
-Test: {^NumExpr: {Expr: "10 - 50"}}
+Test: {^NumExpr: {withExpression: "10 - 50"}}
 """
         expected = """SchemaVersion: '2018-07-01'
 Test: -40
@@ -582,7 +582,7 @@ Test: -40
 
     def test_numexpr_with_dict(self):
         yaml_input = """SchemaVersion: 2018-07-01
-Test: {^NumExpr: {Expr: "a - b", Dict: {a: 100, b: 25}}}
+Test: {^NumExpr: {withExpression: "a - b", andValues: {a: 100, b: 25}}}
 """
 
         expected = """SchemaVersion: '2018-07-01'
@@ -593,7 +593,7 @@ Test: 75
     def test_numexpr_with_dict_parameter(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Param1: &Param1 {^Parameter: {Name: "Name1", Default: 100}}
-Test: {^NumExpr: {Expr: "a - b", Dict: {a: *Param1, b: 25}}}
+Test: {^NumExpr: {withExpression: "a - b", andValues: {a: *Param1, b: 25}}}
 """
 
         expected = """SchemaVersion: '2018-07-01'
@@ -604,13 +604,13 @@ Test: 75
 
     def test_numexpr_non_string_expr_throws(self):
         yaml_input = """SchemaVersion: 2018-07-01
-Test: {^NumExpr: {Expr: 1}}
+Test: {^NumExpr: {withExpression: 1}}
 """
         self._assertParseException(yaml_input)
 
     def test_numexpr_with_dict_string_value_throws(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Param1: &Param1 {^Parameter: {Name: "Name1", Default: 100}}
-Test: {^NumExpr: {Expr: "a - b", Dict: {a: *Param1, b: "25"}}}
+Test: {^NumExpr: {withExpression: "a - b", andValues: {a: *Param1, b: "25"}}}
 """
         self._assertParseException(yaml_input)

--- a/src/lamplib/src/tests/test_preprocess.py
+++ b/src/lamplib/src/tests/test_preprocess.py
@@ -602,6 +602,20 @@ Test: 75
 """
         self._assertYaml(yaml_input, expected)
 
+    def test_numexpr_within_document_generator_expression(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Param1: &Param1 {^Parameter: {Name: "Name1", Default: 3}}
+Document: {^FastRandomString:{length:{^NumExpr: {withExpression: "a + 3", andValues: {a: *Param1}}}}}
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Param1: 3
+Document:
+  ^FastRandomString:
+    length: 6
+"""
+        self._assertYaml(yaml_input, expected)
+
     def test_numexpr_non_string_expr_throws(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Test: {^NumExpr: {withExpression: 1}}

--- a/src/workloads/docs/HelloWorld.yml
+++ b/src/workloads/docs/HelloWorld.yml
@@ -7,7 +7,7 @@ Description: |
 Actors:
 - Name: HelloWorld
   Type: HelloWorld
-  Threads: 2
+  Threads: &Threads 2
   Phases:
   - Message: Hello Phase 0 🐳
     Duration: 50 milliseconds
@@ -26,6 +26,13 @@ Actors:
       Key: UseMe  # Only load the YAML structure from this top-level key.
       Parameters:
         Repeat: 2
+  # To perform arithmetic use the ^NumExpr preprocessor directive
+  - Message: Hello Phase 3
+    TotalMessageCount: &TotalMessageCount 100
+    Repeat:
+      ^NumExpr:
+        withExpression: "messages / threads"
+        andValues: {messages: *TotalMessageCount, threads: *Threads}
 
 # As an alternate phase syntax, use the following for an actor that
 # runs a total of 3 phases, active in phases named 0 and 2 and Nop for the rest:


### PR DESCRIPTION
Many times it would be nice to have arithmetic with parameters in YAML files.

This is a proposal to add this functionality. Not sure if the syntax is the most appropriate, since it might be confusing with doc generators. Given that ^Parameter also follows this ^xxxx style, I used the same. 