### PR TITLE
PERF-2696: Adjust actor and phase threads to match in mixed_workloads_stress

### DIFF
--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -148,7 +148,7 @@ Actors:
   Phases:
   - Repeat: 1
     BatchSize: 100
-    Threads: 8
+    Threads: 1
     DocumentCount: *NumDocs
     Database: *dbname
     CollectionCount: *NumColls

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -144,11 +144,11 @@ ActorTemplates:
 Actors:
 - Name: Setup
   Type: Loader
-  Threads: 1
+  Threads: 8
   Phases:
   - Repeat: 1
     BatchSize: 100
-    Threads: 1
+    Threads: 8
     DocumentCount: *NumDocs
     Database: *dbname
     CollectionCount: *NumColls


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/626adf410ae6067e047fdcb2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

It looks like this workload is still inserting documents, but I don't know how with that setting of threads. This should make it sane. 