### PR TITLE
PERF-2972 Validate results of TPC-H benchmark queries in Genny

### DIFF
--- a/src/cast_core/include/cast_core/actors/AssertiveActor.hpp
+++ b/src/cast_core/include/cast_core/actors/AssertiveActor.hpp
@@ -1,0 +1,81 @@
+// Copyright 2022-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HEADER_9F01CA6C_0D34_4966_A1E0_1BAFCAB49528_INCLUDED
+#define HEADER_9F01CA6C_0D34_4966_A1E0_1BAFCAB49528_INCLUDED
+
+#include <string_view>
+
+#include <mongocxx/pool.hpp>
+
+#include <gennylib/Actor.hpp>
+#include <gennylib/PhaseLoop.hpp>
+#include <gennylib/context.hpp>
+
+#include <metrics/metrics.hpp>
+
+namespace genny::actor {
+
+/**
+ * This actor asserts that the results of two aggregations (or any two valid database commands)
+ * return equivalent results. This is primarily useful for validating the TPC-H workload queries.
+ *
+ * ```yaml
+ * SchemaVersion: 2017-07-01
+ * Actors:
+ * - Name: AssertiveActor
+ *   Type: AssertiveActor
+ *   Phases:
+ *   - Repeat: 1
+ *     Database: test
+ *     Message: coll1 documents with foo=1 are identical to coll2 documents
+ *     Expected:
+ *       aggregate: coll1
+ *       pipeline: [{$match: {foo: 1}}, {$sort: {_id: 1}}]
+ *       cursor: {batchSize: 101}
+ *     Actual:
+ *       aggregate: coll2
+ *       pipeline: [{$sort: {_id: 1}}]
+ *       cursor: {batchSize: 101}
+ * ```
+ *
+ * Owner: "@mongodb/query"
+ */
+
+class AssertFailed : public std::logic_error {
+public:
+    using std::logic_error::logic_error;
+};
+
+class AssertiveActor : public Actor {
+public:
+    explicit AssertiveActor(ActorContext& context);
+    ~AssertiveActor() = default;
+
+    void run() override;
+
+    static std::string_view defaultName() {
+        return "AssertiveActor";
+    }
+
+    struct PhaseConfig;
+private:
+    mongocxx::pool::entry _client;
+    genny::metrics::Operation _assert;
+    PhaseLoop<PhaseConfig> _loop;
+};
+
+}  // namespace genny::actor
+
+#endif  // HEADER_9F01CA6C_0D34_4966_A1E0_1BAFCAB49528_INCLUDED

