### PR TITLE
PERF-2733 Add scale 10 of TPC-H benchmark

### DIFF
--- a/src/workloads/tpch/denormalized/10/Q1.yml
+++ b/src/workloads/tpch/denormalized/10/Q1.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 1 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery1Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q1.yml
+      Key: TPCHDenormalizedQuery1Explain

--- a/src/workloads/tpch/denormalized/10/Q10.yml
+++ b/src/workloads/tpch/denormalized/10/Q10.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 10 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery10Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q10.yml
+      Key: TPCHDenormalizedQuery10Explain

--- a/src/workloads/tpch/denormalized/10/Q11.yml
+++ b/src/workloads/tpch/denormalized/10/Q11.yml
@@ -1,0 +1,19 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 11 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery11Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q11.yml
+      Key: TPCHDenormalizedQuery11Explain

--- a/src/workloads/tpch/denormalized/10/Q11.yml
+++ b/src/workloads/tpch/denormalized/10/Q11.yml
@@ -1,8 +1,7 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 11 against the denormalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
-  documents remain, which ensures that the query executes in its entirety.
+  Run TPC-H query 11 against the denormalized schema for scale 10.
 
 Clients:
   Default:

--- a/src/workloads/tpch/denormalized/10/Q12.yml
+++ b/src/workloads/tpch/denormalized/10/Q12.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 12 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery12Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q12.yml
+      Key: TPCHDenormalizedQuery12Explain

--- a/src/workloads/tpch/denormalized/10/Q13.yml
+++ b/src/workloads/tpch/denormalized/10/Q13.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 13 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery13Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q13.yml
+      Key: TPCHDenormalizedQuery13Explain

--- a/src/workloads/tpch/denormalized/10/Q14.yml
+++ b/src/workloads/tpch/denormalized/10/Q14.yml
@@ -1,0 +1,17 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 14 against the denormalized schema for scale 10.
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery14Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q14.yml
+      Key: TPCHDenormalizedQuery14Explain

--- a/src/workloads/tpch/denormalized/10/Q15.yml
+++ b/src/workloads/tpch/denormalized/10/Q15.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 15 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery15Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q15.yml
+      Key: TPCHDenormalizedQuery15Explain

--- a/src/workloads/tpch/denormalized/10/Q16.yml
+++ b/src/workloads/tpch/denormalized/10/Q16.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 16 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery16Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q16.yml
+      Key: TPCHDenormalizedQuery16Explain

--- a/src/workloads/tpch/denormalized/10/Q17.yml
+++ b/src/workloads/tpch/denormalized/10/Q17.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 17 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery17Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHDenormalizedQuery17Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/denormalized/Q17.yml
+#       Key: TPCHDenormalizedQuery17Explain

--- a/src/workloads/tpch/denormalized/10/Q18.yml
+++ b/src/workloads/tpch/denormalized/10/Q18.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 18 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery18Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q18.yml
+      Key: TPCHDenormalizedQuery18Explain

--- a/src/workloads/tpch/denormalized/10/Q19.yml
+++ b/src/workloads/tpch/denormalized/10/Q19.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 19 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery19Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHDenormalizedQuery19Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/denormalized/Q19.yml
+#       Key: TPCHDenormalizedQuery19Explain

--- a/src/workloads/tpch/denormalized/10/Q2.yml
+++ b/src/workloads/tpch/denormalized/10/Q2.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 2 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery2Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q2.yml
+      Key: TPCHDenormalizedQuery2Explain

--- a/src/workloads/tpch/denormalized/10/Q20.yml
+++ b/src/workloads/tpch/denormalized/10/Q20.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 20 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery20Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHDenormalizedQuery20Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/denormalized/Q20.yml
+#       Key: TPCHDenormalizedQuery20Explain

--- a/src/workloads/tpch/denormalized/10/Q21.yml
+++ b/src/workloads/tpch/denormalized/10/Q21.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 21 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery21Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q21.yml
+      Key: TPCHDenormalizedQuery21Explain

--- a/src/workloads/tpch/denormalized/10/Q22.yml
+++ b/src/workloads/tpch/denormalized/10/Q22.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 22 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery22Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q22.yml
+      Key: TPCHDenormalizedQuery22Explain

