### PR TITLE
PERF-2892 Extend initial performance tests to include overlapping bucket scenarios

### DIFF
--- a/src/phases/execution/TimeSeriesSortCommands.yml
+++ b/src/phases/execution/TimeSeriesSortCommands.yml
@@ -8,3 +8,9 @@ SortCmdTemplate:
   pipeline: [{$sort: {t: 1}}, {$_internalInhibitOptimization: {}}, {$skip: 1e10}]
   cursor: {batchSize: {^Parameter: {Name: "batchSize", Default: 30000}}}
   allowDiskUse: true
+
+SortFirstResultCmdTemplate:
+  aggregate: {^Parameter: {Name: "coll", Default: Collection0}}
+  pipeline: [{$sort: {t: 1}}, {$_internalInhibitOptimization: {}}, {$limit: 1}]
+  cursor: {batchSize: {^Parameter: {Name: "batchSize", Default: 30000}}}
+  allowDiskUse: true

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -561,7 +561,7 @@ Tests:
     GivenTemplate:
       a: {^Concat: {arrays: [{^Array: {of: 1, number: 1}}, {^Array: {of: 2, number: 2}}]}}
     ThenReturns:
-    - a: [1, 2, 2] 
+    - a: [1, 2, 2]
 
   - Name: Concat with generator and literal
     GivenTemplate:
@@ -961,6 +961,39 @@ Tests:
       - {a: qg}
       - {a: qg}
       - {a: qg}
+
+  - Name: Repeat three pre-computed elements
+    GivenTemplate:
+      a: {^Repeat: {count: 3, fromGenerator: {^FastRandomString: {length: {^RandomInt: {min: 2, max: 5}}}}}}
+    ThenReturns:
+      - {a: qg}
+      - {a: qg}
+      - {a: qg}
+      - {a: kt}
+      - {a: kt}
+      - {a: kt}
+      - {a: JJP}
+      - {a: JJP}
+      - {a: JJP}
+
+  - Name: Repeat an integer generator
+    GivenTemplate:
+      a: {^Repeat: {count: 2, fromGenerator: {^RandomInt: {distribution: poisson, mean: 10000000000000}}}}
+    ThenReturns:
+      - {a: 9999997460716}
+      - {a: 9999997460716}
+      - {a: 9999996810402}
+      - {a: 9999996810402}
+      - {a: 9999995032424}
+      - {a: 9999995032424}
+
+  - Name: Repeat with count equal to one
+    GivenTemplate:
+      a: {^Repeat: {count: 1, fromGenerator: {^FastRandomString: {length: {^RandomInt: {min: 2, max: 5}}}}}}
+    ThenReturns:
+      - {a: qg}
+      - {a: kt}
+      - {a: JJP}
 
   - Name: FixedGenerated value for pre-computing, caching and re-using the result of an expensive generator
     GivenTemplate:

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -235,6 +235,10 @@ Actors:
             # generates 10 random strings and will cycle between them in order
             cycleOfRandomStrings: {^Cycle: {ofLength: 10, fromGenerator: {^RandomString: {length: 22}}}}
 
+            # Repeat each value from a generator `count` times. A generator that normally returns
+            # [a b c b] will return [a a b b c c b b] when wrapped with ^Repeat, count=2
+            repeatedStrings: {^Repeat: {count: 5, fromGenerator: {^RandomString: {length: 22}}}}
+
             # Random OID
             roid: {^ObjectId: {^RandomString: {length: 24, alphabet: "0123456789ABCDEF"}}}
 

--- a/src/workloads/execution/TimeSeriesSortOverlappingBuckets.yml
+++ b/src/workloads/execution/TimeSeriesSortOverlappingBuckets.yml
@@ -1,0 +1,107 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test exercises the behavior of the time series bounded sorter with many overlapping buckets,
+  forcing the sort to spill to disk. We insert 1000 independent series with 100 buckets in
+  each series, and each bucket has 100 documents. The documents inserted have the same timestamps,
+  with different meta values.
+
+GlobalDefaults:
+  dbname: &db test
+  coll: &coll Collection0
+  batchSize: &batchSize 30000
+  fieldName: &field "numeric"
+  index: &index
+    keys: {numeric: 1}
+  nop: &Nop {Nop: true}
+
+SortCmd: &SortCmd
+  LoadConfig:
+    Path: "../../phases/execution/TimeSeriesSortCommands.yml"
+    Key: SortFirstResultCmdTemplate
+    Parameters:
+      coll: *coll
+      batchSize: *batchSize
+
+Actors:
+- Name: CreateTimeSeriesCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: *db
+    Operation:
+      OperationMetricsName: CreateTimeSeriesCollection
+      OperationName: RunCommand
+      OperationCommand:
+        {create: *coll, timeseries: {timeField: "t", metaField: "m"}}
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        drop: *coll
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+  - *Nop
+  - *Nop
+
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Collection: *coll
+    Threads: 1
+    CollectionCount: 1
+    DocumentCount: 10010000
+    BatchSize: *batchSize
+    Document:
+      t: {^Repeat: {count: 1000, fromGenerator: {^IncDate: {start: "2022-01-01", step: 36000}}}}
+      m: {^Cycle: {ofLength: 1000, fromGenerator: {^Inc: {start: 0}}}}
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: Queries
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 50
+    Database: *db
+    Operations:
+    - OperationMetricsName: SortQuerySpillBlockingSort
+      OperationName: RunCommand
+      OperationCommand: *SortCmd
+  - *Nop
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - replica
+      - replica-all-feature-flags
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0
+      - v5.1
+      - v5.2
+      - v5.3


### PR DESCRIPTION
Duplicate of [#646 ](https://github.com/mongodb/genny/pull/646)