--- a/src/cast_core/include/cast_core/actors/AssertiveActor.hpp
+++ b/src/cast_core/include/cast_core/actors/AssertiveActor.hpp
@@ -53,7 +53,7 @@ namespace genny::actor {
  * Owner: "@mongodb/query"
  */
 
-class AssertFailed : public std::logic_error {
+class FailedAssertionException : public std::logic_error {
 public:
     using std::logic_error::logic_error;
 };

--- a/src/cast_core/include/cast_core/actors/AssertiveActor.hpp
+++ b/src/cast_core/include/cast_core/actors/AssertiveActor.hpp
@@ -31,6 +31,13 @@ namespace genny::actor {
  * This actor asserts that the results of two aggregations (or any two valid database commands)
  * return equivalent results. This is primarily useful for validating the TPC-H workload queries.
  *
+ * Note: One important caveat to consider is around numeric type comparison. Because aggregations
+ * may result in small rounding errors, and in particular because doubles that are close to ints
+ * may round and be converted to ints (as is the case in the TPC-H validation workload),
+ * the AssertiveActor does not perform an exact comparison on ints. Instead, it considers any pair
+ * of numbers (even if their types differ) as equal if they are close enough according to a hard-coded
+ * limit in the actor.
+ *
  * ```yaml
  * SchemaVersion: 2017-07-01
  * Actors:

--- a/src/cast_core/src/AssertiveActor.cpp
+++ b/src/cast_core/src/AssertiveActor.cpp
@@ -1,0 +1,216 @@
+// Copyright 2022-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cast_core/actors/AssertiveActor.hpp>
+
+#include <memory>
+
+#include <yaml-cpp/yaml.h>
+
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/database.hpp>
+
+#include <boost/log/trivial.hpp>
+#include <boost/throw_exception.hpp>
+
+#include <gennylib/Cast.hpp>
+#include <gennylib/context.hpp>
+
+#include <value_generators/DocumentGenerator.hpp>
+
+namespace genny::actor {
+
+
+struct AssertiveActor::PhaseConfig {
+    mongocxx::database database;
+    DocumentGenerator expectedExpr;
+    DocumentGenerator actualExpr;
+    std::optional<std::string> message;
+    std::set<std::string> ignoreFields;
+
+    PhaseConfig(PhaseContext& phaseContext, mongocxx::database&& db, ActorId id)
+        : database{db},
+          expectedExpr{phaseContext["Expected"].to<DocumentGenerator>(phaseContext, id)},
+          actualExpr{phaseContext["Actual"].to<DocumentGenerator>(phaseContext, id)},
+          message{phaseContext["Message"].maybe<std::string>()} {
+        for (auto [k, fieldNode] : phaseContext["IgnoreFields"]) {
+            ignoreFields.insert(fieldNode.to<std::string>());
+        }
+    }
+};
+
+const std::string prefix(AssertiveActor::PhaseConfig* config) {
+    return "Assert" +(config->message ? " \"" + *(config->message) + "\" ": "") + ": ";
+}
+
+auto runCommandAndGetResult(AssertiveActor::PhaseConfig* config, bsoncxx::document::value& command) {
+    auto cmdView = command.view();
+
+    BOOST_LOG_TRIVIAL(info) << prefix(config) << bsoncxx::to_json(cmdView);
+    auto res = config->database.run_command(std::move(command));
+    auto resView = res.view();
+
+    return res;
+}
+
+auto getBatchFromCommandResult(const bsoncxx::document::view& resView) {
+    if (resView["ok"]) {
+        auto cursor = resView["cursor"].get_document().view();
+        auto firstBatch = cursor["firstBatch"].get_array().value;
+        return firstBatch;
+    }
+    BOOST_THROW_EXCEPTION(AssertFailed("Failed to run command."));
+}
+
+template <typename T>
+double convertNumericToDouble(const T& numeric) {
+    switch(numeric.type()) {
+        case bsoncxx::type::k_double:
+            return numeric.get_double();
+        case bsoncxx::type::k_int32:
+            return numeric.get_int32() * 1.0;
+        case bsoncxx::type::k_int64:
+            return numeric.get_int64() * 1.0;
+        default:
+            BOOST_THROW_EXCEPTION(AssertFailed("not a numeric"));
+    }
+}
+
+bool isNumeric(bsoncxx::type type) {
+    return (type == bsoncxx::type::k_double)
+        || (type == bsoncxx::type::k_int32)
+        || (type == bsoncxx::type::k_int64);
+}
+
+bool equalBSONDocs(AssertiveActor::PhaseConfig* config, const bsoncxx::document::view& expected, const bsoncxx::document::view& actual);
+bool equalBSONArrays(AssertiveActor::PhaseConfig* config, const bsoncxx::array::view& expected, const bsoncxx::array::view& actual);
+
+template <typename T>
+bool equal(AssertiveActor::PhaseConfig* config, const T& expectedVal, const T& actualVal) {
+    auto type = expectedVal.type();
+    if (isNumeric(type) && isNumeric(actualVal.type())) {
+        // Rounding may result in one value being a double while another is integral. Handle this case through double comparison.
+        auto expectedDouble = convertNumericToDouble<T>(expectedVal);
+        auto actualDouble = convertNumericToDouble<T>(actualVal);
+        // Accept a small difference in numeric types.
+        return std::abs(expectedDouble - actualDouble) < 0.001;
+    } else if (type != actualVal.type()) {
+        BOOST_LOG_TRIVIAL(info) << prefix(config) << "Types differ";
+        return false;
+    } else if (type == bsoncxx::type::k_array) {
+        bsoncxx::array::view expectedArr{expectedVal.get_array().value};
+        bsoncxx::array::view actualArr{actualVal.get_array().value};
+        return equalBSONArrays(config, expectedArr, actualArr);
+    } else if (type == bsoncxx::type::k_document) {
+        bsoncxx::document::view expectedDoc{expectedVal.get_document().value};
+        bsoncxx::document::view actualDoc{actualVal.get_document().value};
+        return equalBSONDocs(config, expectedDoc, actualDoc);
+    }
+    return actualVal.get_value() == expectedVal.get_value();
+}
+
+bool equalBSONDocs(AssertiveActor::PhaseConfig* config, const bsoncxx::document::view& expected, const bsoncxx::document::view& actual) {
+    for (auto actualVal : actual) {
+        auto key = actualVal.key();
+        if (key == "_id") {
+            continue;
+        }
+        if (key == "num") {
+            continue;
+        }
+        auto expectedVal = expected[key];
+        if (!equal<bsoncxx::document::element>(config, expectedVal, actualVal)) {
+            BOOST_LOG_TRIVIAL(info) << prefix(config) << "Documents differ in field: " << key;
+            return false;
+        }
+    }
+    for (auto expectedVal: expected) {
+        auto key = expectedVal.key();
+        if (key == "_id") {
+            continue;
+        }
+        if (key == "num") {
+            continue;
+        }
+        if (!actual[key]) {
+            BOOST_LOG_TRIVIAL(info) << prefix(config) << "Documents differ in field: " << key;
+            return false;
+        }
+    }
+    return true;
+}
+
+bool equalBSONArrays(AssertiveActor::PhaseConfig* config, const bsoncxx::array::view& expected, const bsoncxx::array::view& actual) {
+    auto expectedArrLen = std::distance(expected.begin(), expected.end());
+    auto actualArrLen = std::distance(actual.begin(), actual.end());
+    if (expectedArrLen != actualArrLen) {
+        BOOST_LOG_TRIVIAL(info) << prefix(config) << "Arrays differ in length. Expected " << expectedArrLen << " but found " << actualArrLen;
+        return false;
+    }
+
+    auto expectedIt = expected.begin();
+    int count = 0;
+    for (auto actualVal : actual) {
+        auto expectedVal = *expectedIt;
+        if (!equal<bsoncxx::array::element>(config, expectedVal, actualVal)) {
+            BOOST_LOG_TRIVIAL(info) << prefix(config) << "Arrays differ in idx " << count;
+            return false;
+        }
+        ++expectedIt;
+        ++count;
+    }
+
+    return true;
+}
+
+void AssertiveActor::run() {
+    for (auto&& config : _loop) {
+        for (const auto&& _ : config) {
+            auto expected = config->expectedExpr();
+            auto actual = config->actualExpr();
+
+            auto assertOp = _assert.start();
+            try {
+                auto expectedRes = runCommandAndGetResult(config, expected);
+                auto actualRes = runCommandAndGetResult(config, actual);
+                if (equalBSONArrays(config, getBatchFromCommandResult(expectedRes.view()), getBatchFromCommandResult(actualRes.view()))) {
+                    BOOST_LOG_TRIVIAL(info) << prefix(config) << "passed: results are equal.";
+                    assertOp.success();
+                } else {
+                    assertOp.failure();
+                    BOOST_THROW_EXCEPTION(AssertFailed("failed: results were unequal."));
+                }
+            } catch (AssertFailed& e) {
+                BOOST_LOG_TRIVIAL(info) << prefix(config) << "Caught error " << e.what();
+                assertOp.failure();
+                throw;
+            }
+        }
+    }
+}
+
+AssertiveActor::AssertiveActor(genny::ActorContext& context)
+    : Actor{context},
+      _assert{context.operation("Assert", AssertiveActor::id())},
+      _client{context.client()},
+      _loop{context, (*_client)[context["Database"].to<std::string>()], AssertiveActor::id()} {}
+
+namespace {
+auto registerAssertiveActor = Cast::registerDefault<AssertiveActor>();
+}  // namespace
+}  // namespace genny::actor

--- a/src/cast_core/test/AssertiveActor_test.cpp
+++ b/src/cast_core/test/AssertiveActor_test.cpp
@@ -119,13 +119,14 @@ public:
 };
 
 TEST_CASE_METHOD(AssertiveActorTestFixture, "AssertiveActor passes an assert", "[standalone][single_node_replset][three_node_replset][sharded][AssertiveActor]") {
-    prepareDatabase();
-  
     // The test collections are empty, so this should trivially pass.
+    prepareDatabase();
     SECTION("Assert passes because empty collections are equivalent") {
         AssertiveActorTestFixture::expectAssertPasses("EmptyCollections");
     }
 
+    // Compare two identical collections containing the following documents:
+    // {a: 1, b: 'foo', c: {d: 1}, d: [1, 2, 3]}, {a: 1, e: 1.4}
     auto doc1 = bson_builder::make_document(
         bson_builder::kvp("a", 1),
         bson_builder::kvp("b", "foo"),

--- a/src/cast_core/test/AssertiveActor_test.cpp
+++ b/src/cast_core/test/AssertiveActor_test.cpp
@@ -1,0 +1,116 @@
+// Copyright 2022-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+
+#include <boost/exception/diagnostic_information.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+#include <testlib/MongoTestFixture.hpp>
+#include <testlib/ActorHelper.hpp>
+#include <testlib/helpers.hpp>
+
+#include <gennylib/context.hpp>
+
+namespace genny {
+namespace {
+using namespace genny::testing;
+namespace bson_stream = bsoncxx::builder::stream;
+
+TEST_CASE_METHOD(MongoTestFixture, "AssertiveActor passes an assert", "[standalone][single_node_replset][three_node_replset][sharded][AssertiveActor]") {
+
+    dropAllDatabases();
+    auto db = client.database("test");
+  
+    // The test collection is empty, so this should trivially pass.
+    NodeSource passNodes = NodeSource(R"(
+        SchemaVersion: 2018-07-01
+        Clients:
+          Default:
+            URI: )" + MongoTestFixture::connectionUri().to_string() + R"(
+        Actors:
+        - Name: PassAssertiveActor
+          Type: AssertiveActor
+          Database: test
+          Phases:
+          - Repeat: 1
+            Expected:
+              aggregate: test
+              pipeline: []
+              cursor: {batchSize: 101}
+            Actual:
+              aggregate: test
+              pipeline: []
+              cursor: {batchSize: 101}
+    )", __FILE__);
+
+    SECTION("Assert passes") {
+        try {
+            genny::ActorHelper ah(passNodes.root(), 1);
+            ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
+            INFO("Assert passed")
+        } catch (const std::exception& e) {
+            auto diagInfo = boost::diagnostic_information(e);
+            FAIL("Expected assert to pass, but an exception was thrown " << diagInfo);
+        }
+    }
+}
+
+TEST_CASE_METHOD(MongoTestFixture, "AssertiveActor fails an assert", "[standalone][single_node_replset][three_node_replset][sharded][AssertiveActor]") {
+
+    dropAllDatabases();
+    auto db = client.database("test");
+    auto testColl = db.collection("test");
+    testColl.insert_one(bsoncxx::builder::basic::make_document(bsoncxx::builder::basic::kvp("a", 1)));
+    testColl.insert_one(bsoncxx::builder::basic::make_document(bsoncxx::builder::basic::kvp("a", 2)));
+
+    // The test collection is not empty, so this should trivially fail.
+    NodeSource failNodes = NodeSource(R"(
+        SchemaVersion: 2018-07-01
+        Clients:
+          Default:
+            URI: )" + MongoTestFixture::connectionUri().to_string() + R"(
+        Actors:
+        - Name: FailAssertiveActor
+          Type: AssertiveActor
+          Database: test
+          Phases:
+          - Repeat: 1
+            Expected:
+              aggregate: test
+              pipeline: []
+              cursor: {batchSize: 101}
+            Actual:
+              aggregate: emptyColl
+              pipeline: []
+              cursor: {batchSize: 101}
+    )", __FILE__);
+
+    SECTION("Assert fails") {
+        try {
+            genny::ActorHelper ah(failNodes.root(), 1);
+            ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
+            FAIL("Expected assert to fail, but no exception was thrown");
+        } catch (const std::exception& e) {
+            // Exprected assert to reach here.
+            auto diagInfo = boost::diagnostic_information(e);
+            INFO("Assert failed correctly" << diagInfo);
+        }
+    }
+}
+
+}  // namespace
+}  // namespace genny

--- a/src/cast_core/test/AssertiveActor_test.cpp
+++ b/src/cast_core/test/AssertiveActor_test.cpp
@@ -17,6 +17,8 @@
 
 #include <boost/exception/diagnostic_information.hpp>
 
+#include <cast_core/actors/AssertiveActor.hpp>
+
 #include <yaml-cpp/yaml.h>
 
 #include <testlib/MongoTestFixture.hpp>
@@ -28,87 +30,187 @@
 namespace genny {
 namespace {
 using namespace genny::testing;
-namespace bson_stream = bsoncxx::builder::stream;
+namespace bson_builder = bsoncxx::builder::basic;
 
-TEST_CASE_METHOD(MongoTestFixture, "AssertiveActor passes an assert", "[standalone][single_node_replset][three_node_replset][sharded][AssertiveActor]") {
+class AssertiveActorTestFixture : public MongoTestFixture {
+public:
+    void prepareColl(
+        const std::string& collName,
+        const std::vector<bsoncxx::document::view>& docs
+    ) {
+        if (!docs.empty()) {
+            auto db = client.database("test");
+            auto testColl = db.collection(collName);
+            testColl.insert_many(docs.begin(), docs.end());
+        }
+    }
 
-    dropAllDatabases();
-    auto db = client.database("test");
-  
-    // The test collection is empty, so this should trivially pass.
-    NodeSource passNodes = NodeSource(R"(
-        SchemaVersion: 2018-07-01
-        Clients:
-          Default:
-            URI: )" + MongoTestFixture::connectionUri().to_string() + R"(
-        Actors:
-        - Name: PassAssertiveActor
-          Type: AssertiveActor
-          Database: test
-          Phases:
-          - Repeat: 1
-            Expected:
-              aggregate: test
-              pipeline: []
-              cursor: {batchSize: 101}
-            Actual:
-              aggregate: test
-              pipeline: []
-              cursor: {batchSize: 101}
-    )", __FILE__);
+    void prepareDatabase(
+        const std::vector<bsoncxx::document::view>& expectedCollDocs = {},
+        const std::vector<bsoncxx::document::view>& actualCollDocs = {}
+    ) {
+        dropAllDatabases();
+        prepareColl("expected", expectedCollDocs);
+        prepareColl("actual", actualCollDocs);
+    }
 
-    SECTION("Assert passes") {
+    /**
+     * Creates a YAML config for an AssertiveActor that compares the results of aggregation pipelines
+     * against collections 'expected' and 'actual' using the specified value of 'ignoreFields'. If this
+     * is an empty string, the 'IgnoreFields' key is omitted from the YAMl config.
+     */
+    static genny::ActorHelper setupAssertActor(
+        const std::string& actorName,
+        const std::string& ignoreFields
+    ) {
+        const auto ignoreFieldsStr = ignoreFields.empty() ? "" : "IgnoreFields: " + ignoreFields;
+        const auto yaml = R"(
+            SchemaVersion: 2018-07-01
+            Clients:
+              Default:
+                URI: )" + MongoTestFixture::connectionUri().to_string() + R"(
+            Actors:
+            - Name: )" + actorName + R"(
+              Type: AssertiveActor
+              Database: test
+              Phases:
+              - Repeat: 1
+                Expected:
+                  aggregate: expected
+                  pipeline: []
+                  cursor: {batchSize: 101}
+                Actual:
+                  aggregate: actual
+                  pipeline: []
+                  cursor: {batchSize: 101}
+                )" + ignoreFieldsStr;
+        NodeSource nodes = NodeSource(yaml, __FILE__);
+        return genny::ActorHelper(nodes.root(), 1);
+    }
+
+    static void expectAssertPasses(
+        const std::string& actorName,
+        const std::string& ignoreFields = ""
+    ) {
         try {
-            genny::ActorHelper ah(passNodes.root(), 1);
+            genny::ActorHelper ah = setupAssertActor(actorName, ignoreFields);
             ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
             INFO("Assert passed")
-        } catch (const std::exception& e) {
+        } catch (const genny::actor::FailedAssertionException& e) {
+            // Did not expect assert to reach here.
             auto diagInfo = boost::diagnostic_information(e);
-            FAIL("Expected assert to pass, but an exception was thrown " << diagInfo);
+            FAIL("Assert failed" << diagInfo);
         }
+    }
+
+    static void expectAssertFails(
+        const std::string& actorName,
+        const std::string& ignoreFields = ""
+    ) {
+        try {
+            genny::ActorHelper ah = setupAssertActor(actorName, ignoreFields);
+            ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
+            FAIL("Assert passed");
+        } catch (const genny::actor::FailedAssertionException& e) {
+            // Expected assert to reach here.
+            INFO("Assert failed");
+        }
+    }
+};
+
+TEST_CASE_METHOD(AssertiveActorTestFixture, "AssertiveActor passes an assert", "[standalone][single_node_replset][three_node_replset][sharded][AssertiveActor]") {
+    prepareDatabase();
+  
+    // The test collections are empty, so this should trivially pass.
+    SECTION("Assert passes because empty collections are equivalent") {
+        AssertiveActorTestFixture::expectAssertPasses("EmptyCollections");
+    }
+
+    auto doc1 = bson_builder::make_document(
+        bson_builder::kvp("a", 1),
+        bson_builder::kvp("b", "foo"),
+        bson_builder::kvp("c", bson_builder::make_document(bson_builder::kvp("d", 1))),
+        bson_builder::kvp("d", bson_builder::make_array(1, 2, 3))
+    );
+    auto doc2 = bson_builder::make_document(
+        bson_builder::kvp("a", 1),
+        bson_builder::kvp("e", 1.4)
+    );
+    std::vector<bsoncxx::document::view> docs {doc1, doc2};
+    prepareDatabase(docs, docs);
+    SECTION("Assert passes because collections are equivalent") {
+        AssertiveActorTestFixture::expectAssertPasses("EqualCollections");
     }
 }
 
-TEST_CASE_METHOD(MongoTestFixture, "AssertiveActor fails an assert", "[standalone][single_node_replset][three_node_replset][sharded][AssertiveActor]") {
+TEST_CASE_METHOD(AssertiveActorTestFixture, "AssertiveActor fails an assert", "[standalone][single_node_replset][three_node_replset][sharded][AssertiveActor]") {
+    prepareDatabase(
+        {bson_builder::make_document(bson_builder::kvp("a", 1))},
+        {bson_builder::make_document(bson_builder::kvp("a", 2))}
+    );
+    SECTION("Assert fails because {a: 1} differs from {a: 2}") {
+        AssertiveActorTestFixture::expectAssertFails("MismatchedInt");
+    }
 
-    dropAllDatabases();
-    auto db = client.database("test");
-    auto testColl = db.collection("test");
-    testColl.insert_one(bsoncxx::builder::basic::make_document(bsoncxx::builder::basic::kvp("a", 1)));
-    testColl.insert_one(bsoncxx::builder::basic::make_document(bsoncxx::builder::basic::kvp("a", 2)));
+    prepareDatabase(
+        {bson_builder::make_document(bson_builder::kvp("a", "foo"))},
+        {bson_builder::make_document(bson_builder::kvp("a", "bar"))}
+    );
+    SECTION("Assert fails because {a: 'foo'} differs from {a: 'bar'}") {
+        AssertiveActorTestFixture::expectAssertFails("MismatchedStr");
+    }
 
-    // The test collection is not empty, so this should trivially fail.
-    NodeSource failNodes = NodeSource(R"(
-        SchemaVersion: 2018-07-01
-        Clients:
-          Default:
-            URI: )" + MongoTestFixture::connectionUri().to_string() + R"(
-        Actors:
-        - Name: FailAssertiveActor
-          Type: AssertiveActor
-          Database: test
-          Phases:
-          - Repeat: 1
-            Expected:
-              aggregate: test
-              pipeline: []
-              cursor: {batchSize: 101}
-            Actual:
-              aggregate: emptyColl
-              pipeline: []
-              cursor: {batchSize: 101}
-    )", __FILE__);
+    prepareDatabase(
+        {bson_builder::make_document(bson_builder::kvp("a", 1.0))},
+        {bson_builder::make_document(bson_builder::kvp("a", 1.1))}
+    );
+    SECTION("Assert fails because {a: 1.0} differs from {a: 1.1}") {
+        AssertiveActorTestFixture::expectAssertFails("MismatchedDouble");
+    }
 
-    SECTION("Assert fails") {
-        try {
-            genny::ActorHelper ah(failNodes.root(), 1);
-            ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
-            FAIL("Expected assert to fail, but no exception was thrown");
-        } catch (const std::exception& e) {
-            // Exprected assert to reach here.
-            auto diagInfo = boost::diagnostic_information(e);
-            INFO("Assert failed correctly" << diagInfo);
-        }
+    prepareDatabase(
+        {bson_builder::make_document(bson_builder::kvp("a",
+            bson_builder::make_document(bson_builder::kvp("a", 1))))},
+        {bson_builder::make_document(bson_builder::kvp("a", 1))}
+    );
+    SECTION("Assert fails because {a: {a: 1}} differs from {a: 1}") {
+        AssertiveActorTestFixture::expectAssertFails("MismatchedDocNested");
+    }
+
+    prepareDatabase(
+        {bson_builder::make_document(bson_builder::kvp("a", bson_builder::make_array(
+            bson_builder::make_document(bson_builder::kvp("a", 1)),
+            bson_builder::make_document(bson_builder::kvp("b", 1)))))},
+        {bson_builder::make_document(bson_builder::kvp("a", bson_builder::make_array(
+            bson_builder::make_document(bson_builder::kvp("a", 1)),
+            bson_builder::make_document(bson_builder::kvp("b", 2)))))}
+    );
+    SECTION("Assert fails because {a: [{a: 1}, {b: 1}]} differs from {a: [{a: 1}, {b: 2}]}") {
+        AssertiveActorTestFixture::expectAssertFails("MismatchedArrayNested");
+    }
+}
+
+TEST_CASE_METHOD(AssertiveActorTestFixture, "AssertiveActor correctly uses IgnoreFields", "[standalone][single_node_replset][three_node_replset][sharded][AssertiveActor]") {
+    prepareDatabase(
+        {bson_builder::make_document(bson_builder::kvp("a", 1))},
+        {bson_builder::make_document(bson_builder::kvp("a", 1))}
+    );
+
+    SECTION("Assert fails because '_id' fields differ and 'IgnoreFields' is empty") {
+        AssertiveActorTestFixture::expectAssertFails("EmptyIgnoreFieldsActor", "[]");
+    }
+
+    SECTION("Assert passes because '_id' fields are ignored by default") {
+        AssertiveActorTestFixture::expectAssertPasses("MissingIgnoreFieldsActor");
+    }
+
+    prepareDatabase(
+        {bson_builder::make_document(bson_builder::kvp("ignoreMe", 1))},
+        {bson_builder::make_document(bson_builder::kvp("ignoreMe", 2))}
+    );
+
+    SECTION("Assert passes because fields 'ignoreMe' and '_id' are explicitly ignored") {
+        AssertiveActorTestFixture::expectAssertPasses("ExplicitlyIgnoreFieldsActor", "['ignoreMe', '_id']");
     }
 }
 

--- a/src/phases/tpch/denormalized/Q1.yml
+++ b/src/phases/tpch/denormalized/Q1.yml
@@ -7,26 +7,28 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query1Delta: &query1Delta {^Parameter: {Name: "Query1Delta", Default: -90}}
 
+TPCHDenormalizedQuery1Aggregation: &TPCHDenormalizedQuery1Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$replaceWith: "$lineitem"},
+      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
+      {$group: {_id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"}, sum_qty: {$sum: "$l_quantity"}, sum_base_price: {$sum: "$l_extendedprice"}, sum_disc_price: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}, sum_charge: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}, {$add: [1, "$l_tax"]}]}}, avg_qty: {$avg: "$l_quantity"}, avg_price: {$avg: "$l_extendedprice"}, avg_disc: {$avg: "$l_discount"}, count_order: {$count: {}}}},
+      {$project: {_id: 0, l_returnflag: "$_id.l_returnflag", l_linestatus: "$_id.l_linestatus", sum_qty: 1, sum_base_price: 1, sum_disc_price: 1, sum_charge: 1, avg_qty: 1, avg_price: 1, avg_disc: 1, count_order: 1}},
+      {$sort: {l_returnflag: 1, l_linestatus: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery1Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery1Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-          {$unwind: "$lineitem"},
-          {$replaceWith: "$lineitem"},
-          {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
-          {$group: {_id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"}, sum_qty: {$sum: "$l_quantity"}, sum_base_price: {$sum: "$l_extendedprice"}, sum_disc_price: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}, sum_charge: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}, {$add: [1, "$l_tax"]}]}}, avg_qty: {$avg: "$l_quantity"}, avg_price: {$avg: "$l_extendedprice"}, avg_disc: {$avg: "$l_discount"}, count_order: {$count: {}}}},
-          {$project: {_id: 0, l_returnflag: "$_id.l_returnflag", l_linestatus: "$_id.l_linestatus", sum_qty: 1, sum_base_price: 1, sum_disc_price: 1, sum_charge: 1, avg_qty: 1, avg_price: 1, avg_disc: 1, count_order: 1}},
-          {$sort: {l_returnflag: 1, l_linestatus: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery1Aggregation
 
 TPCHDenormalizedQuery1:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q10.yml
+++ b/src/phases/tpch/denormalized/Q10.yml
@@ -7,29 +7,31 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query10Date: &query10Date {^Parameter: {Name: "Query10Date", Default: "1993-10-01"}}
 
+TPCHDenormalizedQuery10Aggregation: &TPCHDenormalizedQuery10Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$match: {"lineitem.l_returnflag": "R"}},
+      {$group: {_id: {c_custkey: "$c_custkey", c_name: "$c_name", c_acctbal: "$c_acctbal", n_name: "$nation.n_name", c_address: "$c_address", c_phone: "$c_phone", c_comment: "$c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
+      {$sort: {revenue: -1}},
+      {$limit: 20}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery10Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery10Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$match: {$and: [
-            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
-            {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
-          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-          {$unwind: "$lineitem"},
-          {$match: {"lineitem.l_returnflag": "R"}},
-          {$group: {_id: {c_custkey: "$c_custkey", c_name: "$c_name", c_acctbal: "$c_acctbal", n_name: "$nation.n_name", c_address: "$c_address", c_phone: "$c_phone", c_comment: "$c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
-          {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
-          {$sort: {revenue: -1}},
-          {$limit: 20}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery10Aggregation
 
 TPCHDenormalizedQuery10:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q11.yml
+++ b/src/phases/tpch/denormalized/Q11.yml
@@ -8,29 +8,31 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query11Nation: &query11Nation {^Parameter: {Name: "Query11Nation", Default: "GERMANY"}}
 query11Fraction: &query11Fraction {^Parameter: {Name: "Query11Fraction", Default: 0.0001}}
 
+TPCHDenormalizedQuery11Aggregation: &TPCHDenormalizedQuery11Aggregation
+  aggregate: partsupp
+  pipeline:
+    [
+      {$lookup: {from: "supplier", localField: "ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query11Nation}}]}},
+      {$unwind: "$supplier"},
+      {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
+      {$group: {_id: "$ps_partkey", value: {$sum: "$total_cost"}}},
+      {$group: {_id: 0, groups: {$push: {ps_partkey: "$_id", value: "$value"}}, total_cost: {$sum: "$value"}}},
+      {$addFields: {threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
+      {$unwind: "$groups"},
+      {$project: {ps_partkey: "$groups.ps_partkey", value: "$groups.value", threshold: 1}},
+      {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
+      {$project: {_id: 0, ps_partkey: 1, value: 1}},
+      {$sort: {value: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery11Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery11Aggregation
-      aggregate: partsupp
-      pipeline:
-        [
-          {$lookup: {from: "supplier", localField: "ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query11Nation}}]}},
-          {$unwind: "$supplier"},
-          {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
-          {$group: {_id: "$ps_partkey", value: {$sum: "$total_cost"}}},
-          {$group: {_id: 0, groups: {$push: {ps_partkey: "$_id", value: "$value"}}, total_cost: {$sum: "$value"}}},
-          {$addFields: {threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
-          {$unwind: "$groups"},
-          {$project: {ps_partkey: "$groups.ps_partkey", value: "$groups.value", threshold: 1}},
-          {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
-          {$project: {_id: 0, ps_partkey: 1, value: 1}},
-          {$sort: {value: -1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery11Aggregation
 
 TPCHDenormalizedQuery11:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q12.yml
+++ b/src/phases/tpch/denormalized/Q12.yml
@@ -10,30 +10,32 @@ query12ShipMode1: &query12ShipMode1 {^Parameter: {Name: "Query12ShipMode1", Defa
 query12ShipMode2: &query12ShipMode2 {^Parameter: {Name: "Query12ShipMode2", Default: "SHIP"}}
 query12Date: &query12Date {^Parameter: {Name: "Query12Date", Default: "1994-01-01"}}
 
+TPCHDenormalizedQuery12Aggregation: &TPCHDenormalizedQuery12Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$or: [{"lineitem.l_shipmode": *query12ShipMode1}, {"lineitem.l_shipmode": *query12ShipMode2}]},
+        {$expr: {$lt: ["$lineitem.l_commitdate", "$lineitem.l_receiptdate"]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", "$lineitem.l_commitdate"]}},
+        {$expr: {$gte: ["$lineitem.l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
+        {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
+      {$group: {_id: "$lineitem.l_shipmode", high_line_count: {$sum: {$cond: {if: {$or: [{$eq: ["$orders.o_orderpriority", "1-URGENT"]}, {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}, low_line_count: {$sum: {$cond: {if: {$and: [{$ne: ["$orders.o_orderpriority", "1-URGENT"]}, {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}}},
+      {$project: {_id: 0, l_shipmode: "$_id", high_line_count: 1, low_line_count: 1}},
+      {$sort: {l_shipmode: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery12Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery12Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-          {$unwind: "$lineitem"},
-          {$match: {$and: [
-            {$or: [{"lineitem.l_shipmode": *query12ShipMode1}, {"lineitem.l_shipmode": *query12ShipMode2}]},
-            {$expr: {$lt: ["$lineitem.l_commitdate", "$lineitem.l_receiptdate"]}},
-            {$expr: {$lt: ["$lineitem.l_shipdate", "$lineitem.l_commitdate"]}},
-            {$expr: {$gte: ["$lineitem.l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
-            {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
-          {$group: {_id: "$lineitem.l_shipmode", high_line_count: {$sum: {$cond: {if: {$or: [{$eq: ["$orders.o_orderpriority", "1-URGENT"]}, {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}, low_line_count: {$sum: {$cond: {if: {$and: [{$ne: ["$orders.o_orderpriority", "1-URGENT"]}, {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}}},
-          {$project: {_id: 0, l_shipmode: "$_id", high_line_count: 1, low_line_count: 1}},
-          {$sort: {l_shipmode: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery12Aggregation
 
 TPCHDenormalizedQuery12:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q13.yml
+++ b/src/phases/tpch/denormalized/Q13.yml
@@ -7,22 +7,24 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query13Regex: &query13Regex {^Parameter: {Name: "Query13Regex", Default: "^.*special.*requests.*$"}}  # `^.*${query13Word1}.*${query13Word2}.*$`
 
+TPCHDenormalizedQuery13Aggregation: &TPCHDenormalizedQuery13Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$project: {c_custkey: 1, c_count: {$size: {$filter: {input: "$orders", cond: {$not: {$regexMatch: {input: "$$this.o_comment", regex: *query13Regex, options: "si"}}}}}}}},
+      {$group: {_id: "$c_count", custdist: {$count: {}}}},
+      {$project: {_id: 0, c_count: "$_id", custdist: 1}},
+      {$sort: {custdist: -1, c_count: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery13Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery13Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$project: {c_custkey: 1, c_count: {$size: {$filter: {input: "$orders", cond: {$not: {$regexMatch: {input: "$$this.o_comment", regex: *query13Regex, options: "si"}}}}}}}},
-          {$group: {_id: "$c_count", custdist: {$count: {}}}},
-          {$project: {_id: 0, c_count: "$_id", custdist: 1}},
-          {$sort: {custdist: -1, c_count: -1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery13Aggregation
 
 TPCHDenormalizedQuery13:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q14.yml
+++ b/src/phases/tpch/denormalized/Q14.yml
@@ -7,27 +7,29 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query14Date: &query14Date {^Parameter: {Name: "Query14Date", Default: "1995-09-01"}}
 
+TPCHDenormalizedQuery14Aggregation: &TPCHDenormalizedQuery14Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
+      {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part"}},
+      {$unwind: "$part"},
+      {$group: {_id: {}, promo_price_total: {$sum: {$cond: {if: {$cond: {if: {$regexMatch: {input: "$part.p_type", regex: "^PROMO.*$", options: "si"}}, then: 1, else: 0}}, then: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}, else: 0}}}, price_total: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}}, {$project: {_id: 0, promo_revenue: {$multiply: [100.0, {$divide: ["$promo_price_total", "$price_total"]}]}}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery14Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery14Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-          {$unwind: "$lineitem"},
-          {$match: {$and: [
-            {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
-            {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
-          {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part"}},
-          {$unwind: "$part"},
-          {$group: {_id: {}, promo_price_total: {$sum: {$cond: {if: {$cond: {if: {$regexMatch: {input: "$part.p_type", regex: "^PROMO.*$", options: "si"}}, then: 1, else: 0}}, then: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}, else: 0}}}, price_total: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}}, {$project: {_id: 0, promo_revenue: {$multiply: [100.0, {$divide: ["$promo_price_total", "$price_total"]}]}}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery14Aggregation
 
 TPCHDenormalizedQuery14:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -89,6 +89,7 @@ TPCHDenormalizedQuery15Explain:
   Operations:
   - OperationMetricsName: Query15
     OperationName: RunCommand
+    OperationLogsResult: true
     OperationCommand:
       explain: *TPCHDenormalizedQuery15Aggregation
       verbosity:

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -37,32 +37,34 @@ TPCHDenormalizedQuery15CreateView: &TPCHDenormalizedQuery15CreateView
           {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
         ]
 
+TPCHDenormalizedQuery15Aggregation: &TPCHDenormalizedQuery15Aggregation
+  aggregate: *query15View
+  pipeline:
+    [
+      {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
+      {$sort: {_id: -1}},
+      {$limit: 1},
+      {$unwind: "$supplier_no"},
+      {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
+      {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$project: {
+        s_suppkey: "$supplier.s_suppkey",
+        s_name: "$supplier.s_name",
+        s_address: "$supplier.s_address",
+        s_phone: "$supplier.s_phone",
+        total_revenue: 1
+      }},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery15Warmup:
   Repeat: *Repeat
   Database: *db
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery15Aggregation
-      aggregate: *query15View
-      pipeline:
-        [
-          {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
-          {$sort: {_id: -1}},
-          {$limit: 1},
-          {$unwind: "$supplier_no"},
-          {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
-          {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
-          {$unwind: "$supplier"},
-          {$project: {
-            s_suppkey: "$supplier.s_suppkey",
-            s_name: "$supplier.s_name",
-            s_address: "$supplier.s_address",
-            s_phone: "$supplier.s_phone",
-            total_revenue: 1
-          }},
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery15Aggregation
 
 TPCHDenormalizedQuery15DropView: &TPCHDenormalizedQuery15DropView
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q16.yml
+++ b/src/phases/tpch/denormalized/Q16.yml
@@ -10,26 +10,28 @@ query16Brand: &query16Brand {^Parameter: {Name: "Query16Brand", Default: "Brand#
 query16Type: &query16Type {^Parameter: {Name: "Query16Type", Default: "^MEDIUM POLISHED.*"}}  # ^${type}.*$"
 query16Sizes: &query16Sizes {^Parameter: {Name: "Query16Sizes", Default: [49, 14, 23, 45, 19, 3, 36, 9]}}
 
+TPCHDenormalizedQuery16Aggregation: &TPCHDenormalizedQuery16Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [{p_brand: {$ne: *query16Brand}}, {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}}, {p_size: {$in: *query16Sizes}}]}},
+      {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}], as: "supplier"}},
+      {$match: {supplier: {$eq: []}}},
+      {$group: {_id: {p_brand: "$p_brand", p_type: "$p_type", p_size: "$p_size"}, ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
+      {$project: {_id: 0, p_brand: "$_id.p_brand", p_type: "$_id.p_type", p_size: "$_id.p_size", supplier_cnt: {$size: "$ps_suppkey"}}},
+      {$sort: {supplier_cnt: -1, p_brand: 1, p_type: 1, p_size: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery16Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery16Aggregation
-      aggregate: part
-      pipeline:
-        [
-          {$match: {$and: [{p_brand: {$ne: *query16Brand}}, {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}}, {p_size: {$in: *query16Sizes}}]}},
-          {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
-          {$unwind: "$partsupp"},
-          {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}], as: "supplier"}},
-          {$match: {supplier: {$eq: []}}},
-          {$group: {_id: {p_brand: "$p_brand", p_type: "$p_type", p_size: "$p_size"}, ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
-          {$project: {_id: 0, p_brand: "$_id.p_brand", p_type: "$_id.p_type", p_size: "$_id.p_size", supplier_cnt: {$size: "$ps_suppkey"}}},
-          {$sort: {supplier_cnt: -1, p_brand: 1, p_type: 1, p_size: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery16Aggregation
 
 TPCHDenormalizedQuery16:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q17.yml
+++ b/src/phases/tpch/denormalized/Q17.yml
@@ -9,31 +9,33 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
 query17Container: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
 
+TPCHDenormalizedQuery17Aggregation: &TPCHDenormalizedQuery17Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
+      {$lookup: {from: "customer", localField: "p_partkey", foreignField: "orders.lineitem.l_partkey", as: "lineitem", let: {p_partkey: "$p_partkey"}, pipeline: [
+        {$unwind: "$orders"},
+        {$unwind: "$orders.lineitem"},
+        {$replaceWith: "$orders.lineitem"},
+        {$match: {$expr: {$eq: ["$l_partkey", "$$p_partkey"]}}},
+        {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
+        {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
+        {$unwind: "$lineitem"},
+        {$replaceWith: "$lineitem"}]}},
+      {$unwind: "$lineitem"},
+      {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
+      {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery17Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery17Aggregation
-      aggregate: part
-      pipeline:
-        [
-          {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
-          {$lookup: {from: "customer", localField: "p_partkey", foreignField: "orders.lineitem.l_partkey", as: "lineitem", let: {p_partkey: "$p_partkey"}, pipeline: [
-            {$unwind: "$orders"},
-            {$unwind: "$orders.lineitem"},
-            {$replaceWith: "$orders.lineitem"},
-            {$match: {$expr: {$eq: ["$l_partkey", "$$p_partkey"]}}},
-            {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
-            {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
-            {$unwind: "$lineitem"},
-            {$replaceWith: "$lineitem"}]}},
-          {$unwind: "$lineitem"},
-          {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
-          {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery17Aggregation
 
 TPCHDenormalizedQuery17:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q18.yml
+++ b/src/phases/tpch/denormalized/Q18.yml
@@ -7,26 +7,28 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query18Quantity: &query18Quantity {^Parameter: {Name: "Query18Quantity", Default: 300}}
 
+TPCHDenormalizedQuery18Aggregation: &TPCHDenormalizedQuery18Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {"sum(l_quantity)": {$reduce: {input: "$orders.lineitem", initialValue: 0, in: {$add: ["$$value", "$$this.l_quantity"]}}}}},
+      {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
+      {$group: {_id: {c_name: "$c_name", c_custkey: "$c_custkey", o_orderkey: "$orders.o_orderkey", o_orderdate: "$orders.o_orderdate", o_totalprice: "$orders.o_totalprice"}, "sum(l_quantity)": {$push: "$sum(l_quantity)"}}},
+      {$unwind: "$sum(l_quantity)"},
+      {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
+      {$sort: {o_totalprice: -1, o_orderdate: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery18Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery18Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$addFields: {"sum(l_quantity)": {$reduce: {input: "$orders.lineitem", initialValue: 0, in: {$add: ["$$value", "$$this.l_quantity"]}}}}},
-          {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
-          {$group: {_id: {c_name: "$c_name", c_custkey: "$c_custkey", o_orderkey: "$orders.o_orderkey", o_orderdate: "$orders.o_orderdate", o_totalprice: "$orders.o_totalprice"}, "sum(l_quantity)": {$push: "$sum(l_quantity)"}}},
-          {$unwind: "$sum(l_quantity)"},
-          {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
-          {$sort: {o_totalprice: -1, o_orderdate: 1}},
-          {$limit: 100}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery18Aggregation
 
 TPCHDenormalizedQuery18:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q19.yml
+++ b/src/phases/tpch/denormalized/Q19.yml
@@ -13,54 +13,56 @@ query19Quantity2: &query19Quantity2 {^Parameter: {Name: "Query19Quantity2", Defa
 query19Brand3: &query19Brand3 {^Parameter: {Name: "Query19Brand3", Default: "Brand#34"}}
 query19Quantity3: &query19Quantity3 {^Parameter: {Name: "Query19Quantity3", Default: 20}}
 
+TPCHDenormalizedQuery19Aggregation: &TPCHDenormalizedQuery19Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$replaceWith: "$lineitem"},
+      {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+        {$match: {$or: [
+          {$and: [
+            {p_brand: *query19Brand1},
+            {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
+            {p_size: {$gte: 1}},
+            {p_size: {$lte: 5}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+          {$and: [
+            {p_brand: *query19Brand2},
+            {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
+            {p_size: {$gte: 1}},
+            {p_size: {$lte: 10}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+          {$and: [
+            {p_brand: *query19Brand3},
+            {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
+            {p_size: {$gte: 1}},
+            {p_size: {$lte: 15}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
+      {$unwind: "$part"},
+      {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+      {$project: {_id: 0, revenue: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery19Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery19Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-          {$unwind: "$lineitem"},
-          {$replaceWith: "$lineitem"},
-          {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-            {$match: {$or: [
-              {$and: [
-                {p_brand: *query19Brand1},
-                {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
-                {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
-                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
-                {p_size: {$gte: 1}},
-                {p_size: {$lte: 5}},
-                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-              {$and: [
-                {p_brand: *query19Brand2},
-                {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
-                {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
-                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
-                {p_size: {$gte: 1}},
-                {p_size: {$lte: 10}},
-                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-              {$and: [
-                {p_brand: *query19Brand3},
-                {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
-                {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
-                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
-                {p_size: {$gte: 1}},
-                {p_size: {$lte: 15}},
-                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
-          {$unwind: "$part"},
-          {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-          {$project: {_id: 0, revenue: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery19Aggregation
 
 TPCHDenormalizedQuery19:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q2.yml
+++ b/src/phases/tpch/denormalized/Q2.yml
@@ -10,29 +10,31 @@ query2Size: &query2Size {^Parameter: {Name: "Query2Size", Default: 15}}
 query2Type: &query2Type {^Parameter: {Name: "Query2Type", Default: "^.*BRASS$"}}  # ^.*{type}$"
 query2Region: &query2Region {^Parameter: {Name: "Query2Region", Default: "EUROPE"}}
 
+TPCHDenormalizedQuery2Aggregation: &TPCHDenormalizedQuery2Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [{p_type: {$regex: *query2Type, $options: "si"}}, {p_size: {$eq: *query2Size}}]}},
+      {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+        {$match: {"nation.region.r_name": {$eq: *query2Region}}}]}},
+      {$unwind: "$supplier"},
+      {$sort: {"partsupp.ps_supplycost": 1}},
+      {$group: {_id: {p_partkey: "$p_partkey", p_mfgr: "$p_mfgr"}, supplier: {$first: {s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment", ps_supplycost: "$partsupp.ps_supplycost", n_name: "$supplier.nation.n_name"}}}},
+      {$project: {_id: 0, s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", n_name: "$supplier.n_name", p_partkey: "$_id.p_partkey", p_mfgr: "$_id.p_mfgr", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment"}},
+      {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery2Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery2Aggregation
-      aggregate: part
-      pipeline:
-        [
-          {$match: {$and: [{p_type: {$regex: *query2Type, $options: "si"}}, {p_size: {$eq: *query2Size}}]}},
-          {$lookup: {from: "partsupp", localField: "p_partkey", foreignField: "ps_partkey", as: "partsupp"}},
-          {$unwind: "$partsupp"},
-          {$lookup: {from: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-            {$match: {"nation.region.r_name": {$eq: *query2Region}}}]}},
-          {$unwind: "$supplier"},
-          {$sort: {"partsupp.ps_supplycost": 1}},
-          {$group: {_id: {p_partkey: "$p_partkey", p_mfgr: "$p_mfgr"}, supplier: {$first: {s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment", ps_supplycost: "$partsupp.ps_supplycost", n_name: "$supplier.nation.n_name"}}}},
-          {$project: {_id: 0, s_acctbal: "$supplier.s_acctbal", s_name: "$supplier.s_name", n_name: "$supplier.n_name", p_partkey: "$_id.p_partkey", p_mfgr: "$_id.p_mfgr", s_address: "$supplier.s_address", s_phone: "$supplier.s_phone", s_comment: "$supplier.s_comment"}},
-          {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
-          {$limit: 100}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery2Aggregation
 
 TPCHDenormalizedQuery2:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q20.yml
+++ b/src/phases/tpch/denormalized/Q20.yml
@@ -10,35 +10,37 @@ query20Nation: &query20Nation {^Parameter: {Name: "Query20Nation", Default: "CAN
 query20Color: &query20Color {^Parameter: {Name: "Query20Color", Default: "^forest.*$"}}  # "^${color}.*$"
 query20Date: &query20Date {^Parameter: {Name: "Query20Date", Default: "1994-01-01"}}
 
+TPCHDenormalizedQuery20Aggregation: &TPCHDenormalizedQuery20Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE", quantity: {$sum: "$orders.lineitem.l_quantity"}}},
+      {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
+      {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
+        {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query20Nation}}]}},
+      {$unwind: "$supplier"},
+      {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [{$match: {p_name: {$regex: *query20Color, "$options": "si"}}}]}},
+      {$unwind: "$part"},
+      {$group: {_id: {s_name: "$supplier.s_name", s_address: "$supplier.s_address"}}},
+      {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
+      {$sort: {s_name: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery20Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery20Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE", quantity: {$sum: "$orders.lineitem.l_quantity"}}},
-          {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
-          {$unwind: "$lineitem"},
-          {$match: {$and: [
-            {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
-            {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
-          {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
-            {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},
-          {$unwind: "$partsupp"},
-          {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [{$match: {"nation.n_name": *query20Nation}}]}},
-          {$unwind: "$supplier"},
-          {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [{$match: {p_name: {$regex: *query20Color, "$options": "si"}}}]}},
-          {$unwind: "$part"},
-          {$group: {_id: {s_name: "$supplier.s_name", s_address: "$supplier.s_address"}}},
-          {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
-          {$sort: {s_name: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery20Aggregation
 
 TPCHDenormalizedQuery20:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q21.yml
+++ b/src/phases/tpch/denormalized/Q21.yml
@@ -7,33 +7,35 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query21Nation: &query21Nation {^Parameter: {Name: "Query21Nation", Default: "SAUDI ARABIA"}}
 
+TPCHDenormalizedQuery21Aggregation: &TPCHDenormalizedQuery21Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {"orders.o_orderstatus": "F"},
+        {$expr: {$gt: [{$size: {$reduce: {input: "$orders.lineitem", initialValue: [], in: {$setUnion: [["$$this.l_suppkey"], "$$value"]}}}}, 1]}}]}},
+      {$addFields: {"orders.lineitem": {$filter: {input: "$orders.lineitem", cond: {$gt: ["$$this.l_receiptdate", "$$this.l_commitdate"]}}}}},
+      {$match: {$expr: {$eq: [{$size: "$orders.lineitem"}, 1]}}},
+      {$unwind: "$orders.lineitem"},
+      {$match: {$expr: {$gt: ["$orders.lineitem.l_receiptdate", "$lineitem.l_commitdate"]}}},
+      {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+        {$match: {"nation.n_name": *query21Nation}}]}},
+      {$unwind: "$supplier"},
+      {$group: {_id: "$supplier.s_name", numwait: {$count: {}}}},
+      {$project: {_id: 0, s_name: "$_id", numwait: 1}},
+      {$sort: {numwait: -1, s_name: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery21Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery21Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$match: {$and: [
-            {"orders.o_orderstatus": "F"},
-            {$expr: {$gt: [{$size: {$reduce: {input: "$orders.lineitem", initialValue: [], in: {$setUnion: [["$$this.l_suppkey"], "$$value"]}}}}, 1]}}]}},
-          {$addFields: {"orders.lineitem": {$filter: {input: "$orders.lineitem", cond: {$gt: ["$$this.l_receiptdate", "$$this.l_commitdate"]}}}}},
-          {$match: {$expr: {$eq: [{$size: "$orders.lineitem"}, 1]}}},
-          {$unwind: "$orders.lineitem"},
-          {$match: {$expr: {$gt: ["$orders.lineitem.l_receiptdate", "$lineitem.l_commitdate"]}}},
-          {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-            {$match: {"nation.n_name": *query21Nation}}]}},
-          {$unwind: "$supplier"},
-          {$group: {_id: "$supplier.s_name", numwait: {$count: {}}}},
-          {$project: {_id: 0, s_name: "$_id", numwait: 1}},
-          {$sort: {numwait: -1, s_name: 1}},
-          {$limit: 100}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery21Aggregation
 
 TPCHDenormalizedQuery21:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q22.yml
+++ b/src/phases/tpch/denormalized/Q22.yml
@@ -16,31 +16,32 @@ query22CountryCodes: &query22CountryCodes {^Parameter: {Name: "Query22CountryCod
   {$toString: "17"}
 ]}}
 
+TPCHDenormalizedQuery22Aggregation: &TPCHDenormalizedQuery22Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$addFields: {custsale: "$orders", orders: "$$REMOVE"}},
+      {$addFields: {cntrycode: {$substr: ["$c_phone", 0, 2]}, custsale: {$size: "$custsale"}}},
+      {$match: {$and: [{$expr: {$in: ["$cntrycode", *query22CountryCodes]}}, {$expr: {$gt: ["$c_acctbal", 0.0]}}]}},
+      {$facet: {
+        customer: [{$project: {cntrycode: 1, c_acctbal: 1, custsale: 1}}],
+        "avg(c_acctbal)": [{$group: {_id: {}, value: {$avg: "$c_acctbal"}}}, {$project: {_id: 0}}]}},
+      {$unwind: "$avg(c_acctbal)"},
+      {$unwind: "$customer"},
+      {$match: {$and: [{$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}, {"customer.custsale": 0}]}},
+      {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
+      {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
+      {$sort: {cntrycode: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery22Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery22Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$addFields: {custsale: "$orders", orders: "$$REMOVE"}},
-          {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
-          {$addFields: {cntrycode: {$substr: ["$c_phone", 0, 2]}}},
-          {$match: {$and: [{$expr: {$in: ["$cntrycode", *query22CountryCodes]}}, {custsale: null}, {$expr: {$gt: ["$c_acctbal", 0.0]}}]}},
-          {$facet: {
-            customer: [{$project: {cntrycode: 1, c_acctbal: 1}}],
-            "avg(c_acctbal)": [{$group: {_id: {}, value: {$avg: "$c_acctbal"}}}, {$project: {_id: 0}}]}},
-          {$unwind: "$avg(c_acctbal)"},
-          {$unwind: "$customer"},
-          {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
-          {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
-          {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
-          {$sort: {cntrycode: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery22Aggregation
 
 TPCHDenormalizedQuery22:
   Repeat: *Repeat
@@ -48,6 +49,7 @@ TPCHDenormalizedQuery22:
   Operations:
   - OperationMetricsName: Query22
     OperationName: RunCommand
+    OperationLogsResult: true
     OperationCommand: *TPCHDenormalizedQuery22Aggregation
 
 TPCHDenormalizedQuery22Explain:

--- a/src/phases/tpch/denormalized/Q3.yml
+++ b/src/phases/tpch/denormalized/Q3.yml
@@ -9,29 +9,31 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query3Segment: &query3Segment {^Parameter: {Name: "Query3Segment", Default: "BUILDING"}}
 query3Date: &query3Date {^Parameter: {Name: "Query3Date", Default: "1995-03-15"}}
 
+TPCHDenormalizedQuery3Aggregation: &TPCHDenormalizedQuery3Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
+      {$unwind: "$orders"},
+      {$match: {$expr: {$lt: ["$orders.o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
+      {$unwind: "$orders.lineitem"},
+      {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}},
+      {$group: {
+        _id: {l_orderkey: "$orders.lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"},
+        revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
+      {$sort: {revenue: -1, o_orderdate: 1}},
+      {$limit: 10}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery3Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery3Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
-          {$unwind: "$orders"},
-          {$match: {$expr: {$lt: ["$orders.o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
-          {$unwind: "$orders.lineitem"},
-          {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}},
-          {$group: {
-            _id: {l_orderkey: "$orders.lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"},
-            revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
-          {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
-          {$sort: {revenue: -1, o_orderdate: 1}},
-          {$limit: 10}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery3Aggregation
 
 TPCHDenormalizedQuery3:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q4.yml
+++ b/src/phases/tpch/denormalized/Q4.yml
@@ -7,26 +7,28 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query4Date: &query4Date {^Parameter: {Name: "Query4Date", Default: "1993-07-01"}}
 
+TPCHDenormalizedQuery4Aggregation: &TPCHDenormalizedQuery4Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}},
+        {$expr: {$gt: [{$size: {$filter: {input: "$orders.lineitem", cond: {$lt: ["$$this.l_commitdate", "$$this.l_receiptdate"]}}}}, 0]}}]}},
+      {$group: {_id: "$orders.o_orderpriority", order_count: {$count: {}}}},
+      {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
+      {$sort: {o_orderpriority: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery4Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery4Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$match: {$and: [
-            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
-            {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}},
-            {$expr: {$gt: [{$size: {$filter: {input: "$orders.lineitem", cond: {$lt: ["$$this.l_commitdate", "$$this.l_receiptdate"]}}}}, 0]}}]}},
-          {$group: {_id: "$orders.o_orderpriority", order_count: {$count: {}}}},
-          {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
-          {$sort: {o_orderpriority: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery4Aggregation
 
 TPCHDenormalizedQuery4:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q5.yml
+++ b/src/phases/tpch/denormalized/Q5.yml
@@ -8,32 +8,34 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query5Region: &query5Region {^Parameter: {Name: "Query5Region", Default: "ASIA"}}
 query5Date: &query5Date {^Parameter: {Name: "Query5Date", Default: "1994-01-01"}}
 
+TPCHDenormalizedQuery5Aggregation: &TPCHDenormalizedQuery5Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$match: {"nation.region.r_name": *query5Region}},
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
+      {$unwind: "$orders.lineitem"},
+      {$lookup: {from: "supplier", as: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", let: {c_nationkey: "$nation.n_nationkey"}, pipeline: [
+        {$match: {$expr: {$eq: ["$nation.n_nationkey", "$$c_nationkey"]}}}]}},
+      {$unwind: "$supplier"},
+      {$group: {
+        _id: "$supplier.nation.n_name",
+        revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, n_name: "$_id", revenue: 1}},
+      {$sort: {revenue: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery5Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery5Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$match: {"nation.region.r_name": *query5Region}},
-          {$unwind: "$orders"},
-          {$match: {$and: [
-            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
-            {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
-          {$unwind: "$orders.lineitem"},
-          {$lookup: {from: "supplier", as: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", let: {c_nationkey: "$nation.n_nationkey"}, pipeline: [
-            {$match: {$expr: {$eq: ["$nation.n_nationkey", "$$c_nationkey"]}}}]}},
-          {$unwind: "$supplier"},
-          {$group: {
-            _id: "$supplier.nation.n_name",
-            revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
-          {$project: {_id: 0, n_name: "$_id", revenue: 1}},
-          {$sort: {revenue: -1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery5Aggregation
 
 TPCHDenormalizedQuery5:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q6.yml
+++ b/src/phases/tpch/denormalized/Q6.yml
@@ -10,30 +10,32 @@ query6Date: &query6Date {^Parameter: {Name: "Query6Date", Default: "1994-01-01"}
 query6Discount: &query6Discount {^Parameter: {Name: "Query6Discount", Default: 0.06}}
 query6Quantity: &query6Quantity {^Parameter: {Name: "Query6Quantity", Default: 24}}
 
+TPCHDenormalizedQuery6Aggregation: &TPCHDenormalizedQuery6Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$replaceWith: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
+        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+        {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
+        {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
+        {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
+      {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
+      {$project: {_id: 0, revenue: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery6Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery6Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-          {$unwind: "$lineitem"},
-          {$replaceWith: "$lineitem"},
-          {$match: {$and: [
-            {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
-            {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
-            {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
-            {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
-            {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
-          {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
-          {$project: {_id: 0, revenue: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery6Aggregation
 
 TPCHDenormalizedQuery6:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q7.yml
+++ b/src/phases/tpch/denormalized/Q7.yml
@@ -8,33 +8,35 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query7Nation1: &query7Nation1 {^Parameter: {Name: "Query7Nation1", Default: "FRANCE"}}
 query7Nation2: &query7Nation2 {^Parameter: {Name: "Query7Nation2", Default: "GERMANY"}}
 
+TPCHDenormalizedQuery7Aggregation: &TPCHDenormalizedQuery7Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
+        {$expr: {$lte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}},
+      {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$match: {$or: [
+        {$and: [{"supplier.nation.n_name": *query7Nation1}, {"nation.n_name": *query7Nation2}]},
+        {$and: [{"supplier.nation.n_name": *query7Nation2}, {"nation.n_name": *query7Nation1}]}]}},
+      {$project: {supp_nation: "$supplier.nation.n_name", cust_nation: "$nation.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
+      {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
+      {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
+      {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery7Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery7Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
-          {$unwind: "$lineitem"},
-          {$match: {$and: [
-            {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
-            {$expr: {$lt: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}},
-          {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
-          {$unwind: "$supplier"},
-          {$match: {$or: [
-            {$and: [{"supplier.nation.n_name": *query7Nation1}, {"nation.n_name": *query7Nation2}]},
-            {$and: [{"supplier.nation.n_name": *query7Nation2}, {"nation.n_name": *query7Nation1}]}]}},
-          {$project: {supp_nation: "$supplier.nation.n_name", cust_nation: "$nation.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
-          {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
-          {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
-          {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery7Aggregation
 
 TPCHDenormalizedQuery7:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q8.yml
+++ b/src/phases/tpch/denormalized/Q8.yml
@@ -10,33 +10,35 @@ query8Type: &query8Type {^Parameter: {Name: "Query8Type", Default: "ECONOMY ANOD
 query8Region: &query8Region {^Parameter: {Name: "Query8Region", Default: "AMERICA"}}
 query8Nation: &query8Nation {^Parameter: {Name: "Query8Nation", Default: "BRAZIL"}}
 
+TPCHDenormalizedQuery8Aggregation: &TPCHDenormalizedQuery8Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$match: {"nation.region.r_name": {$eq: *query8Region}}},
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+      {$unwind: "$orders.lineitem"},
+      {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$lookup: {from: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+        {$match: {p_type: {$eq: *query8Type}}}]}},
+      {$unwind: "$part"},
+      {$project: {o_year: {$year: "$orders.o_orderdate"}, volume: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$orders.lineitem.l_discount"]}]}, nation: "$supplier.nation.n_name"}},
+      {$group: { _id: "$o_year", total_volume: {$sum: "$volume"}, nation_volume: {$sum: {$cond: {if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
+      {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
+      {$sort: {o_year: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery8Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery8Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$match: {"nation.region.r_name": {$eq: *query8Region}}},
-          {$unwind: "$orders"},
-          {$match: {$and: [
-            {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
-            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
-          {$unwind: "$orders.lineitem"},
-          {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
-          {$unwind: "$supplier"},
-          {$lookup: {from: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-            {$match: {p_type: {$eq: *query8Type}}}]}},
-          {$unwind: "$part"},
-          {$project: {o_year: {$year: "$orders.o_orderdate"}, volume: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$orders.lineitem.l_discount"]}]}, nation: "$supplier.nation.n_name"}},
-          {$group: { _id: "$o_year", total_volume: {$sum: "$volume"}, nation_volume: {$sum: {$cond: {if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
-          {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
-          {$sort: {o_year: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery8Aggregation
 
 TPCHDenormalizedQuery8:
   Repeat: *Repeat

--- a/src/phases/tpch/denormalized/Q9.yml
+++ b/src/phases/tpch/denormalized/Q9.yml
@@ -8,40 +8,42 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${color}.*$
 
+TPCHDenormalizedQuery9Aggregation: &TPCHDenormalizedQuery9Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$unwind: "$orders"},
+      {$lookup: {from: "part", as: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", pipeline: [
+        {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}}]}},
+      {$project: {
+        o_year: {$year: "$orders.o_orderdate"},
+        part: {$map: {input: "$part", as: "part", in: {
+          $mergeObjects: ["$$part", {lineitem: {$filter: {input: "$orders.lineitem", as: "lineitem", cond: {$eq: ["$$part.p_partkey", "$$lineitem.l_partkey"]}}}}]}}}}},
+      {$unwind: "$part"},
+      {$unwind: "$part.lineitem"},
+      {$lookup: {from: "supplier", as: "partsupp", localField: "part.lineitem.l_suppkey", foreignField: "s_suppkey", let: {p_partkey: "$part.p_partkey"}, pipeline: [
+        {$lookup: {from: "partsupp", as: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", pipeline: [
+          {$match: {$expr: {$eq: ["$$p_partkey", "$ps_partkey"]}}}]}},
+        {$unwind: "$partsupp"},
+        {$replaceWith: {$mergeObjects: ["$partsupp", {nation: "$nation.n_name"}]}}]}},
+      {$unwind: "$partsupp"},
+      {$group: {
+        _id: {nation: "$partsupp.nation", o_year: "$o_year"},
+        sum_profit: {$sum: {$subtract: [
+          {$multiply: ["$part.lineitem.l_extendedprice", {$subtract: [1, "$part.lineitem.l_discount"]}]},
+          {$multiply: ["$partsupp.ps_supplycost", "$part.lineitem.l_quantity"]}]}}}},
+      {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
+      {$sort: {nation: 1, o_year: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHDenormalizedQuery9Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHDenormalizedQuery9Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$unwind: "$orders"},
-          {$lookup: {from: "part", as: "part", localField: "orders.lineitem.l_partkey", foreignField: "p_partkey", pipeline: [
-            {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}}]}},
-          {$project: {
-            o_year: {$year: "$orders.o_orderdate"},
-            part: {$map: {input: "$part", as: "part", in: {
-              $mergeObjects: ["$$part", {lineitem: {$filter: {input: "$orders.lineitem", as: "lineitem", cond: {$eq: ["$$part.p_partkey", "$$lineitem.l_partkey"]}}}}]}}}}},
-          {$unwind: "$part"},
-          {$unwind: "$part.lineitem"},
-          {$lookup: {from: "supplier", as: "partsupp", localField: "part.lineitem.l_suppkey", foreignField: "s_suppkey", let: {p_partkey: "$part.p_partkey"}, pipeline: [
-            {$lookup: {from: "partsupp", as: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", pipeline: [
-              {$match: {$expr: {$eq: ["$$p_partkey", "$ps_partkey"]}}}]}},
-            {$unwind: "$partsupp"},
-            {$replaceWith: {$mergeObjects: ["$partsupp", {nation: "$nation.n_name"}]}}]}},
-          {$unwind: "$partsupp"},
-          {$group: {
-            _id: {nation: "$partsupp.nation", o_year: "$o_year"},
-            sum_profit: {$sum: {$subtract: [
-              {$multiply: ["$part.lineitem.l_extendedprice", {$subtract: [1, "$part.lineitem.l_discount"]}]},
-              {$multiply: ["$partsupp.ps_supplycost", "$part.lineitem.l_quantity"]}]}}}},
-          {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
-          {$sort: {nation: 1, o_year: -1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHDenormalizedQuery9Aggregation
 
 TPCHDenormalizedQuery9:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q1.yml
+++ b/src/phases/tpch/normalized/Q1.yml
@@ -7,48 +7,50 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query1Delta: &query1Delta {^Parameter: {Name: "Query1Delta", Default: -90}}
 
+TPCHNormalizedQuery1Aggregation: &TPCHNormalizedQuery1Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
+      {$group: {
+        _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
+        sum_qty: {$sum: "$l_quantity"},
+        sum_base_price: {$sum: "$l_extendedprice"},
+        sum_disc_price:
+          {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}},
+        sum_charge: {
+          $sum: {
+            $multiply: [
+              "$l_extendedprice",
+              {$subtract: [1, "$l_discount"]},
+              {$add: [1, "$l_tax"]}]}},
+        avg_qty: {$avg: "$l_quantity"},
+        avg_price: {$avg: "$l_extendedprice"},
+        avg_disc: {$avg: "$l_discount"},
+        count_order: {$count: {}}}},
+      {$project: {
+        _id: 0,
+        l_returnflag: "$_id.l_returnflag",
+        l_linestatus: "$_id.l_linestatus",
+        sum_qty: 1,
+        sum_base_price: 1,
+        sum_disc_price: 1,
+        sum_charge: 1,
+        avg_qty: 1,
+        avg_price: 1,
+        avg_disc: 1,
+        count_order: 1}},
+      {$sort: {l_returnflag: 1, l_linestatus: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery1Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery1Aggregation
-      aggregate: lineitem
-      pipeline:
-        [
-          {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
-          {$group: {
-            _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
-            sum_qty: {$sum: "$l_quantity"},
-            sum_base_price: {$sum: "$l_extendedprice"},
-            sum_disc_price:
-              {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}},
-            sum_charge: {
-              $sum: {
-                $multiply: [
-                  "$l_extendedprice",
-                  {$subtract: [1, "$l_discount"]},
-                  {$add: [1, "$l_tax"]}]}},
-            avg_qty: {$avg: "$l_quantity"},
-            avg_price: {$avg: "$l_extendedprice"},
-            avg_disc: {$avg: "$l_discount"},
-            count_order: {$count: {}}}},
-          {$project: {
-            _id: 0,
-            l_returnflag: "$_id.l_returnflag",
-            l_linestatus: "$_id.l_linestatus",
-            sum_qty: 1,
-            sum_base_price: 1,
-            sum_disc_price: 1,
-            sum_charge: 1,
-            avg_qty: 1,
-            avg_price: 1,
-            avg_disc: 1,
-            count_order: 1}},
-          {$sort: {l_returnflag: 1, l_linestatus: 1}},
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery1Aggregation
 
 TPCHNormalizedQuery1:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q10.yml
+++ b/src/phases/tpch/normalized/Q10.yml
@@ -7,32 +7,34 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query10Date: &query10Date {^Parameter: {Name: "Query10Date", Default: "1993-10-01"}}
 
+TPCHNormalizedQuery10Aggregation: &TPCHNormalizedQuery10Aggregation
+  aggregate: orders
+  pipeline:
+    [
+      {$match: {$and: [
+        {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
+        {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
+      {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+        {$match: {l_returnflag: "R"}}]}},
+      {$unwind: "$lineitem"},
+      {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer", pipeline: [
+        {$lookup: { from: "nation", localField: "c_nationkey", foreignField: "n_nationkey", as: "nation"}},
+        {$unwind: "$nation"}]}},
+      {$unwind: "$customer"},
+      {$group: {_id: {c_custkey: "$customer.c_custkey", c_name: "$customer.c_name", c_acctbal: "$customer.c_acctbal", n_name: "$customer.nation.n_name", c_address: "$customer.c_address", c_phone: "$customer.c_phone", c_comment: "$customer.c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
+      {$sort: {revenue: -1}},
+      {$limit: 20}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery10Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery10Aggregation
-      aggregate: orders
-      pipeline:
-        [
-          {$match: {$and: [
-            {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
-            {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
-          {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-            {$match: {l_returnflag: "R"}}]}},
-          {$unwind: "$lineitem"},
-          {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer", pipeline: [
-            {$lookup: { from: "nation", localField: "c_nationkey", foreignField: "n_nationkey", as: "nation"}},
-            {$unwind: "$nation"}]}},
-          {$unwind: "$customer"},
-          {$group: {_id: {c_custkey: "$customer.c_custkey", c_name: "$customer.c_name", c_acctbal: "$customer.c_acctbal", n_name: "$customer.nation.n_name", c_address: "$customer.c_address", c_phone: "$customer.c_phone", c_comment: "$customer.c_comment"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
-          {$project: {_id: 0, c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", c_acctbal: "$_id.c_acctbal", n_name: "$_id.n_name", c_address: "$_id.c_address", c_phone: "$_id.c_phone", c_comment: "$_id.c_comment", revenue: 1}},
-          {$sort: {revenue: -1}},
-          {$limit: 20}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery10Aggregation
 
 TPCHNormalizedQuery10:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q11.yml
+++ b/src/phases/tpch/normalized/Q11.yml
@@ -8,49 +8,51 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query11Nation: &query11Nation {^Parameter: {Name: "Query11Nation", Default: "GERMANY"}}
 query11Fraction: &query11Fraction {^Parameter: {Name: "Query11Fraction", Default: 0.0001}}
 
+TPCHNormalizedQuery11Aggregation: &TPCHNormalizedQuery11Aggregation
+  aggregate: partsupp
+  pipeline:
+    [
+      {$lookup: {
+        from: "supplier",
+        localField: "ps_suppkey",
+        foreignField: "s_suppkey",
+        as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$lookup: {
+        from: "nation",
+        localField: "supplier.s_nationkey",
+        foreignField: "n_nationkey",
+        pipeline: [{$match: {n_name: *query11Nation}}],
+        as: "nation"}},
+      {$unwind: "$nation"},
+      {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
+      {$group: {
+        _id: "$ps_partkey",
+        value: {$sum: "$total_cost"}}},
+      {$group: {
+        _id: 0,
+        groups: {$push: {ps_partkey: "$_id", value: "$value"}},
+        total_cost: {$sum: "$value"}}},
+      {$addFields: {
+        threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
+      {$unwind: "$groups"},
+      {$project: {
+        ps_partkey: "$groups.ps_partkey",
+        value: "$groups.value",
+        threshold: 1}},
+      {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
+      {$project: {_id: 0, ps_partkey: 1, value: 1}},
+      {$sort: {value: -1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery11Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery11Aggregation
-      aggregate: partsupp
-      pipeline:
-        [
-          {$lookup: {
-            from: "supplier",
-            localField: "ps_suppkey",
-            foreignField: "s_suppkey",
-            as: "supplier"}},
-          {$unwind: "$supplier"},
-          {$lookup: {
-            from: "nation",
-            localField: "supplier.s_nationkey",
-            foreignField: "n_nationkey",
-            pipeline: [{$match: {n_name: *query11Nation}}],
-            as: "nation"}},
-          {$unwind: "$nation"},
-          {$addFields: {total_cost: {$multiply: ["$ps_supplycost", "$ps_availqty"]}}},
-          {$group: {
-            _id: "$ps_partkey",
-            value: {$sum: "$total_cost"}}},
-          {$group: {
-            _id: 0,
-            groups: {$push: {ps_partkey: "$_id", value: "$value"}},
-            total_cost: {$sum: "$value"}}},
-          {$addFields: {
-            threshold: {$multiply: ["$total_cost", *query11Fraction]}}},
-          {$unwind: "$groups"},
-          {$project: {
-            ps_partkey: "$groups.ps_partkey",
-            value: "$groups.value",
-            threshold: 1}},
-          {$match: {$expr: {$gt: ["$value", "$threshold"]}}},
-          {$project: {_id: 0, ps_partkey: 1, value: 1}},
-          {$sort: {value: -1}},
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery11Aggregation
 
 TPCHNormalizedQuery11:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q12.yml
+++ b/src/phases/tpch/normalized/Q12.yml
@@ -10,55 +10,57 @@ query12ShipMode1: &query12ShipMode1 {^Parameter: {Name: "Query12ShipMode1", Defa
 query12ShipMode2: &query12ShipMode2 {^Parameter: {Name: "Query12ShipMode2", Default: "SHIP"}}
 query12Date: &query12Date {^Parameter: {Name: "Query12Date", Default: "1994-01-01"}}
 
+TPCHNormalizedQuery12Aggregation: &TPCHNormalizedQuery12Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$match: {
+        $and: [
+          {$or: [{l_shipmode: *query12ShipMode1}, {l_shipmode: *query12ShipMode2}]},
+          {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
+          {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
+          {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
+          {$expr: {$lt: [
+            "$l_receiptdate",
+            {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
+      {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+      {$unwind: "$orders"},
+      {$group: {
+        _id: "$l_shipmode",
+        high_line_count: {
+          $sum: {
+            $cond: {
+              if: {
+                $or: [
+                  {$eq: ["$orders.o_orderpriority", "1-URGENT"]},
+                  {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]},
+              then: 1,
+              else: 0}}},
+        low_line_count: {
+          $sum: {
+            $cond: {
+              if: {
+                $and: [
+                  {$ne: ["$orders.o_orderpriority", "1-URGENT"]},
+                  {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]},
+              then: 1,
+              else: 0}}}}},
+      {$project: {
+        _id: 0,
+        l_shipmode: "$_id",
+        high_line_count: 1,
+        low_line_count: 1}},
+      {$sort: {l_shipmode: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery12Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery12Aggregation
-      aggregate: lineitem
-      pipeline:
-        [
-          {$match: {
-            $and: [
-              {$or: [{l_shipmode: *query12ShipMode1}, {l_shipmode: *query12ShipMode2}]},
-              {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
-              {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
-              {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
-              {$expr: {$lt: [
-                "$l_receiptdate",
-                {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
-          {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
-          {$unwind: "$orders"},
-          {$group: {
-            _id: "$l_shipmode",
-            high_line_count: {
-              $sum: {
-                $cond: {
-                  if: {
-                    $or: [
-                      {$eq: ["$orders.o_orderpriority", "1-URGENT"]},
-                      {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]},
-                  then: 1,
-                  else: 0}}},
-            low_line_count: {
-              $sum: {
-                $cond: {
-                  if: {
-                    $and: [
-                      {$ne: ["$orders.o_orderpriority", "1-URGENT"]},
-                      {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]},
-                  then: 1,
-                  else: 0}}}}},
-          {$project: {
-            _id: 0,
-            l_shipmode: "$_id",
-            high_line_count: 1,
-            low_line_count: 1}},
-          {$sort: {l_shipmode: 1}},
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery12Aggregation
 
 TPCHNormalizedQuery12:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q13.yml
+++ b/src/phases/tpch/normalized/Q13.yml
@@ -7,24 +7,26 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query13Regex: &query13Regex {^Parameter: {Name: "Query13Regex", Default: "^.*special.*requests.*$"}}  # `^.*${query13Word1}.*${query13Word2}.*$`
 
+TPCHNormalizedQuery13Aggregation: &TPCHNormalizedQuery13Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
+        {$match: {$expr: {$cond: {if: {$regexMatch: {input: "$o_comment", regex: *query13Regex, options: "si"}}, then: 0, else: 1}}}}]}},
+      {$project: {c_custkey: 1, c_count: {$size: "$orders"}}},
+      {$group: {_id: "$c_count", custdist: {$count: {}}}},
+      {$project: {_id: 0, c_count: "$_id", custdist: 1}},
+      {$sort: {custdist: -1, c_count: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery13Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery13Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-            {$match: {$expr: {$cond: {if: {$regexMatch: {input: "$o_comment", regex: *query13Regex, options: "si"}}, then: 0, else: 1}}}}]}},
-          {$project: {c_custkey: 1, c_count: {$size: "$orders"}}},
-          {$group: {_id: "$c_count", custdist: {$count: {}}}},
-          {$project: {_id: 0, c_count: "$_id", custdist: 1}},
-          {$sort: {custdist: -1, c_count: -1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery13Aggregation
 
 TPCHNormalizedQuery13:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q14.yml
+++ b/src/phases/tpch/normalized/Q14.yml
@@ -7,45 +7,47 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query14Date: &query14Date {^Parameter: {Name: "Query14Date", Default: "1995-09-01"}}
 
+TPCHNormalizedQuery14Aggregation: &TPCHNormalizedQuery14Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$match: {
+        $and: [
+          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
+          {$expr: {
+            $lt: [
+              "$l_shipdate",
+              {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
+      {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
+      {$unwind: "$part"},
+      {$group: {
+        _id: {},
+        promo_price_total: {
+          $sum: {
+            $cond: {
+              if: {
+                $cond: {
+                  if: {
+                    $regexMatch: {
+                      input: "$part.p_type",
+                      regex: "^PROMO.*$",
+                      options: "si"}},
+                  then: 1,
+                  else: 0}},
+              then: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]},
+              else: 0}}},
+        price_total: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+      {$project: {_id: 0, promo_revenue: {$multiply: [100.00, {$divide: ["$promo_price_total", "$price_total"]}]}}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery14Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery14Aggregation
-      aggregate: lineitem
-      pipeline:
-        [
-          {$match: {
-            $and: [
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
-              {$expr: {
-                $lt: [
-                  "$l_shipdate",
-                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
-          {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
-          {$unwind: "$part"},
-          {$group: {
-            _id: {},
-            promo_price_total: {
-              $sum: {
-                $cond: {
-                  if: {
-                    $cond: {
-                      if: {
-                        $regexMatch: {
-                          input: "$part.p_type",
-                          regex: "^PROMO.*$",
-                          options: "si"}},
-                      then: 1,
-                      else: 0}},
-                  then: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]},
-                  else: 0}}},
-            price_total: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-          {$project: {_id: 0, promo_revenue: {$multiply: [100.00, {$divide: ["$promo_price_total", "$price_total"]}]}}},
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery14Aggregation
 
 TPCHNormalizedQuery14:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -85,6 +85,7 @@ TPCHNormalizedQuery15Explain:
   Operations:
   - OperationMetricsName: Query15
     OperationName: RunCommand
+    OperationLogsResult: true
     OperationCommand:
       explain: *TPCHNormalizedQuery15Aggregation
       verbosity:

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -33,32 +33,34 @@ TPCHNormalizedQuery15CreateView: &TPCHNormalizedQuery15CreateView
           {$project: {_id: 0, supplier_no: "$_id", total_revenue: 1}},
         ]
 
+TPCHNormalizedQuery15Aggregation: &TPCHNormalizedQuery15Aggregation
+  aggregate: *query15View
+  pipeline:
+    [
+      {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
+      {$sort: {_id: -1}},
+      {$limit: 1},
+      {$unwind: "$supplier_no"},
+      {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
+      {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$project: {
+        s_suppkey: "$supplier.s_suppkey",
+        s_name: "$supplier.s_name",
+        s_address: "$supplier.s_address",
+        s_phone: "$supplier.s_phone",
+        total_revenue: 1
+      }},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery15Warmup:
   Repeat: *Repeat
   Database: *db
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery15Aggregation
-      aggregate: *query15View
-      pipeline:
-        [
-          {$group: {_id: "$total_revenue", supplier_no: {$push: "$supplier_no"}}},
-          {$sort: {_id: -1}},
-          {$limit: 1},
-          {$unwind: "$supplier_no"},
-          {$project: {_id: 0, total_revenue: "$_id", supplier_no: 1}},
-          {$lookup: {from: "supplier", localField: "supplier_no", foreignField: "s_suppkey", as: "supplier"}},
-          {$unwind: "$supplier"},
-          {$project: {
-            s_suppkey: "$supplier.s_suppkey",
-            s_name: "$supplier.s_name",
-            s_address: "$supplier.s_address",
-            s_phone: "$supplier.s_phone",
-            total_revenue: 1
-          }},
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery15Aggregation
 
 TPCHNormalizedQuery15DropView: &TPCHNormalizedQuery15DropView
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q16.yml
+++ b/src/phases/tpch/normalized/Q16.yml
@@ -10,52 +10,54 @@ query16Brand: &query16Brand {^Parameter: {Name: "Query16Brand", Default: "Brand#
 query16Type: &query16Type {^Parameter: {Name: "Query16Type", Default: "^MEDIUM POLISHED.*"}}  # ^${type}.*$"
 query16Sizes: &query16Sizes {^Parameter: {Name: "Query16Sizes", Default: [49, 14, 23, 45, 19, 3, 36, 9]}}
 
+TPCHNormalizedQuery16Aggregation: &TPCHNormalizedQuery16Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [
+        {p_brand: {$ne: *query16Brand}},
+        {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}},
+        {p_size: {$in: *query16Sizes}}]}},
+      {$lookup: {
+        from: "partsupp",
+        localField: "p_partkey",
+        foreignField: "ps_partkey",
+        as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {
+        from: "supplier",
+        localField: "partsupp.ps_suppkey",
+        foreignField: "s_suppkey",
+        pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}],
+        as: "supplier"}},
+      {$match: {supplier: {$eq: []}}},
+      {$group: {
+        _id: {
+          p_brand: "$p_brand",
+          p_type: "$p_type",
+          p_size: "$p_size"},
+        ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
+      {$project: {
+        _id: 0,
+        p_brand: "$_id.p_brand",
+        p_type: "$_id.p_type",
+        p_size: "$_id.p_size",
+        supplier_cnt: {$size: "$ps_suppkey"}}},
+      {$sort: {
+        supplier_cnt: -1,
+        p_brand: 1,
+        p_type: 1,
+        p_size: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery16Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery16Aggregation
-      aggregate: part
-      pipeline:
-        [
-          {$match: {$and: [
-            {p_brand: {$ne: *query16Brand}},
-            {$expr: {$cond: {if: {$regexMatch: {input: "$p_type", regex: *query16Type, options: "si"}}, then: 0, else: 1}}},
-            {p_size: {$in: *query16Sizes}}]}},
-          {$lookup: {
-            from: "partsupp",
-            localField: "p_partkey",
-            foreignField: "ps_partkey",
-            as: "partsupp"}},
-          {$unwind: "$partsupp"},
-          {$lookup: {
-            from: "supplier",
-            localField: "partsupp.ps_suppkey",
-            foreignField: "s_suppkey",
-            pipeline: [{$match: {$expr: {$cond: {if: {$regexMatch: {input: "$s_comment", regex: "^.*Customer.*Complaints.*$", options: "si"}}, then: 1, else: 0}}}}],
-            as: "supplier"}},
-          {$match: {supplier: {$eq: []}}},
-          {$group: {
-            _id: {
-              p_brand: "$p_brand",
-              p_type: "$p_type",
-              p_size: "$p_size"},
-            ps_suppkey: {$addToSet: "$partsupp.ps_suppkey"}}},
-          {$project: {
-            _id: 0,
-            p_brand: "$_id.p_brand",
-            p_type: "$_id.p_type",
-            p_size: "$_id.p_size",
-            supplier_cnt: {$size: "$ps_suppkey"}}},
-          {$sort: {
-            supplier_cnt: -1,
-            p_brand: 1,
-            p_type: 1,
-            p_size: 1}},
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery16Aggregation
 
 TPCHNormalizedQuery16:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q17.yml
+++ b/src/phases/tpch/normalized/Q17.yml
@@ -9,27 +9,29 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query17Brand: &query17Brand {^Parameter: {Name: "Query17Brand", Default: "Brand#23"}}
 query17Container: &query17Container {^Parameter: {Name: "Query17Container", Default: "MED BOX"}}
 
+TPCHNormalizedQuery17Aggregation: &TPCHNormalizedQuery17Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
+      {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem", pipeline: [
+        {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
+        {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
+        {$unwind: "$lineitem"},
+        {$replaceWith: "$lineitem"}]}},
+      {$unwind: "$lineitem"},
+      {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
+      {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery17Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery17Aggregation
-      aggregate: part
-      pipeline:
-        [
-          {$match: {$and: [{$expr: {$eq: ["$p_brand", *query17Brand]}}, {$expr: {$eq: ["$p_container", *query17Container]}}]}},
-          {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem", pipeline: [
-            {$group: {_id: 0, avg_quantity: {$avg: "$l_quantity"}, lineitem: {$push: {l_extendedprice: "$l_extendedprice", l_quantity: "$l_quantity"}}}},
-            {$project: {_id: 0, avg_quantity: 1, lineitem: {$filter: {input: "$lineitem", cond: {$lt: ["$$this.l_quantity", {$multiply: [0.2, "$avg_quantity"]}]}}}}},
-            {$unwind: "$lineitem"},
-            {$replaceWith: "$lineitem"}]}},
-          {$unwind: "$lineitem"},
-          {$group: {_id: 0, avg_total: {$sum: "$lineitem.l_extendedprice"}}},
-          {$project: {_id: 0, avg_yearly: {$divide: ["$avg_total", 7.0]}}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery17Aggregation
 
 TPCHNormalizedQuery17:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q18.yml
+++ b/src/phases/tpch/normalized/Q18.yml
@@ -7,31 +7,33 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query18Quantity: &query18Quantity {^Parameter: {Name: "Query18Quantity", Default: 300}}
 
+TPCHNormalizedQuery18Aggregation: &TPCHNormalizedQuery18Aggregation
+  aggregate: orders
+  pipeline:
+    [
+      {$lookup: {from: "lineitem", let: {o_orderkey: "$o_orderkey"}, as: "lineitem", pipeline: [
+        {$match: {$expr: {$eq: ["$$o_orderkey", "$l_orderkey"]}}},
+        {$group: {_id: "$l_orderkey", "sum(l_quantity)": {$sum: "$l_quantity"}}},
+        {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
+        {$project: {_id: 0, o_orderkey: "$_id", "sum(l_quantity)": 1}}]}},
+      {$unwind: "$lineitem"},
+      {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer"}},
+      {$unwind: "$customer"},
+      {$group: {_id: {c_name: "$customer.c_name", c_custkey: "$customer.c_custkey", o_orderkey: "$o_orderkey", o_orderdate: "$o_orderdate", o_totalprice: "$o_totalprice"}, "sum(l_quantity)": {$push: "$lineitem.sum(l_quantity)"}}},
+      {$unwind: "$sum(l_quantity)"},
+      {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
+      {$sort: {o_totalprice: -1, o_orderdate: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery18Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery18Aggregation
-      aggregate: orders
-      pipeline:
-        [
-          {$lookup: {from: "lineitem", let: {o_orderkey: "$o_orderkey"}, as: "lineitem", pipeline: [
-            {$match: {$expr: {$eq: ["$$o_orderkey", "$l_orderkey"]}}},
-            {$group: {_id: "$l_orderkey", "sum(l_quantity)": {$sum: "$l_quantity"}}},
-            {$match: {$expr: {$gt: ["$sum(l_quantity)", *query18Quantity]}}},
-            {$project: {_id: 0, o_orderkey: "$_id", "sum(l_quantity)": 1}}]}},
-          {$unwind: "$lineitem"},
-          {$lookup: {from: "customer", localField: "o_custkey", foreignField: "c_custkey", as: "customer"}},
-          {$unwind: "$customer"},
-          {$group: {_id: {c_name: "$customer.c_name", c_custkey: "$customer.c_custkey", o_orderkey: "$o_orderkey", o_orderdate: "$o_orderdate", o_totalprice: "$o_totalprice"}, "sum(l_quantity)": {$push: "$lineitem.sum(l_quantity)"}}},
-          {$unwind: "$sum(l_quantity)"},
-          {$project: {_id: 0, o_orderkey: "$_id.o_orderkey", c_custkey: "$_id.c_custkey", c_name: "$_id.c_name", o_orderdate: "$_id.o_orderdate", o_totalprice: "$_id.o_totalprice", "sum(l_quantity)": 1}},
-          {$sort: {o_totalprice: -1, o_orderdate: 1}},
-          {$limit: 100}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery18Aggregation
 
 TPCHNormalizedQuery18:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q19.yml
+++ b/src/phases/tpch/normalized/Q19.yml
@@ -13,47 +13,49 @@ query19Quantity2: &query19Quantity2 {^Parameter: {Name: "Query19Quantity2", Defa
 query19Brand3: &query19Brand3 {^Parameter: {Name: "Query19Brand3", Default: "Brand#34"}}
 query19Quantity3: &query19Quantity3 {^Parameter: {Name: "Query19Quantity3", Default: 20}}
 
+TPCHNormalizedQuery19Aggregation: &TPCHNormalizedQuery19Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
+        {$match: {$or: [
+          {$and: [
+            {p_brand: *query19Brand1},
+            {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
+            {p_size: {$gte: 1}}, {p_size: {$lte: 5}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+          {$and: [
+            {p_brand: *query19Brand2},
+            {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
+            {p_size: {$gte: 1}}, {p_size: {$lte: 10}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
+          {$and: [
+            {p_brand: *query19Brand3},
+            {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
+            {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
+            {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
+            {p_size: {$gte: 1}}, {p_size: {$lte: 15}},
+            {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
+            {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
+      {$unwind: "$part"},
+      {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
+      {$project: {_id: 0, revenue: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery1Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery19Aggregation
-      aggregate: lineitem
-      pipeline:
-        [
-          {$lookup: {from: "part", let: {l_quantity: "$l_quantity", l_shipmode: "$l_shipmode", l_shipinstruct: "$l_shipinstruct"}, localField: "l_partkey", foreignField: "p_partkey", as: "part", pipeline: [
-            {$match: {$or: [
-              {$and: [
-                {p_brand: *query19Brand1},
-                {p_container: {$in: ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]}},
-                {$expr: {$gte: ["$$l_quantity", *query19Quantity1]}},
-                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity1, 10]}]}},
-                {p_size: {$gte: 1}}, {p_size: {$lte: 5}},
-                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-              {$and: [
-                {p_brand: *query19Brand2},
-                {p_container: {$in: ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]}},
-                {$expr: {$gte: ["$$l_quantity", *query19Quantity2]}},
-                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity2, 10]}]}},
-                {p_size: {$gte: 1}}, {p_size: {$lte: 10}},
-                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]},
-              {$and: [
-                {p_brand: *query19Brand3},
-                {p_container: {$in: ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]}},
-                {$expr: {$gte: ["$$l_quantity", *query19Quantity3]}},
-                {$expr: {$lte: ["$$l_quantity", {$add: [*query19Quantity3, 10]}]}},
-                {p_size: {$gte: 1}}, {p_size: {$lte: 15}},
-                {$expr: {$in: ["$$l_shipmode", ["AIR", "AIR REG"]]}},
-                {$expr: {$eq: ["$$l_shipinstruct", "DELIVER IN PERSON"]}}]}]}}]}},
-          {$unwind: "$part"},
-          {$group: {_id: {}, revenue: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}}},
-          {$project: {_id: 0, revenue: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery19Aggregation
 
 TPCHNormalizedQuery19:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q2.yml
+++ b/src/phases/tpch/normalized/Q2.yml
@@ -9,71 +9,73 @@ query2Size: &query2Size {^Parameter: {Name: "Query2Size", Default: 15}}
 query2Type: &query2Type {^Parameter: {Name: "Query2Type", Default: "^.*BRASS$"}}  # ^.*{type}$"
 query2Region: &query2Region {^Parameter: {Name: "Query2Region", Default: "EUROPE"}}
 
+TPCHNormalizedQuery2Aggregation: &TPCHNormalizedQuery2Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$and: [
+        {p_type: {$regex: *query2Type, $options: "si"}},
+        {p_size: {$eq: *query2Size}}]}},
+      {$lookup: {
+        from: "partsupp",
+        localField: "p_partkey",
+        foreignField: "ps_partkey",
+        as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {
+        from: "supplier",
+        localField: "partsupp.ps_suppkey",
+        foreignField: "s_suppkey",
+        as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$lookup: {
+        from: "nation",
+        localField: "supplier.s_nationkey",
+        foreignField: "n_nationkey",
+        as: "nation"}},
+      {$unwind: "$nation"},
+      {$lookup: {
+        from: "region",
+        localField: "nation.n_regionkey",
+        foreignField: "r_regionkey",
+        as: "region"}},
+      {$unwind: "$region"},
+      {$match: {"region.r_name": *query2Region}},
+      {$sort: {"partsupp.ps_supplycost": 1}},
+      {$group: {
+        _id: {
+          p_partkey: "$p_partkey",
+          p_mfgr: "$p_mfgr"},
+        supplier: {$first: {
+          s_acctbal: "$supplier.s_acctbal",
+          s_name: "$supplier.s_name",
+          s_address: "$supplier.s_address",
+          s_phone: "$supplier.s_phone",
+          s_comment: "$supplier.s_comment",
+          ps_supplycost: "$partsupp.ps_supplycost",
+          n_name: "$nation.n_name"}}}},
+      {$project: {
+        _id: 0,
+        s_acctbal: "$supplier.s_acctbal",
+        s_name: "$supplier.s_name",
+        n_name: "$supplier.n_name",
+        p_partkey: "$_id.p_partkey",
+        p_mfgr: "$_id.p_mfgr",
+        s_address: "$supplier.s_address",
+        s_phone: "$supplier.s_phone",
+        s_comment: "$supplier.s_comment"}},
+      {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery2Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery2Aggregation
-      aggregate: part
-      pipeline:
-        [
-          {$match: {$and: [
-            {p_type: {$regex: *query2Type, $options: "si"}},
-            {p_size: {$eq: *query2Size}}]}},
-          {$lookup: {
-            from: "partsupp",
-            localField: "p_partkey",
-            foreignField: "ps_partkey",
-            as: "partsupp"}},
-          {$unwind: "$partsupp"},
-          {$lookup: {
-            from: "supplier",
-            localField: "partsupp.ps_suppkey",
-            foreignField: "s_suppkey",
-            as: "supplier"}},
-          {$unwind: "$supplier"},
-          {$lookup: {
-            from: "nation",
-            localField: "supplier.s_nationkey",
-            foreignField: "n_nationkey",
-            as: "nation"}},
-          {$unwind: "$nation"},
-          {$lookup: {
-            from: "region",
-            localField: "nation.n_regionkey",
-            foreignField: "r_regionkey",
-            as: "region"}},
-          {$unwind: "$region"},
-          {$match: {"region.r_name": *query2Region}},
-          {$sort: {"partsupp.ps_supplycost": 1}},
-          {$group: {
-            _id: {
-              p_partkey: "$p_partkey",
-              p_mfgr: "$p_mfgr"},
-            supplier: {$first: {
-              s_acctbal: "$supplier.s_acctbal",
-              s_name: "$supplier.s_name",
-              s_address: "$supplier.s_address",
-              s_phone: "$supplier.s_phone",
-              s_comment: "$supplier.s_comment",
-              ps_supplycost: "$partsupp.ps_supplycost",
-              n_name: "$nation.n_name"}}}},
-          {$project: {
-            _id: 0,
-            s_acctbal: "$supplier.s_acctbal",
-            s_name: "$supplier.s_name",
-            n_name: "$supplier.n_name",
-            p_partkey: "$_id.p_partkey",
-            p_mfgr: "$_id.p_mfgr",
-            s_address: "$supplier.s_address",
-            s_phone: "$supplier.s_phone",
-            s_comment: "$supplier.s_comment"}},
-          {$sort: {s_acctbal: -1, n_name: 1, s_name: 1, p_partkey: 1}},
-          {$limit: 100}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery2Aggregation
 
 TPCHNormalizedQuery2:
   Repeat: *Repeat
@@ -94,3 +96,11 @@ TPCHNormalizedQuery2Explain:
       explain: *TPCHNormalizedQuery2Aggregation
       verbosity:
         executionStats
+
+ValidateTPCHNormalizedQuery2:
+  LoadConfig:
+    Path: ../../../../phases/tpch/Validate.yml
+    Key: ValidateTPCHQueryResults
+    Parameters:
+      ActualAggregation: *TPCHNormalizedQuery2Aggregation
+      ValidationCollection: res_2

--- a/src/phases/tpch/normalized/Q20.yml
+++ b/src/phases/tpch/normalized/Q20.yml
@@ -10,38 +10,40 @@ query20Nation: &query20Nation {^Parameter: {Name: "Query20Nation", Default: "CAN
 query20Color: &query20Color {^Parameter: {Name: "Query20Color", Default: "^forest.*$"}}  # "^${color}.*$"
 query20Date: &query20Date {^Parameter: {Name: "Query20Date", Default: "1994-01-01"}}
 
+TPCHNormalizedQuery20Aggregation: &TPCHNormalizedQuery20Aggregation
+  aggregate: supplier
+  pipeline:
+    [
+      {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
+      {$unwind: "$nation"},
+      {$match: {"nation.n_name": *query20Nation}},
+      {$lookup: {from: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", as: "partsupp"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "part", localField: "partsupp.ps_partkey", foreignField: "p_partkey", as: "part"}},
+      {$unwind: "$part"},
+      {$match: {"part.p_name": {$regex: *query20Color, $options: "si"}}},
+      {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
+        {$match: {$and: [
+          {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
+          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
+          {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
+        {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
+        {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
+      {$unwind: "$lineitem"},
+      {$match: {$expr: {$gt: ["$partsupp.ps_availqty", "$lineitem.quantity"]}}},
+      {$group: {_id: {s_name: "$s_name", s_address: "$s_address"}}},
+      {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
+      {$sort: {s_name: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery20Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery20Aggregation
-      aggregate: supplier
-      pipeline:
-        [
-          {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
-          {$unwind: "$nation"},
-          {$match: {"nation.n_name": *query20Nation}},
-          {$lookup: {from: "partsupp", localField: "s_suppkey", foreignField: "ps_suppkey", as: "partsupp"}},
-          {$unwind: "$partsupp"},
-          {$lookup: {from: "part", localField: "partsupp.ps_partkey", foreignField: "p_partkey", as: "part"}},
-          {$unwind: "$part"},
-          {$match: {"part.p_name": {$regex: *query20Color, $options: "si"}}},
-          {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
-            {$match: {$and: [
-              {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
-              {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
-            {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
-            {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
-          {$unwind: "$lineitem"},
-          {$match: {$expr: {$gt: ["$partsupp.ps_availqty", "$lineitem.quantity"]}}},
-          {$group: {_id: {s_name: "$s_name", s_address: "$s_address"}}},
-          {$project: {_id: 0, s_name: "$_id.s_name", s_address: "$_id.s_address"}},
-          {$sort: {s_name: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery20Aggregation
 
 TPCHNormalizedQuery20:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q21.yml
+++ b/src/phases/tpch/normalized/Q21.yml
@@ -7,36 +7,38 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query21Nation: &query21Nation {^Parameter: {Name: "Query1Delta", Default: "SAUDI ARABIA"}}
 
+TPCHNormalizedQuery21Aggregation: &TPCHNormalizedQuery21Aggregation
+  aggregate: supplier
+  pipeline:
+    [
+      {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
+      {$unwind: "$nation"},
+      {$match: {"nation.n_name": *query21Nation}},
+      {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "l1", pipeline: [{$match: {$expr: {$gt: ["$l_receiptdate", "$l_commitdate"]}}}]}},
+      {$unwind: "$l1"},
+      {$lookup: {from: "orders", localField: "l1.l_orderkey", foreignField: "o_orderkey", as: "orders", pipeline: [{$match: {o_orderstatus: "F"}}]}},
+      {$unwind: "$orders"},
+      {$lookup: {from: "lineitem", let: {l1: "$l1"}, localField: "l1.l_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+        {$match: {$expr: {$ne: ["$$l1.l_suppkey", "$l_suppkey"]}}},
+        {$group: {_id: {}, l2_count: {$count: {}}, l3_count: {$sum: {$cond: {if: {$gt: ["$l_receiptdate", "$l_commitdate"]}, then: 1, else: 0}}}}}]}},
+      {$unwind: "$lineitem"},
+      {$match: {$and: [
+        {$expr: {$gt: ["$lineitem.l2_count", 0]}},
+        {$expr: {$eq: ["$lineitem.l3_count", 0]}}]}},
+      {$group: {_id: "$s_name", numwait: {$count: {}}}},
+      {$project: {_id: 0, s_name: "$_id", numwait: 1}},
+      {$sort: {numwait: -1, s_name: 1}},
+      {$limit: 100}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery21Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery21Aggregation
-      aggregate: supplier
-      pipeline:
-        [
-          {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation"}},
-          {$unwind: "$nation"},
-          {$match: {"nation.n_name": *query21Nation}},
-          {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "l1", pipeline: [{$match: {$expr: {$gt: ["$l_receiptdate", "$l_commitdate"]}}}]}},
-          {$unwind: "$l1"},
-          {$lookup: {from: "orders", localField: "l1.l_orderkey", foreignField: "o_orderkey", as: "orders", pipeline: [{$match: {o_orderstatus: "F"}}]}},
-          {$unwind: "$orders"},
-          {$lookup: {from: "lineitem", let: {l1: "$l1"}, localField: "l1.l_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-            {$match: {$expr: {$ne: ["$$l1.l_suppkey", "$l_suppkey"]}}},
-            {$group: {_id: {}, l2_count: {$count: {}}, l3_count: {$sum: {$cond: {if: {$gt: ["$l_receiptdate", "$l_commitdate"]}, then: 1, else: 0}}}}}]}},
-          {$unwind: "$lineitem"},
-          {$match: {$and: [
-            {$expr: {$gt: ["$lineitem.l2_count", 0]}},
-            {$expr: {$eq: ["$lineitem.l3_count", 0]}}]}},
-          {$group: {_id: "$s_name", numwait: {$count: {}}}},
-          {$project: {_id: 0, s_name: "$_id", numwait: 1}},
-          {$sort: {numwait: -1, s_name: 1}},
-          {$limit: 100}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery21Aggregation
 
 TPCHNormalizedQuery21:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q22.yml
+++ b/src/phases/tpch/normalized/Q22.yml
@@ -16,37 +16,35 @@ query22CountryCodes: &query22CountryCodes {^Parameter: {Name: "Query22CountryCod
   {$toString: "17"}
 ]}}
 
+TPCHNormalizedQuery22Aggregation: &TPCHNormalizedQuery22Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "custsale"}},
+      {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}, custsale: {$size: "$custsale"}}},
+      {$match: {$and: [{$expr: {$in: ["$cntrycode", *query22CountryCodes]}}, {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
+      {$facet: {
+        customer: [
+          {$project: {cntrycode: 1, c_acctbal: 1, custsale: 1}}],
+        "avg(c_acctbal)": [
+          {$group: {_id: {}, value: {$avg: "$c_acctbal"}}},
+          {$project: {_id: 0}}]}},
+      {$unwind: "$avg(c_acctbal)"},
+      {$unwind: "$customer"},
+      {$match: {$and: [{$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}, {"customer.custsale": 0}]}},
+      {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
+      {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
+      {$sort: {cntrycode: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery22Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery22Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "custsale"}},
-          {$unwind: {path: "$custsale", preserveNullAndEmptyArrays: true}},
-          {$addFields: {cntrycode: { $substr: ["$c_phone", 0, 2]}}},
-          {$match: {$and: [
-            {$expr: {$in: ["$cntrycode", *query22CountryCodes]}},
-            {custsale: null},
-            {$expr: {$gt: ["$c_acctbal", 0.00]}}]}},
-          {$facet: {
-            customer: [
-              {$project: {cntrycode: 1, c_acctbal: 1}}],
-            "avg(c_acctbal)": [
-              {$group: {_id: {}, value: {$avg: "$c_acctbal"}}},
-              {$project: {_id: 0}}]}},
-          {$unwind: "$avg(c_acctbal)"},
-          {$unwind: "$customer"},
-          {$match: {$expr: {$gt: ["$customer.c_acctbal", "$avg(c_acctbal).value"]}}},
-          {$group: {_id: "$customer.cntrycode", numcust: {$count: {}}, totacctbal: {$sum: "$customer.c_acctbal"}}},
-          {$project: {_id: 0, cntrycode: "$_id", numcust: 1, totacctbal: 1}},
-          {$sort: {cntrycode: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery22Aggregation
 
 TPCHNormalizedQuery22:
   Repeat: *Repeat
@@ -54,7 +52,6 @@ TPCHNormalizedQuery22:
   Operations:
   - OperationMetricsName: Query22
     OperationName: RunCommand
-    OperationCommand: *TPCHNormalizedQuery22Aggregation
 
 TPCHNormalizedQuery22Explain:
   Repeat: *Repeat
@@ -65,5 +62,4 @@ TPCHNormalizedQuery22Explain:
     OperationLogsResult: true
     OperationCommand:
       explain: *TPCHNormalizedQuery22Aggregation
-      verbosity:
-        executionStats
+      verbosity: executionStats

--- a/src/phases/tpch/normalized/Q22.yml
+++ b/src/phases/tpch/normalized/Q22.yml
@@ -52,6 +52,7 @@ TPCHNormalizedQuery22:
   Operations:
   - OperationMetricsName: Query22
     OperationName: RunCommand
+    OperationCommand: *TPCHNormalizedQuery22Aggregation
 
 TPCHNormalizedQuery22Explain:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q3.yml
+++ b/src/phases/tpch/normalized/Q3.yml
@@ -9,30 +9,32 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query3Segment: &query3Segment {^Parameter: {Name: "Query3Segment", Default: "BUILDING"}}
 query3Date: &query3Date {^Parameter: {Name: "Query3Date", Default: "1995-03-15"}}
 
+TPCHNormalizedQuery3Aggregation: &TPCHNormalizedQuery3Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
+      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
+        {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
+        {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
+      {$unwind: "$orders"},
+      {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
+        {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}}]}},
+      {$unwind: "$lineitem"},
+      {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
+      {$sort: {revenue: -1, o_orderdate: 1}},
+      {$limit: 10}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery3Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery3Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
-          {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-            {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
-            {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
-          {$unwind: "$orders"},
-          {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-            {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}}]}},
-          {$unwind: "$lineitem"},
-          {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
-          {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},
-          {$sort: {revenue: -1, o_orderdate: 1}},
-          {$limit: 10}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery3Aggregation
 
 TPCHNormalizedQuery3:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q4.yml
+++ b/src/phases/tpch/normalized/Q4.yml
@@ -7,35 +7,37 @@ Description: |
 batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query4Date: &query4Date {^Parameter: {Name: "Query4Date", Default: "1993-07-01"}}
 
+TPCHNormalizedQuery4Aggregation: &TPCHNormalizedQuery4Aggregation
+  aggregate: orders
+  pipeline:
+    [
+      {$match: {
+        $and: [
+          {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
+          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}}]}},
+      {$lookup: {
+        from: "lineitem",
+        localField: "o_orderkey",
+        foreignField: "l_orderkey",
+        pipeline: [{$match: {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}}}, {$count: "count"}],
+        as: "lineitem"}},
+      {$unwind: "$lineitem"},
+      {$match: {$expr: {$gt: ["$lineitem.count", 0]}}},
+      {$group: {
+        _id: "$o_orderpriority",
+        order_count: {$count: {}}}},
+      {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
+      {$sort: {o_orderpriority: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery4Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery4Aggregation
-      aggregate: orders
-      pipeline:
-        [
-          {$match: {
-            $and: [
-              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
-              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}}]}},
-          {$lookup: {
-            from: "lineitem",
-            localField: "o_orderkey",
-            foreignField: "l_orderkey",
-            pipeline: [{$match: {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}}}, {$count: "count"}],
-            as: "lineitem"}},
-          {$unwind: "$lineitem"},
-          {$match: {$expr: {$gt: ["$lineitem.count", 0]}}},
-          {$group: {
-            _id: "$o_orderpriority",
-            order_count: {$count: {}}}},
-          {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},
-          {$sort: {o_orderpriority: 1}},
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery4Aggregation
 
 TPCHNormalizedQuery4:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q5.yml
+++ b/src/phases/tpch/normalized/Q5.yml
@@ -8,36 +8,38 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query5Region: &query5Region {^Parameter: {Name: "Query5Region", Default: "ASIA"}}
 query5Date: &query5Date {^Parameter: {Name: "Query5Date", Default: "1994-01-01"}}
 
+TPCHNormalizedQuery5Aggregation: &TPCHNormalizedQuery5Aggregation
+  aggregate: customer
+  pipeline:
+    [
+      {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
+        {$match: {$and: [
+          {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
+          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
+        {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
+          {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
+            {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
+            {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
+              {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
+                {$match: {r_name: *query5Region}}]}},
+              {$unwind: "$region"}]}},
+            {$unwind: "$nation"}]}},
+          {$unwind: "$supplier"}]}},
+        {$unwind: "$lineitem"}]}},
+      {$unwind: "$orders"},
+      {$group: {_id: "$orders.lineitem.supplier.nation.n_name", revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
+      {$project: {_id: 0, n_name: "$_id", revenue: 1}},
+      {$sort: {revenue: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery5Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery5Aggregation
-      aggregate: customer
-      pipeline:
-        [
-          {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
-            {$match: {$and: [
-              {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
-              {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
-            {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
-              {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
-                {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},
-                {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "nation", pipeline: [
-                  {$lookup: {from: "region", localField: "n_regionkey", foreignField: "r_regionkey", as: "region", pipeline: [
-                    {$match: {r_name: *query5Region}}]}},
-                  {$unwind: "$region"}]}},
-                {$unwind: "$nation"}]}},
-              {$unwind: "$supplier"}]}},
-            {$unwind: "$lineitem"}]}},
-          {$unwind: "$orders"},
-          {$group: {_id: "$orders.lineitem.supplier.nation.n_name", revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},
-          {$project: {_id: 0, n_name: "$_id", revenue: 1}},
-          {$sort: {revenue: -1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery5Aggregation
 
 TPCHNormalizedQuery5:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q6.yml
+++ b/src/phases/tpch/normalized/Q6.yml
@@ -10,26 +10,28 @@ query6Date: &query6Date {^Parameter: {Name: "Query6Date", Default: "1994-01-01"}
 query6Discount: &query6Discount {^Parameter: {Name: "Query6Discount", Default: 0.06}}
 query6Quantity: &query6Quantity {^Parameter: {Name: "Query6Quantity", Default: 24}}
 
+TPCHNormalizedQuery6Aggregation: &TPCHNormalizedQuery6Aggregation
+  aggregate: lineitem
+  pipeline:
+    [
+      {$match: {$and: [
+        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
+        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+        {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
+        {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
+        {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
+      {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
+      {$project: {_id: 0, revenue: 1}},
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery6Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery6Aggregation
-      aggregate: lineitem
-      pipeline:
-        [
-          {$match: {$and: [
-            {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
-            {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
-            {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
-            {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
-            {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},
-          {$group: {_id: 0, revenue: {$sum: {$multiply: ["$l_extendedprice", "$l_discount"]}}}},
-          {$project: {_id: 0, revenue: 1}},
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery6Aggregation
 
 TPCHNormalizedQuery6:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q7.yml
+++ b/src/phases/tpch/normalized/Q7.yml
@@ -8,39 +8,41 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 query7Nation1: &query7Nation1 {^Parameter: {Name: "Query7Nation1", Default: "FRANCE"}}
 query7Nation2: &query7Nation2 {^Parameter: {Name: "Query7Nation2", Default: "GERMANY"}}
 
+TPCHNormalizedQuery7Aggregation: &TPCHNormalizedQuery7Aggregation
+  aggregate: supplier
+  pipeline:
+    [
+      {$project: {s_nationkey: 1, s_suppkey: 1}},
+      {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "n1"}},
+      {$unwind: "$n1"},
+      {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
+        {$match: {$and: [
+          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
+          {$expr: {$lte: ["$l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}}]}},
+      {$unwind: "$lineitem"},
+      {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+      {$unwind: "$orders"},
+      {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
+      {$unwind: "$customer"},
+      {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n2"}},
+      {$unwind: "$n2"},
+      {$match: {$or: [
+        {$and: [{"n1.n_name": *query7Nation1}, {"n2.n_name": *query7Nation2}]},
+        {$and: [{"n1.n_name": *query7Nation2}, {"n2.n_name": *query7Nation1}]}]}},
+      {$project: {supp_nation: "$n1.n_name", cust_nation: "$n2.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
+      {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
+      {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
+      {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery7Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery7Aggregation
-      aggregate: supplier
-      pipeline:
-        [
-          {$project: {s_nationkey: 1, s_suppkey: 1}},
-          {$lookup: {from: "nation", localField: "s_nationkey", foreignField: "n_nationkey", as: "n1"}},
-          {$unwind: "$n1"},
-          {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
-            {$match: {$and: [
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
-              {$expr: {$lt: ["$l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}}]}},
-          {$unwind: "$lineitem"},
-          {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
-          {$unwind: "$orders"},
-          {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
-          {$unwind: "$customer"},
-          {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n2"}},
-          {$unwind: "$n2"},
-          {$match: {$or: [
-            {$and: [{"n1.n_name": *query7Nation1}, {"n2.n_name": *query7Nation2}]},
-            {$and: [{"n1.n_name": *query7Nation2}, {"n2.n_name": *query7Nation1}]}]}},
-          {$project: {supp_nation: "$n1.n_name", cust_nation: "$n2.n_name", l_year: {$year: "$lineitem.l_shipdate"}, volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}},
-          {$group: {_id: {supp_nation: "$supp_nation", cust_nation: "$cust_nation", l_year: "$l_year"}, revenue: {$sum: "$volume"}}},
-          {$project: {_id: 0, supp_nation: "$_id.supp_nation", cust_nation: "$_id.cust_nation", l_year: "$_id.l_year", revenue: 1}},
-          {$sort: {supp_nation: 1, cust_nation: 1, l_year: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery7Aggregation
 
 TPCHNormalizedQuery7:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q8.yml
+++ b/src/phases/tpch/normalized/Q8.yml
@@ -10,46 +10,48 @@ query8Type: &query8Type {^Parameter: {Name: "Query8Type", Default: "ECONOMY ANOD
 query8Region: &query8Region {^Parameter: {Name: "Query8Region", Default: "AMERICA"}}
 query8Nation: &query8Nation {^Parameter: {Name: "Query8Nation", Default: "BRAZIL"}}
 
+TPCHNormalizedQuery8Aggregation: &TPCHNormalizedQuery8Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {p_type: {$eq: *query8Type}}},
+      {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem"}},
+      {$unwind: "$lineitem"},
+      {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
+      {$unwind: "$supplier"},
+      {$lookup: {from: "nation", localField: "supplier.s_nationkey", foreignField: "n_nationkey", as: "n2"}},
+      {$unwind: "$n2"},
+      {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
+      {$unwind: "$orders"},
+      {$match: {$and: [
+        {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+      {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
+      {$unwind: "$customer"},
+      {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n1"}},
+      {$unwind: "$n1"},
+      {$lookup: {from: "region", localField: "n1.n_regionkey", foreignField: "r_regionkey", as: "region"}},
+      {$unwind: "$region"},
+      {$match: {"region.r_name": {$eq: *query8Region}}},
+      {$project: {
+        o_year: {$year: "$orders.o_orderdate"},
+        volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]},
+        nation: "$n2.n_name"}},
+      {$group: {
+        _id: "$o_year", total_volume: {$sum: "$volume"},
+        nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
+      {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
+      {$sort: {o_year: 1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery8Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery8Aggregation
-      aggregate: part
-      pipeline:
-        [
-          {$match: {p_type: {$eq: *query8Type}}},
-          {$lookup: {from: "lineitem", localField: "p_partkey", foreignField: "l_partkey", as: "lineitem"}},
-          {$unwind: "$lineitem"},
-          {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
-          {$unwind: "$supplier"},
-          {$lookup: {from: "nation", localField: "supplier.s_nationkey", foreignField: "n_nationkey", as: "n2"}},
-          {$unwind: "$n2"},
-          {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
-          {$unwind: "$orders"},
-          {$match: {$and: [
-            {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
-            {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
-          {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
-          {$unwind: "$customer"},
-          {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n1"}},
-          {$unwind: "$n1"},
-          {$lookup: {from: "region", localField: "n1.n_regionkey", foreignField: "r_regionkey", as: "region"}},
-          {$unwind: "$region"},
-          {$match: {"region.r_name": {$eq: *query8Region}}},
-          {$project: {
-            o_year: {$year: "$orders.o_orderdate"},
-            volume: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [{$literal: 1}, "$lineitem.l_discount"]}]},
-            nation: "$n2.n_name"}},
-          {$group: {
-            _id: "$o_year", total_volume: {$sum: "$volume"},
-            nation_volume: {$sum: {$cond: { if: {$eq: ["$nation", *query8Nation]}, then: "$volume", else: 0}}}}},
-          {$project: {_id: 0, o_year: "$_id", mkt_share: {$divide: ["$nation_volume", "$total_volume"]}}},
-          {$sort: {o_year: 1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery8Aggregation
 
 TPCHNormalizedQuery8:
   Repeat: *Repeat

--- a/src/phases/tpch/normalized/Q9.yml
+++ b/src/phases/tpch/normalized/Q9.yml
@@ -8,36 +8,38 @@ batchSize: &batchSize {^Parameter: {Name: "BatchSize", Default: 101}}
 
 query9Color: &query9Color {^Parameter: {Name: "Query9Color", Default: "^.*green.*$"}}  # ^.*${color}.*$
 
+TPCHNormalizedQuery9Aggregation: &TPCHNormalizedQuery9Aggregation
+  aggregate: part
+  pipeline:
+    [
+      {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}},
+      {$lookup: {from: "partsupp", as: "partsupp", localField: "p_partkey", foreignField: "ps_partkey"}},
+      {$unwind: "$partsupp"},
+      {$lookup: {from: "supplier", as: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [
+        {$lookup: {from: "nation", as: "nation", localField: "s_nationkey", foreignField: "n_nationkey"}},
+        {$unwind: "$nation"}]}},
+      {$unwind: "$supplier"},
+      {$project: {p_partkey: 1, s_suppkey: "$supplier.s_suppkey", nation: "$supplier.nation.n_name", partsupp: 1}},
+      {$lookup: {from: "lineitem", as: "lineitem", localField: "p_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, pipeline: [
+        {$match: {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}}},
+        {$lookup: {from: "orders", as: "orders", localField: "l_orderkey", foreignField: "o_orderkey"}},
+        {$unwind: "$orders"}]}},
+      {$unwind: "$lineitem"},
+      {$group: {_id: {nation: "$nation", o_year: {$year: "$lineitem.orders.o_orderdate"}}, sum_profit: {$sum: {$subtract: [
+        {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]},
+        {$multiply: ["$partsupp.ps_supplycost", "$lineitem.l_quantity"]}]}}}},
+      {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
+      {$sort: {nation: 1, o_year: -1}}
+    ]
+  cursor: {batchSize: *batchSize}
+  allowDiskUse: true
+
 TPCHNormalizedQuery9Warmup:
   Repeat: &Repeat {^Parameter: {Name: "Repeat", Default: 1}}
   Database: &db tpch
   Operations:
   - OperationName: RunCommand
-    OperationCommand: &TPCHNormalizedQuery9Aggregation
-      aggregate: part
-      pipeline:
-        [
-          {$match: {$expr: {$regexMatch: {input: "$p_name", regex: *query9Color, options: "si"}}}},
-          {$lookup: {from: "partsupp", as: "partsupp", localField: "p_partkey", foreignField: "ps_partkey"}},
-          {$unwind: "$partsupp"},
-          {$lookup: {from: "supplier", as: "supplier", localField: "partsupp.ps_suppkey", foreignField: "s_suppkey", pipeline: [
-            {$lookup: {from: "nation", as: "nation", localField: "s_nationkey", foreignField: "n_nationkey"}},
-            {$unwind: "$nation"}]}},
-          {$unwind: "$supplier"},
-          {$project: {p_partkey: 1, s_suppkey: "$supplier.s_suppkey", nation: "$supplier.nation.n_name", partsupp: 1}},
-          {$lookup: {from: "lineitem", as: "lineitem", localField: "p_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, pipeline: [
-            {$match: {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}}},
-            {$lookup: {from: "orders", as: "orders", localField: "l_orderkey", foreignField: "o_orderkey"}},
-            {$unwind: "$orders"}]}},
-          {$unwind: "$lineitem"},
-          {$group: {_id: {nation: "$nation", o_year: {$year: "$lineitem.orders.o_orderdate"}}, sum_profit: {$sum: {$subtract: [
-            {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]},
-            {$multiply: ["$partsupp.ps_supplycost", "$lineitem.l_quantity"]}]}}}},
-          {$project: {_id: 0, nation: "$_id.nation", o_year: "$_id.o_year", sum_profit: 1}},
-          {$sort: {nation: 1, o_year: -1}}
-        ]
-      cursor: {batchSize: *batchSize}
-      allowDiskUse: true
+    OperationCommand: *TPCHNormalizedQuery9Aggregation
 
 TPCHNormalizedQuery9:
   Repeat: *Repeat

--- a/src/workloads/tpch/denormalized/1/validate.yml
+++ b/src/workloads/tpch/denormalized/1/validate.yml
@@ -27,6 +27,7 @@ ActorTemplates:
     - *Nop
 
 # Note: since the queries are all read-only and we don't care about timing metrics here, we can just run all the queries simultaneously.
+# TODO: disable metrics collection once TIG-4128 is complete.
 Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate

--- a/src/workloads/tpch/denormalized/1/validate.yml
+++ b/src/workloads/tpch/denormalized/1/validate.yml
@@ -1,7 +1,8 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Validate TPC_H denormalized queries for scale 1.
+  Validate TPC_H denormalized queries for scale 1. Note that numeric comparison is not exact in this workload;
+  the AssertiveActor only ensures that any two values of numeric type are approximately equal according to a hard-coded limit.
 
 Clients:
   Default:

--- a/src/workloads/tpch/denormalized/1/validate.yml
+++ b/src/workloads/tpch/denormalized/1/validate.yml
@@ -1,0 +1,230 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Validate TPC_H denormalized queries for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+ActorTemplates:
+- TemplateName: ValidateTPCHQueryActorTemplate
+  Config:
+    Name: &query {^Parameter: {Name: "Query", Default: ""}}
+    Type: AssertiveActor
+    Database: &db tpch
+    Phases:
+    - &Nop {Nop: true}
+    - Repeat: 1
+      Database: *db
+      Message: *query
+      Expected:
+        aggregate: {^Join: {array: ["res_", *query]}}
+        pipeline: [{$sort: {num: 1}}]
+        cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 101}}}
+      Actual: {^Parameter: {Name: "Actual", Default: {}}}
+    - *Nop
+
+# Note: since the queries are all read-only and we don't care about timing metrics here, we can just run all the queries simultaneously.
+Actors:
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 1
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q1.yml
+          Key: TPCHDenormalizedQuery1Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 2
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q2.yml
+          Key: TPCHDenormalizedQuery2Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 3
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q3.yml
+          Key: TPCHDenormalizedQuery3Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 4
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q4.yml
+          Key: TPCHDenormalizedQuery4Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 5
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q5.yml
+          Key: TPCHDenormalizedQuery5Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 6
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q6.yml
+          Key: TPCHDenormalizedQuery6Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 7
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q7.yml
+          Key: TPCHDenormalizedQuery7Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 8
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q8.yml
+          Key: TPCHDenormalizedQuery8Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 9
+      BatchSize: &q9BatchSize 175  # This query is expected to return more documents than the default batch size of 101.
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q9.yml
+          Key: TPCHDenormalizedQuery9Aggregation
+          Parameters:
+            BatchSize: *q9BatchSize
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 10
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q10.yml
+          Key: TPCHDenormalizedQuery10Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 11
+      BatchSize: &q11BatchSize 1048  # This query is expected to return more documents than the default batch size of 101.
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q11.yml
+          Key: TPCHDenormalizedQuery11Aggregation
+          Parameters:
+            BatchSize: *q11BatchSize
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 12
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q12.yml
+          Key: TPCHDenormalizedQuery12Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 13
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q13.yml
+          Key: TPCHDenormalizedQuery13Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 14
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q14.yml
+          Key: TPCHDenormalizedQuery14Aggregation
+# This query creates a view for query 15 before running any workloads, and then destroys the view afterwards.
+- Name: TPCHDenormalizedQuery15AggregationSetup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q15.yml
+      Key: TPCHDenormalizedQuery15CreateView
+  - *Nop
+  - LoadConfig:
+      Path: ../../../../phases/tpch/denormalized/Q15.yml
+      Key: TPCHDenormalizedQuery15DropView
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 15
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q15.yml
+          Key: TPCHDenormalizedQuery15Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 16
+      BatchSize: &q16BatchSize 18314  # This query is expected to return more documents than the default batch size of 101.
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q16.yml
+          Key: TPCHDenormalizedQuery16Aggregation
+          Parameters:
+            BatchSize: *q16BatchSize
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 17
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q17.yml
+          Key: TPCHDenormalizedQuery17Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 18
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q18.yml
+          Key: TPCHDenormalizedQuery18Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 19
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q19.yml
+          Key: TPCHDenormalizedQuery19Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 20
+      BatchSize: &q20BatchSize 186  # This query is expected to return more documents than the default batch size of 101.
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q20.yml
+          Key: TPCHDenormalizedQuery20Aggregation
+          Parameters:
+            BatchSize: *q20BatchSize
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 21
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q21.yml
+          Key: TPCHDenormalizedQuery21Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 22
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/denormalized/Q22.yml
+          Key: TPCHDenormalizedQuery22Aggregation

--- a/src/workloads/tpch/denormalized/1/validate.yml
+++ b/src/workloads/tpch/denormalized/1/validate.yml
@@ -32,7 +32,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q1
+      Query: 1
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q1.yml
@@ -40,7 +40,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q2
+      Query: 2
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q2.yml
@@ -48,7 +48,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q3
+      Query: 3
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q3.yml
@@ -56,7 +56,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q4
+      Query: 4
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q4.yml
@@ -64,7 +64,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q5
+      Query: 5
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q5.yml
@@ -72,7 +72,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q6
+      Query: 6
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q6.yml
@@ -80,7 +80,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q7
+      Query: 7
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q7.yml
@@ -88,7 +88,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q8
+      Query: 8
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q8.yml
@@ -96,7 +96,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q9
+      Query: 9
       BatchSize: &q9BatchSize 175  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -107,7 +107,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q10
+      Query: 10
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q10.yml
@@ -115,7 +115,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q11
+      Query: 11
       BatchSize: &q11BatchSize 1048  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -126,7 +126,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q12
+      Query: 12
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q12.yml
@@ -134,7 +134,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q13
+      Query: 13
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q13.yml
@@ -142,7 +142,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q14
+      Query: 14
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q14.yml
@@ -162,7 +162,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q15
+      Query: 15
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q15.yml
@@ -170,7 +170,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q16
+      Query: 16
       BatchSize: &q16BatchSize 18314  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -181,7 +181,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q17
+      Query: 17
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q17.yml
@@ -189,7 +189,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q18
+      Query: 18
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q18.yml
@@ -197,7 +197,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q19
+      Query: 19
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q19.yml
@@ -205,7 +205,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q20
+      Query: 20
       BatchSize: &q20BatchSize 186  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -216,7 +216,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q21
+      Query: 21
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q21.yml
@@ -224,7 +224,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q22
+      Query: 22
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q22.yml

--- a/src/workloads/tpch/denormalized/1/validate.yml
+++ b/src/workloads/tpch/denormalized/1/validate.yml
@@ -32,7 +32,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 1
+      Query: Q1
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q1.yml
@@ -40,7 +40,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 2
+      Query: Q2
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q2.yml
@@ -48,7 +48,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 3
+      Query: Q3
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q3.yml
@@ -56,7 +56,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 4
+      Query: Q4
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q4.yml
@@ -64,7 +64,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 5
+      Query: Q5
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q5.yml
@@ -72,7 +72,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 6
+      Query: Q6
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q6.yml
@@ -80,7 +80,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 7
+      Query: Q7
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q7.yml
@@ -88,7 +88,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 8
+      Query: Q8
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q8.yml
@@ -96,7 +96,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 9
+      Query: Q9
       BatchSize: &q9BatchSize 175  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -107,7 +107,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 10
+      Query: Q10
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q10.yml
@@ -115,7 +115,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 11
+      Query: Q11
       BatchSize: &q11BatchSize 1048  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -126,7 +126,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 12
+      Query: Q12
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q12.yml
@@ -134,7 +134,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 13
+      Query: Q13
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q13.yml
@@ -142,7 +142,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 14
+      Query: Q14
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q14.yml
@@ -162,7 +162,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 15
+      Query: Q15
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q15.yml
@@ -170,7 +170,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 16
+      Query: Q16
       BatchSize: &q16BatchSize 18314  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -181,7 +181,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 17
+      Query: Q17
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q17.yml
@@ -189,7 +189,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 18
+      Query: Q18
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q18.yml
@@ -197,7 +197,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 19
+      Query: Q19
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q19.yml
@@ -205,7 +205,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 20
+      Query: Q20
       BatchSize: &q20BatchSize 186  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -216,7 +216,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 21
+      Query: Q21
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q21.yml
@@ -224,7 +224,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 22
+      Query: Q22
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/denormalized/Q22.yml

--- a/src/workloads/tpch/denormalized/10/Q22.yml
+++ b/src/workloads/tpch/denormalized/10/Q22.yml
@@ -13,6 +13,14 @@ Actors:
   Type: RunCommand
   Database: tpch
   Phases:
-  - LoadConfig:
-      Path: ../../../../phases/tpch/denormalized/Q22.yml
-      Key: TPCHDenormalizedQuery22Explain
+  - Nop: true
+
+# TODO: PERF-2995 uncomment
+# Error message: document constructed by $facet is 104857668 bytes, which exceeds the limit of 104857600 bytes
+# - Name: TPCHDenormalizedQuery22Explain
+#   Type: RunCommand
+#   Database: tpch
+#   Phases:
+#   - LoadConfig:
+#       Path: ../../../../phases/tpch/normalized/Q22.yml
+#       Key: TPCHDenormalizedQuery22Explain

--- a/src/workloads/tpch/denormalized/10/validate.yml
+++ b/src/workloads/tpch/denormalized/10/validate.yml
@@ -1,0 +1,17 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  The test control for TPC-H expects a validate.yml file to exist in all TPC-H scales.
+  We don't need validation on scale 10, so this is just a Nop.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHDenormalizedValidate
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true

--- a/src/workloads/tpch/normalized/1/validate.yml
+++ b/src/workloads/tpch/normalized/1/validate.yml
@@ -27,6 +27,7 @@ ActorTemplates:
     - *Nop
 
 # Note: since the queries are all read-only and we don't care about timing metrics here, we can just run all the queries simultaneously.
+# TODO: disable metrics collection once TIG-4128 is complete.
 Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate

--- a/src/workloads/tpch/normalized/1/validate.yml
+++ b/src/workloads/tpch/normalized/1/validate.yml
@@ -1,7 +1,8 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-query"
 Description: |
-  Validate TPC_H normalized queries for scale 1.
+  Validate TPC_H normalized queries for scale 1. Note that numeric comparison is not exact in this workload;
+  the AssertiveActor only ensures that any two values of numeric type are approximately equal according to a hard-coded limit.
 
 Clients:
   Default:

--- a/src/workloads/tpch/normalized/1/validate.yml
+++ b/src/workloads/tpch/normalized/1/validate.yml
@@ -32,7 +32,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q1
+      Query: 1
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q1.yml
@@ -40,7 +40,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q2
+      Query: 2
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q2.yml
@@ -48,7 +48,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q3
+      Query: 3
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q3.yml
@@ -56,7 +56,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q4
+      Query: 4
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q4.yml
@@ -64,7 +64,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q5
+      Query: 5
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q5.yml
@@ -72,7 +72,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q6
+      Query: 6
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q6.yml
@@ -80,7 +80,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q7
+      Query: 7
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q7.yml
@@ -88,7 +88,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q8
+      Query: 8
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q8.yml
@@ -96,7 +96,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q9
+      Query: 9
       BatchSize: &q9BatchSize 175  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -107,7 +107,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q10
+      Query: 10
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q10.yml
@@ -115,7 +115,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q11
+      Query: 11
       BatchSize: &q11BatchSize 1048  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -126,7 +126,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q12
+      Query: 12
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q12.yml
@@ -134,7 +134,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q13
+      Query: 13
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q13.yml
@@ -142,7 +142,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q14
+      Query: 14
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q14.yml
@@ -150,7 +150,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q15
+      Query: 15
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q15.yml
@@ -170,7 +170,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q16
+      Query: 16
       BatchSize: &q16BatchSize 18314  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -181,7 +181,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q17
+      Query: 17
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q17.yml
@@ -189,7 +189,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q18
+      Query: 18
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q18.yml
@@ -197,7 +197,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q19
+      Query: 19
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q19.yml
@@ -205,7 +205,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q20
+      Query: 20
       BatchSize: &q20BatchSize 186  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -216,7 +216,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q21
+      Query: 21
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q21.yml
@@ -224,7 +224,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: Q22
+      Query: 22
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q22.yml

--- a/src/workloads/tpch/normalized/1/validate.yml
+++ b/src/workloads/tpch/normalized/1/validate.yml
@@ -32,7 +32,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 1
+      Query: Q1
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q1.yml
@@ -40,7 +40,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 2
+      Query: Q2
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q2.yml
@@ -48,7 +48,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 3
+      Query: Q3
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q3.yml
@@ -56,7 +56,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 4
+      Query: Q4
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q4.yml
@@ -64,7 +64,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 5
+      Query: Q5
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q5.yml
@@ -72,7 +72,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 6
+      Query: Q6
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q6.yml
@@ -80,7 +80,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 7
+      Query: Q7
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q7.yml
@@ -88,7 +88,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 8
+      Query: Q8
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q8.yml
@@ -96,7 +96,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 9
+      Query: Q9
       BatchSize: &q9BatchSize 175  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -107,7 +107,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 10
+      Query: Q10
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q10.yml
@@ -115,7 +115,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 11
+      Query: Q11
       BatchSize: &q11BatchSize 1048  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -126,7 +126,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 12
+      Query: Q12
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q12.yml
@@ -134,7 +134,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 13
+      Query: Q13
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q13.yml
@@ -142,7 +142,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 14
+      Query: Q14
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q14.yml
@@ -150,7 +150,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 15
+      Query: Q15
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q15.yml
@@ -170,7 +170,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 16
+      Query: Q16
       BatchSize: &q16BatchSize 18314  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -181,7 +181,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 17
+      Query: Q17
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q17.yml
@@ -189,7 +189,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 18
+      Query: Q18
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q18.yml
@@ -197,7 +197,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 19
+      Query: Q19
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q19.yml
@@ -205,7 +205,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 20
+      Query: Q20
       BatchSize: &q20BatchSize 186  # This query is expected to return more documents than the default batch size of 101.
       Actual:
         LoadConfig:
@@ -216,7 +216,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 21
+      Query: Q21
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q21.yml
@@ -224,7 +224,7 @@ Actors:
 - ActorFromTemplate:
     TemplateName: ValidateTPCHQueryActorTemplate
     TemplateParameters:
-      Query: 22
+      Query: Q22
       Actual:
         LoadConfig:
           Path: ../../../../phases/tpch/normalized/Q22.yml

--- a/src/workloads/tpch/normalized/1/validate.yml
+++ b/src/workloads/tpch/normalized/1/validate.yml
@@ -1,0 +1,230 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  Validate TPC_H normalized queries for scale 1.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+ActorTemplates:
+- TemplateName: ValidateTPCHQueryActorTemplate
+  Config:
+    Name: &query {^Parameter: {Name: "Query", Default: ""}}
+    Type: AssertiveActor
+    Database: &db tpch
+    Phases:
+    - &Nop {Nop: true}
+    - Repeat: 1
+      Database: *db
+      Message: *query
+      Expected:
+        aggregate: {^Join: {array: ["res_", *query]}}
+        pipeline: [{$sort: {num: 1}}]
+        cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 101}}}
+      Actual: {^Parameter: {Name: "Actual", Default: {}}}
+    - *Nop
+
+# Note: since the queries are all read-only and we don't care about timing metrics here, we can just run all the queries simultaneously.
+Actors:
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 1
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q1.yml
+          Key: TPCHNormalizedQuery1Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 2
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q2.yml
+          Key: TPCHNormalizedQuery2Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 3
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q3.yml
+          Key: TPCHNormalizedQuery3Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 4
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q4.yml
+          Key: TPCHNormalizedQuery4Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 5
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q5.yml
+          Key: TPCHNormalizedQuery5Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 6
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q6.yml
+          Key: TPCHNormalizedQuery6Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 7
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q7.yml
+          Key: TPCHNormalizedQuery7Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 8
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q8.yml
+          Key: TPCHNormalizedQuery8Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 9
+      BatchSize: &q9BatchSize 175  # This query is expected to return more documents than the default batch size of 101.
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q9.yml
+          Key: TPCHNormalizedQuery9Aggregation
+          Parameters:
+            BatchSize: *q9BatchSize
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 10
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q10.yml
+          Key: TPCHNormalizedQuery10Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 11
+      BatchSize: &q11BatchSize 1048  # This query is expected to return more documents than the default batch size of 101.
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q11.yml
+          Key: TPCHNormalizedQuery11Aggregation
+          Parameters:
+            BatchSize: *q11BatchSize
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 12
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q12.yml
+          Key: TPCHNormalizedQuery12Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 13
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q13.yml
+          Key: TPCHNormalizedQuery13Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 14
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q14.yml
+          Key: TPCHNormalizedQuery14Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 15
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q15.yml
+          Key: TPCHNormalizedQuery15Aggregation
+# This query creates a view before running any workloads, and then destroys the view afterwards.
+- Name: TPCHNormalizedQuery15Setup
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q15.yml
+      Key: TPCHNormalizedQuery15CreateView
+  - *Nop
+  - LoadConfig:
+      Path: ../../../../phases/tpch/normalized/Q15.yml
+      Key: TPCHNormalizedQuery15DropView
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 16
+      BatchSize: &q16BatchSize 18314  # This query is expected to return more documents than the default batch size of 101.
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q16.yml
+          Key: TPCHNormalizedQuery16Aggregation
+          Parameters:
+            BatchSize: *q16BatchSize
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 17
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q17.yml
+          Key: TPCHNormalizedQuery17Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 18
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q18.yml
+          Key: TPCHNormalizedQuery18Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 19
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q19.yml
+          Key: TPCHNormalizedQuery19Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 20
+      BatchSize: &q20BatchSize 186  # This query is expected to return more documents than the default batch size of 101.
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q20.yml
+          Key: TPCHNormalizedQuery20Aggregation
+          Parameters:
+            BatchSize: *q20BatchSize
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 21
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q21.yml
+          Key: TPCHNormalizedQuery21Aggregation
+- ActorFromTemplate:
+    TemplateName: ValidateTPCHQueryActorTemplate
+    TemplateParameters:
+      Query: 22
+      Actual:
+        LoadConfig:
+          Path: ../../../../phases/tpch/normalized/Q22.yml
+          Key: TPCHNormalizedQuery22Aggregation

--- a/src/workloads/tpch/normalized/10/validate.yml
+++ b/src/workloads/tpch/normalized/10/validate.yml
@@ -1,0 +1,17 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-query"
+Description: |
+  The test control for TPC-H expects a validate.yml file to exist in all TPC-H scales.
+  We don't need validation on scale 10, so this is just a Nop.
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+Actors:
+- Name: TPCHNormalizedValidate
+  Type: RunCommand
+  Database: tpch
+  Phases:
+  - Nop: true


### PR DESCRIPTION
🌲 [updated patch](https://spruce.mongodb.com/version/628ba64e57e85a02f3cd1baf/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

This PR is split into two (initial) commits:
- commit 1: Actor + workload definition for validation. This is the part that needs a review.
- commit 2: (Many files, few changes) Refactoring phases to use aggregations in validate.yml for both schemas as well as a couple of updates to queries to fix small bugs.

**Note**: I'd recommend using side-by-side view + hide whitespace changes for reviewing commit 2, since that clearly highlights the refactorings vs the fixes. Only Q22 and Q7 for both schemas were the only pipelines that had any changes- every other pipeline was just moved to its own yaml node for use in validate.yml.