--- a/src/workloads/tpch/denormalized/10/Q3.yml
+++ b/src/workloads/tpch/denormalized/10/Q3.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 3 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery3Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q3.yml
+      Key: TPCHDenormalizedQuery3Explain

--- a/src/workloads/tpch/denormalized/10/Q4.yml
+++ b/src/workloads/tpch/denormalized/10/Q4.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 4 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery4Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q4.yml
+      Key: TPCHDenormalizedQuery4Explain

--- a/src/workloads/tpch/denormalized/10/Q5.yml
+++ b/src/workloads/tpch/denormalized/10/Q5.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 5 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery5Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q5.yml
+      Key: TPCHDenormalizedQuery5Explain

--- a/src/workloads/tpch/denormalized/10/Q6.yml
+++ b/src/workloads/tpch/denormalized/10/Q6.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 6 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery6Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q6.yml
+      Key: TPCHDenormalizedQuery6Explain

--- a/src/workloads/tpch/denormalized/10/Q7.yml
+++ b/src/workloads/tpch/denormalized/10/Q7.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 7 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery7Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHDenormalizedQuery7Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/denormalized/Q7.yml
+#       Key: TPCHDenormalizedQuery7Explain

--- a/src/workloads/tpch/denormalized/10/Q8.yml
+++ b/src/workloads/tpch/denormalized/10/Q8.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 8 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery8Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q8.yml
+      Key: TPCHDenormalizedQuery8Explain

--- a/src/workloads/tpch/denormalized/10/Q9.yml
+++ b/src/workloads/tpch/denormalized/10/Q9.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 9 against the denormalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedQuery9Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHDenormalizedQuery9Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/denormalized/Q9.yml
+#       Key: TPCHDenormalizedQuery9Explain

--- a/src/workloads/tpch/normalized/10/Q1.yml
+++ b/src/workloads/tpch/normalized/10/Q1.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 1 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery1Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q1.yml
+      Key: TPCHNormalizedQuery1Explain

--- a/src/workloads/tpch/normalized/10/Q10.yml
+++ b/src/workloads/tpch/normalized/10/Q10.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 10 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery10Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q10.yml
+      Key: TPCHNormalizedQuery10Explain

--- a/src/workloads/tpch/normalized/10/Q11.yml
+++ b/src/workloads/tpch/normalized/10/Q11.yml
@@ -1,8 +1,7 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Run TPC-H query 11 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
-  documents remain, which ensures that the query executes in its entirety.
+  Run TPC-H query 11 against the normalized schema for scale 10.
 
 Clients:
   Default:

--- a/src/workloads/tpch/normalized/10/Q11.yml
+++ b/src/workloads/tpch/normalized/10/Q11.yml
@@ -1,0 +1,26 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 11 against the normalized schema. Using an 'executionStats' explain causes each command to run its execution plan until no
+  documents remain, which ensures that the query executes in its entirety.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery11Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHNormalizedQuery11Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q11.yml
+#       Key: TPCHNormalizedQuery11Explain

--- a/src/workloads/tpch/normalized/10/Q12.yml
+++ b/src/workloads/tpch/normalized/10/Q12.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 12 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery12Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q12.yml
+      Key: TPCHNormalizedQuery12Explain

--- a/src/workloads/tpch/normalized/10/Q13.yml
+++ b/src/workloads/tpch/normalized/10/Q13.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 13 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery13Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q13.yml
+      Key: TPCHNormalizedQuery13Explain

--- a/src/workloads/tpch/normalized/10/Q14.yml
+++ b/src/workloads/tpch/normalized/10/Q14.yml
@@ -1,0 +1,17 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 14 against the normalized schema for scale 10.
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery14Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q14.yml
+      Key: TPCHNormalizedQuery14Explain

--- a/src/workloads/tpch/normalized/10/Q15.yml
+++ b/src/workloads/tpch/normalized/10/Q15.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 15 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery15Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q15.yml
+      Key: TPCHNormalizedQuery15Explain

