### PR TITLE
PERF-2732 Implement "hot data" variant of TPC-H benchmark

### DIFF
--- a/src/phases/tpch/denormalized/Q1.yml
+++ b/src/phases/tpch/denormalized/Q1.yml
@@ -4,31 +4,41 @@ Description: |
   Run TPC-H query 1 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query1Delta: &query1Delta {^Parameter: {Name: "Query1Delta", Default: -90}}
 
+TPCHDenormalizedQuery1Aggregation: &TPCHDenormalizedQuery1Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$replaceWith: "$lineitem"},
+      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
+      {$group: {_id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"}, sum_qty: {$sum: "$l_quantity"}, sum_base_price: {$sum: "$l_extendedprice"}, sum_disc_price: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}, sum_charge: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}, {$add: [1, "$l_tax"]}]}}, avg_qty: {$avg: "$l_quantity"}, avg_price: {$avg: "$l_extendedprice"}, avg_disc: {$avg: "$l_discount"}, count_order: {$count: {}}}},
+      {$project: {_id: 0, l_returnflag: "$_id.l_returnflag", l_linestatus: "$_id.l_linestatus", sum_qty: 1, sum_base_price: 1, sum_disc_price: 1, sum_charge: 1, avg_qty: 1, avg_price: 1, avg_disc: 1, count_order: 1}},
+      {$sort: {l_returnflag: 1, l_linestatus: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery1:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query1
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery1Aggregation
+
+TPCHDenormalizedQuery1Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query1
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: "customer"
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-            {$unwind: "$lineitem"},
-            {$replaceWith: "$lineitem"},
-            {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
-            {$group: {_id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"}, sum_qty: {$sum: "$l_quantity"}, sum_base_price: {$sum: "$l_extendedprice"}, sum_disc_price: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}, sum_charge: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}, {$add: [1, "$l_tax"]}]}}, avg_qty: {$avg: "$l_quantity"}, avg_price: {$avg: "$l_extendedprice"}, avg_disc: {$avg: "$l_discount"}, count_order: {$count: {}}}},
-            {$project: {_id: 0, l_returnflag: "$_id.l_returnflag", l_linestatus: "$_id.l_linestatus", sum_qty: 1, sum_base_price: 1, sum_disc_price: 1, sum_charge: 1, avg_qty: 1, avg_price: 1, avg_disc: 1, count_order: 1}},
-            {$sort: {l_returnflag: 1, l_linestatus: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery1Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q1.yml
+++ b/src/phases/tpch/denormalized/Q1.yml
@@ -7,25 +7,30 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query1Delta: &query1Delta {^Parameter: {Name: "Query1Delta", Default: -90}}
 
-TPCHDenormalizedQuery1Aggregation: &TPCHDenormalizedQuery1Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-      {$unwind: "$lineitem"},
-      {$replaceWith: "$lineitem"},
-      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
-      {$group: {_id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"}, sum_qty: {$sum: "$l_quantity"}, sum_base_price: {$sum: "$l_extendedprice"}, sum_disc_price: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}, sum_charge: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}, {$add: [1, "$l_tax"]}]}}, avg_qty: {$avg: "$l_quantity"}, avg_price: {$avg: "$l_extendedprice"}, avg_disc: {$avg: "$l_discount"}, count_order: {$count: {}}}},
-      {$project: {_id: 0, l_returnflag: "$_id.l_returnflag", l_linestatus: "$_id.l_linestatus", sum_qty: 1, sum_base_price: 1, sum_disc_price: 1, sum_charge: 1, avg_qty: 1, avg_price: 1, avg_disc: 1, count_order: 1}},
-      {$sort: {l_returnflag: 1, l_linestatus: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery1:
+TPCHDenormalizedQuery1Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery1Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+          {$unwind: "$lineitem"},
+          {$replaceWith: "$lineitem"},
+          {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
+          {$group: {_id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"}, sum_qty: {$sum: "$l_quantity"}, sum_base_price: {$sum: "$l_extendedprice"}, sum_disc_price: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}, sum_charge: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}, {$add: [1, "$l_tax"]}]}}, avg_qty: {$avg: "$l_quantity"}, avg_price: {$avg: "$l_extendedprice"}, avg_disc: {$avg: "$l_discount"}, count_order: {$count: {}}}},
+          {$project: {_id: 0, l_returnflag: "$_id.l_returnflag", l_linestatus: "$_id.l_linestatus", sum_qty: 1, sum_base_price: 1, sum_disc_price: 1, sum_charge: 1, avg_qty: 1, avg_price: 1, avg_disc: 1, count_order: 1}},
+          {$sort: {l_returnflag: 1, l_linestatus: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery1:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query1
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q10.yml
+++ b/src/phases/tpch/denormalized/Q10.yml
@@ -4,34 +4,44 @@ Description: |
   Run TPC-H query 10 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query10Date: &query10Date {^Parameter: {Name: "Query10Date", Default: "1993-10-01"}}
 
+TPCHDenormalizedQuery10Aggregation: &TPCHDenormalizedQuery10Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$match: {"lineitem.l_returnflag": "R"}},
+      {$group: {_id: {c_custkey: "$c_custkey", c_name: "$c_name", c_acctbal: "$c_acctbal", n_name: "$nation.n_name", c_address: "$c_address", c_phone: "$c_phone", c_comment: "$c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
+      {$sort: {revenue: -1}},
+      {$limit: 20}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery10:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query10
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery10Aggregation
+
+TPCHDenormalizedQuery10Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query10
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$match: {$and: [
-              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
-              {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
-            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-            {$unwind: "$lineitem"},
-            {$match: {"lineitem.l_returnflag": "R"}},
-            {$group: {_id: {c_custkey: "$c_custkey", c_name: "$c_name", c_acctbal: "$c_acctbal", n_name: "$nation.n_name", c_address: "$c_address", c_phone: "$c_phone", c_comment: "$c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
-            {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
-            {$sort: {revenue: -1}},
-            {$limit: 20}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery10Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q10.yml
+++ b/src/phases/tpch/denormalized/Q10.yml
@@ -7,28 +7,33 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query10Date: &query10Date {^Parameter: {Name: "Query10Date", Default: "1993-10-01"}}
 
-TPCHDenormalizedQuery10Aggregation: &TPCHDenormalizedQuery10Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$match: {$and: [
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
-        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
-      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-      {$unwind: "$lineitem"},
-      {$match: {"lineitem.l_returnflag": "R"}},
-      {$group: {_id: {c_custkey: "$c_custkey", c_name: "$c_name", c_acctbal: "$c_acctbal", n_name: "$nation.n_name", c_address: "$c_address", c_phone: "$c_phone", c_comment: "$c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
-      {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
-      {$sort: {revenue: -1}},
-      {$limit: 20}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery10:
+TPCHDenormalizedQuery10Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery10Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$match: {$and: [
+            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
+            {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+          {$unwind: "$lineitem"},
+          {$match: {"lineitem.l_returnflag": "R"}},
+          {$group: {_id: {c_custkey: "$c_custkey", c_name: "$c_name", c_acctbal: "$c_acctbal", n_name: "$nation.n_name", c_address: "$c_address", c_phone: "$c_phone", c_comment: "$c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+          {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
+          {$sort: {revenue: -1}},
+          {$limit: 20}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery10:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query10
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q11.yml
+++ b/src/phases/tpch/denormalized/Q11.yml
@@ -8,28 +8,33 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query11Nation: &query11Nation {^Parameter: {Name: "Query11Nation", Default: "GERMANY"}}
 query11Fraction: &query11Fraction {^Parameter: {Name: "Query11Fraction", Default: 0.0001}}
 
-TPCHDenormalizedQuery11Aggregation: &TPCHDenormalizedQuery11Aggregation
-  aggregate: partsupp
-  pipeline:
-    [
-      {$lookup: {from: "supplier", localField: "ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query11Nation}}]}},
-      {$unwind: "$supplier"},
-      {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
-      {$group: {_id: "$ps_partkey", value: {$sum: "$total_cost"}}},
-      {$group: {_id: 0, groups: {$push: {ps_partkey: "$_id", value: "$value"}}, total_cost: {$sum: "$value"}}},
-      {$addFields: {threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
-      {$unwind: "$groups"},
-      {$project: {ps_partkey: "$groups.ps_partkey", value: "$groups.value", threshold: 1}},
-      {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
-      {$project: {_id: 0, ps_partkey: 1, value: 1}},
-      {$sort: {value: -1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery11:
+TPCHDenormalizedQuery11Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery11Aggregation
+      aggregate: partsupp
+      pipeline:
+        [
+          {$lookup: {from: "supplier", localField: "ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query11Nation}}]}},
+          {$unwind: "$supplier"},
+          {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
+          {$group: {_id: "$ps_partkey", value: {$sum: "$total_cost"}}},
+          {$group: {_id: 0, groups: {$push: {ps_partkey: "$_id", value: "$value"}}, total_cost: {$sum: "$value"}}},
+          {$addFields: {threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
+          {$unwind: "$groups"},
+          {$project: {ps_partkey: "$groups.ps_partkey", value: "$groups.value", threshold: 1}},
+          {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
+          {$project: {_id: 0, ps_partkey: 1, value: 1}},
+          {$sort: {value: -1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery11:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query11
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q11.yml
+++ b/src/phases/tpch/denormalized/Q11.yml
@@ -4,35 +4,45 @@ Description: |
   Run TPC-H query 11 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query11Nation: &query11Nation {^Parameter: {Name: "Query11Nation", Default: "GERMANY"}}
 query11Fraction: &query11Fraction {^Parameter: {Name: "Query11Fraction", Default: 0.0001}}
 
+TPCHDenormalizedQuery11Aggregation: &TPCHDenormalizedQuery11Aggregation
+  aggregate: partsupp
+  pipeline:
+    [
+      {$lookup: {from: "supplier", localField: "ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query11Nation}}]}},
+      {$unwind: "$supplier"},
+      {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
+      {$group: {_id: "$ps_partkey", value: {$sum: "$total_cost"}}},
+      {$group: {_id: 0, groups: {$push: {ps_partkey: "$_id", value: "$value"}}, total_cost: {$sum: "$value"}}},
+      {$addFields: {threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
+      {$unwind: "$groups"},
+      {$project: {ps_partkey: "$groups.ps_partkey", value: "$groups.value", threshold: 1}},
+      {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
+      {$project: {_id: 0, ps_partkey: 1, value: 1}},
+      {$sort: {value: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery11:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query11
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery11Aggregation
+
+TPCHDenormalizedQuery11Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query11
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: partsupp
-        pipeline:
-          [
-            {$lookup: {from: "supplier", localField: "ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query11Nation}}]}},
-            {$unwind: "$supplier"},
-            {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
-            {$group: {_id: "$ps_partkey", value: {$sum: "$total_cost"}}},
-            {$group: {_id: 0, groups: {$push: {ps_partkey: "$_id", value: "$value"}}, total_cost: {$sum: "$value"}}},
-            {$addFields: {threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
-            {$unwind: "$groups"},
-            {$project: {ps_partkey: "$groups.ps_partkey", value: "$groups.value", threshold: 1}},
-            {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
-            {$project: {_id: 0, ps_partkey: 1, value: 1}},
-            {$sort: {value: -1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery11Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q12.yml
+++ b/src/phases/tpch/denormalized/Q12.yml
@@ -10,29 +10,34 @@ query12ShipMode1: &query12ShipMode1 {^Parameter: {Name: "Query12ShipMode1", Defa
 query12ShipMode2: &query12ShipMode2 {^Parameter: {Name: "Query12ShipMode2", Default: "SHIP"}}
 query12Date: &query12Date {^Parameter: {Name: "Query12Date", Default: "1994-01-01"}}
 
-TPCHDenormalizedQuery12Aggregation: &TPCHDenormalizedQuery12Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-      {$unwind: "$lineitem"},
-      {$match: {$and: [
-        {$or: [{"lineitem.l_shipmode": *query12ShipMode1}, {"lineitem.l_shipmode": *query12ShipMode2}]},
-        {$expr: {$lt: ["$lineitem.l_commitdate", "$lineitem.l_receiptdate"]}},
-        {$expr: {$lt: ["$lineitem.l_shipdate", "$lineitem.l_commitdate"]}},
-        {$expr: {$gte: ["$lineitem.l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
-        {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
-      {$group: {_id: "$lineitem.l_shipmode", high_line_count: {$sum: {$cond: {if: {$or: [{$eq: ["$orders.o_orderpriority", "1-URGENT"]}, {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}, low_line_count: {$sum: {$cond: {if: {$and: [{$ne: ["$orders.o_orderpriority", "1-URGENT"]}, {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}}},
-      {$project: {_id: 0, l_shipmode: "$_id", high_line_count: 1, low_line_count: 1}},
-      {$sort: {l_shipmode: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery12:
+TPCHDenormalizedQuery12Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery12Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+          {$unwind: "$lineitem"},
+          {$match: {$and: [
+            {$or: [{"lineitem.l_shipmode": *query12ShipMode1}, {"lineitem.l_shipmode": *query12ShipMode2}]},
+            {$expr: {$lt: ["$lineitem.l_commitdate", "$lineitem.l_receiptdate"]}},
+            {$expr: {$lt: ["$lineitem.l_shipdate", "$lineitem.l_commitdate"]}},
+            {$expr: {$gte: ["$lineitem.l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
+            {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
+          {$group: {_id: "$lineitem.l_shipmode", high_line_count: {$sum: {$cond: {if: {$or: [{$eq: ["$orders.o_orderpriority", "1-URGENT"]}, {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}, low_line_count: {$sum: {$cond: {if: {$and: [{$ne: ["$orders.o_orderpriority", "1-URGENT"]}, {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}}},
+          {$project: {_id: 0, l_shipmode: "$_id", high_line_count: 1, low_line_count: 1}},
+          {$sort: {l_shipmode: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery12:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query12
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q12.yml
+++ b/src/phases/tpch/denormalized/Q12.yml
@@ -4,38 +4,48 @@ Description: |
   Run TPC-H query 12 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query12ShipMode1: &query12ShipMode1 {^Parameter: {Name: "Query12ShipMode1", Default: "MAIL"}}
 query12ShipMode2: &query12ShipMode2 {^Parameter: {Name: "Query12ShipMode2", Default: "SHIP"}}
 query12Date: &query12Date {^Parameter: {Name: "Query12Date", Default: "1994-01-01"}}
 
+TPCHDenormalizedQuery12Aggregation: &TPCHDenormalizedQuery12Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$or: [{"lineitem.l_shipmode": *query12ShipMode1}, {"lineitem.l_shipmode": *query12ShipMode2}]},
+        {$expr: {$lt: ["$lineitem.l_commitdate", "$lineitem.l_receiptdate"]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", "$lineitem.l_commitdate"]}},
+        {$expr: {$gte: ["$lineitem.l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
+        {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
+      {$group: {_id: "$lineitem.l_shipmode", high_line_count: {$sum: {$cond: {if: {$or: [{$eq: ["$orders.o_orderpriority", "1-URGENT"]}, {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}, low_line_count: {$sum: {$cond: {if: {$and: [{$ne: ["$orders.o_orderpriority", "1-URGENT"]}, {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}}},
+      {$project: {_id: 0, l_shipmode: "$_id", high_line_count: 1, low_line_count: 1}},
+      {$sort: {l_shipmode: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery12:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query12
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery12Aggregation
+
+TPCHDenormalizedQuery12Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query12
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-            {$unwind: "$lineitem"},
-            {$match: {$and: [
-              {$or: [{"lineitem.l_shipmode": *query12ShipMode1}, {"lineitem.l_shipmode": *query12ShipMode2}]},
-              {$expr: {$lt: ["$lineitem.l_commitdate", "$lineitem.l_receiptdate"]}},
-              {$expr: {$lt: ["$lineitem.l_shipdate", "$lineitem.l_commitdate"]}},
-              {$expr: {$gte: ["$lineitem.l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
-              {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
-            {$group: {_id: "$lineitem.l_shipmode", high_line_count: {$sum: {$cond: {if: {$or: [{$eq: ["$orders.o_orderpriority", "1-URGENT"]}, {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}, low_line_count: {$sum: {$cond: {if: {$and: [{$ne: ["$orders.o_orderpriority", "1-URGENT"]}, {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}}},
-            {$project: {_id: 0, l_shipmode: "$_id", high_line_count: 1, low_line_count: 1}},
-            {$sort: {l_shipmode: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery12Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q13.yml
+++ b/src/phases/tpch/denormalized/Q13.yml
@@ -7,21 +7,26 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query13Regex: &query13Regex {^Parameter: {Name: "Query13Regex", Default: "^.*special.*requests.*$"}}  # `^.*${query13Word1}.*${query13Word2}.*$`
 
-TPCHDenormalizedQuery13Aggregation: &TPCHDenormalizedQuery13Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$project: {c_custkey: 1, c_count: {$size: {$filter: {input: "$orders", cond: {$not: {$regexMatch: {input: "$$this.o_comment", regex: *query13Regex, options: "si"}}}}}}}},
-      {$group: {_id: "$c_count", custdist: {$count: {}}}},
-      {$project: {_id: 0, c_count: "$_id", custdist: 1}},
-      {$sort: {custdist: -1, c_count: -1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery13:
+TPCHDenormalizedQuery13Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery13Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$project: {c_custkey: 1, c_count: {$size: {$filter: {input: "$orders", cond: {$not: {$regexMatch: {input: "$$this.o_comment", regex: *query13Regex, options: "si"}}}}}}}},
+          {$group: {_id: "$c_count", custdist: {$count: {}}}},
+          {$project: {_id: 0, c_count: "$_id", custdist: 1}},
+          {$sort: {custdist: -1, c_count: -1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery13:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query13
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q13.yml
+++ b/src/phases/tpch/denormalized/Q13.yml
@@ -4,27 +4,36 @@ Description: |
   Run TPC-H query 13 gainst the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query13Regex: &query13Regex {^Parameter: {Name: "Query13Regex", Default: "^.*special.*requests.*$"}}  # `^.*${query13Word1}.*${query13Word2}.*$`
 
+TPCHDenormalizedQuery13Aggregation: &TPCHDenormalizedQuery13Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$project: {c_custkey: 1, c_count: {$size: {$filter: {input: "$orders", cond: {$not: {$regexMatch: {input: "$$this.o_comment", regex: *query13Regex, options: "si"}}}}}}}},
+      {$group: {_id: "$c_count", custdist: {$count: {}}}},
+      {$project: {_id: 0, c_count: "$_id", custdist: 1}},
+      {$sort: {custdist: -1, c_count: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+
 TPCHDenormalizedQuery13:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query13
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery13Aggregation
+
+TPCHDenormalizedQuery13Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query13
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$project: {c_custkey: 1, c_count: {$size: {$filter: {input: "$orders", cond: {$not: {$regexMatch: {input: "$$this.o_comment", regex: *query13Regex, options: "si"}}}}}}}},
-            {$group: {_id: "$c_count", custdist: {$count: {}}}},
-            {$project: {_id: 0, c_count: "$_id", custdist: 1}},
-            {$sort: {custdist: -1, c_count: -1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery13Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q13.yml
+++ b/src/phases/tpch/denormalized/Q13.yml
@@ -17,6 +17,7 @@ TPCHDenormalizedQuery13Aggregation: &TPCHDenormalizedQuery13Aggregation
       {$sort: {custdist: -1, c_count: -1}}
     ]
   cursor: {batchSize: *batchSize}
+  allowDiskUse: true
 
 TPCHDenormalizedQuery13:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}

--- a/src/phases/tpch/denormalized/Q14.yml
+++ b/src/phases/tpch/denormalized/Q14.yml
@@ -4,32 +4,42 @@ Description: |
   Run TPC-H query 14 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query14Date: &query14Date {^Parameter: {Name: "Query14Date", Default: "1995-09-01"}}
 
+TPCHDenormalizedQuery14Aggregation: &TPCHDenormalizedQuery14Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
+      {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part"}},
+      {$unwind: "$part"},
+      {$group: {_id: {}, promo_price_total: {$sum: {$cond: {if: {$cond: {if: {$regexMatch: {input: "$part.p_type", regex: "^PROMO.*$", options: "si"}}, then: 1, else: 0}}, then: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}, else: 0}}}, price_total: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}}, {$project: {_id: 0, promo_revenue: {$multiply: [100.0, {$divide: ["$promo_price_total", "$price_total"]}]}}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery14:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query14
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery14Aggregation
+
+TPCHDenormalizedQuery14Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query14
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-            {$unwind: "$lineitem"},
-            {$match: {$and: [
-              {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
-              {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
-            {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part"}},
-            {$unwind: "$part"},
-            {$group: {_id: {}, promo_price_total: {$sum: {$cond: {if: {$cond: {if: {$regexMatch: {input: "$part.p_type", regex: "^PROMO.*$", options: "si"}}, then: 1, else: 0}}, then: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}, else: 0}}}, price_total: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}}, {$project: {_id: 0, promo_revenue: {$multiply: [100.0, {$divide: ["$promo_price_total", "$price_total"]}]}}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery14Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q14.yml
+++ b/src/phases/tpch/denormalized/Q14.yml
@@ -7,26 +7,31 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query14Date: &query14Date {^Parameter: {Name: "Query14Date", Default: "1995-09-01"}}
 
-TPCHDenormalizedQuery14Aggregation: &TPCHDenormalizedQuery14Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-      {$unwind: "$lineitem"},
-      {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
-        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
-      {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part"}},
-      {$unwind: "$part"},
-      {$group: {_id: {}, promo_price_total: {$sum: {$cond: {if: {$cond: {if: {$regexMatch: {input: "$part.p_type", regex: "^PROMO.*$", options: "si"}}, then: 1, else: 0}}, then: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}, else: 0}}}, price_total: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}}, {$project: {_id: 0, promo_revenue: {$multiply: [100.0, {$divide: ["$promo_price_total", "$price_total"]}]}}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery14:
+TPCHDenormalizedQuery14Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery14Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+          {$unwind: "$lineitem"},
+          {$match: {$and: [
+            {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
+            {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
+          {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part"}},
+          {$unwind: "$part"},
+          {$group: {_id: {}, promo_price_total: {$sum: {$cond: {if: {$cond: {if: {$regexMatch: {input: "$part.p_type", regex: "^PROMO.*$", options: "si"}}, then: 1, else: 0}}, then: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}, else: 0}}}, price_total: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}}, {$project: {_id: 0, promo_revenue: {$multiply: [100.0, {$divide: ["$promo_price_total", "$price_total"]}]}}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery14:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query14
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -8,7 +8,7 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query15Date: &query15Date {^Parameter: {Name: "Query15Date", Default: "1996-01-01"}}
 
 TPCHDenormalizedQuery15CreateView: &TPCHDenormalizedQuery15CreateView
-  create: &view revenue
+  create: &query15View revenue
   viewOn: customer
   pipeline:
     [
@@ -24,7 +24,7 @@ TPCHDenormalizedQuery15CreateView: &TPCHDenormalizedQuery15CreateView
     ]
 
 TPCHDenormalizedQuery15Aggregation: &TPCHDenormalizedQuery15Aggregation
-  aggregate: *view
+  aggregate: *query15View
   pipeline:
     [
       {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
@@ -46,7 +46,7 @@ TPCHDenormalizedQuery15Aggregation: &TPCHDenormalizedQuery15Aggregation
   allowDiskUse: true
 
 TPCHDenormalizedQuery15DropView: &TPCHDenormalizedQuery15DropView
-  drop: *view
+  drop: *query15View
 
 TPCHDenormalizedQuery15:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -8,20 +8,33 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query15Date: &query15Date {^Parameter: {Name: "Query15Date", Default: "1996-01-01"}}
 
 TPCHDenormalizedQuery15CreateView: &TPCHDenormalizedQuery15CreateView
-  create: &query15View revenue
-  viewOn: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-      {$unwind: "$lineitem"},
-      {$replaceWith: "$lineitem"},
-      {$match: {$and: [
-        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
-        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}]}}]}},
-      {$group: {_id: "$l_suppkey", total_revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-      {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}}
-    ]
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand:
+      create: &query15View revenue
+      viewOn: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+          {$unwind: "$lineitem"},
+          {$replaceWith: "$lineitem"},
+          {$match: {
+            $and: [
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
+              {$expr: {
+                $lt: [
+                  "$l_shipdate",
+                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}
+                ]}}]}},
+          {$group: {
+            _id: "$l_suppkey",
+            total_revenue:
+              {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+          {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
+        ]
 
 TPCHDenormalizedQuery15Aggregation: &TPCHDenormalizedQuery15Aggregation
   aggregate: *query15View
@@ -46,11 +59,16 @@ TPCHDenormalizedQuery15Aggregation: &TPCHDenormalizedQuery15Aggregation
   allowDiskUse: true
 
 TPCHDenormalizedQuery15DropView: &TPCHDenormalizedQuery15DropView
-  drop: *query15View
+  Repeat: *Repeat
+  Database: *db
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand:
+      drop: *query15View
 
 TPCHDenormalizedQuery15:
-  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
-  Database: &db tpch
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query15
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -52,7 +52,8 @@ TPCHDenormalizedQuery15:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
-  - OperationName: RunCommand
+  - OperationMetricsName: Query15
+    OperationName: RunCommand
     OperationCommand: *TPCHDenormalizedQuery15Aggregation
 
 TPCHDenormalizedQuery15Explain:

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -36,27 +36,32 @@ TPCHDenormalizedQuery15CreateView: &TPCHDenormalizedQuery15CreateView
           {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
         ]
 
-TPCHDenormalizedQuery15Aggregation: &TPCHDenormalizedQuery15Aggregation
-  aggregate: *query15View
-  pipeline:
-    [
-      {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
-      {$sort: {_id: -1}},
-      {$limit: 1},
-      {$unwind: "$supplier_no"},
-      {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
-      {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
-      {$unwind: "$supplier"},
-      {$project: {
-        s_suppkey: "$supplier.s_suppkey",
-        s_name: "$supplier.s_name",
-        s_address: "$supplier.s_address",
-        s_phone: "$supplier.s_phone",
-        total_revenue: 1
-      }},
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
+TPCHDenormalizedQuery15Warmup:
+  Repeat: *Repeat
+  Database: *db
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery15Aggregation
+      aggregate: *query15View
+      pipeline:
+        [
+          {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
+          {$sort: {_id: -1}},
+          {$limit: 1},
+          {$unwind: "$supplier_no"},
+          {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
+          {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
+          {$unwind: "$supplier"},
+          {$project: {
+            s_suppkey: "$supplier.s_suppkey",
+            s_name: "$supplier.s_name",
+            s_address: "$supplier.s_address",
+            s_phone: "$supplier.s_phone",
+            total_revenue: 1
+          }},
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
 
 TPCHDenormalizedQuery15DropView: &TPCHDenormalizedQuery15DropView
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -4,57 +4,64 @@ Description: |
   Run TPC-H query 15 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query15Date: &query15Date {^Parameter: {Name: "Query15Date", Default: "1996-01-01"}}
 
+TPCHDenormalizedQuery15CreateView: &TPCHDenormalizedQuery15CreateView
+  create: &view revenue
+  viewOn: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$replaceWith: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
+        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}]}}]}},
+      {$group: {_id: "$l_suppkey", total_revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+      {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}}
+    ]
+
+TPCHDenormalizedQuery15Aggregation: &TPCHDenormalizedQuery15Aggregation
+  aggregate: *view
+  pipeline:
+    [
+      {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
+      {$sort: {_id: -1}},
+      {$limit: 1},
+      {$unwind: "$supplier_no"},
+      {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
+      {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$project: {
+        s_suppkey: "$supplier.s_suppkey",
+        s_name: "$supplier.s_name",
+        s_address: "$supplier.s_address",
+        s_phone: "$supplier.s_phone",
+        total_revenue: 1
+      }},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
+TPCHDenormalizedQuery15DropView: &TPCHDenormalizedQuery15DropView
+  drop: *view
+
 TPCHDenormalizedQuery15:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
   Operations:
-  - OperationMetricsName: Query15CreateView
-    OperationName: RunCommand
-    OperationCommand:
-      create: revenue
-      viewOn: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-          {$unwind: "$lineitem"},
-          {$replaceWith: "$lineitem"},
-          {$match: {$and: [
-            {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
-            {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}]}}]}},
-          {$group: {_id: "$l_suppkey", total_revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-          {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}}
-        ]
+  - OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery15Aggregation
+
+TPCHDenormalizedQuery15Explain:
+  Repeat: *Repeat
+  Database: *db
+  Operations:
   - OperationMetricsName: Query15
     OperationName: RunCommand
-    OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: revenue
-        pipeline:
-          [
-            {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
-            {$sort: {_id: -1}},
-            {$limit: 1},
-            {$unwind: "$supplier_no"},
-            {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
-            {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
-            {$unwind: "$supplier"},
-            {$project: {
-              s_suppkey: "$supplier.s_suppkey",
-              s_name: "$supplier.s_name",
-              s_address: "$supplier.s_address",
-              s_phone: "$supplier.s_phone",
-              total_revenue: 1
-            }},
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery15Aggregation
       verbosity:
         executionStats
-  - OperationName: RunCommand
-    OperationCommand:
-      drop: revenue

--- a/src/phases/tpch/denormalized/Q16.yml
+++ b/src/phases/tpch/denormalized/Q16.yml
@@ -10,25 +10,30 @@ query16Brand: &query16Brand {^Parameter: {Name: "Query16Brand", Default: "Brand#
 query16Type: &query16Type {^Parameter: {Name: "Query16Type", Default: "^MEDIUM POLISHED.*"}}  # ^${type}.*$"
 query16Sizes: &query16Sizes {^Parameter: {Name: "Query16Sizes", Default: [49, 14, 23, 45, 19, 3, 36, 9]}}
 
-TPCHDenormalizedQuery16Aggregation: &TPCHDenormalizedQuery16Aggregation
-  aggregate: part
-  pipeline:
-    [
-      {$match: {$and: [{p_brand: {$ne: *query16Brand}}, {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}}, {p_size: {$in: *query16Sizes}}]}},
-      {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
-      {$unwind: "$partsupp"},
-      {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}], as: "supplier"}},
-      {$match: {supplier: {$eq: []}}},
-      {$group: {_id: {p_brand: "$p_brand", p_type: "$p_type", p_size: "$p_size"}, ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
-      {$project: {_id: 0, p_brand: "$_id.p_brand", p_type: "$_id.p_type", p_size: "$_id.p_size", supplier_cnt: {$size: "$ps_suppkey"}}},
-      {$sort: {supplier_cnt: -1, p_brand: 1, p_type: 1, p_size: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery16:
+TPCHDenormalizedQuery16Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery16Aggregation
+      aggregate: part
+      pipeline:
+        [
+          {$match: {$and: [{p_brand: {$ne: *query16Brand}}, {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}}, {p_size: {$in: *query16Sizes}}]}},
+          {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
+          {$unwind: "$partsupp"},
+          {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}], as: "supplier"}},
+          {$match: {supplier: {$eq: []}}},
+          {$group: {_id: {p_brand: "$p_brand", p_type: "$p_type", p_size: "$p_size"}, ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
+          {$project: {_id: 0, p_brand: "$_id.p_brand", p_type: "$_id.p_type", p_size: "$_id.p_size", supplier_cnt: {$size: "$ps_suppkey"}}},
+          {$sort: {supplier_cnt: -1, p_brand: 1, p_type: 1, p_size: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery16:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query16
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q16.yml
+++ b/src/phases/tpch/denormalized/Q16.yml
@@ -4,34 +4,44 @@ Description: |
   Run TPC-H query 16 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query16Brand: &query16Brand {^Parameter: {Name: "Query16Brand", Default: "Brand#45"}}
 query16Type: &query16Type {^Parameter: {Name: "Query16Type", Default: "^MEDIUM POLISHED.*"}}  # ^${type}.*$"
 query16Sizes: &query16Sizes {^Parameter: {Name: "Query16Sizes", Default: [49, 14, 23, 45, 19, 3, 36, 9]}}
 
+TPCHDenormalizedQuery16Aggregation: &TPCHDenormalizedQuery16Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [{p_brand: {$ne: *query16Brand}}, {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}}, {p_size: {$in: *query16Sizes}}]}},
+      {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}], as: "supplier"}},
+      {$match: {supplier: {$eq: []}}},
+      {$group: {_id: {p_brand: "$p_brand", p_type: "$p_type", p_size: "$p_size"}, ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
+      {$project: {_id: 0, p_brand: "$_id.p_brand", p_type: "$_id.p_type", p_size: "$_id.p_size", supplier_cnt: {$size: "$ps_suppkey"}}},
+      {$sort: {supplier_cnt: -1, p_brand: 1, p_type: 1, p_size: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery16:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query16
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery16Aggregation
+
+TPCHDenormalizedQuery16Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query16
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: part
-        pipeline:
-          [
-            {$match: {$and: [{p_brand: {$ne: *query16Brand}}, {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}}, {p_size: {$in: *query16Sizes}}]}},
-            {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
-            {$unwind: "$partsupp"},
-            {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}], as: "supplier"}},
-            {$match: {supplier: {$eq: []}}},
-            {$group: {_id: {p_brand: "$p_brand", p_type: "$p_type", p_size: "$p_size"}, ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
-            {$project: {_id: 0, p_brand: "$_id.p_brand", p_type: "$_id.p_type", p_size: "$_id.p_size", supplier_cnt: {$size: "$ps_suppkey"}}},
-            {$sort: {supplier_cnt: -1, p_brand: 1, p_type: 1, p_size: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery16Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q17.yml
+++ b/src/phases/tpch/denormalized/Q17.yml
@@ -4,38 +4,48 @@ Description: |
   Run TPC-H query 17 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
 query17Container: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
 
+TPCHDenormalizedQuery17Aggregation: &TPCHDenormalizedQuery17Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
+      {$lookup: {from: "customer", localField: "p_partkey", foreignField: "orders.lineitem.l_partkey", as: "lineitem", let: {p_partkey: "$p_partkey"}, pipeline: [
+        {$unwind: "$orders"},
+        {$unwind: "$orders.lineitem"},
+        {$replaceWith: "$orders.lineitem"},
+        {$match: {$expr: {$eq: ["$l_partkey", "$$p_partkey"]}}},
+        {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
+        {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
+        {$unwind: "$lineitem"},
+        {$replaceWith: "$lineitem"}]}},
+      {$unwind: "$lineitem"},
+      {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
+      {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery17:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query17
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery17Aggregation
+
+TPCHDenormalizedQuery17Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query17
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: part
-        pipeline:
-          [
-            {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
-            {$lookup: {from: "customer", localField: "p_partkey", foreignField: "orders.lineitem.l_partkey", as: "lineitem", let: {p_partkey: "$p_partkey"}, pipeline: [
-              {$unwind: "$orders"},
-              {$unwind: "$orders.lineitem"},
-              {$replaceWith: "$orders.lineitem"},
-              {$match: {$expr: {$eq: ["$l_partkey", "$$p_partkey"]}}},
-              {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
-              {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
-              {$unwind: "$lineitem"},
-              {$replaceWith: "$lineitem"}]}},
-            {$unwind: "$lineitem"},
-            {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
-            {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery17Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q17.yml
+++ b/src/phases/tpch/denormalized/Q17.yml
@@ -9,30 +9,35 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
 query17Container: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
 
-TPCHDenormalizedQuery17Aggregation: &TPCHDenormalizedQuery17Aggregation
-  aggregate: part
-  pipeline:
-    [
-      {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
-      {$lookup: {from: "customer", localField: "p_partkey", foreignField: "orders.lineitem.l_partkey", as: "lineitem", let: {p_partkey: "$p_partkey"}, pipeline: [
-        {$unwind: "$orders"},
-        {$unwind: "$orders.lineitem"},
-        {$replaceWith: "$orders.lineitem"},
-        {$match: {$expr: {$eq: ["$l_partkey", "$$p_partkey"]}}},
-        {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
-        {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
-        {$unwind: "$lineitem"},
-        {$replaceWith: "$lineitem"}]}},
-      {$unwind: "$lineitem"},
-      {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
-      {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery17:
+TPCHDenormalizedQuery17Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery17Aggregation
+      aggregate: part
+      pipeline:
+        [
+          {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
+          {$lookup: {from: "customer", localField: "p_partkey", foreignField: "orders.lineitem.l_partkey", as: "lineitem", let: {p_partkey: "$p_partkey"}, pipeline: [
+            {$unwind: "$orders"},
+            {$unwind: "$orders.lineitem"},
+            {$replaceWith: "$orders.lineitem"},
+            {$match: {$expr: {$eq: ["$l_partkey", "$$p_partkey"]}}},
+            {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
+            {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
+            {$unwind: "$lineitem"},
+            {$replaceWith: "$lineitem"}]}},
+          {$unwind: "$lineitem"},
+          {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
+          {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery17:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query17
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q18.yml
+++ b/src/phases/tpch/denormalized/Q18.yml
@@ -4,31 +4,41 @@ Description: |
   Run TPC-H query 18 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query18Quantity: &query18Quantity {^Parameter: {Name: "Query18Quantity", Default: 300}}
 
+TPCHDenormalizedQuery18Aggregation: &TPCHDenormalizedQuery18Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {"sum(l_quantity)": {$reduce: {input: "$orders.lineitem", initialValue: 0, in: {$add: ["$$value", "$$this.l_quantity"]}}}}},
+      {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
+      {$group: {_id: {c_name: "$c_name", c_custkey: "$c_custkey", o_orderkey: "$orders.o_orderkey", o_orderdate: "$orders.o_orderdate", o_totalprice: "$orders.o_totalprice"}, "sum(l_quantity)": {$push: "$sum(l_quantity)"}}},
+      {$unwind: "$sum(l_quantity)"},
+      {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
+      {$sort: {o_totalprice: -1, o_orderdate: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery18:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query18
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery18Aggregation
+
+TPCHDenormalizedQuery18Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query18
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$addFields: {"sum(l_quantity)": {$reduce: {input: "$orders.lineitem", initialValue: 0, in: {$add: ["$$value", "$$this.l_quantity"]}}}}},
-            {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
-            {$group: {_id: {c_name: "$c_name", c_custkey: "$c_custkey", o_orderkey: "$orders.o_orderkey", o_orderdate: "$orders.o_orderdate", o_totalprice: "$orders.o_totalprice"}, "sum(l_quantity)": {$push: "$sum(l_quantity)"}}},
-            {$unwind: "$sum(l_quantity)"},
-            {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
-            {$sort: {o_totalprice: -1, o_orderdate: 1}},
-            {$limit: 100}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery18Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q18.yml
+++ b/src/phases/tpch/denormalized/Q18.yml
@@ -7,25 +7,30 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query18Quantity: &query18Quantity {^Parameter: {Name: "Query18Quantity", Default: 300}}
 
-TPCHDenormalizedQuery18Aggregation: &TPCHDenormalizedQuery18Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$addFields: {"sum(l_quantity)": {$reduce: {input: "$orders.lineitem", initialValue: 0, in: {$add: ["$$value", "$$this.l_quantity"]}}}}},
-      {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
-      {$group: {_id: {c_name: "$c_name", c_custkey: "$c_custkey", o_orderkey: "$orders.o_orderkey", o_orderdate: "$orders.o_orderdate", o_totalprice: "$orders.o_totalprice"}, "sum(l_quantity)": {$push: "$sum(l_quantity)"}}},
-      {$unwind: "$sum(l_quantity)"},
-      {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
-      {$sort: {o_totalprice: -1, o_orderdate: 1}},
-      {$limit: 100}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery18:
+TPCHDenormalizedQuery18Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery18Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {"sum(l_quantity)": {$reduce: {input: "$orders.lineitem", initialValue: 0, in: {$add: ["$$value", "$$this.l_quantity"]}}}}},
+          {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
+          {$group: {_id: {c_name: "$c_name", c_custkey: "$c_custkey", o_orderkey: "$orders.o_orderkey", o_orderdate: "$orders.o_orderdate", o_totalprice: "$orders.o_totalprice"}, "sum(l_quantity)": {$push: "$sum(l_quantity)"}}},
+          {$unwind: "$sum(l_quantity)"},
+          {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
+          {$sort: {o_totalprice: -1, o_orderdate: 1}},
+          {$limit: 100}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery18:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query18
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q19.yml
+++ b/src/phases/tpch/denormalized/Q19.yml
@@ -13,53 +13,58 @@ query19Quantity2: &query19Quantity2 {^Parameter: {Name: "Query19Quantity2", Defa
 query19Brand3: &query19Brand3 {^Parameter: {Name: "Query19Brand3", Default: "Brand#34"}}
 query19Quantity3: &query19Quantity3 {^Parameter: {Name: "Query19Quantity3", Default: 20}}
 
-TPCHDenormalizedQuery19Aggregation: &TPCHDenormalizedQuery19Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-      {$unwind: "$lineitem"},
-      {$replaceWith: "$lineitem"},
-      {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-        {$match: {$or: [
-          {$and: [
-            {p_brand: *query19Brand1},
-            {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
-            {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
-            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
-            {p_size: {$gte: 1}},
-            {p_size: {$lte: 5}},
-            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-          {$and: [
-            {p_brand: *query19Brand2},
-            {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
-            {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
-            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
-            {p_size: {$gte: 1}},
-            {p_size: {$lte: 10}},
-            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-          {$and: [
-            {p_brand: *query19Brand3},
-            {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
-            {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
-            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
-            {p_size: {$gte: 1}},
-            {p_size: {$lte: 15}},
-            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
-      {$unwind: "$part"},
-      {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-      {$project: {_id: 0, revenue: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery19:
+TPCHDenormalizedQuery19Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery19Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+          {$unwind: "$lineitem"},
+          {$replaceWith: "$lineitem"},
+          {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+            {$match: {$or: [
+              {$and: [
+                {p_brand: *query19Brand1},
+                {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
+                {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
+                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
+                {p_size: {$gte: 1}},
+                {p_size: {$lte: 5}},
+                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+              {$and: [
+                {p_brand: *query19Brand2},
+                {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
+                {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
+                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
+                {p_size: {$gte: 1}},
+                {p_size: {$lte: 10}},
+                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+              {$and: [
+                {p_brand: *query19Brand3},
+                {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
+                {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
+                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
+                {p_size: {$gte: 1}},
+                {p_size: {$lte: 15}},
+                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
+          {$unwind: "$part"},
+          {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+          {$project: {_id: 0, revenue: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery19:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query19
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q19.yml
+++ b/src/phases/tpch/denormalized/Q19.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 19 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query19Brand1: &query19Brand1 {^Parameter: {Name: "Query19Brand1", Default: "Brand#12"}}
 query19Quantity1: &query19Quantity1 {^Parameter: {Name: "Query19Quantity1", Default: 1}}
@@ -13,56 +13,66 @@ query19Quantity2: &query19Quantity2 {^Parameter: {Name: "Query19Quantity2", Defa
 query19Brand3: &query19Brand3 {^Parameter: {Name: "Query19Brand3", Default: "Brand#34"}}
 query19Quantity3: &query19Quantity3 {^Parameter: {Name: "Query19Quantity3", Default: 20}}
 
+TPCHDenormalizedQuery19Aggregation: &TPCHDenormalizedQuery19Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$replaceWith: "$lineitem"},
+      {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+        {$match: {$or: [
+          {$and: [
+            {p_brand: *query19Brand1},
+            {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
+            {p_size: {$gte: 1}},
+            {p_size: {$lte: 5}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+          {$and: [
+            {p_brand: *query19Brand2},
+            {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
+            {p_size: {$gte: 1}},
+            {p_size: {$lte: 10}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+          {$and: [
+            {p_brand: *query19Brand3},
+            {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
+            {p_size: {$gte: 1}},
+            {p_size: {$lte: 15}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
+      {$unwind: "$part"},
+      {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+      {$project: {_id: 0, revenue: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery19:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query19
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery19Aggregation
+
+TPCHDenormalizedQuery19Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query19
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-            {$unwind: "$lineitem"},
-            {$replaceWith: "$lineitem"},
-            {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-              {$match: {$or: [
-                {$and: [
-                  {p_brand: *query19Brand1},
-                  {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
-                  {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
-                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
-                  {p_size: {$gte: 1}},
-                  {p_size: {$lte: 5}},
-                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-                {$and: [
-                  {p_brand: *query19Brand2},
-                  {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
-                  {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
-                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
-                  {p_size: {$gte: 1}},
-                  {p_size: {$lte: 10}},
-                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-                {$and: [
-                  {p_brand: *query19Brand3},
-                  {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
-                  {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
-                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
-                  {p_size: {$gte: 1}},
-                  {p_size: {$lte: 15}},
-                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
-            {$unwind: "$part"},
-            {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-            {$project: {_id: 0, revenue: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery19Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q2.yml
+++ b/src/phases/tpch/denormalized/Q2.yml
@@ -10,28 +10,33 @@ query2Size: &query2Size {^Parameter: {Name: "Query2Size", Default: 15}}
 query2Type: &query2Type {^Parameter: {Name: "Query2Type", Default: "^.*BRASS$"}}  # ^.*{type}$"
 query2Region: &query2Region {^Parameter: {Name: "Query2Region", Default: "EUROPE"}}
 
-TPCHDenormalizedQuery2Aggregation: &TPCHDenormalizedQuery2Aggregation
-  aggregate: part
-  pipeline:
-    [
-      {$match: {$and: [{p_type: {$regex: *query2Type, $options: "si"}}, {p_size: {$eq: *query2Size}}]}},
-      {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
-      {$unwind: "$partsupp"},
-      {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-        {$match: {"nation.region.r_name": {$eq: *query2Region}}}]}},
-      {$unwind: "$supplier"},
-      {$sort: {"partsupp.ps_supplycost": 1}},
-      {$group: {_id: {p_partkey: "$p_partkey", p_mfgr: "$p_mfgr"}, supplier: {$first: {s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment", ps_supplycost: "$partsupp.ps_supplycost", n_name: "$supplier.nation.n_name"}}}},
-      {$project: {_id: 0, s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", n_name: "$supplier.n_name", p_partkey: "$_id.p_partkey", p_mfgr: "$_id.p_mfgr", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment"}},
-      {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
-      {$limit: 100}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery2:
+TPCHDenormalizedQuery2Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery2Aggregation
+      aggregate: part
+      pipeline:
+        [
+          {$match: {$and: [{p_type: {$regex: *query2Type, $options: "si"}}, {p_size: {$eq: *query2Size}}]}},
+          {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
+          {$unwind: "$partsupp"},
+          {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+            {$match: {"nation.region.r_name": {$eq: *query2Region}}}]}},
+          {$unwind: "$supplier"},
+          {$sort: {"partsupp.ps_supplycost": 1}},
+          {$group: {_id: {p_partkey: "$p_partkey", p_mfgr: "$p_mfgr"}, supplier: {$first: {s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment", ps_supplycost: "$partsupp.ps_supplycost", n_name: "$supplier.nation.n_name"}}}},
+          {$project: {_id: 0, s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", n_name: "$supplier.n_name", p_partkey: "$_id.p_partkey", p_mfgr: "$_id.p_mfgr", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment"}},
+          {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
+          {$limit: 100}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery2:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query2
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q2.yml
+++ b/src/phases/tpch/denormalized/Q2.yml
@@ -4,37 +4,47 @@ Description: |
   Run TPC-H query 2 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query2Size: &query2Size {^Parameter: {Name: "Query2Size", Default: 15}}
 query2Type: &query2Type {^Parameter: {Name: "Query2Type", Default: "^.*BRASS$"}}  # ^.*{type}$"
 query2Region: &query2Region {^Parameter: {Name: "Query2Region", Default: "EUROPE"}}
 
+TPCHDenormalizedQuery2Aggregation: &TPCHDenormalizedQuery2Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [{p_type: {$regex: *query2Type, $options: "si"}}, {p_size: {$eq: *query2Size}}]}},
+      {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+        {$match: {"nation.region.r_name": {$eq: *query2Region}}}]}},
+      {$unwind: "$supplier"},
+      {$sort: {"partsupp.ps_supplycost": 1}},
+      {$group: {_id: {p_partkey: "$p_partkey", p_mfgr: "$p_mfgr"}, supplier: {$first: {s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment", ps_supplycost: "$partsupp.ps_supplycost", n_name: "$supplier.nation.n_name"}}}},
+      {$project: {_id: 0, s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", n_name: "$supplier.n_name", p_partkey: "$_id.p_partkey", p_mfgr: "$_id.p_mfgr", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment"}},
+      {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery2:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query2
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery2Aggregation
+
+TPCHDenormalizedQuery2Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query2
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: part
-        pipeline:
-          [
-            {$match: {$and: [{p_type: {$regex: *query2Type, $options: "si"}}, {p_size: {$eq: *query2Size}}]}},
-            {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
-            {$unwind: "$partsupp"},
-            {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-              {$match: {"nation.region.r_name": {$eq: *query2Region}}}]}},
-            {$unwind: "$supplier"},
-            {$sort: {"partsupp.ps_supplycost": 1}},
-            {$group: {_id: {p_partkey: "$p_partkey", p_mfgr: "$p_mfgr"}, supplier: {$first: {s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment", ps_supplycost: "$partsupp.ps_supplycost", n_name: "$supplier.nation.n_name"}}}},
-            {$project: {_id: 0, s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", n_name: "$supplier.n_name", p_partkey: "$_id.p_partkey", p_mfgr: "$_id.p_mfgr", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment"}},
-            {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
-            {$limit: 100}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery2Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q20.yml
+++ b/src/phases/tpch/denormalized/Q20.yml
@@ -10,34 +10,39 @@ query20Nation: &query20Nation {^Parameter: {Name: "Query20Nation", Default: "CAN
 query20Color: &query20Color {^Parameter: {Name: "Query20Color", Default: "^forest.*$"}}  # "^${color}.*$"
 query20Date: &query20Date {^Parameter: {Name: "Query20Date", Default: "1994-01-01"}}
 
-TPCHDenormalizedQuery20Aggregation: &TPCHDenormalizedQuery20Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE", quantity: {$sum: "$orders.lineitem.l_quantity"}}},
-      {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
-      {$unwind: "$lineitem"},
-      {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
-        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
-      {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
-        {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},
-      {$unwind: "$partsupp"},
-      {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query20Nation}}]}},
-      {$unwind: "$supplier"},
-      {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [{$match: {p_name: {$regex: *query20Color, "$options": "si"}}}]}},
-      {$unwind: "$part"},
-      {$group: {_id: {s_name: "$supplier.s_name", s_address: "$supplier.s_address"}}},
-      {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
-      {$sort: {s_name: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery20:
+TPCHDenormalizedQuery20Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery20Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE", quantity: {$sum: "$orders.lineitem.l_quantity"}}},
+          {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
+          {$unwind: "$lineitem"},
+          {$match: {$and: [
+            {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
+            {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
+          {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
+            {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},
+          {$unwind: "$partsupp"},
+          {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query20Nation}}]}},
+          {$unwind: "$supplier"},
+          {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [{$match: {p_name: {$regex: *query20Color, "$options": "si"}}}]}},
+          {$unwind: "$part"},
+          {$group: {_id: {s_name: "$supplier.s_name", s_address: "$supplier.s_address"}}},
+          {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
+          {$sort: {s_name: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery20:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query20
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q20.yml
+++ b/src/phases/tpch/denormalized/Q20.yml
@@ -4,43 +4,53 @@ Description: |
   Run TPC-H query 20 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query20Nation: &query20Nation {^Parameter: {Name: "Query20Nation", Default: "CANADA"}}
 query20Color: &query20Color {^Parameter: {Name: "Query20Color", Default: "^forest.*$"}}  # "^${color}.*$"
 query20Date: &query20Date {^Parameter: {Name: "Query20Date", Default: "1994-01-01"}}
 
+TPCHDenormalizedQuery20Aggregation: &TPCHDenormalizedQuery20Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE", quantity: {$sum: "$orders.lineitem.l_quantity"}}},
+      {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
+      {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
+        {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query20Nation}}]}},
+      {$unwind: "$supplier"},
+      {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [{$match: {p_name: {$regex: *query20Color, "$options": "si"}}}]}},
+      {$unwind: "$part"},
+      {$group: {_id: {s_name: "$supplier.s_name", s_address: "$supplier.s_address"}}},
+      {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
+      {$sort: {s_name: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery20:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query20
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery20Aggregation
+
+TPCHDenormalizedQuery20Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query20
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE", quantity: {$sum: "$orders.lineitem.l_quantity"}}},
-            {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
-            {$unwind: "$lineitem"},
-            {$match: {$and: [
-              {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
-              {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
-            {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
-              {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},
-            {$unwind: "$partsupp"},
-            {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query20Nation}}]}},
-            {$unwind: "$supplier"},
-            {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [{$match: {p_name: {$regex: *query20Color, "$options": "si"}}}]}},
-            {$unwind: "$part"},
-            {$group: {_id: {s_name: "$supplier.s_name", s_address: "$supplier.s_address"}}},
-            {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
-            {$sort: {s_name: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery20Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q21.yml
+++ b/src/phases/tpch/denormalized/Q21.yml
@@ -4,38 +4,48 @@ Description: |
   Run TPC-H query 21 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query21Nation: &query21Nation {^Parameter: {Name: "Query21Nation", Default: "SAUDI ARABIA"}}
 
+TPCHDenormalizedQuery21Aggregation: &TPCHDenormalizedQuery21Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {"orders.o_orderstatus": "F"},
+        {$expr: {$gt: [{$size: {$reduce: {input: "$orders.lineitem", initialValue: [], in: {$setUnion: [["$$this.l_suppkey"], "$$value"]}}}}, 1]}}]}},
+      {$addFields: {"orders.lineitem": {$filter: {input: "$orders.lineitem", cond: {$gt: ["$$this.l_receiptdate", "$$this.l_commitdate"]}}}}},
+      {$match: {$expr: {$eq: [{$size: "$orders.lineitem"}, 1]}}},
+      {$unwind: "$orders.lineitem"},
+      {$match: {$expr: {$gt: ["$orders.lineitem.l_receiptdate", "$lineitem.l_commitdate"]}}},
+      {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+        {$match: {"nation.n_name": *query21Nation}}]}},
+      {$unwind: "$supplier"},
+      {$group: {_id: "$supplier.s_name", numwait: {$count: {}}}},
+      {$project: {_id: 0, s_name: "$_id", numwait: 1}},
+      {$sort: {numwait: -1, s_name: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery21:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query21
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery21Aggregation
+
+TPCHDenormalizedQuery21Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query21
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$match: {$and: [
-              {"orders.o_orderstatus": "F"},
-              {$expr: {$gt: [{$size: {$reduce: {input: "$orders.lineitem", initialValue: [], in: {$setUnion: [["$$this.l_suppkey"], "$$value"]}}}}, 1]}}]}},
-            {$addFields: {"orders.lineitem": {$filter: {input: "$orders.lineitem", cond: {$gt: ["$$this.l_receiptdate", "$$this.l_commitdate"]}}}}},
-            {$match: {$expr: {$eq: [{$size: "$orders.lineitem"}, 1]}}},
-            {$unwind: "$orders.lineitem"},
-            {$match: {$expr: {$gt: ["$orders.lineitem.l_receiptdate", "$lineitem.l_commitdate"]}}},
-            {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-              {$match: {"nation.n_name": *query21Nation}}]}},
-            {$unwind: "$supplier"},
-            {$group: {_id: "$supplier.s_name", numwait: {$count: {}}}},
-            {$project: {_id: 0, s_name: "$_id", numwait: 1}},
-            {$sort: {numwait: -1, s_name: 1}},
-            {$limit: 100}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery21Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q21.yml
+++ b/src/phases/tpch/denormalized/Q21.yml
@@ -7,32 +7,37 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query21Nation: &query21Nation {^Parameter: {Name: "Query21Nation", Default: "SAUDI ARABIA"}}
 
-TPCHDenormalizedQuery21Aggregation: &TPCHDenormalizedQuery21Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$match: {$and: [
-        {"orders.o_orderstatus": "F"},
-        {$expr: {$gt: [{$size: {$reduce: {input: "$orders.lineitem", initialValue: [], in: {$setUnion: [["$$this.l_suppkey"], "$$value"]}}}}, 1]}}]}},
-      {$addFields: {"orders.lineitem": {$filter: {input: "$orders.lineitem", cond: {$gt: ["$$this.l_receiptdate", "$$this.l_commitdate"]}}}}},
-      {$match: {$expr: {$eq: [{$size: "$orders.lineitem"}, 1]}}},
-      {$unwind: "$orders.lineitem"},
-      {$match: {$expr: {$gt: ["$orders.lineitem.l_receiptdate", "$lineitem.l_commitdate"]}}},
-      {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-        {$match: {"nation.n_name": *query21Nation}}]}},
-      {$unwind: "$supplier"},
-      {$group: {_id: "$supplier.s_name", numwait: {$count: {}}}},
-      {$project: {_id: 0, s_name: "$_id", numwait: 1}},
-      {$sort: {numwait: -1, s_name: 1}},
-      {$limit: 100}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery21:
+TPCHDenormalizedQuery21Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery21Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$match: {$and: [
+            {"orders.o_orderstatus": "F"},
+            {$expr: {$gt: [{$size: {$reduce: {input: "$orders.lineitem", initialValue: [], in: {$setUnion: [["$$this.l_suppkey"], "$$value"]}}}}, 1]}}]}},
+          {$addFields: {"orders.lineitem": {$filter: {input: "$orders.lineitem", cond: {$gt: ["$$this.l_receiptdate", "$$this.l_commitdate"]}}}}},
+          {$match: {$expr: {$eq: [{$size: "$orders.lineitem"}, 1]}}},
+          {$unwind: "$orders.lineitem"},
+          {$match: {$expr: {$gt: ["$orders.lineitem.l_receiptdate", "$lineitem.l_commitdate"]}}},
+          {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+            {$match: {"nation.n_name": *query21Nation}}]}},
+          {$unwind: "$supplier"},
+          {$group: {_id: "$supplier.s_name", numwait: {$count: {}}}},
+          {$project: {_id: 0, s_name: "$_id", numwait: 1}},
+          {$sort: {numwait: -1, s_name: 1}},
+          {$limit: 100}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery21:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query21
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q22.yml
+++ b/src/phases/tpch/denormalized/Q22.yml
@@ -16,30 +16,35 @@ query22CountryCodes: &query22CountryCodes {^Parameter: {Name: "Query22CountryCod
   {$toString: "17"}
 ]}}
 
-TPCHDenormalizedQuery22Aggregation: &TPCHDenormalizedQuery22Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$addFields: {custsale: "$orders", orders: "$$REMOVE"}},
-      {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
-      {$addFields: {cntrycode: {$substr: ["$c_phone", 0, 2]}}},
-      {$match: {$and: [{$expr: {$in: ["$cntrycode", *query22CountryCodes]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.0]}}]}},
-      {$facet: {
-        customer: [{$project: {cntrycode: 1, c_acctbal: 1}}],
-        "avg(c_acctbal)": [{$group: {_id: {}, value: {$avg: "$c_acctbal"}}}, {$project: {_id: 0}}]}},
-      {$unwind: "$avg(c_acctbal)"},
-      {$unwind: "$customer"},
-      {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
-      {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
-      {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
-      {$sort: {cntrycode: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery22:
+TPCHDenormalizedQuery22Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery22Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$addFields: {custsale: "$orders", orders: "$$REMOVE"}},
+          {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
+          {$addFields: {cntrycode: {$substr: ["$c_phone", 0, 2]}}},
+          {$match: {$and: [{$expr: {$in: ["$cntrycode", *query22CountryCodes]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.0]}}]}},
+          {$facet: {
+            customer: [{$project: {cntrycode: 1, c_acctbal: 1}}],
+            "avg(c_acctbal)": [{$group: {_id: {}, value: {$avg: "$c_acctbal"}}}, {$project: {_id: 0}}]}},
+          {$unwind: "$avg(c_acctbal)"},
+          {$unwind: "$customer"},
+          {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
+          {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
+          {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
+          {$sort: {cntrycode: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery22:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query22
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q22.yml
+++ b/src/phases/tpch/denormalized/Q22.yml
@@ -4,51 +4,60 @@ Description: |
   Run TPC-H query 22 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
-# Sadly, using an array here parses as an array of numbers instead of as an array of strings.
-# To work around this, use separate parameters for each entry in the array.
-query22CountryCode1: &query22CountryCode1 {^Parameter: {Name: "Query22CountryCode1", Default: "13"}}
-query22CountryCode2: &query22CountryCode2 {^Parameter: {Name: "Query22CountryCode2", Default: "31"}}
-query22CountryCode3: &query22CountryCode3 {^Parameter: {Name: "Query22CountryCode3", Default: "23"}}
-query22CountryCode4: &query22CountryCode4 {^Parameter: {Name: "Query22CountryCode4", Default: "29"}}
-query22CountryCode5: &query22CountryCode5 {^Parameter: {Name: "Query22CountryCode5", Default: "30"}}
-query22CountryCode6: &query22CountryCode6 {^Parameter: {Name: "Query22CountryCode6", Default: "18"}}
-query22CountryCode7: &query22CountryCode7 {^Parameter: {Name: "Query22CountryCode7", Default: "17"}}
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
+# This is a hack, because yml parses these strings into ints before outputting the pipeline.
+query22CountryCode1: &query22CountryCode1 {^Parameter: {Name: "Query22CountryCode1", Default: {$toString: "13"}}}
+query22CountryCode2: &query22CountryCode2 {^Parameter: {Name: "Query22CountryCode2", Default: {$toString: "31"}}}
+query22CountryCode3: &query22CountryCode3 {^Parameter: {Name: "Query22CountryCode3", Default: {$toString: "23"}}}
+query22CountryCode4: &query22CountryCode4 {^Parameter: {Name: "Query22CountryCode4", Default: {$toString: "29"}}}
+query22CountryCode5: &query22CountryCode5 {^Parameter: {Name: "Query22CountryCode5", Default: {$toString: "30"}}}
+query22CountryCode6: &query22CountryCode6 {^Parameter: {Name: "Query22CountryCode6", Default: {$toString: "18"}}}
+query22CountryCode7: &query22CountryCode7 {^Parameter: {Name: "Query22CountryCode7", Default: {$toString: "17"}}}
+
+TPCHDenormalizedQuery22Aggregation: &TPCHDenormalizedQuery22Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$addFields: {custsale: "$orders", orders: "$$REMOVE"}},
+      {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
+      {$addFields: {cntrycode: {$substr: ["$c_phone", 0, 2]}}},
+      {$match: {$and: [{$expr: {$in: ["$cntrycode", [
+        *query22CountryCode1,
+        *query22CountryCode2,
+        *query22CountryCode3,
+        *query22CountryCode4,
+        *query22CountryCode5,
+        *query22CountryCode6,
+        *query22CountryCode7]]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.0]}}]}},
+      {$facet: {
+        customer: [{$project: {cntrycode: 1, c_acctbal: 1}}],
+        "avg(c_acctbal)": [{$group: {_id: {}, value: {$avg: "$c_acctbal"}}}, {$project: {_id: 0}}]}},
+      {$unwind: "$avg(c_acctbal)"},
+      {$unwind: "$customer"},
+      {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
+      {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
+      {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
+      {$sort: {cntrycode: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
 
 TPCHDenormalizedQuery22:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query22
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery22Aggregation
+
+TPCHDenormalizedQuery22Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query22
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$addFields: {custsale: "$orders", orders: "$$REMOVE"}},
-            {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
-            {$addFields: {cntrycode: {$substr: ["$c_phone", 0, 2]}}},
-            {$match: {$and: [{$expr: {$in: ["$cntrycode", [
-              *query22CountryCode1,
-              *query22CountryCode2,
-              *query22CountryCode3,
-              *query22CountryCode4,
-              *query22CountryCode5,
-              *query22CountryCode6,
-              *query22CountryCode7]]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.0]}}]}},
-            {$facet: {
-              customer: [{$project: {cntrycode: 1, c_acctbal: 1}}],
-              "avg(c_acctbal)": [{$group: {_id: {}, value: {$avg: "$c_acctbal"}}}, {$project: {_id: 0}}]}},
-            {$unwind: "$avg(c_acctbal)"},
-            {$unwind: "$customer"},
-            {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
-            {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
-            {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
-            {$sort: {cntrycode: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery22Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q22.yml
+++ b/src/phases/tpch/denormalized/Q22.yml
@@ -5,14 +5,16 @@ Description: |
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
-# This is a hack, because yml parses these strings into ints before outputting the pipeline.
-query22CountryCode1: &query22CountryCode1 {^Parameter: {Name: "Query22CountryCode1", Default: {$toString: "13"}}}
-query22CountryCode2: &query22CountryCode2 {^Parameter: {Name: "Query22CountryCode2", Default: {$toString: "31"}}}
-query22CountryCode3: &query22CountryCode3 {^Parameter: {Name: "Query22CountryCode3", Default: {$toString: "23"}}}
-query22CountryCode4: &query22CountryCode4 {^Parameter: {Name: "Query22CountryCode4", Default: {$toString: "29"}}}
-query22CountryCode5: &query22CountryCode5 {^Parameter: {Name: "Query22CountryCode5", Default: {$toString: "30"}}}
-query22CountryCode6: &query22CountryCode6 {^Parameter: {Name: "Query22CountryCode6", Default: {$toString: "18"}}}
-query22CountryCode7: &query22CountryCode7 {^Parameter: {Name: "Query22CountryCode7", Default: {$toString: "17"}}}
+# Use $toString as a hack, because yml parses these strings into ints before outputting the pipeline.
+query22CountryCodes: &query22CountryCodes {^Parameter: {Name: "Query22CountryCodes", Default: [
+  {$toString: "13"},
+  {$toString: "31"},
+  {$toString: "23"},
+  {$toString: "29"},
+  {$toString: "30"},
+  {$toString: "18"},
+  {$toString: "17"}
+]}}
 
 TPCHDenormalizedQuery22Aggregation: &TPCHDenormalizedQuery22Aggregation
   aggregate: customer
@@ -21,14 +23,7 @@ TPCHDenormalizedQuery22Aggregation: &TPCHDenormalizedQuery22Aggregation
       {$addFields: {custsale: "$orders", orders: "$$REMOVE"}},
       {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
       {$addFields: {cntrycode: {$substr: ["$c_phone", 0, 2]}}},
-      {$match: {$and: [{$expr: {$in: ["$cntrycode", [
-        *query22CountryCode1,
-        *query22CountryCode2,
-        *query22CountryCode3,
-        *query22CountryCode4,
-        *query22CountryCode5,
-        *query22CountryCode6,
-        *query22CountryCode7]]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.0]}}]}},
+      {$match: {$and: [{$expr: {$in: ["$cntrycode", *query22CountryCodes]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.0]}}]}},
       {$facet: {
         customer: [{$project: {cntrycode: 1, c_acctbal: 1}}],
         "avg(c_acctbal)": [{$group: {_id: {}, value: {$avg: "$c_acctbal"}}}, {$project: {_id: 0}}]}},

--- a/src/phases/tpch/denormalized/Q3.yml
+++ b/src/phases/tpch/denormalized/Q3.yml
@@ -9,28 +9,33 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query3Segment: &query3Segment {^Parameter: {Name: "Query3Segment", Default: "BUILDING"}}
 query3Date: &query3Date {^Parameter: {Name: "Query3Date", Default: "1995-03-15"}}
 
-TPCHDenormalizedQuery3Aggregation: &TPCHDenormalizedQuery3Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
-      {$unwind: "$orders"},
-      {$match: {$expr: {$lt: ["$orders.o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
-      {$unwind: "$orders.lineitem"},
-      {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}},
-      {$group: {
-        _id: {l_orderkey: "$orders.lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"},
-        revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
-      {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
-      {$sort: {revenue: -1, o_orderdate: 1}},
-      {$limit: 10}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery3:
+TPCHDenormalizedQuery3Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery3Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
+          {$unwind: "$orders"},
+          {$match: {$expr: {$lt: ["$orders.o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
+          {$unwind: "$orders.lineitem"},
+          {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}},
+          {$group: {
+            _id: {l_orderkey: "$orders.lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"},
+            revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+          {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
+          {$sort: {revenue: -1, o_orderdate: 1}},
+          {$limit: 10}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery3:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query3
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q3.yml
+++ b/src/phases/tpch/denormalized/Q3.yml
@@ -4,36 +4,46 @@ Description: |
   Run TPC-H query 3 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query3Segment: &query3Segment {^Parameter: {Name: "Query3Segment", Default: "BUILDING"}}
 query3Date: &query3Date {^Parameter: {Name: "Query3Date", Default: "1995-03-15"}}
 
+TPCHDenormalizedQuery3Aggregation: &TPCHDenormalizedQuery3Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
+      {$unwind: "$orders"},
+      {$match: {$expr: {$lt: ["$orders.o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
+      {$unwind: "$orders.lineitem"},
+      {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}},
+      {$group: {
+        _id: {l_orderkey: "$orders.lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"},
+        revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
+      {$sort: {revenue: -1, o_orderdate: 1}},
+      {$limit: 10}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery3:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query3
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery3Aggregation
+
+TPCHDenormalizedQuery3Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query3
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
-            {$unwind: "$orders"},
-            {$match: {$expr: {$lt: ["$orders.o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
-            {$unwind: "$orders.lineitem"},
-            {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}},
-            {$group: {
-              _id: {l_orderkey: "$orders.lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"},
-              revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
-            {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
-            {$sort: {revenue: -1, o_orderdate: 1}},
-            {$limit: 10}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery3Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q4.yml
+++ b/src/phases/tpch/denormalized/Q4.yml
@@ -4,31 +4,41 @@ Description: |
   Run TPC-H query 4 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query4Date: &query4Date {^Parameter: {Name: "Query4Date", Default: "1993-07-01"}}
 
+TPCHDenormalizedQuery4Aggregation: &TPCHDenormalizedQuery4Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}},
+        {$expr: {$gt: [{$size: {$filter: {input: "$orders.lineitem", cond: {$lt: ["$$this.l_commitdate", "$$this.l_receiptdate"]}}}}, 0]}}]}},
+      {$group: {_id: "$orders.o_orderpriority", order_count: {$count: {}}}},
+      {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
+      {$sort: {o_orderpriority: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery4:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query4
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery4Aggregation
+
+TPCHDenormalizedQuery4Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query4
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$match: {$and: [
-              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
-              {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}},
-              {$expr: {$gt: [{$size: {$filter: {input: "$orders.lineitem", cond: {$lt: ["$$this.l_commitdate", "$$this.l_receiptdate"]}}}}, 0]}}]}},
-            {$group: {_id: "$orders.o_orderpriority", order_count: {$count: {}}}},
-            {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
-            {$sort: {o_orderpriority: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery4Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q4.yml
+++ b/src/phases/tpch/denormalized/Q4.yml
@@ -7,25 +7,30 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query4Date: &query4Date {^Parameter: {Name: "Query4Date", Default: "1993-07-01"}}
 
-TPCHDenormalizedQuery4Aggregation: &TPCHDenormalizedQuery4Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$match: {$and: [
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
-        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}},
-        {$expr: {$gt: [{$size: {$filter: {input: "$orders.lineitem", cond: {$lt: ["$$this.l_commitdate", "$$this.l_receiptdate"]}}}}, 0]}}]}},
-      {$group: {_id: "$orders.o_orderpriority", order_count: {$count: {}}}},
-      {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
-      {$sort: {o_orderpriority: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery4:
+TPCHDenormalizedQuery4Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery4Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$match: {$and: [
+            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
+            {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}},
+            {$expr: {$gt: [{$size: {$filter: {input: "$orders.lineitem", cond: {$lt: ["$$this.l_commitdate", "$$this.l_receiptdate"]}}}}, 0]}}]}},
+          {$group: {_id: "$orders.o_orderpriority", order_count: {$count: {}}}},
+          {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
+          {$sort: {o_orderpriority: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery4:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query4
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q5.yml
+++ b/src/phases/tpch/denormalized/Q5.yml
@@ -8,31 +8,36 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query5Region: &query5Region {^Parameter: {Name: "Query5Region", Default: "ASIA"}}
 query5Date: &query5Date {^Parameter: {Name: "Query5Date", Default: "1994-01-01"}}
 
-TPCHDenormalizedQuery5Aggregation: &TPCHDenormalizedQuery5Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$match: {"nation.region.r_name": *query5Region}},
-      {$unwind: "$orders"},
-      {$match: {$and: [
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
-        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
-      {$unwind: "$orders.lineitem"},
-      {$lookup: {from: "supplier", as: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", let: {c_nationkey: "$nation.n_nationkey"}, pipeline: [
-        {$match: {$expr: {$eq: ["$nation.n_nationkey", "$$c_nationkey"]}}}]}},
-      {$unwind: "$supplier"},
-      {$group: {
-        _id: "$supplier.nation.n_name",
-        revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
-      {$project: {_id: 0, n_name: "$_id", revenue: 1}},
-      {$sort: {revenue: -1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery5:
+TPCHDenormalizedQuery5Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery5Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$match: {"nation.region.r_name": *query5Region}},
+          {$unwind: "$orders"},
+          {$match: {$and: [
+            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
+            {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
+          {$unwind: "$orders.lineitem"},
+          {$lookup: {from: "supplier", as: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", let: {c_nationkey: "$nation.n_nationkey"}, pipeline: [
+            {$match: {$expr: {$eq: ["$nation.n_nationkey", "$$c_nationkey"]}}}]}},
+          {$unwind: "$supplier"},
+          {$group: {
+            _id: "$supplier.nation.n_name",
+            revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+          {$project: {_id: 0, n_name: "$_id", revenue: 1}},
+          {$sort: {revenue: -1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery5:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query5
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q5.yml
+++ b/src/phases/tpch/denormalized/Q5.yml
@@ -4,38 +4,48 @@ Description: |
   Run TPC-H query 5 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query5Region: &query5Region {^Parameter: {Name: "Query5Region", Default: "ASIA"}}
 query5Date: &query5Date {^Parameter: {Name: "Query5Date", Default: "1994-01-01"}}
 
+TPCHDenormalizedQuery5Aggregation: &TPCHDenormalizedQuery5Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$match: {"nation.region.r_name": *query5Region}},
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
+      {$unwind: "$orders.lineitem"},
+      {$lookup: {from: "supplier", as: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", let: {c_nationkey: "$nation.n_nationkey"}, pipeline: [
+        {$match: {$expr: {$eq: ["$nation.n_nationkey", "$$c_nationkey"]}}}]}},
+      {$unwind: "$supplier"},
+      {$group: {
+        _id: "$supplier.nation.n_name",
+        revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, n_name: "$_id", revenue: 1}},
+      {$sort: {revenue: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery5:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query5
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery5Aggregation
+
+TPCHDenormalizedQuery5Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query5
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$match: {"nation.region.r_name": *query5Region}},
-            {$unwind: "$orders"},
-            {$match: {$and: [
-              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
-              {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
-            {$unwind: "$orders.lineitem"},
-            {$lookup: {from: "supplier", as: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", let: {c_nationkey: "$nation.n_nationkey"}, pipeline: [
-              {$match: {$expr: {$eq: ["$nation.n_nationkey", "$$c_nationkey"]}}}]}},
-            {$unwind: "$supplier"},
-            {$group: {
-              _id: "$supplier.nation.n_name",
-              revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
-            {$project: {_id: 0, n_name: "$_id", revenue: 1}},
-            {$sort: {revenue: -1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery5Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q6.yml
+++ b/src/phases/tpch/denormalized/Q6.yml
@@ -4,38 +4,48 @@ Description: |
   Run TPC-H query 6 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query6Date: &query6Date {^Parameter: {Name: "Query6Date", Default: "1994-01-01"}}
 query6Discount: &query6Discount {^Parameter: {Name: "Query6Discount", Default: 0.06}}
 query6Quantity: &query6Quantity {^Parameter: {Name: "Query6Quantity", Default: 24}}
 
+TPCHDenormalizedQuery6Aggregation: &TPCHDenormalizedQuery6Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$replaceWith: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
+        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+        {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
+        {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
+        {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
+      {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
+      {$project: {_id: 0, revenue: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery6:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query6
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery6Aggregation
+
+TPCHDenormalizedQuery6Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query6
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-            {$unwind: "$lineitem"},
-            {$replaceWith: "$lineitem"},
-            {$match: {$and: [
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
-              {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
-              {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
-              {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
-              {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
-            {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
-            {$project: {_id: 0, revenue: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery6Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q6.yml
+++ b/src/phases/tpch/denormalized/Q6.yml
@@ -10,29 +10,34 @@ query6Date: &query6Date {^Parameter: {Name: "Query6Date", Default: "1994-01-01"}
 query6Discount: &query6Discount {^Parameter: {Name: "Query6Discount", Default: 0.06}}
 query6Quantity: &query6Quantity {^Parameter: {Name: "Query6Quantity", Default: 24}}
 
-TPCHDenormalizedQuery6Aggregation: &TPCHDenormalizedQuery6Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-      {$unwind: "$lineitem"},
-      {$replaceWith: "$lineitem"},
-      {$match: {$and: [
-        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
-        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
-        {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
-        {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
-        {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
-      {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
-      {$project: {_id: 0, revenue: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery6:
+TPCHDenormalizedQuery6Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery6Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+          {$unwind: "$lineitem"},
+          {$replaceWith: "$lineitem"},
+          {$match: {$and: [
+            {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
+            {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+            {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
+            {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
+            {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
+          {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
+          {$project: {_id: 0, revenue: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery6:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query6
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q7.yml
+++ b/src/phases/tpch/denormalized/Q7.yml
@@ -8,32 +8,37 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query7Nation1: &query7Nation1 {^Parameter: {Name: "Query7Nation1", Default: "FRANCE"}}
 query7Nation2: &query7Nation2 {^Parameter: {Name: "Query7Nation2", Default: "GERMANY"}}
 
-TPCHDenormalizedQuery7Aggregation: &TPCHDenormalizedQuery7Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-      {$unwind: "$lineitem"},
-      {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
-        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}},
-      {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
-      {$unwind: "$supplier"},
-      {$match: {$or: [
-        {$and: [{"supplier.nation.n_name": *query7Nation1}, {"nation.n_name": *query7Nation2}]},
-        {$and: [{"supplier.nation.n_name": *query7Nation2}, {"nation.n_name": *query7Nation1}]}]}},
-      {$project: {supp_nation: "$supplier.nation.n_name", cust_nation: "$nation.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
-      {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
-      {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
-      {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery7:
+TPCHDenormalizedQuery7Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery7Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+          {$unwind: "$lineitem"},
+          {$match: {$and: [
+            {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
+            {$expr: {$lt: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}},
+          {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+          {$unwind: "$supplier"},
+          {$match: {$or: [
+            {$and: [{"supplier.nation.n_name": *query7Nation1}, {"nation.n_name": *query7Nation2}]},
+            {$and: [{"supplier.nation.n_name": *query7Nation2}, {"nation.n_name": *query7Nation1}]}]}},
+          {$project: {supp_nation: "$supplier.nation.n_name", cust_nation: "$nation.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
+          {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
+          {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
+          {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery7:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query7
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q7.yml
+++ b/src/phases/tpch/denormalized/Q7.yml
@@ -4,39 +4,49 @@ Description: |
   Run TPC-H query 7 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query7Nation1: &query7Nation1 {^Parameter: {Name: "Query7Nation1", Default: "FRANCE"}}
 query7Nation2: &query7Nation2 {^Parameter: {Name: "Query7Nation2", Default: "GERMANY"}}
 
+TPCHDenormalizedQuery7Aggregation: &TPCHDenormalizedQuery7Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}},
+      {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$match: {$or: [
+        {$and: [{"supplier.nation.n_name": *query7Nation1}, {"nation.n_name": *query7Nation2}]},
+        {$and: [{"supplier.nation.n_name": *query7Nation2}, {"nation.n_name": *query7Nation1}]}]}},
+      {$project: {supp_nation: "$supplier.nation.n_name", cust_nation: "$nation.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
+      {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
+      {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
+      {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery7:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query7
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery7Aggregation
+
+TPCHDenormalizedQuery7Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query7
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-            {$unwind: "$lineitem"},
-            {$match: {$and: [
-              {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
-              {$expr: {$lt: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}},
-            {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
-            {$unwind: "$supplier"},
-            {$match: {$or: [
-              {$and: [{"supplier.nation.n_name": *query7Nation1}, {"nation.n_name": *query7Nation2}]},
-              {$and: [{"supplier.nation.n_name": *query7Nation2}, {"nation.n_name": *query7Nation1}]}]}},
-            {$project: {supp_nation: "$supplier.nation.n_name", cust_nation: "$nation.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
-            {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
-            {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
-            {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery7Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q8.yml
+++ b/src/phases/tpch/denormalized/Q8.yml
@@ -4,41 +4,51 @@ Description: |
   Run TPC-H query 8 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query8Type: &query8Type {^Parameter: {Name: "Query8Type", Default: "ECONOMY ANODIZED STEEL"}}
 query8Region: &query8Region {^Parameter: {Name: "Query8Region", Default: "AMERICA"}}
 query8Nation: &query8Nation {^Parameter: {Name: "Query8Nation", Default: "BRAZIL"}}
 
+TPCHDenormalizedQuery8Aggregation: &TPCHDenormalizedQuery8Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$match: {"nation.region.r_name": {$eq: *query8Region}}},
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+      {$unwind: "$orders.lineitem"},
+      {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$lookup: {from: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+        {$match: {p_type: {$eq: *query8Type}}}]}},
+      {$unwind: "$part"},
+      {$project: {o_year: {$year: "$orders.o_orderdate"}, volume: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$orders.lineitem.l_discount"]}]}, nation: "$supplier.nation.n_name"}},
+      {$group: { _id: "$o_year", total_volume: {$sum: "$volume"}, nation_volume: {$sum: {$cond: {if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
+      {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
+      {$sort: {o_year: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery8:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query8
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery8Aggregation
+
+TPCHDenormalizedQuery8Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query8
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$match: {"nation.region.r_name": {$eq: *query8Region}}},
-            {$unwind: "$orders"},
-            {$match: {$and: [
-              {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
-              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
-            {$unwind: "$orders.lineitem"},
-            {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
-            {$unwind: "$supplier"},
-            {$lookup: {from: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-              {$match: {p_type: {$eq: *query8Type}}}]}},
-            {$unwind: "$part"},
-            {$project: {o_year: {$year: "$orders.o_orderdate"}, volume: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$orders.lineitem.l_discount"]}]}, nation: "$supplier.nation.n_name"}},
-            {$group: { _id: "$o_year", total_volume: {$sum: "$volume"}, nation_volume: {$sum: {$cond: {if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
-            {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
-            {$sort: {o_year: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery8Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/denormalized/Q8.yml
+++ b/src/phases/tpch/denormalized/Q8.yml
@@ -10,32 +10,37 @@ query8Type: &query8Type {^Parameter: {Name: "Query8Type", Default: "ECONOMY ANOD
 query8Region: &query8Region {^Parameter: {Name: "Query8Region", Default: "AMERICA"}}
 query8Nation: &query8Nation {^Parameter: {Name: "Query8Nation", Default: "BRAZIL"}}
 
-TPCHDenormalizedQuery8Aggregation: &TPCHDenormalizedQuery8Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$match: {"nation.region.r_name": {$eq: *query8Region}}},
-      {$unwind: "$orders"},
-      {$match: {$and: [
-        {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
-      {$unwind: "$orders.lineitem"},
-      {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
-      {$unwind: "$supplier"},
-      {$lookup: {from: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-        {$match: {p_type: {$eq: *query8Type}}}]}},
-      {$unwind: "$part"},
-      {$project: {o_year: {$year: "$orders.o_orderdate"}, volume: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$orders.lineitem.l_discount"]}]}, nation: "$supplier.nation.n_name"}},
-      {$group: { _id: "$o_year", total_volume: {$sum: "$volume"}, nation_volume: {$sum: {$cond: {if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
-      {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
-      {$sort: {o_year: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery8:
+TPCHDenormalizedQuery8Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery8Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$match: {"nation.region.r_name": {$eq: *query8Region}}},
+          {$unwind: "$orders"},
+          {$match: {$and: [
+            {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
+            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+          {$unwind: "$orders.lineitem"},
+          {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+          {$unwind: "$supplier"},
+          {$lookup: {from: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+            {$match: {p_type: {$eq: *query8Type}}}]}},
+          {$unwind: "$part"},
+          {$project: {o_year: {$year: "$orders.o_orderdate"}, volume: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$orders.lineitem.l_discount"]}]}, nation: "$supplier.nation.n_name"}},
+          {$group: { _id: "$o_year", total_volume: {$sum: "$volume"}, nation_volume: {$sum: {$cond: {if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
+          {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
+          {$sort: {o_year: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery8:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query8
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q9.yml
+++ b/src/phases/tpch/denormalized/Q9.yml
@@ -8,39 +8,44 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${color}.*$
 
-TPCHDenormalizedQuery9Aggregation: &TPCHDenormalizedQuery9Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$unwind: "$orders"},
-      {$lookup: {from: "part", as: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", pipeline: [
-        {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}}]}},
-      {$project: {
-        o_year: {$year: "$orders.o_orderdate"},
-        part: {$map: {input: "$part", as: "part", in: {
-          $mergeObjects: ["$$part", {lineitem: {$filter: {input: "$orders.lineitem", as: "lineitem", cond: {$eq: ["$$part.p_partkey", "$$lineitem.l_partkey"]}}}}]}}}}},
-      {$unwind: "$part"},
-      {$unwind: "$part.lineitem"},
-      {$lookup: {from: "supplier", as: "partsupp", localField: "part.lineitem.l_suppkey", foreignField: "s_suppkey", let: {p_partkey: "$part.p_partkey"}, pipeline: [
-        {$lookup: {from: "partsupp", as: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", pipeline: [
-          {$match: {$expr: {$eq: ["$$p_partkey", "$ps_partkey"]}}}]}},
-        {$unwind: "$partsupp"},
-        {$replaceWith: {$mergeObjects: ["$partsupp", {nation: "$nation.n_name"}]}}]}},
-      {$unwind: "$partsupp"},
-      {$group: {
-        _id: {nation: "$partsupp.nation", o_year: "$o_year"},
-        sum_profit: {$sum: {$subtract: [
-          {$multiply: ["$part.lineitem.l_extendedprice", {$subtract: [1, "$part.lineitem.l_discount"]}]},
-          {$multiply: ["$partsupp.ps_supplycost", "$part.lineitem.l_quantity"]}]}}}},
-      {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
-      {$sort: {nation: 1, o_year: -1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHDenormalizedQuery9:
+TPCHDenormalizedQuery9Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHDenormalizedQuery9Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$unwind: "$orders"},
+          {$lookup: {from: "part", as: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", pipeline: [
+            {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}}]}},
+          {$project: {
+            o_year: {$year: "$orders.o_orderdate"},
+            part: {$map: {input: "$part", as: "part", in: {
+              $mergeObjects: ["$$part", {lineitem: {$filter: {input: "$orders.lineitem", as: "lineitem", cond: {$eq: ["$$part.p_partkey", "$$lineitem.l_partkey"]}}}}]}}}}},
+          {$unwind: "$part"},
+          {$unwind: "$part.lineitem"},
+          {$lookup: {from: "supplier", as: "partsupp", localField: "part.lineitem.l_suppkey", foreignField: "s_suppkey", let: {p_partkey: "$part.p_partkey"}, pipeline: [
+            {$lookup: {from: "partsupp", as: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", pipeline: [
+              {$match: {$expr: {$eq: ["$$p_partkey", "$ps_partkey"]}}}]}},
+            {$unwind: "$partsupp"},
+            {$replaceWith: {$mergeObjects: ["$partsupp", {nation: "$nation.n_name"}]}}]}},
+          {$unwind: "$partsupp"},
+          {$group: {
+            _id: {nation: "$partsupp.nation", o_year: "$o_year"},
+            sum_profit: {$sum: {$subtract: [
+              {$multiply: ["$part.lineitem.l_extendedprice", {$subtract: [1, "$part.lineitem.l_discount"]}]},
+              {$multiply: ["$partsupp.ps_supplycost", "$part.lineitem.l_quantity"]}]}}}},
+          {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
+          {$sort: {nation: 1, o_year: -1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHDenormalizedQuery9:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query9
     OperationName: RunCommand

--- a/src/phases/tpch/denormalized/Q9.yml
+++ b/src/phases/tpch/denormalized/Q9.yml
@@ -4,46 +4,56 @@ Description: |
   Run TPC-H query 9 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${color}.*$
 
+TPCHDenormalizedQuery9Aggregation: &TPCHDenormalizedQuery9Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$lookup: {from: "part", as: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", pipeline: [
+        {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}}]}},
+      {$project: {
+        o_year: {$year: "$orders.o_orderdate"},
+        part: {$map: {input: "$part", as: "part", in: {
+          $mergeObjects: ["$$part", {lineitem: {$filter: {input: "$orders.lineitem", as: "lineitem", cond: {$eq: ["$$part.p_partkey", "$$lineitem.l_partkey"]}}}}]}}}}},
+      {$unwind: "$part"},
+      {$unwind: "$part.lineitem"},
+      {$lookup: {from: "supplier", as: "partsupp", localField: "part.lineitem.l_suppkey", foreignField: "s_suppkey", let: {p_partkey: "$part.p_partkey"}, pipeline: [
+        {$lookup: {from: "partsupp", as: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", pipeline: [
+          {$match: {$expr: {$eq: ["$$p_partkey", "$ps_partkey"]}}}]}},
+        {$unwind: "$partsupp"},
+        {$replaceWith: {$mergeObjects: ["$partsupp", {nation: "$nation.n_name"}]}}]}},
+      {$unwind: "$partsupp"},
+      {$group: {
+        _id: {nation: "$partsupp.nation", o_year: "$o_year"},
+        sum_profit: {$sum: {$subtract: [
+          {$multiply: ["$part.lineitem.l_extendedprice", {$subtract: [1, "$part.lineitem.l_discount"]}]},
+          {$multiply: ["$partsupp.ps_supplycost", "$part.lineitem.l_quantity"]}]}}}},
+      {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
+      {$sort: {nation: 1, o_year: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery9:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query9
+    OperationName: RunCommand
+    OperationCommand: *TPCHDenormalizedQuery9Aggregation
+
+TPCHDenormalizedQuery9Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query9
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$unwind: "$orders"},
-            {$lookup: {from: "part", as: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", pipeline: [
-              {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}}]}},
-            {$project: {
-              o_year: {$year: "$orders.o_orderdate"},
-              part: {$map: {input: "$part", as: "part", in: {
-                $mergeObjects: ["$$part", {lineitem: {$filter: {input: "$orders.lineitem", as: "lineitem", cond: {$eq: ["$$part.p_partkey", "$$lineitem.l_partkey"]}}}}]}}}}},
-            {$unwind: "$part"},
-            {$unwind: "$part.lineitem"},
-            {$lookup: {from: "supplier", as: "partsupp", localField: "part.lineitem.l_suppkey", foreignField: "s_suppkey", let: {p_partkey: "$part.p_partkey"}, pipeline: [
-              {$lookup: {from: "partsupp", as: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", pipeline: [
-                {$match: {$expr: {$eq: ["$$p_partkey", "$ps_partkey"]}}}]}},
-              {$unwind: "$partsupp"},
-              {$replaceWith: {$mergeObjects: ["$partsupp", {nation: "$nation.n_name"}]}}]}},
-            {$unwind: "$partsupp"},
-            {$group: {
-              _id: {nation: "$partsupp.nation", o_year: "$o_year"},
-              sum_profit: {$sum: {$subtract: [
-                {$multiply: ["$part.lineitem.l_extendedprice", {$subtract: [1, "$part.lineitem.l_discount"]}]},
-                {$multiply: ["$partsupp.ps_supplycost", "$part.lineitem.l_quantity"]}]}}}},
-            {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
-            {$sort: {nation: 1, o_year: -1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHDenormalizedQuery9Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q1.yml
+++ b/src/phases/tpch/normalized/Q1.yml
@@ -7,47 +7,52 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query1Delta: &query1Delta {^Parameter: {Name: "Query1Delta", Default: -90}}
 
-TPCHNormalizedQuery1Aggregation: &TPCHNormalizedQuery1Aggregation
-  aggregate: lineitem
-  pipeline:
-    [
-      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
-      {$group: {
-        _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
-        sum_qty: {$sum: "$l_quantity"},
-        sum_base_price: {$sum: "$l_extendedprice"},
-        sum_disc_price:
-          {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}},
-        sum_charge: {
-          $sum: {
-            $multiply: [
-              "$l_extendedprice",
-              {$subtract: [1, "$l_discount"]},
-              {$add: [1, "$l_tax"]}]}},
-        avg_qty: {$avg: "$l_quantity"},
-        avg_price: {$avg: "$l_extendedprice"},
-        avg_disc: {$avg: "$l_discount"},
-        count_order: {$count: {}}}},
-      {$project: {
-        _id: 0,
-        l_returnflag: "$_id.l_returnflag",
-        l_linestatus: "$_id.l_linestatus",
-        sum_qty: 1,
-        sum_base_price: 1,
-        sum_disc_price: 1,
-        sum_charge: 1,
-        avg_qty: 1,
-        avg_price: 1,
-        avg_disc: 1,
-        count_order: 1}},
-      {$sort: {l_returnflag: 1, l_linestatus: 1}},
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery1:
+TPCHNormalizedQuery1Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery1Aggregation
+      aggregate: lineitem
+      pipeline:
+        [
+          {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
+          {$group: {
+            _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
+            sum_qty: {$sum: "$l_quantity"},
+            sum_base_price: {$sum: "$l_extendedprice"},
+            sum_disc_price:
+              {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}},
+            sum_charge: {
+              $sum: {
+                $multiply: [
+                  "$l_extendedprice",
+                  {$subtract: [1, "$l_discount"]},
+                  {$add: [1, "$l_tax"]}]}},
+            avg_qty: {$avg: "$l_quantity"},
+            avg_price: {$avg: "$l_extendedprice"},
+            avg_disc: {$avg: "$l_discount"},
+            count_order: {$count: {}}}},
+          {$project: {
+            _id: 0,
+            l_returnflag: "$_id.l_returnflag",
+            l_linestatus: "$_id.l_linestatus",
+            sum_qty: 1,
+            sum_base_price: 1,
+            sum_disc_price: 1,
+            sum_charge: 1,
+            avg_qty: 1,
+            avg_price: 1,
+            avg_disc: 1,
+            count_order: 1}},
+          {$sort: {l_returnflag: 1, l_linestatus: 1}},
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery1:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query1
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q1.yml
+++ b/src/phases/tpch/normalized/Q1.yml
@@ -4,53 +4,63 @@ Description: |
   Run TPC-H query 1 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query1Delta: &query1Delta {^Parameter: {Name: "Query1Delta", Default: -90}}
 
+TPCHNormalizedQuery1Aggregation: &TPCHNormalizedQuery1Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
+      {$group: {
+        _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
+        sum_qty: {$sum: "$l_quantity"},
+        sum_base_price: {$sum: "$l_extendedprice"},
+        sum_disc_price:
+          {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}},
+        sum_charge: {
+          $sum: {
+            $multiply: [
+              "$l_extendedprice",
+              {$subtract: [1, "$l_discount"]},
+              {$add: [1, "$l_tax"]}]}},
+        avg_qty: {$avg: "$l_quantity"},
+        avg_price: {$avg: "$l_extendedprice"},
+        avg_disc: {$avg: "$l_discount"},
+        count_order: {$count: {}}}},
+      {$project: {
+        _id: 0,
+        l_returnflag: "$_id.l_returnflag",
+        l_linestatus: "$_id.l_linestatus",
+        sum_qty: 1,
+        sum_base_price: 1,
+        sum_disc_price: 1,
+        sum_charge: 1,
+        avg_qty: 1,
+        avg_price: 1,
+        avg_disc: 1,
+        count_order: 1}},
+      {$sort: {l_returnflag: 1, l_linestatus: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery1:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query1
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery1Aggregation
+
+TPCHNormalizedQuery1Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query1
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: lineitem
-        pipeline:
-          [
-            {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
-            {$group: {
-              _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
-              sum_qty: {$sum: "$l_quantity"},
-              sum_base_price: {$sum: "$l_extendedprice"},
-              sum_disc_price:
-                {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}},
-              sum_charge: {
-                $sum: {
-                  $multiply: [
-                    "$l_extendedprice",
-                    {$subtract: [1, "$l_discount"]},
-                    {$add: [1, "$l_tax"]}]}},
-              avg_qty: {$avg: "$l_quantity"},
-              avg_price: {$avg: "$l_extendedprice"},
-              avg_disc: {$avg: "$l_discount"},
-              count_order: {$count: {}}}},
-            {$project: {
-              _id: 0,
-              l_returnflag: "$_id.l_returnflag",
-              l_linestatus: "$_id.l_linestatus",
-              sum_qty: 1,
-              sum_base_price: 1,
-              sum_disc_price: 1,
-              sum_charge: 1,
-              avg_qty: 1,
-              avg_price: 1,
-              avg_disc: 1,
-              count_order: 1}},
-            {$sort: {l_returnflag: 1, l_linestatus: 1}},
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery1Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q10.yml
+++ b/src/phases/tpch/normalized/Q10.yml
@@ -4,37 +4,47 @@ Description: |
   Run TPC-H query 10 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query10Date: &query10Date {^Parameter: {Name: "Query10Date", Default: "1993-10-01"}}
 
+TPCHNormalizedQuery10Aggregation: &TPCHNormalizedQuery10Aggregation
+  aggregate: orders
+  pipeline:
+    [
+      {$match: {$and: [
+        {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
+        {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
+      {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+        {$match: {l_returnflag: "R"}}]}},
+      {$unwind: "$lineitem"},
+      {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer", pipeline: [
+        {$lookup: { from: "nation", localField: "c_nationkey", foreignField: "n_nationkey", as: "nation"}},
+        {$unwind: "$nation"}]}},
+      {$unwind: "$customer"},
+      {$group: {_id: {c_custkey: "$customer.c_custkey", c_name: "$customer.c_name", c_acctbal: "$customer.c_acctbal", n_name: "$customer.nation.n_name", c_address: "$customer.c_address", c_phone: "$customer.c_phone", c_comment: "$customer.c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
+      {$sort: {revenue: -1}},
+      {$limit: 20}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery10:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query10
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery10Aggregation
+
+TPCHNormalizedQuery10Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query10
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: orders
-        pipeline:
-          [
-            {$match: {$and: [
-              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
-              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
-            {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-              {$match: {l_returnflag: "R"}}]}},
-            {$unwind: "$lineitem"},
-            {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer", pipeline: [
-              {$lookup: { from: "nation", localField: "c_nationkey", foreignField: "n_nationkey", as: "nation"}},
-              {$unwind: "$nation"}]}},
-            {$unwind: "$customer"},
-            {$group: {_id: {c_custkey: "$customer.c_custkey", c_name: "$customer.c_name", c_acctbal: "$customer.c_acctbal", n_name: "$customer.nation.n_name", c_address: "$customer.c_address", c_phone: "$customer.c_phone", c_comment: "$customer.c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
-            {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
-            {$sort: {revenue: -1}},
-            {$limit: 20}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery10Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q10.yml
+++ b/src/phases/tpch/normalized/Q10.yml
@@ -7,31 +7,36 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query10Date: &query10Date {^Parameter: {Name: "Query10Date", Default: "1993-10-01"}}
 
-TPCHNormalizedQuery10Aggregation: &TPCHNormalizedQuery10Aggregation
-  aggregate: orders
-  pipeline:
-    [
-      {$match: {$and: [
-        {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
-        {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
-      {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-        {$match: {l_returnflag: "R"}}]}},
-      {$unwind: "$lineitem"},
-      {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer", pipeline: [
-        {$lookup: { from: "nation", localField: "c_nationkey", foreignField: "n_nationkey", as: "nation"}},
-        {$unwind: "$nation"}]}},
-      {$unwind: "$customer"},
-      {$group: {_id: {c_custkey: "$customer.c_custkey", c_name: "$customer.c_name", c_acctbal: "$customer.c_acctbal", n_name: "$customer.nation.n_name", c_address: "$customer.c_address", c_phone: "$customer.c_phone", c_comment: "$customer.c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
-      {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
-      {$sort: {revenue: -1}},
-      {$limit: 20}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery10:
+TPCHNormalizedQuery10Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery10Aggregation
+      aggregate: orders
+      pipeline:
+        [
+          {$match: {$and: [
+            {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
+            {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
+          {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+            {$match: {l_returnflag: "R"}}]}},
+          {$unwind: "$lineitem"},
+          {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer", pipeline: [
+            {$lookup: { from: "nation", localField: "c_nationkey", foreignField: "n_nationkey", as: "nation"}},
+            {$unwind: "$nation"}]}},
+          {$unwind: "$customer"},
+          {$group: {_id: {c_custkey: "$customer.c_custkey", c_name: "$customer.c_name", c_acctbal: "$customer.c_acctbal", n_name: "$customer.nation.n_name", c_address: "$customer.c_address", c_phone: "$customer.c_phone", c_comment: "$customer.c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+          {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
+          {$sort: {revenue: -1}},
+          {$limit: 20}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery10:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query10
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q11.yml
+++ b/src/phases/tpch/normalized/Q11.yml
@@ -8,48 +8,53 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query11Nation: &query11Nation {^Parameter: {Name: "Query11Nation", Default: "GERMANY"}}
 query11Fraction: &query11Fraction {^Parameter: {Name: "Query11Fraction", Default: 0.0001}}
 
-TPCHNormalizedQuery11Aggregation: &TPCHNormalizedQuery11Aggregation
-  aggregate: partsupp
-  pipeline:
-    [
-      {$lookup: {
-        from: "supplier",
-        localField: "ps_suppkey",
-        foreignField: "s_suppkey",
-        as: "supplier"}},
-      {$unwind: "$supplier"},
-      {$lookup: {
-        from: "nation",
-        localField: "supplier.s_nationkey",
-        foreignField: "n_nationkey",
-        pipeline: [{$match: {n_name: *query11Nation}}],
-        as: "nation"}},
-      {$unwind: "$nation"},
-      {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
-      {$group: {
-        _id: "$ps_partkey",
-        value: {$sum: "$total_cost"}}},
-      {$group: {
-        _id: 0,
-        groups: {$push: {ps_partkey: "$_id", value: "$value"}},
-        total_cost: {$sum: "$value"}}},
-      {$addFields: {
-        threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
-      {$unwind: "$groups"},
-      {$project: {
-        ps_partkey: "$groups.ps_partkey",
-        value: "$groups.value",
-        threshold: 1}},
-      {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
-      {$project: {_id: 0, ps_partkey: 1, value: 1}},
-      {$sort: {value: -1}},
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery11:
+TPCHNormalizedQuery11Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery11Aggregation
+      aggregate: partsupp
+      pipeline:
+        [
+          {$lookup: {
+            from: "supplier",
+            localField: "ps_suppkey",
+            foreignField: "s_suppkey",
+            as: "supplier"}},
+          {$unwind: "$supplier"},
+          {$lookup: {
+            from: "nation",
+            localField: "supplier.s_nationkey",
+            foreignField: "n_nationkey",
+            pipeline: [{$match: {n_name: *query11Nation}}],
+            as: "nation"}},
+          {$unwind: "$nation"},
+          {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
+          {$group: {
+            _id: "$ps_partkey",
+            value: {$sum: "$total_cost"}}},
+          {$group: {
+            _id: 0,
+            groups: {$push: {ps_partkey: "$_id", value: "$value"}},
+            total_cost: {$sum: "$value"}}},
+          {$addFields: {
+            threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
+          {$unwind: "$groups"},
+          {$project: {
+            ps_partkey: "$groups.ps_partkey",
+            value: "$groups.value",
+            threshold: 1}},
+          {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
+          {$project: {_id: 0, ps_partkey: 1, value: 1}},
+          {$sort: {value: -1}},
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery11:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query11
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q11.yml
+++ b/src/phases/tpch/normalized/Q11.yml
@@ -4,55 +4,65 @@ Description: |
   Run TPC-H query 11 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query11Nation: &query11Nation {^Parameter: {Name: "Query11Nation", Default: "GERMANY"}}
 query11Fraction: &query11Fraction {^Parameter: {Name: "Query11Fraction", Default: 0.0001}}
 
+TPCHNormalizedQuery11Aggregation: &TPCHNormalizedQuery11Aggregation
+  aggregate: partsupp
+  pipeline:
+    [
+      {$lookup: {
+        from: "supplier",
+        localField: "ps_suppkey",
+        foreignField: "s_suppkey",
+        as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$lookup: {
+        from: "nation",
+        localField: "supplier.s_nationkey",
+        foreignField: "n_nationkey",
+        pipeline: [{$match: {n_name: *query11Nation}}],
+        as: "nation"}},
+      {$unwind: "$nation"},
+      {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
+      {$group: {
+        _id: "$ps_partkey",
+        value: {$sum: "$total_cost"}}},
+      {$group: {
+        _id: 0,
+        groups: {$push: {ps_partkey: "$_id", value: "$value"}},
+        total_cost: {$sum: "$value"}}},
+      {$addFields: {
+        threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
+      {$unwind: "$groups"},
+      {$project: {
+        ps_partkey: "$groups.ps_partkey",
+        value: "$groups.value",
+        threshold: 1}},
+      {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
+      {$project: {_id: 0, ps_partkey: 1, value: 1}},
+      {$sort: {value: -1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery11:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query11
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery11Aggregation
+
+TPCHNormalizedQuery11Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query11
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: partsupp
-        pipeline:
-          [
-            {$lookup: {
-              from: "supplier",
-              localField: "ps_suppkey",
-              foreignField: "s_suppkey",
-              as: "supplier"}},
-            {$unwind: "$supplier"},
-            {$lookup: {
-              from: "nation",
-              localField: "supplier.s_nationkey",
-              foreignField: "n_nationkey",
-              pipeline: [{$match: {n_name: *query11Nation}}],
-              as: "nation"}},
-            {$unwind: "$nation"},
-            {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
-            {$group: {
-              _id: "$ps_partkey",
-              value: {$sum: "$total_cost"}}},
-            {$group: {
-              _id: 0,
-              groups: {$push: {ps_partkey: "$_id", value: "$value"}},
-              total_cost: {$sum: "$value"}}},
-            {$addFields: {
-              threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
-            {$unwind: "$groups"},
-            {$project: {
-              ps_partkey: "$groups.ps_partkey",
-              value: "$groups.value",
-              threshold: 1}},
-            {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
-            {$project: {_id: 0, ps_partkey: 1, value: 1}},
-            {$sort: {value: -1}},
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery11Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q12.yml
+++ b/src/phases/tpch/normalized/Q12.yml
@@ -10,54 +10,59 @@ query12ShipMode1: &query12ShipMode1 {^Parameter: {Name: "Query12ShipMode1", Defa
 query12ShipMode2: &query12ShipMode2 {^Parameter: {Name: "Query12ShipMode2", Default: "SHIP"}}
 query12Date: &query12Date {^Parameter: {Name: "Query12Date", Default: "1994-01-01"}}
 
-TPCHNormalizedQuery12Aggregation: &TPCHNormalizedQuery12Aggregation
-  aggregate: lineitem
-  pipeline:
-    [
-      {$match: {
-        $and: [
-          {$or: [{l_shipmode: *query12ShipMode1}, {l_shipmode: *query12ShipMode2}]},
-          {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
-          {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
-          {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
-          {$expr: {$lt: [
-            "$l_receiptdate",
-            {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
-      {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
-      {$unwind: "$orders"},
-      {$group: {
-        _id: "$l_shipmode",
-        high_line_count: {
-          $sum: {
-            $cond: {
-              if: {
-                $or: [
-                  {$eq: ["$orders.o_orderpriority", "1-URGENT"]},
-                  {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]},
-              then: 1,
-              else: 0}}},
-        low_line_count: {
-          $sum: {
-            $cond: {
-              if: {
-                $and: [
-                  {$ne: ["$orders.o_orderpriority", "1-URGENT"]},
-                  {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]},
-              then: 1,
-              else: 0}}}}},
-      {$project: {
-        _id: 0,
-        l_shipmode: "$_id",
-        high_line_count: 1,
-        low_line_count: 1}},
-      {$sort: {l_shipmode: 1}},
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery12:
+TPCHNormalizedQuery12Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery12Aggregation
+      aggregate: lineitem
+      pipeline:
+        [
+          {$match: {
+            $and: [
+              {$or: [{l_shipmode: *query12ShipMode1}, {l_shipmode: *query12ShipMode2}]},
+              {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
+              {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
+              {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
+              {$expr: {$lt: [
+                "$l_receiptdate",
+                {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
+          {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+          {$unwind: "$orders"},
+          {$group: {
+            _id: "$l_shipmode",
+            high_line_count: {
+              $sum: {
+                $cond: {
+                  if: {
+                    $or: [
+                      {$eq: ["$orders.o_orderpriority", "1-URGENT"]},
+                      {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]},
+                  then: 1,
+                  else: 0}}},
+            low_line_count: {
+              $sum: {
+                $cond: {
+                  if: {
+                    $and: [
+                      {$ne: ["$orders.o_orderpriority", "1-URGENT"]},
+                      {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]},
+                  then: 1,
+                  else: 0}}}}},
+          {$project: {
+            _id: 0,
+            l_shipmode: "$_id",
+            high_line_count: 1,
+            low_line_count: 1}},
+          {$sort: {l_shipmode: 1}},
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery12:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query12
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q12.yml
+++ b/src/phases/tpch/normalized/Q12.yml
@@ -4,63 +4,73 @@ Description: |
   Run TPC-H query 12 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query12ShipMode1: &query12ShipMode1 {^Parameter: {Name: "Query12ShipMode1", Default: "MAIL"}}
 query12ShipMode2: &query12ShipMode2 {^Parameter: {Name: "Query12ShipMode2", Default: "SHIP"}}
 query12Date: &query12Date {^Parameter: {Name: "Query12Date", Default: "1994-01-01"}}
 
+TPCHNormalizedQuery12Aggregation: &TPCHNormalizedQuery12Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$match: {
+        $and: [
+          {$or: [{l_shipmode: *query12ShipMode1}, {l_shipmode: *query12ShipMode2}]},
+          {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
+          {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
+          {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
+          {$expr: {$lt: [
+            "$l_receiptdate",
+            {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
+      {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+      {$unwind: "$orders"},
+      {$group: {
+        _id: "$l_shipmode",
+        high_line_count: {
+          $sum: {
+            $cond: {
+              if: {
+                $or: [
+                  {$eq: ["$orders.o_orderpriority", "1-URGENT"]},
+                  {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]},
+              then: 1,
+              else: 0}}},
+        low_line_count: {
+          $sum: {
+            $cond: {
+              if: {
+                $and: [
+                  {$ne: ["$orders.o_orderpriority", "1-URGENT"]},
+                  {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]},
+              then: 1,
+              else: 0}}}}},
+      {$project: {
+        _id: 0,
+        l_shipmode: "$_id",
+        high_line_count: 1,
+        low_line_count: 1}},
+      {$sort: {l_shipmode: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery12:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query12
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery12Aggregation
+
+TPCHNormalizedQuery12Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query12
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: lineitem
-        pipeline:
-          [
-            {$match: {
-              $and: [
-                {$or: [{l_shipmode: *query12ShipMode1}, {l_shipmode: *query12ShipMode2}]},
-                {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
-                {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
-                {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
-                {$expr: {$lt: [
-                  "$l_receiptdate",
-                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
-            {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
-            {$unwind: "$orders"},
-            {$group: {
-              _id: "$l_shipmode",
-              high_line_count: {
-                $sum: {
-                  $cond: {
-                    if: {
-                      $or: [
-                        {$eq: ["$orders.o_orderpriority", "1-URGENT"]},
-                        {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]},
-                    then: 1,
-                    else: 0}}},
-              low_line_count: {
-                $sum: {
-                  $cond: {
-                    if: {
-                      $and: [
-                        {$ne: ["$orders.o_orderpriority", "1-URGENT"]},
-                        {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]},
-                    then: 1,
-                    else: 0}}}}},
-            {$project: {
-              _id: 0,
-              l_shipmode: "$_id",
-              high_line_count: 1,
-              low_line_count: 1}},
-            {$sort: {l_shipmode: 1}},
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery12Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q13.yml
+++ b/src/phases/tpch/normalized/Q13.yml
@@ -7,23 +7,28 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query13Regex: &query13Regex {^Parameter: {Name: "Query13Regex", Default: "^.*special.*requests.*$"}}  # `^.*${query13Word1}.*${query13Word2}.*$`
 
-TPCHNormalizedQuery13Aggregation: &TPCHNormalizedQuery13Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-        {$match: {$expr: {$cond: {if: {$regexMatch: {input: "$o_comment", regex: *query13Regex, options: "si"}}, then: 0, else: 1}}}}]}},
-      {$project: {c_custkey: 1, c_count: {$size: "$orders"}}},
-      {$group: {_id: "$c_count", custdist: {$count: {}}}},
-      {$project: {_id: 0, c_count: "$_id", custdist: 1}},
-      {$sort: {custdist: -1, c_count: -1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery13:
+TPCHNormalizedQuery13Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery13Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
+            {$match: {$expr: {$cond: {if: {$regexMatch: {input: "$o_comment", regex: *query13Regex, options: "si"}}, then: 0, else: 1}}}}]}},
+          {$project: {c_custkey: 1, c_count: {$size: "$orders"}}},
+          {$group: {_id: "$c_count", custdist: {$count: {}}}},
+          {$project: {_id: 0, c_count: "$_id", custdist: 1}},
+          {$sort: {custdist: -1, c_count: -1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery13:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query13
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q13.yml
+++ b/src/phases/tpch/normalized/Q13.yml
@@ -4,29 +4,39 @@ Description: |
   Run TPC-H query 13 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query13Regex: &query13Regex {^Parameter: {Name: "Query13Regex", Default: "^.*special.*requests.*$"}}  # `^.*${query13Word1}.*${query13Word2}.*$`
 
+TPCHNormalizedQuery13Aggregation: &TPCHNormalizedQuery13Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
+        {$match: {$expr: {$cond: {if: {$regexMatch: {input: "$o_comment", regex: *query13Regex, options: "si"}}, then: 0, else: 1}}}}]}},
+      {$project: {c_custkey: 1, c_count: {$size: "$orders"}}},
+      {$group: {_id: "$c_count", custdist: {$count: {}}}},
+      {$project: {_id: 0, c_count: "$_id", custdist: 1}},
+      {$sort: {custdist: -1, c_count: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery13:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query13
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery13Aggregation
+
+TPCHNormalizedQuery13Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query13
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-              {$match: {$expr: {$cond: {if: {$regexMatch: {input: "$o_comment", regex: *query13Regex, options: "si"}}, then: 0, else: 1}}}}]}},
-            {$project: {c_custkey: 1, c_count: {$size: "$orders"}}},
-            {$group: {_id: "$c_count", custdist: {$count: {}}}},
-            {$project: {_id: 0, c_count: "$_id", custdist: 1}},
-            {$sort: {custdist: -1, c_count: -1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery13Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q14.yml
+++ b/src/phases/tpch/normalized/Q14.yml
@@ -7,44 +7,49 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query14Date: &query14Date {^Parameter: {Name: "Query14Date", Default: "1995-09-01"}}
 
-TPCHNormalizedQuery14Aggregation: &TPCHNormalizedQuery14Aggregation
-  aggregate: lineitem
-  pipeline:
-    [
-      {$match: {
-        $and: [
-          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
-          {$expr: {
-            $lt: [
-              "$l_shipdate",
-              {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
-      {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
-      {$unwind: "$part"},
-      {$group: {
-        _id: {},
-        promo_price_total: {
-          $sum: {
-            $cond: {
-              if: {
-                $cond: {
-                  if: {
-                    $regexMatch: {
-                      input: "$part.p_type",
-                      regex: "^PROMO.*$",
-                      options: "si"}},
-                  then: 1,
-                  else: 0}},
-              then: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]},
-              else: 0}}},
-        price_total: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-      {$project: {_id: 0, promo_revenue: {$multiply: [100.00, {$divide: ["$promo_price_total", "$price_total"]}]}}},
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery14:
+TPCHNormalizedQuery14Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery14Aggregation
+      aggregate: lineitem
+      pipeline:
+        [
+          {$match: {
+            $and: [
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
+              {$expr: {
+                $lt: [
+                  "$l_shipdate",
+                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
+          {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
+          {$unwind: "$part"},
+          {$group: {
+            _id: {},
+            promo_price_total: {
+              $sum: {
+                $cond: {
+                  if: {
+                    $cond: {
+                      if: {
+                        $regexMatch: {
+                          input: "$part.p_type",
+                          regex: "^PROMO.*$",
+                          options: "si"}},
+                      then: 1,
+                      else: 0}},
+                  then: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]},
+                  else: 0}}},
+            price_total: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+          {$project: {_id: 0, promo_revenue: {$multiply: [100.00, {$divide: ["$promo_price_total", "$price_total"]}]}}},
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery14:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query14
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q14.yml
+++ b/src/phases/tpch/normalized/Q14.yml
@@ -4,50 +4,60 @@ Description: |
   Run TPC-H query 14 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query14Date: &query14Date {^Parameter: {Name: "Query14Date", Default: "1995-09-01"}}
 
+TPCHNormalizedQuery14Aggregation: &TPCHNormalizedQuery14Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$match: {
+        $and: [
+          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
+          {$expr: {
+            $lt: [
+              "$l_shipdate",
+              {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
+      {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
+      {$unwind: "$part"},
+      {$group: {
+        _id: {},
+        promo_price_total: {
+          $sum: {
+            $cond: {
+              if: {
+                $cond: {
+                  if: {
+                    $regexMatch: {
+                      input: "$part.p_type",
+                      regex: "^PROMO.*$",
+                      options: "si"}},
+                  then: 1,
+                  else: 0}},
+              then: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]},
+              else: 0}}},
+        price_total: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+      {$project: {_id: 0, promo_revenue: {$multiply: [100.00, {$divide: ["$promo_price_total", "$price_total"]}]}}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery14:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query14
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery14Aggregation
+
+TPCHNormalizedQuery14Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query14
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: lineitem
-        pipeline:
-          [
-            {$match: {
-              $and: [
-                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
-                {$expr: {
-                  $lt: [
-                    "$l_shipdate",
-                    {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
-            {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
-            {$unwind: "$part"},
-            {$group: {
-              _id: {},
-              promo_price_total: {
-                $sum: {
-                  $cond: {
-                    if: {
-                      $cond: {
-                        if: {
-                          $regexMatch: {
-                            input: "$part.p_type",
-                            regex: "^PROMO.*$",
-                            options: "si"}},
-                        then: 1,
-                        else: 0}},
-                    then: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]},
-                    else: 0}}},
-              price_total: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-            {$project: {_id: 0, promo_revenue: {$multiply: [100.00, {$divide: ["$promo_price_total", "$price_total"]}]}}},
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery14Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -8,7 +8,7 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query15Date: &query15Date {^Parameter: {Name: "Query15Date", Default: "1996-01-01"}}
 
 TPCHNormalizedQuery15CreateView: &TPCHNormalizedQuery15CreateView
-  create: &view revenue
+  create: &query15View revenue
   viewOn: lineitem
   pipeline:
     [
@@ -28,7 +28,7 @@ TPCHNormalizedQuery15CreateView: &TPCHNormalizedQuery15CreateView
     ]
 
 TPCHNormalizedQuery15Aggregation: &TPCHNormalizedQuery15Aggregation
-  aggregate: *view
+  aggregate: *query15View
   pipeline:
     [
       {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
@@ -50,7 +50,7 @@ TPCHNormalizedQuery15Aggregation: &TPCHNormalizedQuery15Aggregation
   allowDiskUse: true
 
 TPCHNormalizedQuery15DropView: &TPCHNormalizedQuery15DropView
-  drop: *view
+  drop: *query15View
 
 TPCHNormalizedQuery15:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -8,24 +8,29 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query15Date: &query15Date {^Parameter: {Name: "Query15Date", Default: "1996-01-01"}}
 
 TPCHNormalizedQuery15CreateView: &TPCHNormalizedQuery15CreateView
-  create: &query15View revenue
-  viewOn: lineitem
-  pipeline:
-    [
-      {$match: {
-        $and: [
-          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
-          {$expr: {
-            $lt: [
-              "$l_shipdate",
-              {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}
-            ]}}]}},
-      {$group: {
-        _id: "$l_suppkey",
-        total_revenue:
-          {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-      {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
-    ]
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand:
+      create: &query15View revenue
+      viewOn: lineitem
+      pipeline:
+        [
+          {$match: {
+            $and: [
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
+              {$expr: {
+                $lt: [
+                  "$l_shipdate",
+                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}
+                ]}}]}},
+          {$group: {
+            _id: "$l_suppkey",
+            total_revenue:
+              {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+          {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
+        ]
 
 TPCHNormalizedQuery15Aggregation: &TPCHNormalizedQuery15Aggregation
   aggregate: *query15View
@@ -50,11 +55,16 @@ TPCHNormalizedQuery15Aggregation: &TPCHNormalizedQuery15Aggregation
   allowDiskUse: true
 
 TPCHNormalizedQuery15DropView: &TPCHNormalizedQuery15DropView
-  drop: *query15View
+  Repeat: *Repeat
+  Database: *db
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand:
+      drop: *query15View
 
 TPCHNormalizedQuery15:
-  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
-  Database: &db tpch
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query15
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -4,61 +4,69 @@ Description: |
   Run TPC-H query 15 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query15Date: &query15Date {^Parameter: {Name: "Query15Date", Default: "1996-01-01"}}
 
+TPCHNormalizedQuery15CreateView: &TPCHNormalizedQuery15CreateView
+  create: &view revenue
+  viewOn: lineitem
+  pipeline:
+    [
+      {$match: {
+        $and: [
+          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
+          {$expr: {
+            $lt: [
+              "$l_shipdate",
+              {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}
+            ]}}]}},
+      {$group: {
+        _id: "$l_suppkey",
+        total_revenue:
+          {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+      {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
+    ]
+
+TPCHNormalizedQuery15Aggregation: &TPCHNormalizedQuery15Aggregation
+  aggregate: *view
+  pipeline:
+    [
+      {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
+      {$sort: {_id: -1}},
+      {$limit: 1},
+      {$unwind: "$supplier_no"},
+      {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
+      {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$project: {
+        s_suppkey: "$supplier.s_suppkey",
+        s_name: "$supplier.s_name",
+        s_address: "$supplier.s_address",
+        s_phone: "$supplier.s_phone",
+        total_revenue: 1
+      }},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
+TPCHNormalizedQuery15DropView: &TPCHNormalizedQuery15DropView
+  drop: *view
+
 TPCHNormalizedQuery15:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
   Operations:
-  - OperationMetricsName: Query15CreateView
+  - OperationMetricsName: Query15
     OperationName: RunCommand
-    OperationLogsResult: true
-    OperationCommand:
-      create: revenue
-      viewOn: lineitem
-      pipeline:
-        [
-          {$match: {
-            $and: [
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
-              {$expr: {
-                $lt: [
-                  "$l_shipdate",
-                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}
-                ]}}]}},
-          {$group: {
-            _id: "$l_suppkey",
-            total_revenue:
-              {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-          {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
-        ]
+    OperationCommand: *TPCHNormalizedQuery15Aggregation
+
+TPCHNormalizedQuery15Explain:
+  Repeat: *Repeat
+  Database: *db
+  Operations:
   - OperationMetricsName: Query15
     OperationName: RunCommand
     OperationCommand:
-      explain:
-        aggregate: revenue
-        pipeline:
-          [
-            {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
-            {$sort: {_id: -1}},
-            {$limit: 1},
-            {$unwind: "$supplier_no"},
-            {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
-            {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
-            {$unwind: "$supplier"},
-            {$project: {
-              s_suppkey: "$supplier.s_suppkey",
-              s_name: "$supplier.s_name",
-              s_address: "$supplier.s_address",
-              s_phone: "$supplier.s_phone",
-              total_revenue: 1
-            }},
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery15Aggregation
       verbosity:
         executionStats
-  - OperationName: RunCommand
-    OperationCommand:
-      drop: revenue

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -32,27 +32,32 @@ TPCHNormalizedQuery15CreateView: &TPCHNormalizedQuery15CreateView
           {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
         ]
 
-TPCHNormalizedQuery15Aggregation: &TPCHNormalizedQuery15Aggregation
-  aggregate: *query15View
-  pipeline:
-    [
-      {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
-      {$sort: {_id: -1}},
-      {$limit: 1},
-      {$unwind: "$supplier_no"},
-      {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
-      {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
-      {$unwind: "$supplier"},
-      {$project: {
-        s_suppkey: "$supplier.s_suppkey",
-        s_name: "$supplier.s_name",
-        s_address: "$supplier.s_address",
-        s_phone: "$supplier.s_phone",
-        total_revenue: 1
-      }},
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
+TPCHNormalizedQuery15Warmup:
+  Repeat: *Repeat
+  Database: *db
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery15Aggregation
+      aggregate: *query15View
+      pipeline:
+        [
+          {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
+          {$sort: {_id: -1}},
+          {$limit: 1},
+          {$unwind: "$supplier_no"},
+          {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
+          {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
+          {$unwind: "$supplier"},
+          {$project: {
+            s_suppkey: "$supplier.s_suppkey",
+            s_name: "$supplier.s_name",
+            s_address: "$supplier.s_address",
+            s_phone: "$supplier.s_phone",
+            total_revenue: 1
+          }},
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
 
 TPCHNormalizedQuery15DropView: &TPCHNormalizedQuery15DropView
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q16.yml
+++ b/src/phases/tpch/normalized/Q16.yml
@@ -10,51 +10,56 @@ query16Brand: &query16Brand {^Parameter: {Name: "Query16Brand", Default: "Brand#
 query16Type: &query16Type {^Parameter: {Name: "Query16Type", Default: "^MEDIUM POLISHED.*"}}  # ^${type}.*$"
 query16Sizes: &query16Sizes {^Parameter: {Name: "Query16Sizes", Default: [49, 14, 23, 45, 19, 3, 36, 9]}}
 
-TPCHNormalizedQuery16Aggregation: &TPCHNormalizedQuery16Aggregation
-  aggregate: part
-  pipeline:
-    [
-      {$match: {$and: [
-        {p_brand: {$ne: *query16Brand}},
-        {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}},
-        {p_size: {$in: *query16Sizes}}]}},
-      {$lookup: {
-        from: "partsupp",
-        localField: "p_partkey",
-        foreignField: "ps_partkey",
-        as: "partsupp"}},
-      {$unwind: "$partsupp"},
-      {$lookup: {
-        from: "supplier",
-        localField: "partsupp.ps_suppkey",
-        foreignField: "s_suppkey",
-        pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}],
-        as: "supplier"}},
-      {$match: {supplier: {$eq: []}}},
-      {$group: {
-        _id: {
-          p_brand: "$p_brand",
-          p_type: "$p_type",
-          p_size: "$p_size"},
-        ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
-      {$project: {
-        _id: 0,
-        p_brand: "$_id.p_brand",
-        p_type: "$_id.p_type",
-        p_size: "$_id.p_size",
-        supplier_cnt: {$size: "$ps_suppkey"}}},
-      {$sort: {
-        supplier_cnt: -1,
-        p_brand: 1,
-        p_type: 1,
-        p_size: 1}},
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery16:
+TPCHNormalizedQuery16Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery16Aggregation
+      aggregate: part
+      pipeline:
+        [
+          {$match: {$and: [
+            {p_brand: {$ne: *query16Brand}},
+            {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}},
+            {p_size: {$in: *query16Sizes}}]}},
+          {$lookup: {
+            from: "partsupp",
+            localField: "p_partkey",
+            foreignField: "ps_partkey",
+            as: "partsupp"}},
+          {$unwind: "$partsupp"},
+          {$lookup: {
+            from: "supplier",
+            localField: "partsupp.ps_suppkey",
+            foreignField: "s_suppkey",
+            pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}],
+            as: "supplier"}},
+          {$match: {supplier: {$eq: []}}},
+          {$group: {
+            _id: {
+              p_brand: "$p_brand",
+              p_type: "$p_type",
+              p_size: "$p_size"},
+            ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
+          {$project: {
+            _id: 0,
+            p_brand: "$_id.p_brand",
+            p_type: "$_id.p_type",
+            p_size: "$_id.p_size",
+            supplier_cnt: {$size: "$ps_suppkey"}}},
+          {$sort: {
+            supplier_cnt: -1,
+            p_brand: 1,
+            p_type: 1,
+            p_size: 1}},
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery16:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query16
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q16.yml
+++ b/src/phases/tpch/normalized/Q16.yml
@@ -4,60 +4,70 @@ Description: |
   Run TPC-H query 16 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query16Brand: &query16Brand {^Parameter: {Name: "Query16Brand", Default: "Brand#45"}}
 query16Type: &query16Type {^Parameter: {Name: "Query16Type", Default: "^MEDIUM POLISHED.*"}}  # ^${type}.*$"
 query16Sizes: &query16Sizes {^Parameter: {Name: "Query16Sizes", Default: [49, 14, 23, 45, 19, 3, 36, 9]}}
 
+TPCHNormalizedQuery16Aggregation: &TPCHNormalizedQuery16Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [
+        {p_brand: {$ne: *query16Brand}},
+        {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}},
+        {p_size: {$in: *query16Sizes}}]}},
+      {$lookup: {
+        from: "partsupp",
+        localField: "p_partkey",
+        foreignField: "ps_partkey",
+        as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {
+        from: "supplier",
+        localField: "partsupp.ps_suppkey",
+        foreignField: "s_suppkey",
+        pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}],
+        as: "supplier"}},
+      {$match: {supplier: {$eq: []}}},
+      {$group: {
+        _id: {
+          p_brand: "$p_brand",
+          p_type: "$p_type",
+          p_size: "$p_size"},
+        ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
+      {$project: {
+        _id: 0,
+        p_brand: "$_id.p_brand",
+        p_type: "$_id.p_type",
+        p_size: "$_id.p_size",
+        supplier_cnt: {$size: "$ps_suppkey"}}},
+      {$sort: {
+        supplier_cnt: -1,
+        p_brand: 1,
+        p_type: 1,
+        p_size: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery16:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query16
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery16Aggregation
+
+TPCHNormalizedQuery16Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query16
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: part
-        pipeline:
-          [
-            {$match: {$and: [
-              {p_brand: {$ne: *query16Brand}},
-              {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}},
-              {p_size: {$in: *query16Sizes}}]}},
-            {$lookup: {
-              from: "partsupp",
-              localField: "p_partkey",
-              foreignField: "ps_partkey",
-              as: "partsupp"}},
-            {$unwind: "$partsupp"},
-            {$lookup: {
-              from: "supplier",
-              localField: "partsupp.ps_suppkey",
-              foreignField: "s_suppkey",
-              pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}],
-              as: "supplier"}},
-            {$match: {supplier: {$eq: []}}},
-            {$group: {
-              _id: {
-                p_brand: "$p_brand",
-                p_type: "$p_type",
-                p_size: "$p_size"},
-              ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
-            {$project: {
-              _id: 0,
-              p_brand: "$_id.p_brand",
-              p_type: "$_id.p_type",
-              p_size: "$_id.p_size",
-              supplier_cnt: {$size: "$ps_suppkey"}}},
-            {$sort: {
-              supplier_cnt: -1,
-              p_brand: 1,
-              p_type: 1,
-              p_size: 1}},
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery16Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q17.yml
+++ b/src/phases/tpch/normalized/Q17.yml
@@ -9,26 +9,31 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
 query17Container: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
 
-TPCHNormalizedQuery17Aggregation: &TPCHNormalizedQuery17Aggregation
-  aggregate: part
-  pipeline:
-    [
-      {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
-      {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem", pipeline: [
-        {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
-        {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
-        {$unwind: "$lineitem"},
-        {$replaceWith: "$lineitem"}]}},
-      {$unwind: "$lineitem"},
-      {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
-      {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery17:
+TPCHNormalizedQuery17Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery17Aggregation
+      aggregate: part
+      pipeline:
+        [
+          {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
+          {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem", pipeline: [
+            {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
+            {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
+            {$unwind: "$lineitem"},
+            {$replaceWith: "$lineitem"}]}},
+          {$unwind: "$lineitem"},
+          {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
+          {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery17:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query17
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q17.yml
+++ b/src/phases/tpch/normalized/Q17.yml
@@ -4,34 +4,44 @@ Description: |
   Run TPC-H query 17 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
 query17Container: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
 
+TPCHNormalizedQuery17Aggregation: &TPCHNormalizedQuery17Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
+      {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem", pipeline: [
+        {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
+        {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
+        {$unwind: "$lineitem"},
+        {$replaceWith: "$lineitem"}]}},
+      {$unwind: "$lineitem"},
+      {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
+      {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery17:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query17
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery17Aggregation
+
+TPCHNormalizedQuery17Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query17
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: part
-        pipeline:
-          [
-            {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
-            {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem", pipeline: [
-              {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
-              {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
-              {$unwind: "$lineitem"},
-              {$replaceWith: "$lineitem"}]}},
-            {$unwind: "$lineitem"},
-            {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
-            {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery17Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q18.yml
+++ b/src/phases/tpch/normalized/Q18.yml
@@ -7,30 +7,35 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query18Quantity: &query18Quantity {^Parameter: {Name: "Query18Quantity", Default: 300}}
 
-TPCHNormalizedQuery18Aggregation: &TPCHNormalizedQuery18Aggregation
-  aggregate: orders
-  pipeline:
-    [
-      {$lookup: {from: "lineitem", let: {o_orderkey: "$o_orderkey"}, as: "lineitem", pipeline: [
-        {$match: {$expr: {$eq: ["$$o_orderkey", "$l_orderkey"]}}},
-        {$group: {_id: "$l_orderkey", "sum(l_quantity)": {$sum: "$l_quantity"}}},
-        {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
-        {$project: {_id: 0, o_orderkey: "$_id", "sum(l_quantity)": 1}}]}},
-      {$unwind: "$lineitem"},
-      {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer"}},
-      {$unwind: "$customer"},
-      {$group: {_id: {c_name: "$customer.c_name", c_custkey: "$customer.c_custkey", o_orderkey: "$o_orderkey", o_orderdate: "$o_orderdate", o_totalprice: "$o_totalprice"}, "sum(l_quantity)": {$push: "$lineitem.sum(l_quantity)"}}},
-      {$unwind: "$sum(l_quantity)"},
-      {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
-      {$sort: {o_totalprice: -1, o_orderdate: 1}},
-      {$limit: 100}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery18:
+TPCHNormalizedQuery18Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery18Aggregation
+      aggregate: orders
+      pipeline:
+        [
+          {$lookup: {from: "lineitem", let: {o_orderkey: "$o_orderkey"}, as: "lineitem", pipeline: [
+            {$match: {$expr: {$eq: ["$$o_orderkey", "$l_orderkey"]}}},
+            {$group: {_id: "$l_orderkey", "sum(l_quantity)": {$sum: "$l_quantity"}}},
+            {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
+            {$project: {_id: 0, o_orderkey: "$_id", "sum(l_quantity)": 1}}]}},
+          {$unwind: "$lineitem"},
+          {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer"}},
+          {$unwind: "$customer"},
+          {$group: {_id: {c_name: "$customer.c_name", c_custkey: "$customer.c_custkey", o_orderkey: "$o_orderkey", o_orderdate: "$o_orderdate", o_totalprice: "$o_totalprice"}, "sum(l_quantity)": {$push: "$lineitem.sum(l_quantity)"}}},
+          {$unwind: "$sum(l_quantity)"},
+          {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
+          {$sort: {o_totalprice: -1, o_orderdate: 1}},
+          {$limit: 100}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery18:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query18
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q18.yml
+++ b/src/phases/tpch/normalized/Q18.yml
@@ -4,36 +4,46 @@ Description: |
   Run TPC-H query 18 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query18Quantity: &query18Quantity {^Parameter: {Name: "Query18Quantity", Default: 300}}
 
+TPCHNormalizedQuery18Aggregation: &TPCHNormalizedQuery18Aggregation
+  aggregate: orders
+  pipeline:
+    [
+      {$lookup: {from: "lineitem", let: {o_orderkey: "$o_orderkey"}, as: "lineitem", pipeline: [
+        {$match: {$expr: {$eq: ["$$o_orderkey", "$l_orderkey"]}}},
+        {$group: {_id: "$l_orderkey", "sum(l_quantity)": {$sum: "$l_quantity"}}},
+        {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
+        {$project: {_id: 0, o_orderkey: "$_id", "sum(l_quantity)": 1}}]}},
+      {$unwind: "$lineitem"},
+      {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer"}},
+      {$unwind: "$customer"},
+      {$group: {_id: {c_name: "$customer.c_name", c_custkey: "$customer.c_custkey", o_orderkey: "$o_orderkey", o_orderdate: "$o_orderdate", o_totalprice: "$o_totalprice"}, "sum(l_quantity)": {$push: "$lineitem.sum(l_quantity)"}}},
+      {$unwind: "$sum(l_quantity)"},
+      {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
+      {$sort: {o_totalprice: -1, o_orderdate: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery18:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query18
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery18Aggregation
+
+TPCHNormalizedQuery18Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query18
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: orders
-        pipeline:
-          [
-            {$lookup: {from: "lineitem", let: {o_orderkey: "$o_orderkey"}, as: "lineitem", pipeline: [
-              {$match: {$expr: {$eq: ["$$o_orderkey", "$l_orderkey"]}}},
-              {$group: {_id: "$l_orderkey", "sum(l_quantity)": {$sum: "$l_quantity"}}},
-              {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
-              {$project: {_id: 0, o_orderkey: "$_id", "sum(l_quantity)": 1}}]}},
-            {$unwind: "$lineitem"},
-            {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer"}},
-            {$unwind: "$customer"},
-            {$group: {_id: {c_name: "$customer.c_name", c_custkey: "$customer.c_custkey", o_orderkey: "$o_orderkey", o_orderdate: "$o_orderdate", o_totalprice: "$o_totalprice"}, "sum(l_quantity)": {$push: "$lineitem.sum(l_quantity)"}}},
-            {$unwind: "$sum(l_quantity)"},
-            {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
-            {$sort: {o_totalprice: -1, o_orderdate: 1}},
-            {$limit: 100}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery18Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q19.yml
+++ b/src/phases/tpch/normalized/Q19.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 19 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query19Brand1: &query19Brand1 {^Parameter: {Name: "Query19Brand1", Default: "Brand#12"}}
 query19Quantity1: &query19Quantity1 {^Parameter: {Name: "Query19Quantity1", Default: 1}}
@@ -13,49 +13,59 @@ query19Quantity2: &query19Quantity2 {^Parameter: {Name: "Query19Quantity2", Defa
 query19Brand3: &query19Brand3 {^Parameter: {Name: "Query19Brand3", Default: "Brand#34"}}
 query19Quantity3: &query19Quantity3 {^Parameter: {Name: "Query19Quantity3", Default: 20}}
 
+TPCHNormalizedQuery19Aggregation: &TPCHNormalizedQuery19Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+        {$match: {$or: [
+          {$and: [
+            {p_brand: *query19Brand1},
+            {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
+            {p_size: {$gte: 1}}, {p_size: {$lte: 5}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+          {$and: [
+            {p_brand: *query19Brand2},
+            {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
+            {p_size: {$gte: 1}}, {p_size: {$lte: 10}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+          {$and: [
+            {p_brand: *query19Brand3},
+            {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
+            {p_size: {$gte: 1}}, {p_size: {$lte: 15}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
+      {$unwind: "$part"},
+      {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+      {$project: {_id: 0, revenue: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery19:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query19
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery19Aggregation
+
+TPCHNormalizedQuery19Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query19
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: lineitem
-        pipeline:
-          [
-            {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-              {$match: {$or: [
-                {$and: [
-                  {p_brand: *query19Brand1},
-                  {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
-                  {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
-                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
-                  {p_size: {$gte: 1}}, {p_size: {$lte: 5}},
-                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-                {$and: [
-                  {p_brand: *query19Brand2},
-                  {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
-                  {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
-                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
-                  {p_size: {$gte: 1}}, {p_size: {$lte: 10}},
-                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-                {$and: [
-                  {p_brand: *query19Brand3},
-                  {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
-                  {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
-                  {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
-                  {p_size: {$gte: 1}}, {p_size: {$lte: 15}},
-                  {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                  {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
-            {$unwind: "$part"},
-            {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-            {$project: {_id: 0, revenue: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery19Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q19.yml
+++ b/src/phases/tpch/normalized/Q19.yml
@@ -13,46 +13,51 @@ query19Quantity2: &query19Quantity2 {^Parameter: {Name: "Query19Quantity2", Defa
 query19Brand3: &query19Brand3 {^Parameter: {Name: "Query19Brand3", Default: "Brand#34"}}
 query19Quantity3: &query19Quantity3 {^Parameter: {Name: "Query19Quantity3", Default: 20}}
 
-TPCHNormalizedQuery19Aggregation: &TPCHNormalizedQuery19Aggregation
-  aggregate: lineitem
-  pipeline:
-    [
-      {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-        {$match: {$or: [
-          {$and: [
-            {p_brand: *query19Brand1},
-            {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
-            {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
-            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
-            {p_size: {$gte: 1}}, {p_size: {$lte: 5}},
-            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-          {$and: [
-            {p_brand: *query19Brand2},
-            {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
-            {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
-            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
-            {p_size: {$gte: 1}}, {p_size: {$lte: 10}},
-            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-          {$and: [
-            {p_brand: *query19Brand3},
-            {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
-            {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
-            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
-            {p_size: {$gte: 1}}, {p_size: {$lte: 15}},
-            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
-      {$unwind: "$part"},
-      {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-      {$project: {_id: 0, revenue: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery19:
+TPCHNormalizedQuery1Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery19Aggregation
+      aggregate: lineitem
+      pipeline:
+        [
+          {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+            {$match: {$or: [
+              {$and: [
+                {p_brand: *query19Brand1},
+                {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
+                {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
+                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
+                {p_size: {$gte: 1}}, {p_size: {$lte: 5}},
+                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+              {$and: [
+                {p_brand: *query19Brand2},
+                {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
+                {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
+                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
+                {p_size: {$gte: 1}}, {p_size: {$lte: 10}},
+                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+              {$and: [
+                {p_brand: *query19Brand3},
+                {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
+                {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
+                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
+                {p_size: {$gte: 1}}, {p_size: {$lte: 15}},
+                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
+          {$unwind: "$part"},
+          {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+          {$project: {_id: 0, revenue: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery19:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query19
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q2.yml
+++ b/src/phases/tpch/normalized/Q2.yml
@@ -9,70 +9,75 @@ query2Size: &query2Size {^Parameter: {Name: "Query2Size", Default: 15}}
 query2Type: &query2Type {^Parameter: {Name: "Query2Type", Default: "^.*BRASS$"}}  # ^.*{type}$"
 query2Region: &query2Region {^Parameter: {Name: "Query2Region", Default: "EUROPE"}}
 
-TPCHNormalizedQuery2Aggregation: &TPCHNormalizedQuery2Aggregation
-  aggregate: part
-  pipeline:
-    [
-      {$match: {$and: [
-        {p_type: {$regex: *query2Type, $options: "si"}},
-        {p_size: {$eq: *query2Size}}]}},
-      {$lookup: {
-        from: "partsupp",
-        localField: "p_partkey",
-        foreignField: "ps_partkey",
-        as: "partsupp"}},
-      {$unwind: "$partsupp"},
-      {$lookup: {
-        from: "supplier",
-        localField: "partsupp.ps_suppkey",
-        foreignField: "s_suppkey",
-        as: "supplier"}},
-      {$unwind: "$supplier"},
-      {$lookup: {
-        from: "nation",
-        localField: "supplier.s_nationkey",
-        foreignField: "n_nationkey",
-        as: "nation"}},
-      {$unwind: "$nation"},
-      {$lookup: {
-        from: "region",
-        localField: "nation.n_regionkey",
-        foreignField: "r_regionkey",
-        as: "region"}},
-      {$unwind: "$region"},
-      {$match: {"region.r_name": *query2Region}},
-      {$sort: {"partsupp.ps_supplycost": 1}},
-      {$group: {
-        _id: {
-          p_partkey: "$p_partkey",
-          p_mfgr: "$p_mfgr"},
-        supplier: {$first: {
-          s_acctbal: "$supplier.s_acctbal",
-          s_name: "$supplier.s_name",
-          s_address: "$supplier.s_address",
-          s_phone: "$supplier.s_phone",
-          s_comment: "$supplier.s_comment",
-          ps_supplycost: "$partsupp.ps_supplycost",
-          n_name: "$nation.n_name"}}}},
-      {$project: {
-        _id: 0,
-        s_acctbal: "$supplier.s_acctbal",
-        s_name: "$supplier.s_name",
-        n_name: "$supplier.n_name",
-        p_partkey: "$_id.p_partkey",
-        p_mfgr: "$_id.p_mfgr",
-        s_address: "$supplier.s_address",
-        s_phone: "$supplier.s_phone",
-        s_comment: "$supplier.s_comment"}},
-      {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
-      {$limit: 100}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery2:
+TPCHNormalizedQuery2Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery2Aggregation
+      aggregate: part
+      pipeline:
+        [
+          {$match: {$and: [
+            {p_type: {$regex: *query2Type, $options: "si"}},
+            {p_size: {$eq: *query2Size}}]}},
+          {$lookup: {
+            from: "partsupp",
+            localField: "p_partkey",
+            foreignField: "ps_partkey",
+            as: "partsupp"}},
+          {$unwind: "$partsupp"},
+          {$lookup: {
+            from: "supplier",
+            localField: "partsupp.ps_suppkey",
+            foreignField: "s_suppkey",
+            as: "supplier"}},
+          {$unwind: "$supplier"},
+          {$lookup: {
+            from: "nation",
+            localField: "supplier.s_nationkey",
+            foreignField: "n_nationkey",
+            as: "nation"}},
+          {$unwind: "$nation"},
+          {$lookup: {
+            from: "region",
+            localField: "nation.n_regionkey",
+            foreignField: "r_regionkey",
+            as: "region"}},
+          {$unwind: "$region"},
+          {$match: {"region.r_name": *query2Region}},
+          {$sort: {"partsupp.ps_supplycost": 1}},
+          {$group: {
+            _id: {
+              p_partkey: "$p_partkey",
+              p_mfgr: "$p_mfgr"},
+            supplier: {$first: {
+              s_acctbal: "$supplier.s_acctbal",
+              s_name: "$supplier.s_name",
+              s_address: "$supplier.s_address",
+              s_phone: "$supplier.s_phone",
+              s_comment: "$supplier.s_comment",
+              ps_supplycost: "$partsupp.ps_supplycost",
+              n_name: "$nation.n_name"}}}},
+          {$project: {
+            _id: 0,
+            s_acctbal: "$supplier.s_acctbal",
+            s_name: "$supplier.s_name",
+            n_name: "$supplier.n_name",
+            p_partkey: "$_id.p_partkey",
+            p_mfgr: "$_id.p_mfgr",
+            s_address: "$supplier.s_address",
+            s_phone: "$supplier.s_phone",
+            s_comment: "$supplier.s_comment"}},
+          {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
+          {$limit: 100}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery2:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query2
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q2.yml
+++ b/src/phases/tpch/normalized/Q2.yml
@@ -1,82 +1,91 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 2 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
-  documents remain, which ensures that the query executes in its entirety.
+  Run TPC-H query 2 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query2Size: &query2Size {^Parameter: {Name: "Query2Size", Default: 15}}
 query2Type: &query2Type {^Parameter: {Name: "Query2Type", Default: "^.*BRASS$"}}  # ^.*{type}$"
 query2Region: &query2Region {^Parameter: {Name: "Query2Region", Default: "EUROPE"}}
 
+TPCHNormalizedQuery2Aggregation: &TPCHNormalizedQuery2Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [
+        {p_type: {$regex: *query2Type, $options: "si"}},
+        {p_size: {$eq: *query2Size}}]}},
+      {$lookup: {
+        from: "partsupp",
+        localField: "p_partkey",
+        foreignField: "ps_partkey",
+        as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {
+        from: "supplier",
+        localField: "partsupp.ps_suppkey",
+        foreignField: "s_suppkey",
+        as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$lookup: {
+        from: "nation",
+        localField: "supplier.s_nationkey",
+        foreignField: "n_nationkey",
+        as: "nation"}},
+      {$unwind: "$nation"},
+      {$lookup: {
+        from: "region",
+        localField: "nation.n_regionkey",
+        foreignField: "r_regionkey",
+        as: "region"}},
+      {$unwind: "$region"},
+      {$match: {"region.r_name": *query2Region}},
+      {$sort: {"partsupp.ps_supplycost": 1}},
+      {$group: {
+        _id: {
+          p_partkey: "$p_partkey",
+          p_mfgr: "$p_mfgr"},
+        supplier: {$first: {
+          s_acctbal: "$supplier.s_acctbal",
+          s_name: "$supplier.s_name",
+          s_address: "$supplier.s_address",
+          s_phone: "$supplier.s_phone",
+          s_comment: "$supplier.s_comment",
+          ps_supplycost: "$partsupp.ps_supplycost",
+          n_name: "$nation.n_name"}}}},
+      {$project: {
+        _id: 0,
+        s_acctbal: "$supplier.s_acctbal",
+        s_name: "$supplier.s_name",
+        n_name: "$supplier.n_name",
+        p_partkey: "$_id.p_partkey",
+        p_mfgr: "$_id.p_mfgr",
+        s_address: "$supplier.s_address",
+        s_phone: "$supplier.s_phone",
+        s_comment: "$supplier.s_comment"}},
+      {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery2:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query2
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery2Aggregation
+
+TPCHNormalizedQuery2Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query2
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: part
-        pipeline:
-          [
-            {$match: {$and: [
-              {p_type: {$regex: *query2Type, $options: "si"}},
-              {p_size: {$eq: *query2Size}}]}},
-            {$lookup: {
-              from: "partsupp",
-              localField: "p_partkey",
-              foreignField: "ps_partkey",
-              as: "partsupp"}},
-            {$unwind: "$partsupp"},
-            {$lookup: {
-              from: "supplier",
-              localField: "partsupp.ps_suppkey",
-              foreignField: "s_suppkey",
-              as: "supplier"}},
-            {$unwind: "$supplier"},
-            {$lookup: {
-              from: "nation",
-              localField: "supplier.s_nationkey",
-              foreignField: "n_nationkey",
-              as: "nation"}},
-            {$unwind: "$nation"},
-            {$lookup: {
-              from: "region",
-              localField: "nation.n_regionkey",
-              foreignField: "r_regionkey",
-              as: "region"}},
-            {$unwind: "$region"},
-            {$match: {"region.r_name": *query2Region}},
-            {$sort: {"partsupp.ps_supplycost": 1}},
-            {$group: {
-              _id: {
-                p_partkey: "$p_partkey",
-                p_mfgr: "$p_mfgr"},
-              supplier: {$first: {
-                s_acctbal: "$supplier.s_acctbal",
-                s_name: "$supplier.s_name",
-                s_address: "$supplier.s_address",
-                s_phone: "$supplier.s_phone",
-                s_comment: "$supplier.s_comment",
-                ps_supplycost: "$partsupp.ps_supplycost",
-                n_name: "$nation.n_name"}}}},
-            {$project: {
-              _id: 0,
-              s_acctbal: "$supplier.s_acctbal",
-              s_name: "$supplier.s_name",
-              n_name: "$supplier.n_name",
-              p_partkey: "$_id.p_partkey",
-              p_mfgr: "$_id.p_mfgr",
-              s_address: "$supplier.s_address",
-              s_phone: "$supplier.s_phone",
-              s_comment: "$supplier.s_comment"}},
-            {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
-            {$limit: 100}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery2Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q20.yml
+++ b/src/phases/tpch/normalized/Q20.yml
@@ -10,37 +10,42 @@ query20Nation: &query20Nation {^Parameter: {Name: "Query20Nation", Default: "CAN
 query20Color: &query20Color {^Parameter: {Name: "Query20Color", Default: "^forest.*$"}}  # "^${color}.*$"
 query20Date: &query20Date {^Parameter: {Name: "Query20Date", Default: "1994-01-01"}}
 
-TPCHNormalizedQuery20Aggregation: &TPCHNormalizedQuery20Aggregation
-  aggregate: supplier
-  pipeline:
-    [
-      {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
-      {$unwind: "$nation"},
-      {$match: {"nation.n_name": *query20Nation}},
-      {$lookup: {from: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", as: "partsupp"}},
-      {$unwind: "$partsupp"},
-      {$lookup: {from: "part", localField: "partsupp.ps_partkey", foreignField: "p_partkey", as: "part"}},
-      {$unwind: "$part"},
-      {$match: {"part.p_name": {$regex: *query20Color, $options: "si"}}},
-      {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
-        {$match: {$and: [
-          {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
-          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
-          {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
-        {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
-        {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
-      {$unwind: "$lineitem"},
-      {$match: {$expr: {$gt: ["$partsupp.ps_availqty", "$lineitem.quantity"]}}},
-      {$group: {_id: {s_name: "$s_name", s_address: "$s_address"}}},
-      {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
-      {$sort: {s_name: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery20:
+TPCHNormalizedQuery20Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery20Aggregation
+      aggregate: supplier
+      pipeline:
+        [
+          {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
+          {$unwind: "$nation"},
+          {$match: {"nation.n_name": *query20Nation}},
+          {$lookup: {from: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", as: "partsupp"}},
+          {$unwind: "$partsupp"},
+          {$lookup: {from: "part", localField: "partsupp.ps_partkey", foreignField: "p_partkey", as: "part"}},
+          {$unwind: "$part"},
+          {$match: {"part.p_name": {$regex: *query20Color, $options: "si"}}},
+          {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
+            {$match: {$and: [
+              {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
+              {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
+            {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
+            {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
+          {$unwind: "$lineitem"},
+          {$match: {$expr: {$gt: ["$partsupp.ps_availqty", "$lineitem.quantity"]}}},
+          {$group: {_id: {s_name: "$s_name", s_address: "$s_address"}}},
+          {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
+          {$sort: {s_name: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery20:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query20
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q20.yml
+++ b/src/phases/tpch/normalized/Q20.yml
@@ -4,46 +4,56 @@ Description: |
   Run TPC-H query 20 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query20Nation: &query20Nation {^Parameter: {Name: "Query20Nation", Default: "CANADA"}}
 query20Color: &query20Color {^Parameter: {Name: "Query20Color", Default: "^forest.*$"}}  # "^${color}.*$"
 query20Date: &query20Date {^Parameter: {Name: "Query20Date", Default: "1994-01-01"}}
 
+TPCHNormalizedQuery20Aggregation: &TPCHNormalizedQuery20Aggregation
+  aggregate: supplier
+  pipeline:
+    [
+      {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
+      {$unwind: "$nation"},
+      {$match: {"nation.n_name": *query20Nation}},
+      {$lookup: {from: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "part", localField: "partsupp.ps_partkey", foreignField: "p_partkey", as: "part"}},
+      {$unwind: "$part"},
+      {$match: {"part.p_name": {$regex: *query20Color, $options: "si"}}},
+      {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
+        {$match: {$and: [
+          {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
+          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
+          {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
+        {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
+        {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
+      {$unwind: "$lineitem"},
+      {$match: {$expr: {$gt: ["$partsupp.ps_availqty", "$lineitem.quantity"]}}},
+      {$group: {_id: {s_name: "$s_name", s_address: "$s_address"}}},
+      {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
+      {$sort: {s_name: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery20:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query20
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery20Aggregation
+
+TPCHNormalizedQuery20Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query20
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: supplier
-        pipeline:
-          [
-            {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
-            {$unwind: "$nation"},
-            {$match: {"nation.n_name": *query20Nation}},
-            {$lookup: {from: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", as: "partsupp"}},
-            {$unwind: "$partsupp"},
-            {$lookup: {from: "part", localField: "partsupp.ps_partkey", foreignField: "p_partkey", as: "part"}},
-            {$unwind: "$part"},
-            {$match: {"part.p_name": {$regex: *query20Color, $options: "si"}}},
-            {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
-              {$match: {$and: [
-                {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
-                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
-                {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
-              {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
-              {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
-            {$unwind: "$lineitem"},
-            {$match: {$expr: {$gt: ["$partsupp.ps_availqty", "$lineitem.quantity"]}}},
-            {$group: {_id: {s_name: "$s_name", s_address: "$s_address"}}},
-            {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
-            {$sort: {s_name: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery20Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q21.yml
+++ b/src/phases/tpch/normalized/Q21.yml
@@ -4,41 +4,51 @@ Description: |
   Run TPC-H query 21 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query21Nation: &query21Nation {^Parameter: {Name: "Query1Delta", Default: "SAUDI ARABIA"}}
 
+TPCHNormalizedQuery21Aggregation: &TPCHNormalizedQuery21Aggregation
+  aggregate: supplier
+  pipeline:
+    [
+      {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
+      {$unwind: "$nation"},
+      {$match: {"nation.n_name": *query21Nation}},
+      {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "l1", pipeline: [{$match: {$expr: {$gt: ["$l_receiptdate", "$l_commitdate"]}}}]}},
+      {$unwind: "$l1"},
+      {$lookup: {from: "orders", localField: "l1.l_orderkey", foreignField: "o_orderkey", as: "orders", pipeline: [{$match: {o_orderstatus: "F"}}]}},
+      {$unwind: "$orders"},
+      {$lookup: {from: "lineitem", let: {l1: "$l1"}, localField: "l1.l_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+        {$match: {$expr: {$ne: ["$$l1.l_suppkey", "$l_suppkey"]}}},
+        {$group: {_id: {}, l2_count: {$count: {}}, l3_count: {$sum: {$cond: {if: {$gt: ["$l_receiptdate", "$l_commitdate"]}, then: 1, else: 0}}}}}]}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gt: ["$lineitem.l2_count", 0]}},
+        {$expr: {$eq: ["$lineitem.l3_count", 0]}}]}},
+      {$group: {_id: "$s_name", numwait: {$count: {}}}},
+      {$project: {_id: 0, s_name: "$_id", numwait: 1}},
+      {$sort: {numwait: -1, s_name: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery21:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query21
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery21Aggregation
+
+TPCHNormalizedQuery21Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query21
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: supplier
-        pipeline:
-          [
-            {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
-            {$unwind: "$nation"},
-            {$match: {"nation.n_name": *query21Nation}},
-            {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "l1", pipeline: [{$match: {$expr: {$gt: ["$l_receiptdate", "$l_commitdate"]}}}]}},
-            {$unwind: "$l1"},
-            {$lookup: {from: "orders", localField: "l1.l_orderkey", foreignField: "o_orderkey", as: "orders", pipeline: [{$match: {o_orderstatus: "F"}}]}},
-            {$unwind: "$orders"},
-            {$lookup: {from: "lineitem", let: {l1: "$l1"}, localField: "l1.l_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-              {$match: {$expr: {$ne: ["$$l1.l_suppkey", "$l_suppkey"]}}},
-              {$group: {_id: {}, l2_count: {$count: {}}, l3_count: {$sum: {$cond: {if: {$gt: ["$l_receiptdate", "$l_commitdate"]}, then: 1, else: 0}}}}}]}},
-            {$unwind: "$lineitem"},
-            {$match: {$and: [
-              {$expr: {$gt: ["$lineitem.l2_count", 0]}},
-              {$expr: {$eq: ["$lineitem.l3_count", 0]}}]}},
-            {$group: {_id: "$s_name", numwait: {$count: {}}}},
-            {$project: {_id: 0, s_name: "$_id", numwait: 1}},
-            {$sort: {numwait: -1, s_name: 1}},
-            {$limit: 100}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery21Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q21.yml
+++ b/src/phases/tpch/normalized/Q21.yml
@@ -7,35 +7,40 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query21Nation: &query21Nation {^Parameter: {Name: "Query1Delta", Default: "SAUDI ARABIA"}}
 
-TPCHNormalizedQuery21Aggregation: &TPCHNormalizedQuery21Aggregation
-  aggregate: supplier
-  pipeline:
-    [
-      {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
-      {$unwind: "$nation"},
-      {$match: {"nation.n_name": *query21Nation}},
-      {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "l1", pipeline: [{$match: {$expr: {$gt: ["$l_receiptdate", "$l_commitdate"]}}}]}},
-      {$unwind: "$l1"},
-      {$lookup: {from: "orders", localField: "l1.l_orderkey", foreignField: "o_orderkey", as: "orders", pipeline: [{$match: {o_orderstatus: "F"}}]}},
-      {$unwind: "$orders"},
-      {$lookup: {from: "lineitem", let: {l1: "$l1"}, localField: "l1.l_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-        {$match: {$expr: {$ne: ["$$l1.l_suppkey", "$l_suppkey"]}}},
-        {$group: {_id: {}, l2_count: {$count: {}}, l3_count: {$sum: {$cond: {if: {$gt: ["$l_receiptdate", "$l_commitdate"]}, then: 1, else: 0}}}}}]}},
-      {$unwind: "$lineitem"},
-      {$match: {$and: [
-        {$expr: {$gt: ["$lineitem.l2_count", 0]}},
-        {$expr: {$eq: ["$lineitem.l3_count", 0]}}]}},
-      {$group: {_id: "$s_name", numwait: {$count: {}}}},
-      {$project: {_id: 0, s_name: "$_id", numwait: 1}},
-      {$sort: {numwait: -1, s_name: 1}},
-      {$limit: 100}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery21:
+TPCHNormalizedQuery21Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery21Aggregation
+      aggregate: supplier
+      pipeline:
+        [
+          {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
+          {$unwind: "$nation"},
+          {$match: {"nation.n_name": *query21Nation}},
+          {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "l1", pipeline: [{$match: {$expr: {$gt: ["$l_receiptdate", "$l_commitdate"]}}}]}},
+          {$unwind: "$l1"},
+          {$lookup: {from: "orders", localField: "l1.l_orderkey", foreignField: "o_orderkey", as: "orders", pipeline: [{$match: {o_orderstatus: "F"}}]}},
+          {$unwind: "$orders"},
+          {$lookup: {from: "lineitem", let: {l1: "$l1"}, localField: "l1.l_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+            {$match: {$expr: {$ne: ["$$l1.l_suppkey", "$l_suppkey"]}}},
+            {$group: {_id: {}, l2_count: {$count: {}}, l3_count: {$sum: {$cond: {if: {$gt: ["$l_receiptdate", "$l_commitdate"]}, then: 1, else: 0}}}}}]}},
+          {$unwind: "$lineitem"},
+          {$match: {$and: [
+            {$expr: {$gt: ["$lineitem.l2_count", 0]}},
+            {$expr: {$eq: ["$lineitem.l3_count", 0]}}]}},
+          {$group: {_id: "$s_name", numwait: {$count: {}}}},
+          {$project: {_id: 0, s_name: "$_id", numwait: 1}},
+          {$sort: {numwait: -1, s_name: 1}},
+          {$limit: 100}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery21:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query21
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q22.yml
+++ b/src/phases/tpch/normalized/Q22.yml
@@ -4,7 +4,7 @@ Description: |
   Run TPC-H query 22 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 # Sadly, using an array here parses as an array of numbers instead of as an array of strings.
 # To work around this, use separate parameters for each entry in the array.
 query22CountryCode1: &query22CountryCode1 {^Parameter: {Name: "Query22CountryCode1", Default: "13"}}
@@ -15,46 +15,56 @@ query22CountryCode5: &query22CountryCode5 {^Parameter: {Name: "Query22CountryCod
 query22CountryCode6: &query22CountryCode6 {^Parameter: {Name: "Query22CountryCode6", Default: "18"}}
 query22CountryCode7: &query22CountryCode7 {^Parameter: {Name: "Query22CountryCode7", Default: "17"}}
 
+TPCHNormalizedQuery22Aggregation: &TPCHNormalizedQuery22Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "custsale"}},
+      {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
+      {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}}},
+      {$match: {$and: [
+        {$expr: {$in: ["$cntrycode", [
+          *query22CountryCode1,
+          *query22CountryCode2,
+          *query22CountryCode3,
+          *query22CountryCode4,
+          *query22CountryCode5,
+          *query22CountryCode6,
+          *query22CountryCode7]]}},
+        {custsale: null},
+        {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
+      {$facet: {
+        customer: [
+          {$project: {cntrycode: 1, c_acctbal: 1}}],
+        "avg(c_acctbal)": [
+          {$group: {_id: {}, value: {$avg: "$c_acctbal"}}},
+          {$project: {_id: 0}}]}},
+      {$unwind: "$avg(c_acctbal)"},
+      {$unwind: "$customer"},
+      {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
+      {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
+      {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
+      {$sort: {cntrycode: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery22:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query22
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery22Aggregation
+
+TPCHNormalizedQuery22Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query22
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "custsale"}},
-            {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
-            {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}}},
-            {$match: {$and: [
-              {$expr: {$in: ["$cntrycode", [
-                *query22CountryCode1,
-                *query22CountryCode2,
-                *query22CountryCode3,
-                *query22CountryCode4,
-                *query22CountryCode5,
-                *query22CountryCode6,
-                *query22CountryCode7]]}},
-              {custsale: null},
-              {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
-            {$facet: {
-              customer: [
-                {$project: {cntrycode: 1, c_acctbal: 1}}],
-              "avg(c_acctbal)": [
-                {$group: {_id: {}, value: {$avg: "$c_acctbal"}}},
-                {$project: {_id: 0}}]}},
-            {$unwind: "$avg(c_acctbal)"},
-            {$unwind: "$customer"},
-            {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
-            {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
-            {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
-            {$sort: {cntrycode: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery22Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q22.yml
+++ b/src/phases/tpch/normalized/Q22.yml
@@ -5,15 +5,16 @@ Description: |
   documents remain, which ensures that the query executes in its entirety.
 
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
-# Sadly, using an array here parses as an array of numbers instead of as an array of strings.
-# To work around this, use separate parameters for each entry in the array.
-query22CountryCode1: &query22CountryCode1 {^Parameter: {Name: "Query22CountryCode1", Default: "13"}}
-query22CountryCode2: &query22CountryCode2 {^Parameter: {Name: "Query22CountryCode2", Default: "31"}}
-query22CountryCode3: &query22CountryCode3 {^Parameter: {Name: "Query22CountryCode3", Default: "23"}}
-query22CountryCode4: &query22CountryCode4 {^Parameter: {Name: "Query22CountryCode4", Default: "29"}}
-query22CountryCode5: &query22CountryCode5 {^Parameter: {Name: "Query22CountryCode5", Default: "30"}}
-query22CountryCode6: &query22CountryCode6 {^Parameter: {Name: "Query22CountryCode6", Default: "18"}}
-query22CountryCode7: &query22CountryCode7 {^Parameter: {Name: "Query22CountryCode7", Default: "17"}}
+# Use $toString as a hack, because yml parses these strings into ints before outputting the pipeline.
+query22CountryCodes: &query22CountryCodes {^Parameter: {Name: "Query22CountryCodes", Default: [
+  {$toString: "13"},
+  {$toString: "31"},
+  {$toString: "23"},
+  {$toString: "29"},
+  {$toString: "30"},
+  {$toString: "18"},
+  {$toString: "17"}
+]}}
 
 TPCHNormalizedQuery22Aggregation: &TPCHNormalizedQuery22Aggregation
   aggregate: customer
@@ -23,14 +24,7 @@ TPCHNormalizedQuery22Aggregation: &TPCHNormalizedQuery22Aggregation
       {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
       {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}}},
       {$match: {$and: [
-        {$expr: {$in: ["$cntrycode", [
-          *query22CountryCode1,
-          *query22CountryCode2,
-          *query22CountryCode3,
-          *query22CountryCode4,
-          *query22CountryCode5,
-          *query22CountryCode6,
-          *query22CountryCode7]]}},
+        {$expr: {$in: ["$cntrycode", *query22CountryCodes]}},
         {custsale: null},
         {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
       {$facet: {

--- a/src/phases/tpch/normalized/Q22.yml
+++ b/src/phases/tpch/normalized/Q22.yml
@@ -16,36 +16,41 @@ query22CountryCodes: &query22CountryCodes {^Parameter: {Name: "Query22CountryCod
   {$toString: "17"}
 ]}}
 
-TPCHNormalizedQuery22Aggregation: &TPCHNormalizedQuery22Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "custsale"}},
-      {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
-      {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}}},
-      {$match: {$and: [
-        {$expr: {$in: ["$cntrycode", *query22CountryCodes]}},
-        {custsale: null},
-        {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
-      {$facet: {
-        customer: [
-          {$project: {cntrycode: 1, c_acctbal: 1}}],
-        "avg(c_acctbal)": [
-          {$group: {_id: {}, value: {$avg: "$c_acctbal"}}},
-          {$project: {_id: 0}}]}},
-      {$unwind: "$avg(c_acctbal)"},
-      {$unwind: "$customer"},
-      {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
-      {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
-      {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
-      {$sort: {cntrycode: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery22:
+TPCHNormalizedQuery22Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery22Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "custsale"}},
+          {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
+          {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}}},
+          {$match: {$and: [
+            {$expr: {$in: ["$cntrycode", *query22CountryCodes]}},
+            {custsale: null},
+            {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
+          {$facet: {
+            customer: [
+              {$project: {cntrycode: 1, c_acctbal: 1}}],
+            "avg(c_acctbal)": [
+              {$group: {_id: {}, value: {$avg: "$c_acctbal"}}},
+              {$project: {_id: 0}}]}},
+          {$unwind: "$avg(c_acctbal)"},
+          {$unwind: "$customer"},
+          {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
+          {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
+          {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
+          {$sort: {cntrycode: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery22:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query22
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q3.yml
+++ b/src/phases/tpch/normalized/Q3.yml
@@ -9,29 +9,34 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query3Segment: &query3Segment {^Parameter: {Name: "Query3Segment", Default: "BUILDING"}}
 query3Date: &query3Date {^Parameter: {Name: "Query3Date", Default: "1995-03-15"}}
 
-TPCHNormalizedQuery3Aggregation: &TPCHNormalizedQuery3Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
-      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-        {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
-        {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
-      {$unwind: "$orders"},
-      {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-        {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}}]}},
-      {$unwind: "$lineitem"},
-      {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
-      {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
-      {$sort: {revenue: -1, o_orderdate: 1}},
-      {$limit: 10}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery3:
+TPCHNormalizedQuery3Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery3Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
+          {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
+            {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
+            {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
+          {$unwind: "$orders"},
+          {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+            {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}}]}},
+          {$unwind: "$lineitem"},
+          {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+          {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
+          {$sort: {revenue: -1, o_orderdate: 1}},
+          {$limit: 10}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery3:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query3
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q3.yml
+++ b/src/phases/tpch/normalized/Q3.yml
@@ -4,37 +4,47 @@ Description: |
   Run TPC-H query 3 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query3Segment: &query3Segment {^Parameter: {Name: "Query3Segment", Default: "BUILDING"}}
 query3Date: &query3Date {^Parameter: {Name: "Query3Date", Default: "1995-03-15"}}
 
+TPCHNormalizedQuery3Aggregation: &TPCHNormalizedQuery3Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
+      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
+        {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
+        {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
+      {$unwind: "$orders"},
+      {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+        {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}}]}},
+      {$unwind: "$lineitem"},
+      {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
+      {$sort: {revenue: -1, o_orderdate: 1}},
+      {$limit: 10}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery3:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query3
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery3Aggregation
+
+TPCHNormalizedQuery3Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query3
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
-            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-              {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
-              {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
-            {$unwind: "$orders"},
-            {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-              {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}}]}},
-            {$unwind: "$lineitem"},
-            {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
-            {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
-            {$sort: {revenue: -1, o_orderdate: 1}},
-            {$limit: 10}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery3Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q4.yml
+++ b/src/phases/tpch/normalized/Q4.yml
@@ -7,34 +7,39 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query4Date: &query4Date {^Parameter: {Name: "Query4Date", Default: "1993-07-01"}}
 
-TPCHNormalizedQuery4Aggregation: &TPCHNormalizedQuery4Aggregation
-  aggregate: orders
-  pipeline:
-    [
-      {$match: {
-        $and: [
-          {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
-          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}}]}},
-      {$lookup: {
-        from: "lineitem",
-        localField: "o_orderkey",
-        foreignField: "l_orderkey",
-        pipeline: [{$match: {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}}}, {$count: "count"}],
-        as: "lineitem"}},
-      {$unwind: "$lineitem"},
-      {$match: {$expr: {$gt: ["$lineitem.count", 0]}}},
-      {$group: {
-        _id: "$o_orderpriority",
-        order_count: {$count: {}}}},
-      {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
-      {$sort: {o_orderpriority: 1}},
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery4:
+TPCHNormalizedQuery4Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery4Aggregation
+      aggregate: orders
+      pipeline:
+        [
+          {$match: {
+            $and: [
+              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
+              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}}]}},
+          {$lookup: {
+            from: "lineitem",
+            localField: "o_orderkey",
+            foreignField: "l_orderkey",
+            pipeline: [{$match: {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}}}, {$count: "count"}],
+            as: "lineitem"}},
+          {$unwind: "$lineitem"},
+          {$match: {$expr: {$gt: ["$lineitem.count", 0]}}},
+          {$group: {
+            _id: "$o_orderpriority",
+            order_count: {$count: {}}}},
+          {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
+          {$sort: {o_orderpriority: 1}},
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery4:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query4
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q4.yml
+++ b/src/phases/tpch/normalized/Q4.yml
@@ -4,40 +4,50 @@ Description: |
   Run TPC-H query 4 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query4Date: &query4Date {^Parameter: {Name: "Query4Date", Default: "1993-07-01"}}
 
+TPCHNormalizedQuery4Aggregation: &TPCHNormalizedQuery4Aggregation
+  aggregate: orders
+  pipeline:
+    [
+      {$match: {
+        $and: [
+          {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
+          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}}]}},
+      {$lookup: {
+        from: "lineitem",
+        localField: "o_orderkey",
+        foreignField: "l_orderkey",
+        pipeline: [{$match: {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}}}, {$count: "count"}],
+        as: "lineitem"}},
+      {$unwind: "$lineitem"},
+      {$match: {$expr: {$gt: ["$lineitem.count", 0]}}},
+      {$group: {
+        _id: "$o_orderpriority",
+        order_count: {$count: {}}}},
+      {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
+      {$sort: {o_orderpriority: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery4:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query4
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery4Aggregation
+
+TPCHNormalizedQuery4Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query4
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: orders
-        pipeline:
-          [
-            {$match: {
-              $and: [
-                {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
-                {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}}]}},
-            {$lookup: {
-              from: "lineitem",
-              localField: "o_orderkey",
-              foreignField: "l_orderkey",
-              pipeline: [{$match: {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}}}, {$count: "count"}],
-              as: "lineitem"}},
-            {$unwind: "$lineitem"},
-            {$match: {$expr: {$gt: ["$lineitem.count", 0]}}},
-            {$group: {
-              _id: "$o_orderpriority",
-              order_count: {$count: {}}}},
-            {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
-            {$sort: {o_orderpriority: 1}},
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery4Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q5.yml
+++ b/src/phases/tpch/normalized/Q5.yml
@@ -8,35 +8,40 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query5Region: &query5Region {^Parameter: {Name: "Query5Region", Default: "ASIA"}}
 query5Date: &query5Date {^Parameter: {Name: "Query5Date", Default: "1994-01-01"}}
 
-TPCHNormalizedQuery5Aggregation: &TPCHNormalizedQuery5Aggregation
-  aggregate: customer
-  pipeline:
-    [
-      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
-        {$match: {$and: [
-          {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
-          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
-        {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
-          {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-            {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
-            {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
-              {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
-                {$match: {r_name: *query5Region}}]}},
-              {$unwind: "$region"}]}},
-            {$unwind: "$nation"}]}},
-          {$unwind: "$supplier"}]}},
-        {$unwind: "$lineitem"}]}},
-      {$unwind: "$orders"},
-      {$group: {_id: "$orders.lineitem.supplier.nation.n_name", revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
-      {$project: {_id: 0, n_name: "$_id", revenue: 1}},
-      {$sort: {revenue: -1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery5:
+TPCHNormalizedQuery5Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery5Aggregation
+      aggregate: customer
+      pipeline:
+        [
+          {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
+            {$match: {$and: [
+              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
+              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
+            {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
+              {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+                {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
+                {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
+                  {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
+                    {$match: {r_name: *query5Region}}]}},
+                  {$unwind: "$region"}]}},
+                {$unwind: "$nation"}]}},
+              {$unwind: "$supplier"}]}},
+            {$unwind: "$lineitem"}]}},
+          {$unwind: "$orders"},
+          {$group: {_id: "$orders.lineitem.supplier.nation.n_name", revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+          {$project: {_id: 0, n_name: "$_id", revenue: 1}},
+          {$sort: {revenue: -1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery5:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query5
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q5.yml
+++ b/src/phases/tpch/normalized/Q5.yml
@@ -4,42 +4,52 @@ Description: |
   Run TPC-H query 5 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query5Region: &query5Region {^Parameter: {Name: "Query5Region", Default: "ASIA"}}
 query5Date: &query5Date {^Parameter: {Name: "Query5Date", Default: "1994-01-01"}}
 
+TPCHNormalizedQuery5Aggregation: &TPCHNormalizedQuery5Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
+        {$match: {$and: [
+          {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
+          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
+        {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
+          {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+            {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
+            {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
+              {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
+                {$match: {r_name: *query5Region}}]}},
+              {$unwind: "$region"}]}},
+            {$unwind: "$nation"}]}},
+          {$unwind: "$supplier"}]}},
+        {$unwind: "$lineitem"}]}},
+      {$unwind: "$orders"},
+      {$group: {_id: "$orders.lineitem.supplier.nation.n_name", revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, n_name: "$_id", revenue: 1}},
+      {$sort: {revenue: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery5:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query5
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery5Aggregation
+
+TPCHNormalizedQuery5Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query5
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: customer
-        pipeline:
-          [
-            {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
-              {$match: {$and: [
-                {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
-                {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
-              {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
-                {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-                  {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
-                  {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
-                    {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
-                      {$match: {r_name: *query5Region}}]}},
-                    {$unwind: "$region"}]}},
-                  {$unwind: "$nation"}]}},
-                {$unwind: "$supplier"}]}},
-              {$unwind: "$lineitem"}]}},
-            {$unwind: "$orders"},
-            {$group: {_id: "$orders.lineitem.supplier.nation.n_name", revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
-            {$project: {_id: 0, n_name: "$_id", revenue: 1}},
-            {$sort: {revenue: -1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery5Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q6.yml
+++ b/src/phases/tpch/normalized/Q6.yml
@@ -10,25 +10,30 @@ query6Date: &query6Date {^Parameter: {Name: "Query6Date", Default: "1994-01-01"}
 query6Discount: &query6Discount {^Parameter: {Name: "Query6Discount", Default: 0.06}}
 query6Quantity: &query6Quantity {^Parameter: {Name: "Query6Quantity", Default: 24}}
 
-TPCHNormalizedQuery6Aggregation: &TPCHNormalizedQuery6Aggregation
-  aggregate: lineitem
-  pipeline:
-    [
-      {$match: {$and: [
-        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
-        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
-        {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
-        {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
-        {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
-      {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
-      {$project: {_id: 0, revenue: 1}},
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery6:
+TPCHNormalizedQuery6Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery6Aggregation
+      aggregate: lineitem
+      pipeline:
+        [
+          {$match: {$and: [
+            {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
+            {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+            {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
+            {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
+            {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
+          {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
+          {$project: {_id: 0, revenue: 1}},
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery6:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query6
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q6.yml
+++ b/src/phases/tpch/normalized/Q6.yml
@@ -4,34 +4,44 @@ Description: |
   Run TPC-H query 6 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query6Date: &query6Date {^Parameter: {Name: "Query6Date", Default: "1994-01-01"}}
 query6Discount: &query6Discount {^Parameter: {Name: "Query6Discount", Default: 0.06}}
 query6Quantity: &query6Quantity {^Parameter: {Name: "Query6Quantity", Default: 24}}
 
+TPCHNormalizedQuery6Aggregation: &TPCHNormalizedQuery6Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$match: {$and: [
+        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
+        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+        {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
+        {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
+        {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
+      {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
+      {$project: {_id: 0, revenue: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery6:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query6
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery6Aggregation
+
+TPCHNormalizedQuery6Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query6
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: lineitem
-        pipeline:
-          [
-            {$match: {$and: [
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
-              {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
-              {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
-              {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
-              {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
-            {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
-            {$project: {_id: 0, revenue: 1}},
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery6Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q7.yml
+++ b/src/phases/tpch/normalized/Q7.yml
@@ -8,38 +8,43 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query7Nation1: &query7Nation1 {^Parameter: {Name: "Query7Nation1", Default: "FRANCE"}}
 query7Nation2: &query7Nation2 {^Parameter: {Name: "Query7Nation2", Default: "GERMANY"}}
 
-TPCHNormalizedQuery7Aggregation: &TPCHNormalizedQuery7Aggregation
-  aggregate: supplier
-  pipeline:
-    [
-      {$project: {s_nationkey: 1, s_suppkey: 1}},
-      {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "n1"}},
-      {$unwind: "$n1"},
-      {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
-        {$match: {$and: [
-          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
-          {$expr: {$lt: ["$l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}}]}},
-      {$unwind: "$lineitem"},
-      {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
-      {$unwind: "$orders"},
-      {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
-      {$unwind: "$customer"},
-      {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n2"}},
-      {$unwind: "$n2"},
-      {$match: {$or: [
-        {$and: [{"n1.n_name": *query7Nation1}, {"n2.n_name": *query7Nation2}]},
-        {$and: [{"n1.n_name": *query7Nation2}, {"n2.n_name": *query7Nation1}]}]}},
-      {$project: {supp_nation: "$n1.n_name", cust_nation: "$n2.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
-      {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
-      {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
-      {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery7:
+TPCHNormalizedQuery7Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery7Aggregation
+      aggregate: supplier
+      pipeline:
+        [
+          {$project: {s_nationkey: 1, s_suppkey: 1}},
+          {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "n1"}},
+          {$unwind: "$n1"},
+          {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
+            {$match: {$and: [
+              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
+              {$expr: {$lt: ["$l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}}]}},
+          {$unwind: "$lineitem"},
+          {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+          {$unwind: "$orders"},
+          {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
+          {$unwind: "$customer"},
+          {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n2"}},
+          {$unwind: "$n2"},
+          {$match: {$or: [
+            {$and: [{"n1.n_name": *query7Nation1}, {"n2.n_name": *query7Nation2}]},
+            {$and: [{"n1.n_name": *query7Nation2}, {"n2.n_name": *query7Nation1}]}]}},
+          {$project: {supp_nation: "$n1.n_name", cust_nation: "$n2.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
+          {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
+          {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
+          {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery7:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query7
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q7.yml
+++ b/src/phases/tpch/normalized/Q7.yml
@@ -4,45 +4,55 @@ Description: |
   Run TPC-H query 7 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query7Nation1: &query7Nation1 {^Parameter: {Name: "Query7Nation1", Default: "FRANCE"}}
 query7Nation2: &query7Nation2 {^Parameter: {Name: "Query7Nation2", Default: "GERMANY"}}
 
+TPCHNormalizedQuery7Aggregation: &TPCHNormalizedQuery7Aggregation
+  aggregate: supplier
+  pipeline:
+    [
+      {$project: {s_nationkey: 1, s_suppkey: 1}},
+      {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "n1"}},
+      {$unwind: "$n1"},
+      {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
+        {$match: {$and: [
+          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
+          {$expr: {$lt: ["$l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}}]}},
+      {$unwind: "$lineitem"},
+      {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+      {$unwind: "$orders"},
+      {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
+      {$unwind: "$customer"},
+      {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n2"}},
+      {$unwind: "$n2"},
+      {$match: {$or: [
+        {$and: [{"n1.n_name": *query7Nation1}, {"n2.n_name": *query7Nation2}]},
+        {$and: [{"n1.n_name": *query7Nation2}, {"n2.n_name": *query7Nation1}]}]}},
+      {$project: {supp_nation: "$n1.n_name", cust_nation: "$n2.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
+      {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
+      {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
+      {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery7:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query7
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery7Aggregation
+
+TPCHNormalizedQuery7Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query7
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: supplier
-        pipeline:
-          [
-            {$project: {s_nationkey: 1, s_suppkey: 1}},
-            {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "n1"}},
-            {$unwind: "$n1"},
-            {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
-              {$match: {$and: [
-                {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
-                {$expr: {$lt: ["$l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}}]}},
-            {$unwind: "$lineitem"},
-            {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
-            {$unwind: "$orders"},
-            {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
-            {$unwind: "$customer"},
-            {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n2"}},
-            {$unwind: "$n2"},
-            {$match: {$or: [
-              {$and: [{"n1.n_name": *query7Nation1}, {"n2.n_name": *query7Nation2}]},
-              {$and: [{"n1.n_name": *query7Nation2}, {"n2.n_name": *query7Nation1}]}]}},
-            {$project: {supp_nation: "$n1.n_name", cust_nation: "$n2.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
-            {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
-            {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
-            {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery7Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q8.yml
+++ b/src/phases/tpch/normalized/Q8.yml
@@ -4,54 +4,64 @@ Description: |
   Run TPC-H query 8 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query8Type: &query8Type {^Parameter: {Name: "Query8Type", Default: "ECONOMY ANODIZED STEEL"}}
 query8Region: &query8Region {^Parameter: {Name: "Query8Region", Default: "AMERICA"}}
 query8Nation: &query8Nation {^Parameter: {Name: "Query8Nation", Default: "BRAZIL"}}
 
+TPCHNormalizedQuery8Aggregation: &TPCHNormalizedQuery8Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {p_type: {$eq: *query8Type}}},
+      {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem"}},
+      {$unwind: "$lineitem"},
+      {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$lookup: {from: "nation", localField: "supplier.s_nationkey", foreignField: "n_nationkey", as: "n2"}},
+      {$unwind: "$n2"},
+      {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+      {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
+      {$unwind: "$customer"},
+      {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n1"}},
+      {$unwind: "$n1"},
+      {$lookup: {from: "region", localField: "n1.n_regionkey", foreignField: "r_regionkey", as: "region"}},
+      {$unwind: "$region"},
+      {$match: {"region.r_name": {$eq: *query8Region}}},
+      {$project: {
+        o_year: {$year: "$orders.o_orderdate"},
+        volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]},
+        nation: "$n2.n_name"}},
+      {$group: {
+        _id: "$o_year", total_volume: {$sum: "$volume"},
+        nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
+      {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
+      {$sort: {o_year: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery8:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query8
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery8Aggregation
+
+TPCHNormalizedQuery8Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query8
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: part
-        pipeline:
-          [
-            {$match: {p_type: {$eq: *query8Type}}},
-            {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem"}},
-            {$unwind: "$lineitem"},
-            {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
-            {$unwind: "$supplier"},
-            {$lookup: {from: "nation", localField: "supplier.s_nationkey", foreignField: "n_nationkey", as: "n2"}},
-            {$unwind: "$n2"},
-            {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
-            {$unwind: "$orders"},
-            {$match: {$and: [
-              {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
-              {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
-            {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
-            {$unwind: "$customer"},
-            {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n1"}},
-            {$unwind: "$n1"},
-            {$lookup: {from: "region", localField: "n1.n_regionkey", foreignField: "r_regionkey", as: "region"}},
-            {$unwind: "$region"},
-            {$match: {"region.r_name": {$eq: *query8Region}}},
-            {$project: {
-              o_year: {$year: "$orders.o_orderdate"},
-              volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]},
-              nation: "$n2.n_name"}},
-            {$group: {
-              _id: "$o_year", total_volume: {$sum: "$volume"},
-              nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
-            {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
-            {$sort: {o_year: 1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery8Aggregation
       verbosity:
         executionStats

--- a/src/phases/tpch/normalized/Q8.yml
+++ b/src/phases/tpch/normalized/Q8.yml
@@ -10,45 +10,50 @@ query8Type: &query8Type {^Parameter: {Name: "Query8Type", Default: "ECONOMY ANOD
 query8Region: &query8Region {^Parameter: {Name: "Query8Region", Default: "AMERICA"}}
 query8Nation: &query8Nation {^Parameter: {Name: "Query8Nation", Default: "BRAZIL"}}
 
-TPCHNormalizedQuery8Aggregation: &TPCHNormalizedQuery8Aggregation
-  aggregate: part
-  pipeline:
-    [
-      {$match: {p_type: {$eq: *query8Type}}},
-      {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem"}},
-      {$unwind: "$lineitem"},
-      {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
-      {$unwind: "$supplier"},
-      {$lookup: {from: "nation", localField: "supplier.s_nationkey", foreignField: "n_nationkey", as: "n2"}},
-      {$unwind: "$n2"},
-      {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
-      {$unwind: "$orders"},
-      {$match: {$and: [
-        {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
-      {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
-      {$unwind: "$customer"},
-      {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n1"}},
-      {$unwind: "$n1"},
-      {$lookup: {from: "region", localField: "n1.n_regionkey", foreignField: "r_regionkey", as: "region"}},
-      {$unwind: "$region"},
-      {$match: {"region.r_name": {$eq: *query8Region}}},
-      {$project: {
-        o_year: {$year: "$orders.o_orderdate"},
-        volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]},
-        nation: "$n2.n_name"}},
-      {$group: {
-        _id: "$o_year", total_volume: {$sum: "$volume"},
-        nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
-      {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
-      {$sort: {o_year: 1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery8:
+TPCHNormalizedQuery8Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery8Aggregation
+      aggregate: part
+      pipeline:
+        [
+          {$match: {p_type: {$eq: *query8Type}}},
+          {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem"}},
+          {$unwind: "$lineitem"},
+          {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+          {$unwind: "$supplier"},
+          {$lookup: {from: "nation", localField: "supplier.s_nationkey", foreignField: "n_nationkey", as: "n2"}},
+          {$unwind: "$n2"},
+          {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+          {$unwind: "$orders"},
+          {$match: {$and: [
+            {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
+            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+          {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
+          {$unwind: "$customer"},
+          {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n1"}},
+          {$unwind: "$n1"},
+          {$lookup: {from: "region", localField: "n1.n_regionkey", foreignField: "r_regionkey", as: "region"}},
+          {$unwind: "$region"},
+          {$match: {"region.r_name": {$eq: *query8Region}}},
+          {$project: {
+            o_year: {$year: "$orders.o_orderdate"},
+            volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]},
+            nation: "$n2.n_name"}},
+          {$group: {
+            _id: "$o_year", total_volume: {$sum: "$volume"},
+            nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
+          {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
+          {$sort: {o_year: 1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery8:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query8
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q9.yml
+++ b/src/phases/tpch/normalized/Q9.yml
@@ -8,35 +8,40 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${color}.*$
 
-TPCHNormalizedQuery9Aggregation: &TPCHNormalizedQuery9Aggregation
-  aggregate: part
-  pipeline:
-    [
-      {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}},
-      {$lookup: {from: "partsupp", as: "partsupp", localField: "p_partkey", foreignField: "ps_partkey"}},
-      {$unwind: "$partsupp"},
-      {$lookup: {from: "supplier", as: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [
-        {$lookup: {from: "nation", as: "nation", localField: "s_nationkey", foreignField: "n_nationkey"}},
-        {$unwind: "$nation"}]}},
-      {$unwind: "$supplier"},
-      {$project: {p_partkey: 1, s_suppkey: "$supplier.s_suppkey", nation: "$supplier.nation.n_name", partsupp: 1}},
-      {$lookup: {from: "lineitem", as: "lineitem", localField: "p_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, pipeline: [
-        {$match: {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}}},
-        {$lookup: {from: "orders", as: "orders", localField: "l_orderkey", foreignField: "o_orderkey"}},
-        {$unwind: "$orders"}]}},
-      {$unwind: "$lineitem"},
-      {$group: {_id: {nation: "$nation", o_year: {$year: "$lineitem.orders.o_orderdate"}}, sum_profit: {$sum: {$subtract: [
-        {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]},
-        {$multiply: ["$partsupp.ps_supplycost", "$lineitem.l_quantity"]}]}}}},
-      {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
-      {$sort: {nation: 1, o_year: -1}}
-    ]
-  cursor: {batchSize: *batchSize}
-  allowDiskUse: true
-
-TPCHNormalizedQuery9:
+TPCHNormalizedQuery9Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
+  Operations:
+  - OperationName: RunCommand
+    OperationCommand: &TPCHNormalizedQuery9Aggregation
+      aggregate: part
+      pipeline:
+        [
+          {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}},
+          {$lookup: {from: "partsupp", as: "partsupp", localField: "p_partkey", foreignField: "ps_partkey"}},
+          {$unwind: "$partsupp"},
+          {$lookup: {from: "supplier", as: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [
+            {$lookup: {from: "nation", as: "nation", localField: "s_nationkey", foreignField: "n_nationkey"}},
+            {$unwind: "$nation"}]}},
+          {$unwind: "$supplier"},
+          {$project: {p_partkey: 1, s_suppkey: "$supplier.s_suppkey", nation: "$supplier.nation.n_name", partsupp: 1}},
+          {$lookup: {from: "lineitem", as: "lineitem", localField: "p_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, pipeline: [
+            {$match: {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}}},
+            {$lookup: {from: "orders", as: "orders", localField: "l_orderkey", foreignField: "o_orderkey"}},
+            {$unwind: "$orders"}]}},
+          {$unwind: "$lineitem"},
+          {$group: {_id: {nation: "$nation", o_year: {$year: "$lineitem.orders.o_orderdate"}}, sum_profit: {$sum: {$subtract: [
+            {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]},
+            {$multiply: ["$partsupp.ps_supplycost", "$lineitem.l_quantity"]}]}}}},
+          {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
+          {$sort: {nation: 1, o_year: -1}}
+        ]
+      cursor: {batchSize: *batchSize}
+      allowDiskUse: true
+
+TPCHNormalizedQuery9:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query9
     OperationName: RunCommand

--- a/src/phases/tpch/normalized/Q9.yml
+++ b/src/phases/tpch/normalized/Q9.yml
@@ -4,42 +4,52 @@ Description: |
   Run TPC-H query 9 (see http://tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.0.pdf) against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
   documents remain, which ensures that the query executes in its entirety.
 
-batchSize: &batchSize 101  # The default batch size.
+batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${color}.*$
 
+TPCHNormalizedQuery9Aggregation: &TPCHNormalizedQuery9Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}},
+      {$lookup: {from: "partsupp", as: "partsupp", localField: "p_partkey", foreignField: "ps_partkey"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "supplier", as: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [
+        {$lookup: {from: "nation", as: "nation", localField: "s_nationkey", foreignField: "n_nationkey"}},
+        {$unwind: "$nation"}]}},
+      {$unwind: "$supplier"},
+      {$project: {p_partkey: 1, s_suppkey: "$supplier.s_suppkey", nation: "$supplier.nation.n_name", partsupp: 1}},
+      {$lookup: {from: "lineitem", as: "lineitem", localField: "p_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, pipeline: [
+        {$match: {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}}},
+        {$lookup: {from: "orders", as: "orders", localField: "l_orderkey", foreignField: "o_orderkey"}},
+        {$unwind: "$orders"}]}},
+      {$unwind: "$lineitem"},
+      {$group: {_id: {nation: "$nation", o_year: {$year: "$lineitem.orders.o_orderdate"}}, sum_profit: {$sum: {$subtract: [
+        {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]},
+        {$multiply: ["$partsupp.ps_supplycost", "$lineitem.l_quantity"]}]}}}},
+      {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
+      {$sort: {nation: 1, o_year: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery9:
-  Repeat: 1
-  Database: tpch
+  Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
+  Database: &db tpch
+  Operations:
+  - OperationMetricsName: Query9
+    OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery9Aggregation
+
+TPCHNormalizedQuery9Explain:
+  Repeat: *Repeat
+  Database: *db
   Operations:
   - OperationMetricsName: Query9
     OperationName: RunCommand
     OperationLogsResult: true
     OperationCommand:
-      explain:
-        aggregate: part
-        pipeline:
-          [
-            {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}},
-            {$lookup: {from: "partsupp", as: "partsupp", localField: "p_partkey", foreignField: "ps_partkey"}},
-            {$unwind: "$partsupp"},
-            {$lookup: {from: "supplier", as: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [
-              {$lookup: {from: "nation", as: "nation", localField: "s_nationkey", foreignField: "n_nationkey"}},
-              {$unwind: "$nation"}]}},
-            {$unwind: "$supplier"},
-            {$project: {p_partkey: 1, s_suppkey: "$supplier.s_suppkey", nation: "$supplier.nation.n_name", partsupp: 1}},
-            {$lookup: {from: "lineitem", as: "lineitem", localField: "p_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, pipeline: [
-              {$match: {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}}},
-              {$lookup: {from: "orders", as: "orders", localField: "l_orderkey", foreignField: "o_orderkey"}},
-              {$unwind: "$orders"}]}},
-            {$unwind: "$lineitem"},
-            {$group: {_id: {nation: "$nation", o_year: {$year: "$lineitem.orders.o_orderdate"}}, sum_profit: {$sum: {$subtract: [
-              {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]},
-              {$multiply: ["$partsupp.ps_supplycost", "$lineitem.l_quantity"]}]}}}},
-            {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
-            {$sort: {nation: 1, o_year: -1}}
-          ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+      explain: *TPCHNormalizedQuery9Aggregation
       verbosity:
         executionStats

--- a/src/workloads/tpch/denormalized/1/Q1.yml
+++ b/src/workloads/tpch/denormalized/1/Q1.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery1
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery1Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q1.yml
+      Key: TPCHDenormalizedQuery1Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery1Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q1.yml
+          Key: TPCHDenormalizedQuery1Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery1Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q1.yml
       Key: TPCHDenormalizedQuery1
       Parameters:
-        Query1Delta: -90
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q1.yml
+++ b/src/workloads/tpch/denormalized/1/Q1.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q1.yml
-          Key: TPCHDenormalizedQuery1Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q1.yml
+      Key: TPCHDenormalizedQuery1Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q10.yml
+++ b/src/workloads/tpch/denormalized/1/Q10.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q10.yml
-          Key: TPCHDenormalizedQuery10Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q10.yml
+      Key: TPCHDenormalizedQuery10Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q10.yml
+++ b/src/workloads/tpch/denormalized/1/Q10.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery10
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery10Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q10.yml
+      Key: TPCHDenormalizedQuery10Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery10Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q10.yml
+          Key: TPCHDenormalizedQuery10Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery10Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q10.yml
       Key: TPCHDenormalizedQuery10
       Parameters:
-        Query10Date: "1993-10-01"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q11.yml
+++ b/src/workloads/tpch/denormalized/1/Q11.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q11.yml
-          Key: TPCHDenormalizedQuery11Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q11.yml
+      Key: TPCHDenormalizedQuery11Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q11.yml
+++ b/src/workloads/tpch/denormalized/1/Q11.yml
@@ -1,8 +1,7 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 11 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
-  documents remain, which ensures that the query executes in its entirety.
+  Run TPC-H query 11 against the denormalized schema for scale 1.
 
 Clients:
   Default:
@@ -10,13 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery11
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery11Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q11.yml
+      Key: TPCHDenormalizedQuery11Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery11Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q11.yml
+          Key: TPCHDenormalizedQuery11Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery11Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q11.yml
       Key: TPCHDenormalizedQuery11
       Parameters:
-        Query11Nation: "GERMANY"
-        Query11Fraction: 0.0001
+        Repeat: 3
+        BatchSize: 1048  # This query is expected to return more documents than the default batch size of 101.

--- a/src/workloads/tpch/denormalized/1/Q12.yml
+++ b/src/workloads/tpch/denormalized/1/Q12.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q12.yml
-          Key: TPCHDenormalizedQuery12Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q12.yml
+      Key: TPCHDenormalizedQuery12Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q12.yml
+++ b/src/workloads/tpch/denormalized/1/Q12.yml
@@ -9,14 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery12
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery12Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q12.yml
+      Key: TPCHDenormalizedQuery12Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery12Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q12.yml
+          Key: TPCHDenormalizedQuery12Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery12Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q12.yml
       Key: TPCHDenormalizedQuery12
       Parameters:
-        Query12ShipMode1: "MAIL"
-        Query12ShipMode2: "SHIP"
-        Query12Date: "1994-01-01"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q13.yml
+++ b/src/workloads/tpch/denormalized/1/Q13.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery13
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery13Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q13.yml
+      Key: TPCHDenormalizedQuery13Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery13Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q13.yml
+          Key: TPCHDenormalizedQuery13Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery13Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q13.yml
       Key: TPCHDenormalizedQuery13
       Parameters:
-        Query13Regex: "^.*special.*requests.*$"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q13.yml
+++ b/src/workloads/tpch/denormalized/1/Q13.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q13.yml
-          Key: TPCHDenormalizedQuery13Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q13.yml
+      Key: TPCHDenormalizedQuery13Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q14.yml
+++ b/src/workloads/tpch/denormalized/1/Q14.yml
@@ -2,18 +2,54 @@ SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
   Run TPC-H query 14 against the denormalized schema for scale 1.
+
 Clients:
   Default:
     QueryOptions:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery14
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery14Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q14.yml
+      Key: TPCHDenormalizedQuery14Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery14Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q14.yml
+          Key: TPCHDenormalizedQuery14Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery14Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q14.yml
       Key: TPCHDenormalizedQuery14
       Parameters:
-        Query4Date: "1995-09-01"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q14.yml
+++ b/src/workloads/tpch/denormalized/1/Q14.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q14.yml
-          Key: TPCHDenormalizedQuery14Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q14.yml
+      Key: TPCHDenormalizedQuery14Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q15.yml
+++ b/src/workloads/tpch/denormalized/1/Q15.yml
@@ -9,12 +9,78 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery15
+
+# This query creates a view before running any workloads, and then destroys the view afterwards.
+- Name: TPCHDenormalizedQuery15Setup
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - Repeat: 1
+    Database: *db
+    Operation:
+      OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q15.yml
+          Key: TPCHDenormalizedQuery15CreateView
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operation:
+      OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q15.yml
+          Key: TPCHDenormalizedQuery15DropView
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery15Cold
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q15.yml
+      Key: TPCHDenormalizedQuery15Explain
+  - *Nop
+  - *Nop
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery15Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q15.yml
+          Key: TPCHDenormalizedQuery15Aggregation
+  - *Nop
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery15Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q15.yml
       Key: TPCHDenormalizedQuery15
       Parameters:
-        Query15Date: "1996-01-01"
+        Repeat: 3
+  - *Nop

--- a/src/workloads/tpch/denormalized/1/Q15.yml
+++ b/src/workloads/tpch/denormalized/1/Q15.yml
@@ -11,29 +11,19 @@ Clients:
 Actors:
 
 # This query creates a view before running any workloads, and then destroys the view afterwards.
-- Name: TPCHDenormalizedQuery15Setup
+- Name: TPCHDenormalizedQuery15SetupAndCleanup
   Type: RunCommand
   Database: &db tpch
   Phases:
-  - Repeat: 1
-    Database: *db
-    Operation:
-      OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q15.yml
-          Key: TPCHDenormalizedQuery15CreateView
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q15.yml
+      Key: TPCHDenormalizedQuery15CreateView
   - &Nop {Nop: true}
   - *Nop
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operation:
-      OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q15.yml
-          Key: TPCHDenormalizedQuery15DropView
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q15.yml
+      Key: TPCHDenormalizedQuery15DropView
 
 # At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
 # This is when we start the cold data run. We use 'executionStats' here to cause each command to run its

--- a/src/workloads/tpch/denormalized/1/Q15.yml
+++ b/src/workloads/tpch/denormalized/1/Q15.yml
@@ -49,14 +49,9 @@ Actors:
   Phases:
   - *Nop
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q15.yml
-          Key: TPCHDenormalizedQuery15Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q15.yml
+      Key: TPCHDenormalizedQuery15Warmup
   - *Nop
   - *Nop
 

--- a/src/workloads/tpch/denormalized/1/Q16.yml
+++ b/src/workloads/tpch/denormalized/1/Q16.yml
@@ -9,14 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery16
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery16Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q16.yml
+      Key: TPCHDenormalizedQuery16Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery16Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q16.yml
+          Key: TPCHDenormalizedQuery16Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery16Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q16.yml
       Key: TPCHDenormalizedQuery16
       Parameters:
-        Query16Brand: "Brand#45"
-        Query16Type: "^MEDIUM POLISHED.*"
-        Query16Sizes: [49, 14, 23, 45, 19, 3, 36, 9]
+        Repeat: 3
+        BatchSize: 18314  # This query is expected to return more documents than the default batch size of 101.

--- a/src/workloads/tpch/denormalized/1/Q16.yml
+++ b/src/workloads/tpch/denormalized/1/Q16.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q16.yml
-          Key: TPCHDenormalizedQuery16Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q16.yml
+      Key: TPCHDenormalizedQuery16Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q17.yml
+++ b/src/workloads/tpch/denormalized/1/Q17.yml
@@ -32,14 +32,9 @@ Actors:
 #   Database: *db
 #   Phases:
 #   - *Nop
-#   - Repeat: 1
-#     Database: *db
-#     Operations:
-#     - OperationName: RunCommand
-#       OperationCommand:
-#         LoadConfig:
-#           Path: ../../../../phases/tpch/denormalized/Q17.yml
-#           Key: TPCHDenormalizedQuery17Aggregation
+# - LoadConfig:
+#     Path: ../../../../phases/tpch/denormalized/Q17.yml
+#     Key: TPCHDenormalizedQuery17Warmup
 #   - *Nop
 
 # # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q17.yml
+++ b/src/workloads/tpch/denormalized/1/Q17.yml
@@ -9,13 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery17
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery17Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q17.yml
-      Key: TPCHDenormalizedQuery17
-      Parameters:
-        Query17Brand: "Brand#23"
-        Query17Container: "MED BOX"
+      Key: TPCHDenormalizedQuery17Explain
+# TODO: uncomment once this query is sped up. >10 minute execution time.
+#   - &Nop {Nop: true}
+#   - *Nop
+
+# # After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# # with explain normally does not result in caching of plans.
+# - Name: TPCHDenormalizedQuery17Warmup
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - Repeat: 1
+#     Database: *db
+#     Operations:
+#     - OperationName: RunCommand
+#       OperationCommand:
+#         LoadConfig:
+#           Path: ../../../../phases/tpch/denormalized/Q17.yml
+#           Key: TPCHDenormalizedQuery17Aggregation
+#   - *Nop
+
+# # After the cold run, our caches should be warmed up.
+# - Name: TPCHDenormalizedQuery17Hot
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - *Nop
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/denormalized/Q17.yml
+#       Key: TPCHDenormalizedQuery17
+#       Parameters:
+#         Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q17.yml
+++ b/src/workloads/tpch/denormalized/1/Q17.yml
@@ -21,7 +21,7 @@ Actors:
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q17.yml
       Key: TPCHDenormalizedQuery17Explain
-# TODO: uncomment once this query is sped up. >10 minute execution time.
+# TODO: PERF-2995 uncomment
 #   - &Nop {Nop: true}
 #   - *Nop
 

--- a/src/workloads/tpch/denormalized/1/Q18.yml
+++ b/src/workloads/tpch/denormalized/1/Q18.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q18.yml
-          Key: TPCHDenormalizedQuery18Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q18.yml
+      Key: TPCHDenormalizedQuery18Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q18.yml
+++ b/src/workloads/tpch/denormalized/1/Q18.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery18
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery18Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q18.yml
+      Key: TPCHDenormalizedQuery18Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery18Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q18.yml
+          Key: TPCHDenormalizedQuery18Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery18Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q18.yml
       Key: TPCHDenormalizedQuery18
       Parameters:
-        Query18Quantity: 300
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q19.yml
+++ b/src/workloads/tpch/denormalized/1/Q19.yml
@@ -9,17 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery19
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery19Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q19.yml
-      Key: TPCHDenormalizedQuery19
-      Parameters:
-        Query19Brand1: "Brand#12"
-        Query19Quantity1: 1
-        Query19Brand2: "Brand#23"
-        Query19Quantity2: 10
-        Query19Brand3: "Brand#34"
-        Query19Quantity3: 20
+      Key: TPCHDenormalizedQuery19Explain
+# TODO: uncomment once this query is sped up. >10 minute execution time.
+#   - &Nop {Nop: true}
+#   - *Nop
+
+# # After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# # with explain normally does not result in caching of plans.
+# - Name: TPCHDenormalizedQuery19Warmup
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - Repeat: 1
+#     Database: *db
+#     Operations:
+#     - OperationName: RunCommand
+#       OperationCommand:
+#         LoadConfig:
+#           Path: ../../../../phases/tpch/denormalized/Q19.yml
+#           Key: TPCHDenormalizedQuery19Aggregation
+#   - *Nop
+
+# # After the cold run, our caches should be warmed up.
+# - Name: TPCHDenormalizedQuery19Hot
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - *Nop
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/denormalized/Q19.yml
+#       Key: TPCHDenormalizedQuery19
+#       Parameters:
+#         Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q19.yml
+++ b/src/workloads/tpch/denormalized/1/Q19.yml
@@ -21,7 +21,7 @@ Actors:
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q19.yml
       Key: TPCHDenormalizedQuery19Explain
-# TODO: uncomment once this query is sped up. >10 minute execution time.
+# TODO: PERF-2995 uncomment
 #   - &Nop {Nop: true}
 #   - *Nop
 

--- a/src/workloads/tpch/denormalized/1/Q19.yml
+++ b/src/workloads/tpch/denormalized/1/Q19.yml
@@ -32,14 +32,9 @@ Actors:
 #   Database: *db
 #   Phases:
 #   - *Nop
-#   - Repeat: 1
-#     Database: *db
-#     Operations:
-#     - OperationName: RunCommand
-#       OperationCommand:
-#         LoadConfig:
-#           Path: ../../../../phases/tpch/denormalized/Q19.yml
-#           Key: TPCHDenormalizedQuery19Aggregation
+# - LoadConfig:
+#     Path: ../../../../phases/tpch/denormalized/Q19.yml
+#     Key: TPCHDenormalizedQuery19Warmup
 #   - *Nop
 
 # # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q2.yml
+++ b/src/workloads/tpch/denormalized/1/Q2.yml
@@ -9,14 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery2
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery2Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q2.yml
+      Key: TPCHDenormalizedQuery2Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery2Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q2.yml
+          Key: TPCHDenormalizedQuery2Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery2Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q2.yml
       Key: TPCHDenormalizedQuery2
       Parameters:
-        Query2Size: 15
-        Query2Type: "^.*BRASS$"
-        Query2Region: "EUROPE"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q2.yml
+++ b/src/workloads/tpch/denormalized/1/Q2.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q2.yml
-          Key: TPCHDenormalizedQuery2Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q2.yml
+      Key: TPCHDenormalizedQuery2Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q20.yml
+++ b/src/workloads/tpch/denormalized/1/Q20.yml
@@ -32,14 +32,9 @@ Actors:
 #   Database: *db
 #   Phases:
 #   - *Nop
-#   - Repeat: 1
-#     Database: *db
-#     Operations:
-#     - OperationName: RunCommand
-#       OperationCommand:
-#         LoadConfig:
-#           Path: ../../../../phases/tpch/denormalized/Q20.yml
-#           Key: TPCHDenormalizedQuery20Aggregation
+# - LoadConfig:
+#     Path: ../../../../phases/tpch/denormalized/Q20.yml
+#     Key: TPCHDenormalizedQuery20Warmup
 #   - *Nop
 
 # # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q20.yml
+++ b/src/workloads/tpch/denormalized/1/Q20.yml
@@ -9,14 +9,49 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery20
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery20Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q20.yml
-      Key: TPCHDenormalizedQuery20
-      Parameters:
-        Query20Nation: "CANADA"
-        Query20Color: "^forest.*$"
-        Query20Date: "1994-01-01"
+      Key: TPCHDenormalizedQuery20Explain
+# TODO: uncomment once this query is sped up. >10 minute execution time.
+#   - &Nop {Nop: true}
+#   - *Nop
+
+# # After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# # with explain normally does not result in caching of plans.
+# - Name: TPCHDenormalizedQuery20Warmup
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - Repeat: 1
+#     Database: *db
+#     Operations:
+#     - OperationName: RunCommand
+#       OperationCommand:
+#         LoadConfig:
+#           Path: ../../../../phases/tpch/denormalized/Q20.yml
+#           Key: TPCHDenormalizedQuery20Aggregation
+#   - *Nop
+
+# # After the cold run, our caches should be warmed up.
+# - Name: TPCHDenormalizedQuery20Hot
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - *Nop
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/denormalized/Q20.yml
+#       Key: TPCHDenormalizedQuery20
+#       Parameters:
+#         Repeat: 3
+#         BatchSize: 186  # This query is expected to return more documents than the default batch size of 101.

--- a/src/workloads/tpch/denormalized/1/Q20.yml
+++ b/src/workloads/tpch/denormalized/1/Q20.yml
@@ -21,7 +21,7 @@ Actors:
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q20.yml
       Key: TPCHDenormalizedQuery20Explain
-# TODO: uncomment once this query is sped up. >10 minute execution time.
+# # TODO: PERF-2995 uncomment
 #   - &Nop {Nop: true}
 #   - *Nop
 

--- a/src/workloads/tpch/denormalized/1/Q21.yml
+++ b/src/workloads/tpch/denormalized/1/Q21.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery21
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery21Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q21.yml
+      Key: TPCHDenormalizedQuery21Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery21Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q21.yml
+          Key: TPCHDenormalizedQuery21Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery21Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q21.yml
       Key: TPCHDenormalizedQuery21
       Parameters:
-        Query21Nation: "SAUDI ARABIA"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q21.yml
+++ b/src/workloads/tpch/denormalized/1/Q21.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q21.yml
-          Key: TPCHDenormalizedQuery21Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q21.yml
+      Key: TPCHDenormalizedQuery21Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q22.yml
+++ b/src/workloads/tpch/denormalized/1/Q22.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q22.yml
-          Key: TPCHDenormalizedQuery22Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q22.yml
+      Key: TPCHDenormalizedQuery22Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q22.yml
+++ b/src/workloads/tpch/denormalized/1/Q22.yml
@@ -9,18 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery22
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery22Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q22.yml
+      Key: TPCHDenormalizedQuery22Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery22Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q22.yml
+          Key: TPCHDenormalizedQuery22Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery22Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q22.yml
       Key: TPCHDenormalizedQuery22
-      Parameters:  # This is a hack, because yml parses these strings into ints before outputting the pipeline.
-        Query22CountryCode1: {$toString: "13"}
-        Query22CountryCode2: {$toString: "31"}
-        Query22CountryCode3: {$toString: "23"}
-        Query22CountryCode4: {$toString: "29"}
-        Query22CountryCode5: {$toString: "30"}
-        Query22CountryCode6: {$toString: "18"}
-        Query22CountryCode7: {$toString: "17"}
+      Parameters:
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q3.yml
+++ b/src/workloads/tpch/denormalized/1/Q3.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q3.yml
-          Key: TPCHDenormalizedQuery3Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q3.yml
+      Key: TPCHDenormalizedQuery3Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q3.yml
+++ b/src/workloads/tpch/denormalized/1/Q3.yml
@@ -9,13 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery3
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery3Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q3.yml
+      Key: TPCHDenormalizedQuery3Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery3Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q3.yml
+          Key: TPCHDenormalizedQuery3Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery3Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q3.yml
       Key: TPCHDenormalizedQuery3
       Parameters:
-        Query3Segment: "BUILDING"
-        Query3Date: "1995-03-15"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q4.yml
+++ b/src/workloads/tpch/denormalized/1/Q4.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery4
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery4Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q4.yml
+      Key: TPCHDenormalizedQuery4Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery4Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q4.yml
+          Key: TPCHDenormalizedQuery4Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery4Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q4.yml
       Key: TPCHDenormalizedQuery4
       Parameters:
-        Query4Date: "1993-07-01"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q4.yml
+++ b/src/workloads/tpch/denormalized/1/Q4.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q4.yml
-          Key: TPCHDenormalizedQuery4Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q4.yml
+      Key: TPCHDenormalizedQuery4Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q5.yml
+++ b/src/workloads/tpch/denormalized/1/Q5.yml
@@ -9,13 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery5
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery5Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q5.yml
+      Key: TPCHDenormalizedQuery5Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery5Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q5.yml
+          Key: TPCHDenormalizedQuery5Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery5Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q5.yml
       Key: TPCHDenormalizedQuery5
       Parameters:
-        Query5Date: "1994-01-01"
-        Query5Region: "ASIA"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q5.yml
+++ b/src/workloads/tpch/denormalized/1/Q5.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q5.yml
-          Key: TPCHDenormalizedQuery5Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q5.yml
+      Key: TPCHDenormalizedQuery5Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q6.yml
+++ b/src/workloads/tpch/denormalized/1/Q6.yml
@@ -9,14 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery6
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery6Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q6.yml
+      Key: TPCHDenormalizedQuery6Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery6Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q6.yml
+          Key: TPCHDenormalizedQuery6Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery6Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q6.yml
       Key: TPCHDenormalizedQuery6
       Parameters:
-        Query6Date: "1994-01-01"
-        Query6Discount: 0.06
-        Query6Quantity: 24
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q6.yml
+++ b/src/workloads/tpch/denormalized/1/Q6.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q6.yml
-          Key: TPCHDenormalizedQuery6Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q6.yml
+      Key: TPCHDenormalizedQuery6Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q7.yml
+++ b/src/workloads/tpch/denormalized/1/Q7.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q7.yml
-          Key: TPCHDenormalizedQuery7Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q7.yml
+      Key: TPCHDenormalizedQuery7Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q7.yml
+++ b/src/workloads/tpch/denormalized/1/Q7.yml
@@ -9,13 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery7
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery7Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q7.yml
+      Key: TPCHDenormalizedQuery7Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery7Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q7.yml
+          Key: TPCHDenormalizedQuery7Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery7Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q7.yml
       Key: TPCHDenormalizedQuery7
       Parameters:
-        Query7Nation1: "FRANCE"
-        Query7Nation2: "GERMANY"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q8.yml
+++ b/src/workloads/tpch/denormalized/1/Q8.yml
@@ -9,14 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery8
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery8Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q8.yml
+      Key: TPCHDenormalizedQuery8Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHDenormalizedQuery8Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q8.yml
+          Key: TPCHDenormalizedQuery8Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHDenormalizedQuery8Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q8.yml
       Key: TPCHDenormalizedQuery8
       Parameters:
-        Query8Type: "ECONOMY ANODIZED STEEL"
-        Query8Region: "AMERICA"
-        Query8Nation: "BRAZIL"
+        Repeat: 3

--- a/src/workloads/tpch/denormalized/1/Q8.yml
+++ b/src/workloads/tpch/denormalized/1/Q8.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/denormalized/Q8.yml
-          Key: TPCHDenormalizedQuery8Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q8.yml
+      Key: TPCHDenormalizedQuery8Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q9.yml
+++ b/src/workloads/tpch/denormalized/1/Q9.yml
@@ -32,14 +32,9 @@ Actors:
 #   Database: *db
 #   Phases:
 #   - *Nop
-#   - Repeat: 1
-#     Database: *db
-#     Operations:
-#     - OperationName: RunCommand
-#       OperationCommand:
-#         LoadConfig:
-#           Path: ../../../../phases/tpch/denormalized/Q9.yml
-#           Key: TPCHDenormalizedQuery9Aggregation
+# - LoadConfig:
+#     Path: ../../../../phases/tpch/denormalized/Q9.yml
+#     Key: TPCHDenormalizedQuery9Warmup
 #   - *Nop
 
 # # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/denormalized/1/Q9.yml
+++ b/src/workloads/tpch/denormalized/1/Q9.yml
@@ -9,12 +9,49 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHDenormalizedQuery9
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHDenormalizedQuery9Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q9.yml
-      Key: TPCHDenormalizedQuery9
-      Parameters:
-        Query9Color: "^.*green.*$"
+      Key: TPCHDenormalizedQuery9Explain
+# TODO: uncomment once this query is sped up. >10 minute execution time.
+#   - &Nop {Nop: true}
+#   - *Nop
+
+# # After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# # with explain normally does not result in caching of plans.
+# - Name: TPCHDenormalizedQuery9Warmup
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - Repeat: 1
+#     Database: *db
+#     Operations:
+#     - OperationName: RunCommand
+#       OperationCommand:
+#         LoadConfig:
+#           Path: ../../../../phases/tpch/denormalized/Q9.yml
+#           Key: TPCHDenormalizedQuery9Aggregation
+#   - *Nop
+
+# # After the cold run, our caches should be warmed up.
+# - Name: TPCHDenormalizedQuery9Hot
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - *Nop
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/denormalized/Q9.yml
+#       Key: TPCHDenormalizedQuery9
+#       Parameters:
+#         Repeat: 3
+#         BatchSize: 175  # This query is expected to return more documents than the default batch size of 101.

--- a/src/workloads/tpch/denormalized/1/Q9.yml
+++ b/src/workloads/tpch/denormalized/1/Q9.yml
@@ -21,7 +21,7 @@ Actors:
   - LoadConfig:
       Path: ../../../../phases/tpch/denormalized/Q9.yml
       Key: TPCHDenormalizedQuery9Explain
-# TODO: uncomment once this query is sped up. >10 minute execution time.
+# # TODO: PERF-2995 uncomment
 #   - &Nop {Nop: true}
 #   - *Nop
 

--- a/src/workloads/tpch/normalized/1/Q1.yml
+++ b/src/workloads/tpch/normalized/1/Q1.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery1
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery1Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q1.yml
+      Key: TPCHNormalizedQuery1Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery1Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q1.yml
+          Key: TPCHNormalizedQuery1Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery1Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q1.yml
       Key: TPCHNormalizedQuery1
       Parameters:
-        Query1Delta: -90
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q1.yml
+++ b/src/workloads/tpch/normalized/1/Q1.yml
@@ -31,12 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - LoadConfig:
-        Path: ../../../../phases/tpch/normalized/Q1.yml
-        Key: TPCHNormalizedQuery1Warmup
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q1.yml
+      Key: TPCHNormalizedQuery1Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q1.yml
+++ b/src/workloads/tpch/normalized/1/Q1.yml
@@ -34,11 +34,9 @@ Actors:
   - Repeat: 1
     Database: *db
     Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q1.yml
-          Key: TPCHNormalizedQuery1Aggregation
+    - LoadConfig:
+        Path: ../../../../phases/tpch/normalized/Q1.yml
+        Key: TPCHNormalizedQuery1Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q10.yml
+++ b/src/workloads/tpch/normalized/1/Q10.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q10.yml
-          Key: TPCHNormalizedQuery10Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q10.yml
+      Key: TPCHNormalizedQuery10Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q10.yml
+++ b/src/workloads/tpch/normalized/1/Q10.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery10
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery10Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q10.yml
+      Key: TPCHNormalizedQuery10Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery10Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q10.yml
+          Key: TPCHNormalizedQuery10Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery10Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q10.yml
       Key: TPCHNormalizedQuery10
       Parameters:
-        Query10Date: "1993-10-01"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q11.yml
+++ b/src/workloads/tpch/normalized/1/Q11.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q11.yml
-          Key: TPCHNormalizedQuery11Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q11.yml
+      Key: TPCHNormalizedQuery11Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q11.yml
+++ b/src/workloads/tpch/normalized/1/Q11.yml
@@ -1,8 +1,7 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 11 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
-  documents remain, which ensures that the query executes in its entirety.
+  Run TPC-H query 11 against the normalized schema for scale 1.
 
 Clients:
   Default:
@@ -10,13 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery11
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery11Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q11.yml
+      Key: TPCHNormalizedQuery11Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery11Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q11.yml
+          Key: TPCHNormalizedQuery11Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery11Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q11.yml
       Key: TPCHNormalizedQuery11
       Parameters:
-        Query11Nation: "GERMANY"
-        Query11Fraction: 0.0001
+        Repeat: 3
+        BatchSize: 1048  # This query is expected to return more documents than the default batch size of 101.

--- a/src/workloads/tpch/normalized/1/Q12.yml
+++ b/src/workloads/tpch/normalized/1/Q12.yml
@@ -9,14 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery12
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery12Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q12.yml
+      Key: TPCHNormalizedQuery12Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery12Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q12.yml
+          Key: TPCHNormalizedQuery12Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery12Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q12.yml
       Key: TPCHNormalizedQuery12
       Parameters:
-        Query12ShipMode1: "MAIL"
-        Query12ShipMode2: "SHIP"
-        Query12Date: "1994-01-01"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q12.yml
+++ b/src/workloads/tpch/normalized/1/Q12.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q12.yml
-          Key: TPCHNormalizedQuery12Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q12.yml
+      Key: TPCHNormalizedQuery12Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q13.yml
+++ b/src/workloads/tpch/normalized/1/Q13.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery13
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery13Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q13.yml
+      Key: TPCHNormalizedQuery13Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery13Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q13.yml
+          Key: TPCHNormalizedQuery13Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery13Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q13.yml
       Key: TPCHNormalizedQuery13
       Parameters:
-        Query13Regex: "^.*special.*requests.*$"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q13.yml
+++ b/src/workloads/tpch/normalized/1/Q13.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q13.yml
-          Key: TPCHNormalizedQuery13Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q13.yml
+      Key: TPCHNormalizedQuery13Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q14.yml
+++ b/src/workloads/tpch/normalized/1/Q14.yml
@@ -2,18 +2,54 @@ SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
   Run TPC-H query 14 against the normalized schema for scale 1.
+
 Clients:
   Default:
     QueryOptions:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery14
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery14Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q14.yml
+      Key: TPCHNormalizedQuery14Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery14Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q14.yml
+          Key: TPCHNormalizedQuery14Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery14Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q14.yml
       Key: TPCHNormalizedQuery14
       Parameters:
-        Query4Date: "1995-09-01"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q14.yml
+++ b/src/workloads/tpch/normalized/1/Q14.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q14.yml
-          Key: TPCHNormalizedQuery14Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q14.yml
+      Key: TPCHNormalizedQuery14Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q15.yml
+++ b/src/workloads/tpch/normalized/1/Q15.yml
@@ -11,29 +11,19 @@ Clients:
 Actors:
 
 # This query creates a view before running any workloads, and then destroys the view afterwards.
-- Name: TPCHNormalizedQuery15Setup
+- Name: TPCHNormalizedQuery15SetupAndCleanup
   Type: RunCommand
   Database: &db tpch
   Phases:
-  - Repeat: 1
-    Database: *db
-    Operation:
-      OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q15.yml
-          Key: TPCHNormalizedQuery15CreateView
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q15.yml
+      Key: TPCHNormalizedQuery15CreateView
   - &Nop {Nop: true}
   - *Nop
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operation:
-      OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q15.yml
-          Key: TPCHNormalizedQuery15DropView
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q15.yml
+      Key: TPCHNormalizedQuery15DropView
 
 # At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
 # This is when we start the cold data run. We use 'executionStats' here to cause each command to run its

--- a/src/workloads/tpch/normalized/1/Q15.yml
+++ b/src/workloads/tpch/normalized/1/Q15.yml
@@ -49,14 +49,9 @@ Actors:
   Phases:
   - *Nop
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operation:
-      OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q15.yml
-          Key: TPCHNormalizedQuery15Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q15.yml
+      Key: TPCHNormalizedQuery15Warmup
   - *Nop
   - *Nop
 

--- a/src/workloads/tpch/normalized/1/Q15.yml
+++ b/src/workloads/tpch/normalized/1/Q15.yml
@@ -9,12 +9,78 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery15
+
+# This query creates a view before running any workloads, and then destroys the view afterwards.
+- Name: TPCHNormalizedQuery15Setup
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - Repeat: 1
+    Database: *db
+    Operation:
+      OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q15.yml
+          Key: TPCHNormalizedQuery15CreateView
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operation:
+      OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q15.yml
+          Key: TPCHNormalizedQuery15DropView
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery15Cold
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q15.yml
+      Key: TPCHNormalizedQuery15Explain
+  - *Nop
+  - *Nop
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery15Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operation:
+      OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q15.yml
+          Key: TPCHNormalizedQuery15Aggregation
+  - *Nop
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery15Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q15.yml
       Key: TPCHNormalizedQuery15
       Parameters:
-        Query15Date: "1996-01-01"
+        Repeat: 3
+  - *Nop

--- a/src/workloads/tpch/normalized/1/Q16.yml
+++ b/src/workloads/tpch/normalized/1/Q16.yml
@@ -9,14 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery16
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery16Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q16.yml
+      Key: TPCHNormalizedQuery16Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery16Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q16.yml
+          Key: TPCHNormalizedQuery16Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery16Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q16.yml
       Key: TPCHNormalizedQuery16
       Parameters:
-        Query16Brand: "Brand#45"
-        Query16Type: "^MEDIUM POLISHED.*"
-        Query16Sizes: [49, 14, 23, 45, 19, 3, 36, 9]
+        Repeat: 3
+        BatchSize: 18314  # This query is expected to return more documents than the default batch size of 101.

--- a/src/workloads/tpch/normalized/1/Q16.yml
+++ b/src/workloads/tpch/normalized/1/Q16.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q16.yml
-          Key: TPCHNormalizedQuery16Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q16.yml
+      Key: TPCHNormalizedQuery16Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q17.yml
+++ b/src/workloads/tpch/normalized/1/Q17.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q17.yml
-          Key: TPCHNormalizedQuery17Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q17.yml
+      Key: TPCHNormalizedQuery17Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q17.yml
+++ b/src/workloads/tpch/normalized/1/Q17.yml
@@ -9,13 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery17
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery17Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q17.yml
+      Key: TPCHNormalizedQuery17Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery17Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q17.yml
+          Key: TPCHNormalizedQuery17Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery17Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q17.yml
       Key: TPCHNormalizedQuery17
       Parameters:
-        Query17Brand: "Brand#23"
-        Query17Container: "MED BOX"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q18.yml
+++ b/src/workloads/tpch/normalized/1/Q18.yml
@@ -21,7 +21,7 @@ Actors:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q18.yml
       Key: TPCHNormalizedQuery18Explain
-# TODO: uncomment once this query is sped up. >10 minute execution time.
+# TODO: PERF-2995 uncomment
 #   - &Nop {Nop: true}
 #   - *Nop
 

--- a/src/workloads/tpch/normalized/1/Q18.yml
+++ b/src/workloads/tpch/normalized/1/Q18.yml
@@ -9,12 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery18
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery18Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q18.yml
-      Key: TPCHNormalizedQuery18
-      Parameters:
-        Query18Quantity: 300
+      Key: TPCHNormalizedQuery18Explain
+# TODO: uncomment once this query is sped up. >10 minute execution time.
+#   - &Nop {Nop: true}
+#   - *Nop
+
+# # After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# # with explain normally does not result in caching of plans.
+# - Name: TPCHNormalizedQuery18Warmup
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - Repeat: 1
+#     Database: *db
+#     Operations:
+#     - OperationName: RunCommand
+#       OperationCommand:
+#         LoadConfig:
+#           Path: ../../../../phases/tpch/normalized/Q18.yml
+#           Key: TPCHNormalizedQuery18Aggregation
+#   - *Nop
+
+# # After the cold run, our caches should be warmed up.
+# - Name: TPCHNormalizedQuery18Hot
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - *Nop
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q18.yml
+#       Key: TPCHNormalizedQuery18
+#       Parameters:
+#         Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q18.yml
+++ b/src/workloads/tpch/normalized/1/Q18.yml
@@ -32,14 +32,9 @@ Actors:
 #   Database: *db
 #   Phases:
 #   - *Nop
-#   - Repeat: 1
-#     Database: *db
-#     Operations:
-#     - OperationName: RunCommand
-#       OperationCommand:
-#         LoadConfig:
-#           Path: ../../../../phases/tpch/normalized/Q18.yml
-#           Key: TPCHNormalizedQuery18Aggregation
+# - LoadConfig:
+#     Path: ../../../../phases/tpch/normalized/Q18.yml
+#     Key: TPCHNormalizedQuery18Warmup
 #   - *Nop
 
 # # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q19.yml
+++ b/src/workloads/tpch/normalized/1/Q19.yml
@@ -9,17 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery19
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery19Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q19.yml
-      Key: TPCHNormalizedQuery19
-      Parameters:
-        Query19Brand1: "Brand#12"
-        Query19Quantity1: 1
-        Query19Brand2: "Brand#23"
-        Query19Quantity2: 10
-        Query19Brand3: "Brand#34"
-        Query19Quantity3: 20
+      Key: TPCHNormalizedQuery19Explain
+# TODO: uncomment once this query is sped up. >10 minute execution time.
+#   - &Nop {Nop: true}
+#   - *Nop
+
+# # After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# # with explain normally does not result in caching of plans.
+# - Name: TPCHNormalizedQuery19Warmup
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - Repeat: 1
+#     Database: *db
+#     Operations:
+#     - OperationName: RunCommand
+#       OperationCommand:
+#         LoadConfig:
+#           Path: ../../../../phases/tpch/normalized/Q19.yml
+#           Key: TPCHNormalizedQuery19Aggregation
+#   - *Nop
+
+# # After the cold run, our caches should be warmed up.
+# - Name: TPCHNormalizedQuery19Hot
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - *Nop
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q19.yml
+#       Key: TPCHNormalizedQuery19
+#       Parameters:
+#         Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q19.yml
+++ b/src/workloads/tpch/normalized/1/Q19.yml
@@ -21,7 +21,7 @@ Actors:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q19.yml
       Key: TPCHNormalizedQuery19Explain
-# TODO: uncomment once this query is sped up. >10 minute execution time.
+# TODO: PERF-2995 uncomment
 #   - &Nop {Nop: true}
 #   - *Nop
 

--- a/src/workloads/tpch/normalized/1/Q19.yml
+++ b/src/workloads/tpch/normalized/1/Q19.yml
@@ -32,14 +32,9 @@ Actors:
 #   Database: *db
 #   Phases:
 #   - *Nop
-#   - Repeat: 1
-#     Database: *db
-#     Operations:
-#     - OperationName: RunCommand
-#       OperationCommand:
-#         LoadConfig:
-#           Path: ../../../../phases/tpch/normalized/Q19.yml
-#           Key: TPCHNormalizedQuery19Aggregation
+# - LoadConfig:
+#     Path: ../../../../phases/tpch/normalized/Q19.yml
+#     Key: TPCHNormalizedQuery19Warmup
 #   - *Nop
 
 # # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q2.yml
+++ b/src/workloads/tpch/normalized/1/Q2.yml
@@ -9,14 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery2
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery2Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q2.yml
+      Key: TPCHNormalizedQuery2Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery2Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q2.yml
+          Key: TPCHNormalizedQuery2Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery2Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q2.yml
       Key: TPCHNormalizedQuery2
       Parameters:
-        Query2Size: 15
-        Query2Type: "^.*BRASS$"
-        Query2Region: "EUROPE"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q2.yml
+++ b/src/workloads/tpch/normalized/1/Q2.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q2.yml
-          Key: TPCHNormalizedQuery2Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q2.yml
+      Key: TPCHNormalizedQuery2Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q20.yml
+++ b/src/workloads/tpch/normalized/1/Q20.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q20.yml
-          Key: TPCHNormalizedQuery20Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q20.yml
+      Key: TPCHNormalizedQuery20Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q20.yml
+++ b/src/workloads/tpch/normalized/1/Q20.yml
@@ -9,14 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery20
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery20Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q20.yml
+      Key: TPCHNormalizedQuery20Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery20Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q20.yml
+          Key: TPCHNormalizedQuery20Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery20Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q20.yml
       Key: TPCHNormalizedQuery20
       Parameters:
-        Query20Nation: "CANADA"
-        Query20Color: "^forest.*$"
-        Query20Date: "1994-01-01"
+        Repeat: 3
+        BatchSize: 186  # This query is expected to return more documents than the default batch size of 101.

--- a/src/workloads/tpch/normalized/1/Q21.yml
+++ b/src/workloads/tpch/normalized/1/Q21.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery21
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery21Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q21.yml
+      Key: TPCHNormalizedQuery21Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery21Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q21.yml
+          Key: TPCHNormalizedQuery21Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery21Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q21.yml
       Key: TPCHNormalizedQuery21
       Parameters:
-        Query21Nation: "SAUDI ARABIA"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q21.yml
+++ b/src/workloads/tpch/normalized/1/Q21.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q21.yml
-          Key: TPCHNormalizedQuery21Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q21.yml
+      Key: TPCHNormalizedQuery21Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q22.yml
+++ b/src/workloads/tpch/normalized/1/Q22.yml
@@ -9,18 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery22
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery22Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q22.yml
+      Key: TPCHNormalizedQuery22Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery22Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q22.yml
+          Key: TPCHNormalizedQuery22Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery22Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q22.yml
       Key: TPCHNormalizedQuery22
-      Parameters:  # This is a hack, because yml parses these strings into ints before outputting the pipeline.
-        Query22CountryCode1: {$toString: "13"}
-        Query22CountryCode2: {$toString: "31"}
-        Query22CountryCode3: {$toString: "23"}
-        Query22CountryCode4: {$toString: "29"}
-        Query22CountryCode5: {$toString: "30"}
-        Query22CountryCode6: {$toString: "18"}
-        Query22CountryCode7: {$toString: "17"}
+      Parameters:
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q22.yml
+++ b/src/workloads/tpch/normalized/1/Q22.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q22.yml
-          Key: TPCHNormalizedQuery22Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q22.yml
+      Key: TPCHNormalizedQuery22Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q3.yml
+++ b/src/workloads/tpch/normalized/1/Q3.yml
@@ -9,13 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery3
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery3Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q3.yml
+      Key: TPCHNormalizedQuery3Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery3Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q3.yml
+          Key: TPCHNormalizedQuery3Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery3Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q3.yml
       Key: TPCHNormalizedQuery3
       Parameters:
-        Query3Segment: "BUILDING"
-        Query3Date: "1995-03-15"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q3.yml
+++ b/src/workloads/tpch/normalized/1/Q3.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q3.yml
-          Key: TPCHNormalizedQuery3Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q3.yml
+      Key: TPCHNormalizedQuery3Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q4.yml
+++ b/src/workloads/tpch/normalized/1/Q4.yml
@@ -9,12 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery4
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery4Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q4.yml
+      Key: TPCHNormalizedQuery4Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery4Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q4.yml
+          Key: TPCHNormalizedQuery4Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery4Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q4.yml
       Key: TPCHNormalizedQuery4
       Parameters:
-        Query4Date: "1993-07-01"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q4.yml
+++ b/src/workloads/tpch/normalized/1/Q4.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q4.yml
-          Key: TPCHNormalizedQuery4Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q4.yml
+      Key: TPCHNormalizedQuery4Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q5.yml
+++ b/src/workloads/tpch/normalized/1/Q5.yml
@@ -9,13 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery5
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery5Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q5.yml
-      Key: TPCHNormalizedQuery5
-      Parameters:
-        Query5Date: "1994-01-01"
-        Query5Region: "ASIA"
+      Key: TPCHNormalizedQuery5Explain
+# TODO: uncomment once this query is sped up. >10 minute execution time.
+#   - &Nop {Nop: true}
+#   - *Nop
+
+# # After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# # with explain normally does not result in caching of plans.
+# - Name: TPCHNormalizedQuery5Warmup
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - Repeat: 1
+#     Database: *db
+#     Operations:
+#     - OperationName: RunCommand
+#       OperationCommand:
+#         LoadConfig:
+#           Path: ../../../../phases/tpch/normalized/Q5.yml
+#           Key: TPCHNormalizedQuery5Aggregation
+#   - *Nop
+
+# # After the cold run, our caches should be warmed up.
+# - Name: TPCHNormalizedQuery5Hot
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - *Nop
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q5.yml
+#       Key: TPCHNormalizedQuery5
+#       Parameters:
+#         Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q5.yml
+++ b/src/workloads/tpch/normalized/1/Q5.yml
@@ -32,14 +32,9 @@ Actors:
 #   Database: *db
 #   Phases:
 #   - *Nop
-#   - Repeat: 1
-#     Database: *db
-#     Operations:
-#     - OperationName: RunCommand
-#       OperationCommand:
-#         LoadConfig:
-#           Path: ../../../../phases/tpch/normalized/Q5.yml
-#           Key: TPCHNormalizedQuery5Aggregation
+# - LoadConfig:
+#     Path: ../../../../phases/tpch/normalized/Q5.yml
+#     Key: TPCHNormalizedQuery5Warmup
 #   - *Nop
 
 # # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q5.yml
+++ b/src/workloads/tpch/normalized/1/Q5.yml
@@ -21,7 +21,7 @@ Actors:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q5.yml
       Key: TPCHNormalizedQuery5Explain
-# TODO: uncomment once this query is sped up. >10 minute execution time.
+# TODO: PERF-2995 uncomment
 #   - &Nop {Nop: true}
 #   - *Nop
 

--- a/src/workloads/tpch/normalized/1/Q6.yml
+++ b/src/workloads/tpch/normalized/1/Q6.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q6.yml
-          Key: TPCHNormalizedQuery6Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q6.yml
+      Key: TPCHNormalizedQuery6Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q6.yml
+++ b/src/workloads/tpch/normalized/1/Q6.yml
@@ -9,14 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery6
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery6Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q6.yml
+      Key: TPCHNormalizedQuery6Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery6Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q6.yml
+          Key: TPCHNormalizedQuery6Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery6Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q6.yml
       Key: TPCHNormalizedQuery6
       Parameters:
-        Query6Date: "1994-01-01"
-        Query6Discount: 0.06
-        Query6Quantity: 24
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q7.yml
+++ b/src/workloads/tpch/normalized/1/Q7.yml
@@ -32,14 +32,9 @@ Actors:
 #   Database: *db
 #   Phases:
 #   - *Nop
-#   - Repeat: 1
-#     Database: *db
-#     Operations:
-#     - OperationName: RunCommand
-#       OperationCommand:
-#         LoadConfig:
-#           Path: ../../../../phases/tpch/normalized/Q7.yml
-#           Key: TPCHNormalizedQuery7Aggregation
+# - LoadConfig:
+#     Path: ../../../../phases/tpch/normalized/Q7.yml
+#     Key: TPCHNormalizedQuery7Warmup
 #   - *Nop
 
 # # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q7.yml
+++ b/src/workloads/tpch/normalized/1/Q7.yml
@@ -9,13 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery7
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery7Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q7.yml
-      Key: TPCHNormalizedQuery7
-      Parameters:
-        Query7Nation1: "FRANCE"
-        Query7Nation2: "GERMANY"
+      Key: TPCHNormalizedQuery7Explain
+# TODO: uncomment once this query is sped up. >10 minute execution time.
+#   - &Nop {Nop: true}
+#   - *Nop
+
+# # After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# # with explain normally does not result in caching of plans.
+# - Name: TPCHNormalizedQuery7Warmup
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - Repeat: 1
+#     Database: *db
+#     Operations:
+#     - OperationName: RunCommand
+#       OperationCommand:
+#         LoadConfig:
+#           Path: ../../../../phases/tpch/normalized/Q7.yml
+#           Key: TPCHNormalizedQuery7Aggregation
+#   - *Nop
+
+# # After the cold run, our caches should be warmed up.
+# - Name: TPCHNormalizedQuery7Hot
+#   Type: RunCommand
+#   Database: *db
+#   Phases:
+#   - *Nop
+#   - *Nop
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q7.yml
+#       Key: TPCHNormalizedQuery7
+#       Parameters:
+#         Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q7.yml
+++ b/src/workloads/tpch/normalized/1/Q7.yml
@@ -21,7 +21,7 @@ Actors:
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q7.yml
       Key: TPCHNormalizedQuery7Explain
-# TODO: uncomment once this query is sped up. >10 minute execution time.
+# TODO: PERF-2995 uncomment
 #   - &Nop {Nop: true}
 #   - *Nop
 

--- a/src/workloads/tpch/normalized/1/Q8.yml
+++ b/src/workloads/tpch/normalized/1/Q8.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q8.yml
-          Key: TPCHNormalizedQuery8Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q8.yml
+      Key: TPCHNormalizedQuery8Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.

--- a/src/workloads/tpch/normalized/1/Q8.yml
+++ b/src/workloads/tpch/normalized/1/Q8.yml
@@ -9,14 +9,47 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery8
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery8Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q8.yml
+      Key: TPCHNormalizedQuery8Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery8Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q8.yml
+          Key: TPCHNormalizedQuery8Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery8Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q8.yml
       Key: TPCHNormalizedQuery8
       Parameters:
-        Query8Type: "ECONOMY ANODIZED STEEL"
-        Query8Region: "AMERICA"
-        Query8Nation: "BRAZIL"
+        Repeat: 3

--- a/src/workloads/tpch/normalized/1/Q9.yml
+++ b/src/workloads/tpch/normalized/1/Q9.yml
@@ -9,12 +9,48 @@ Clients:
       socketTimeoutMS: -1
 
 Actors:
-- Name: TPCHNormalizedQuery9
+
+# At the start of the workload, the mongod will have been restarted and all caches will have been cleared.
+# This is when we start the cold data run. We use 'executionStats' here to cause each command to run its
+# execution plan until no documents remain, which ensures that the query executes in its entirety.
+# This is also configured to log an explain for the query plan to help debug regressions.
+- Name: TPCHNormalizedQuery9Cold
   Type: RunCommand
-  Database: tpch
+  Database: &db tpch
   Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q9.yml
+      Key: TPCHNormalizedQuery9Explain
+  - &Nop {Nop: true}
+  - *Nop
+
+# After the cold run, we need to warm up our caches. This is necessary since running aggregations
+# with explain normally does not result in caching of plans.
+- Name: TPCHNormalizedQuery9Warmup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q9.yml
+          Key: TPCHNormalizedQuery9Aggregation
+  - *Nop
+
+# After the cold run, our caches should be warmed up.
+- Name: TPCHNormalizedQuery9Hot
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
   - LoadConfig:
       Path: ../../../../phases/tpch/normalized/Q9.yml
       Key: TPCHNormalizedQuery9
       Parameters:
-        Query9Color: "^.*green.*$"
+        Repeat: 3
+        BatchSize: 175  # This query is expected to return more documents than the default batch size of 101.

--- a/src/workloads/tpch/normalized/1/Q9.yml
+++ b/src/workloads/tpch/normalized/1/Q9.yml
@@ -31,14 +31,9 @@ Actors:
   Database: *db
   Phases:
   - *Nop
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        LoadConfig:
-          Path: ../../../../phases/tpch/normalized/Q9.yml
-          Key: TPCHNormalizedQuery9Aggregation
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q9.yml
+      Key: TPCHNormalizedQuery9Warmup
   - *Nop
 
 # After the cold run, our caches should be warmed up.


### PR DESCRIPTION
🌲 [patch](https://spruce.mongodb.com/version/62601889c9ec441c3a55e0b5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

The change is large, but it's entirely refactoring/repetitive (sorry about that). I split the commits up to help with the review:
1. Commit [#1](https://github.com/mongodb/genny/pull/668/commits/f97469a6ccfd05e2b9ca84282e6fbffa2b7f4f57) ("Refactor phases") splits each phase into:
   - an aggregation
   - an explain command that logs its output
   - a query that can be run repeatedly for the hot data phase
2. Commit [#2](https://github.com/mongodb/genny/pull/668/commits/9555c13945765b4dddd65d6fd50a2c87105e143c) ("Add hot data variant to workloads") splits each workload into:
   - a cold data run (this runs immediately after caches are cleared)
   - a warmup phase (the cold data run uses explain, which does not cache the query)
   - a hot phase that runs the query 3x
  
**A caveat**: A few queries were too slow to allow the hot data version of TPC-H to complete within the default time limit. These queries are commented out for now, hopefully to be enabled at some later date if we can speed them up:
- denormalized schema: Q17, Q19, Q20, Q9
- normalized schema: Q18, Q19, Q5, Q7