--- a/src/workloads/tpch/normalized/10/Q16.yml
+++ b/src/workloads/tpch/normalized/10/Q16.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 16 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery16Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q16.yml
+      Key: TPCHNormalizedQuery16Explain

--- a/src/workloads/tpch/normalized/10/Q17.yml
+++ b/src/workloads/tpch/normalized/10/Q17.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 17 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery17Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q17.yml
+      Key: TPCHNormalizedQuery17Explain

--- a/src/workloads/tpch/normalized/10/Q18.yml
+++ b/src/workloads/tpch/normalized/10/Q18.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 18 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery18Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHNormalizedQuery18Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q18.yml
+#       Key: TPCHNormalizedQuery18Explain

--- a/src/workloads/tpch/normalized/10/Q19.yml
+++ b/src/workloads/tpch/normalized/10/Q19.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 19 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery19Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHNormalizedQuery19Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q19.yml
+#       Key: TPCHNormalizedQuery19Explain

--- a/src/workloads/tpch/normalized/10/Q2.yml
+++ b/src/workloads/tpch/normalized/10/Q2.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 2 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery2Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q2.yml
+      Key: TPCHNormalizedQuery2Explain

--- a/src/workloads/tpch/normalized/10/Q20.yml
+++ b/src/workloads/tpch/normalized/10/Q20.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 20 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery20Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHNormalizedQuery20Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q20.yml
+#       Key: TPCHNormalizedQuery20Explain

--- a/src/workloads/tpch/normalized/10/Q21.yml
+++ b/src/workloads/tpch/normalized/10/Q21.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 21 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery21Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q21.yml
+      Key: TPCHNormalizedQuery21Explain

--- a/src/workloads/tpch/normalized/10/Q22.yml
+++ b/src/workloads/tpch/normalized/10/Q22.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 22 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery22Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHNormalizedQuery22Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q22.yml
+#       Key: TPCHNormalizedQuery22Explain

--- a/src/workloads/tpch/normalized/10/Q3.yml
+++ b/src/workloads/tpch/normalized/10/Q3.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 3 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery3Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q3.yml
+      Key: TPCHNormalizedQuery3Explain

--- a/src/workloads/tpch/normalized/10/Q4.yml
+++ b/src/workloads/tpch/normalized/10/Q4.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 4 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery4Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q4.yml
+      Key: TPCHNormalizedQuery4Explain

--- a/src/workloads/tpch/normalized/10/Q5.yml
+++ b/src/workloads/tpch/normalized/10/Q5.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 5 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery5Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHNormalizedQuery5Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q5.yml
+#       Key: TPCHNormalizedQuery5Explain

--- a/src/workloads/tpch/normalized/10/Q6.yml
+++ b/src/workloads/tpch/normalized/10/Q6.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 6 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery6Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q6.yml
+      Key: TPCHNormalizedQuery6Explain

--- a/src/workloads/tpch/normalized/10/Q7.yml
+++ b/src/workloads/tpch/normalized/10/Q7.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 7 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery7Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHNormalizedQuery7Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q7.yml
+#       Key: TPCHNormalizedQuery7Explain

--- a/src/workloads/tpch/normalized/10/Q8.yml
+++ b/src/workloads/tpch/normalized/10/Q8.yml
@@ -1,0 +1,18 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 8 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery8Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q8.yml
+      Key: TPCHNormalizedQuery8Explain

--- a/src/workloads/tpch/normalized/10/Q9.yml
+++ b/src/workloads/tpch/normalized/10/Q9.yml
@@ -1,0 +1,25 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Run TPC-H query 9 against the normalized schema for scale 10.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedQuery9Explain
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# - Name: TPCHNormalizedQuery9Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q19.yml
+#       Key: TPCHNormalizedQuery9Explain


### PR DESCRIPTION
🌲 [patch](https://spruce.mongodb.com/version/626a90972a60ed78753dc4e3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

A few queries are commented out for now; this is because they take >90 mins to run on scale 10. They are:
- denormalized schema: Q7, Q9, Q17, Q19, Q20
- normalized schema: Q5, Q7, Q11, Q18, Q19, Q20

A few queries run in time on standalones, but not on replicasets, and are also commented out:
- normalized schema: Q9, Q22