### PR TITLE
PERF-2985 Add query workloads for columnar indexes

### DIFF
--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -36,7 +36,6 @@ TotalTenantCreatedQuery: &TotalTenantCreatedQuery
       {"$project": {"value": "$__alias_0", "_id": 0}},
       {"$limit": 5000}
     ]
-  allowDiskUse: true
   cursor: {batchSize: 5000}
 
 ActiveCloudUsersLastMonthQuery: &ActiveCloudUsersLastMonthQuery
@@ -56,7 +55,6 @@ ActiveCloudUsersLastMonthQuery: &ActiveCloudUsersLastMonthQuery
       {"$project": {"value": "$__alias_0", "target": "$__alias_1", "_id": 0}},
       {"$limit": 5000}
     ]
-  allowDiskUse: true
   cursor: {batchSize: 5000}
 
 VersionsHistogramQuery: &VersionsHistogramQuery
@@ -81,7 +79,6 @@ VersionsHistogramQuery: &VersionsHistogramQuery
       {"$project": {"x": "$__alias_0", "y": "$__alias_2", "color": "$__alias_1", "_id": 0}},
       {"$limit": 50000}
     ]
-  allowDiskUse: true
   cursor: {batchSize: 50000}
 
 UniqueUsersPerMonthQuery: &UniqueUsersPerMonthQuery
@@ -134,7 +131,6 @@ UniqueUsersPerMonthQuery: &UniqueUsersPerMonthQuery
       {"$sort": {"x.year": 1, "x.month": 1}},
       {"$limit": 5000}
     ]
-  allowDiskUse: true
   cursor: {batchSize: 5000}
 
 TopErrorsQuery: &TopErrorsQuery
@@ -182,7 +178,6 @@ TopErrorsQuery: &TopErrorsQuery
       },
       {"$limit": 50000}
     ]
-  allowDiskUse: true
   cursor: {batchSize: 50000}
 
 NumberOfChartsPerTypeQuery: &NumberOfChartsPerTypeQuery
@@ -202,7 +197,6 @@ NumberOfChartsPerTypeQuery: &NumberOfChartsPerTypeQuery
       {"$project": {"x": "$__alias_1", "y": "$__alias_0", "_id": 0}},
       {"$limit": 5000}
     ]
-  allowDiskUse: true
   cursor: {batchSize: 5000}
 
 EventsByVersionQuery: &EventsByVersionQuery
@@ -246,7 +240,6 @@ EventsByVersionQuery: &EventsByVersionQuery
       {"$sort": {"x.year": 1, "x.month": 1, "x.date": 1, "x.hours": 1}},
       {"$limit": 5000}
     ]
-  allowDiskUse: true
   cursor: {batchSize: 5000}
 
 BrowserUsageByDistinctUserQuery: &BrowserUsageByDistinctUserQuery
@@ -281,7 +274,6 @@ BrowserUsageByDistinctUserQuery: &BrowserUsageByDistinctUserQuery
       {"$project": {"label": "$__alias_0", "value": "$__alias_1", "_id": 0}},
       {"$limit": 5000}
     ]
-  allowDiskUse: true
   cursor: {batchSize: 5000}
 
 TopTenantsByNoOfEventsQuery: &TopTenantsByNoOfEventsQuery
@@ -310,7 +302,6 @@ TopTenantsByNoOfEventsQuery: &TopTenantsByNoOfEventsQuery
       {"$project": {"color": "$__alias_0", "x": "$__alias_2", "y": "$__alias_1", "_id": 0}},
       {"$limit": 50000}
     ]
-  allowDiskUse: true
   cursor: {batchSize: 50000}
 
 # Defines test operations.

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -20,33 +20,12 @@ Database: &db charts-metrics
 # Defines the collection name.
 Collection: &Collection events
 
-DateFieldProjectionQuery: &DateFieldProjectionQuery
-  aggregate: *Collection
-  pipeline:
-    [{"$project": {"_id": 0, "created_at": 1}}]
-  allowDiskUse: true
-  cursor: {batchSize: 2000}
-
-DistinctStringFieldProjectionQuery: &DistinctStringFieldProjectionQuery
-  aggregate: *Collection
-  pipeline:
-    [{"$project": {"_id": 0, "metadata.tenant_id": 1}}]
-  allowDiskUse: true
-  cursor: {batchSize: 2000}
-
-DuplicatedStringFieldProjectionQuery: &DuplicatedStringFieldProjectionQuery
-  aggregate: *Collection
-  pipeline:
-    [{"$project": {"_id": 0, "action": 1}}]
-  allowDiskUse: true
-  cursor: {batchSize: 2000}
-
 CountPerActionQuery: &CountPerActionQuery
   aggregate: *Collection
   pipeline:
-    [{"$group": {"_id": "$action", o: {$sum: 1}}}]
+          [{"$group": {"_id": "$action", o: {$sum: 1}}}, {"$limit": 5000}]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
+  cursor: {batchSize: 5000}
 
 TotalTenantCreatedQuery: &TotalTenantCreatedQuery
   aggregate: *Collection
@@ -59,7 +38,7 @@ TotalTenantCreatedQuery: &TotalTenantCreatedQuery
       {"$limit": 5000}
     ]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
+  cursor: {batchSize: 5000}
 
 ActiveCloudUsersLastMonthQuery: &ActiveCloudUsersLastMonthQuery
   aggregate: *Collection
@@ -79,7 +58,7 @@ ActiveCloudUsersLastMonthQuery: &ActiveCloudUsersLastMonthQuery
       {"$limit": 5000}
     ]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
+  cursor: {batchSize: 5000}
 
 VersionsHistogramQuery: &VersionsHistogramQuery
   aggregate: *Collection
@@ -104,7 +83,7 @@ VersionsHistogramQuery: &VersionsHistogramQuery
       {"$limit": 50000}
     ]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
+  cursor: {batchSize: 50000}
 
 UniqueUsersPerMonthQuery: &UniqueUsersPerMonthQuery
   aggregate: *Collection
@@ -157,7 +136,7 @@ UniqueUsersPerMonthQuery: &UniqueUsersPerMonthQuery
       {"$limit": 5000}
     ]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
+  cursor: {batchSize: 5000}
 
 TopErrorsQuery: &TopErrorsQuery
   aggregate: *Collection
@@ -205,7 +184,7 @@ TopErrorsQuery: &TopErrorsQuery
       {"$limit": 50000}
     ]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
+  cursor: {batchSize: 50000}
 
 NumberOfChartsPerTypeQuery: &NumberOfChartsPerTypeQuery
   aggregate: *Collection
@@ -225,7 +204,7 @@ NumberOfChartsPerTypeQuery: &NumberOfChartsPerTypeQuery
       {"$limit": 5000}
     ]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
+  cursor: {batchSize: 5000}
 
 EventsByVersionQuery: &EventsByVersionQuery
   aggregate: *Collection
@@ -269,7 +248,7 @@ EventsByVersionQuery: &EventsByVersionQuery
       {"$limit": 5000}
     ]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
+  cursor: {batchSize: 5000}
 
 BrowserUsageByDistinctUserQuery: &BrowserUsageByDistinctUserQuery
   aggregate: *Collection
@@ -304,7 +283,7 @@ BrowserUsageByDistinctUserQuery: &BrowserUsageByDistinctUserQuery
       {"$limit": 5000}
     ]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
+  cursor: {batchSize: 5000}
 
 TopTenantsByNoOfEventsQuery: &TopTenantsByNoOfEventsQuery
   aggregate: *Collection
@@ -333,20 +312,10 @@ TopTenantsByNoOfEventsQuery: &TopTenantsByNoOfEventsQuery
       {"$limit": 50000}
     ]
   allowDiskUse: true
-  cursor: {batchSize: 2000}
-
+  cursor: {batchSize: 50000}
 
 # Defines test operations.
 TestOperations: &TestOperations
-- OperationMetricsName: DateFieldProjectionQuery
-  OperationName: RunCommand
-  OperationCommand: *DateFieldProjectionQuery
-- OperationMetricsName: DistinctStringFieldProjectionQuery
-  OperationName: RunCommand
-  OperationCommand: *DistinctStringFieldProjectionQuery
-- OperationMetricsName: DuplicatedStringFieldProjectionQuery
-  OperationName: RunCommand
-  OperationCommand: *DuplicatedStringFieldProjectionQuery
 - OperationMetricsName: CountPerActionQuery
   OperationName: RunCommand
   OperationCommand: *CountPerActionQuery

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -1,14 +1,14 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query-execution"
 Description: |
-  This workload measures $lookup performance for scenarios that look up local integer key against
+  This workload compares the query performance with columnar indexes to performances without them.
 
   The workload consists of the following phases and actors:
     0. Warm up cache.
-    1. Run queries without columnstore indexes.
-    2. Create columnstore indexes.
-    3. Warm up cache again for columnstore indexes.
-    4. Run queries with columnstore indexes.
+    1. Run queries with columnstore indexes.
+    2. Drop columnstore indexes.
+    3. Warm up cache again for regular scans.
+    4. Run queries without columnstore indexes.
 
 Keywords:
 - columnstore
@@ -353,30 +353,30 @@ TestOperations: &TestOperations
 - OperationMetricsName: TotalTenantCreatedQuery
   OperationName: RunCommand
   OperationCommand: *TotalTenantCreatedQuery
-# - OperationMetricsName: ActiveCloudUsersLastMonthQuery
-#   OperationName: RunCommand
-#   OperationCommand: *ActiveCloudUsersLastMonthQuery
-# - OperationMetricsName: VersionsHistogramQuery
-#   OperationName: RunCommand
-#   OperationCommand: *VersionsHistogramQuery
-# - OperationMetricsName: UniqueUsersPerMonthQuery
-#   OperationName: RunCommand
-#   OperationCommand: *UniqueUsersPerMonthQuery
-# - OperationMetricsName: TopErrorsQuery
-#   OperationName: RunCommand
-#   OperationCommand: *TopErrorsQuery
-# - OperationMetricsName: NumberOfChartsPerTypeQuery
-#   OperationName: RunCommand
-#   OperationCommand: *NumberOfChartsPerTypeQuery
-# - OperationMetricsName: EventsByVersionQuery
-#   OperationName: RunCommand
-#   OperationCommand: *EventsByVersionQuery
-# - OperationMetricsName: BrowserUsageByDistinctUserQuery
-#   OperationName: RunCommand
-#   OperationCommand: *BrowserUsageByDistinctUserQuery
-# - OperationMetricsName: TopTenantsByNoOfEventsQuery
-#   OperationName: RunCommand
-#   OperationCommand: *TopTenantsByNoOfEventsQuery
+- OperationMetricsName: ActiveCloudUsersLastMonthQuery
+  OperationName: RunCommand
+  OperationCommand: *ActiveCloudUsersLastMonthQuery
+- OperationMetricsName: VersionsHistogramQuery
+  OperationName: RunCommand
+  OperationCommand: *VersionsHistogramQuery
+- OperationMetricsName: UniqueUsersPerMonthQuery
+  OperationName: RunCommand
+  OperationCommand: *UniqueUsersPerMonthQuery
+- OperationMetricsName: TopErrorsQuery
+  OperationName: RunCommand
+  OperationCommand: *TopErrorsQuery
+- OperationMetricsName: NumberOfChartsPerTypeQuery
+  OperationName: RunCommand
+  OperationCommand: *NumberOfChartsPerTypeQuery
+- OperationMetricsName: EventsByVersionQuery
+  OperationName: RunCommand
+  OperationCommand: *EventsByVersionQuery
+- OperationMetricsName: BrowserUsageByDistinctUserQuery
+  OperationName: RunCommand
+  OperationCommand: *BrowserUsageByDistinctUserQuery
+- OperationMetricsName: TopTenantsByNoOfEventsQuery
+  OperationName: RunCommand
+  OperationCommand: *TopTenantsByNoOfEventsQuery
 
 # Defines how many times each test operation is executed.
 TestRepeatCount: &TestRepeatCount 10
@@ -395,7 +395,7 @@ Actors:
   - Phase: 1..4
     Nop: true
 
-# The 'CollScan' actor measures the perf without columnar indexes.
+# The 'ColumnstoreScan' actor measures the perf with columnar indexes.
 - Name: ColumnstoreScan
   Type: RunCommand
   Database: *db
@@ -407,7 +407,7 @@ Actors:
   - Phase: 2..4
     Nop: true
 
-# The 'CreateColumnstoreIndexes' actor create columnstore indexes.
+# The 'DropColumnstoreIndexes' actor drops columnstore indexes.
 - Name: DropColumnstoreIndex
   Type: RunCommand
   Database: *db
@@ -425,7 +425,7 @@ Actors:
   - *Nop
   - *Nop
 
-# The 'WarmupCache2' actor warms up the buffer cache for columnar indexes.
+# The 'WarmupCache2' actor warms up the buffer cache for a regular scan.
 - Name: WarmupCache2
   Type: RunCommand
   Database: *db
@@ -439,7 +439,7 @@ Actors:
     Operations: *TestOperations
   - *Nop
 
-# The 'ColumnstoreScan' actor measures the perf with columnar indexes.
+# The 'CollScan' actor measures the perf without columnar indexes.
 - Name: CollScan
   Type: RunCommand
   Database: *db

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -1,0 +1,420 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query-execution"
+Description: |
+  This workload measures $lookup performance for scenarios that look up local integer key against
+
+  The workload consists of the following phases and actors:
+    0. Warm up cache.
+    1. Run queries without columnstore indexes.
+    2. Create columnstore indexes.
+    3. Warm up cache again for columnstore indexes.
+    4. Run queries with columnstore indexes.
+
+Keywords:
+- columnstore
+- analytics
+
+# Defines the database name.
+Database: &db charts-metrics
+
+# Defines the collection name.
+Collection: &Collection events
+
+TotalTenantCreatedQuery: &TotalTenantCreatedQuery
+  aggregate: *Collection
+  pipeline:
+    [
+      {"$match": {"metadata.target": "cloud"}},
+      {"$group": {"_id": {}, "__alias_0": {"$addToSet": "$metadata.tenant_id"}}},
+      {"$project": {"_id": 0, "__alias_0": {"$size": "$__alias_0"}}},
+      {"$project": {"value": "$__alias_0", "_id": 0}},
+      {"$limit": 5000}
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+ActiveCloudUsersLastMonthQuery: &ActiveCloudUsersLastMonthQuery
+  aggregate: *Collection
+  pipeline:
+    [
+      {"$addFields": {"target": 3000}},
+      {
+        "$match": {
+          "metadata.target": {"$in": ["cloud"]},
+          "created_at": {"$gte": {"$date": "2020-03-09T01:10:04Z"}},
+          "resource": {"$in": ["Dashboard"]}
+        }
+      },
+      {"$group": {"_id": {}, "__alias_0": {"$addToSet": "$user_id"}, "__alias_1": {"$min": "$target"}}},
+      {"$project": {"_id": 0, "__alias_0": {"$size": "$__alias_0"}, "__alias_1": 1}},
+      {"$project": {"value": "$__alias_0", "target": "$__alias_1", "_id": 0}},
+      {"$limit": 5000}
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+VersionsHistogramQuery: &VersionsHistogramQuery
+  aggregate: *Collection
+  pipeline:
+    [
+      {"$match": {"metadata.target": {"$exists": true}}},
+      {
+        "$match": {
+          "created_at": {"$gte": {"$date": "2020-04-02T01:10:52Z"}},
+          "metadata.version": {"$nin": [null]},
+          "resource": {"$nin": ["Error"]}
+        }
+      },
+      {
+        "$group": {
+          "_id": {"__alias_0": "$metadata.version", "__alias_1": "$metadata.target"},
+          "__alias_2": {"$sum": 1}
+        }
+      },
+      {"$project": {"_id": 0, "__alias_0": "$_id.__alias_0", "__alias_1": "$_id.__alias_1", "__alias_2": 1}},
+      {"$project": {"x": "$__alias_0", "y": "$__alias_2", "color": "$__alias_1", "_id": 0}},
+      {"$limit": 50000}
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+UniqueUsersPerMonthQuery: &UniqueUsersPerMonthQuery
+  aggregate: *Collection
+  pipeline:
+    [
+      {
+        "$match": {
+          "resource": {"$in": ["Dashboard"]},
+          "created_at": {"$gte": {"$date": "2019-07-09T01:12:32Z"}},
+          "metadata.target": {"$nin": [null, ""]}
+        }
+      },
+      {
+        "$addFields": {
+          "created_at": {
+            "$cond": {
+              "if": {"$eq": [{"$type": "$created_at"}, "date"]},
+              "then": "$created_at",
+              "else": null
+            }
+          }
+        }
+      },
+      {
+        "$addFields": {
+          "__alias_0": {
+            "year": {"$year": "$created_at"},
+            "month": {"$subtract": [{"$month": "$created_at"}, 1]}
+          }
+        }
+      },
+      {
+        "$group": {
+          "_id": {"__alias_0": "$__alias_0", "__alias_1": "$metadata.target"},
+          "__alias_2": {"$addToSet": "$user_id"}
+        }
+      },
+      {
+        "$project": {
+          "_id": 0,
+          "__alias_0": "$_id.__alias_0",
+          "__alias_1": "$_id.__alias_1",
+          "__alias_2": {
+            "$size": "$__alias_2"
+          }
+        }
+      },
+      {"$project": {"x": "$__alias_0", "y": "$__alias_2", "color": "$__alias_1", "_id": 0}},
+      {"$sort": {"x.year": 1, "x.month": 1}},
+      {"$limit": 5000}
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+TopErrorsQuery: &TopErrorsQuery
+  aggregate: *Collection
+  pipeline:
+    [
+      {
+        "$match": {
+          "created_at": {"$gte": {"$date": "2020-04-02T01:13:04Z"}},
+          "resource": {"$in": ["Error"]}
+        }
+      },
+      {
+        "$group": {
+          "_id": {
+            "__alias_0": "$metadata.message",
+            "__alias_1": "$metadata.name",
+            "__alias_2": "$metadata.version"
+          },
+          "__alias_3": {"$sum": 1},
+          "__alias_4": {"$addToSet": "$stitch_user_id"}
+        }
+      },
+      {
+        "$project": {
+          "_id": 0,
+          "__alias_0": "$_id.__alias_0",
+          "__alias_1": "$_id.__alias_1",
+          "__alias_2": "$_id.__alias_2",
+          "__alias_3": 1,
+          "__alias_4": {
+            "$size": "$__alias_4"
+          }
+        }
+      },
+      {
+        "$project": {
+          "group": "$__alias_0",
+          "value": "$__alias_3",
+          "group_series_0": "$__alias_1",
+          "group_series_1": "$__alias_2",
+          "value_series_0": "$__alias_4",
+          "_id": 0
+        }
+      },
+      {"$limit": 50000}
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+NumberOfChartsPerTypeQuery: &NumberOfChartsPerTypeQuery
+  aggregate: *Collection
+  pipeline:
+    [
+      {
+        "$match": {
+          "resource": {"$in": ["DashboardItem"]},
+          "action": {"$in": ["added"]},
+          "metadata.version": {"$nin": [null, "0.0.0"]},
+          "created_at": {"$gte": {"$date": "2020-01-09T01:13:37Z"}}
+        }
+      },
+      {"$group": {"_id": {"__alias_0": "$metadata.chart_type"}, "__alias_1": {"$sum": 1}}},
+      {"$project": {"_id": 0, "__alias_0": "$_id.__alias_0", "__alias_1": 1}},
+      {"$project": {"x": "$__alias_1", "y": "$__alias_0", "_id": 0}},
+      {"$limit": 5000}
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+EventsByVersionQuery: &EventsByVersionQuery
+  aggregate: *Collection
+  pipeline:
+    [
+      {
+        "$match": {
+          "created_at": {
+            "$gte": {"$date": "2020-04-08T01:14:07Z"}, "$lte": { "$date": "2020-04-09T01:14:07Z"}
+          },
+          "resource": {"$nin": []},
+          "metadata.version": {"$nin": [null]}
+        }
+      },
+      {
+        "$addFields": {
+          "created_at": {
+            "$cond": {"if": {"$eq": [{"$type": "$created_at"}, "date"]}, "then": "$created_at", "else": null}
+          }
+        }
+      },
+      {
+        "$addFields": {
+          "__alias_0": {
+            "year": {"$year": {"date": "$created_at", "timezone": "Australia/Sydney"}},
+            "month": {"$subtract": [{"$month": {"date": "$created_at", "timezone": "Australia/Sydney"}}, 1]},
+            "date": {"$dayOfMonth": {"date": "$created_at", "timezone": "Australia/Sydney"}},
+            "hours": {"$hour": {"date": "$created_at", "timezone": "Australia/Sydney"}}
+          }
+        }
+      },
+      {
+        "$group": {
+          "_id": {"__alias_0": "$__alias_0", "__alias_1": "$metadata.version"},
+          "__alias_2": {"$sum": 1}
+        }
+      },
+      {"$project": {"_id": 0, "__alias_0": "$_id.__alias_0", "__alias_1": "$_id.__alias_1", "__alias_2": 1}},
+      {"$project": {"x": "$__alias_0", "y": "$__alias_2", "color": "$__alias_1", "_id": 0}},
+      {"$sort": {"x.year": 1, "x.month": 1, "x.date": 1, "x.hours": 1}},
+      {"$limit": 5000}
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+BrowserUsageByDistinctUserQuery: &BrowserUsageByDistinctUserQuery
+  aggregate: *Collection
+  pipeline:
+    [
+      {"$match": {"metadata.browser": {"$exists": true}}},
+      {
+        "$addFields": {
+          "metadata.browser_name": {
+            "$arrayElemAt": [{"$split": ["$metadata.browser", " "]}, 0]
+          }
+        }
+      },
+      {
+        "$match": {
+          "metadata.browser_name": {"$nin": [null, "", "null"]},
+          "created_at": {"$gte": {"$date": "2020-03-10T01:17:41Z"}}
+        }
+      },
+      {
+        "$group": {
+          "_id": {"__alias_0": "$metadata.browser_name"},
+          "__alias_1": {"$addToSet": "$user_id"}
+        }
+      },
+      {
+        "$project": {
+          "_id": 0, "__alias_0": "$_id.__alias_0", "__alias_1": { "$size": "$__alias_1"}
+        }
+      },
+      {"$project": {"label": "$__alias_0", "value": "$__alias_1", "_id": 0}},
+      {"$limit": 5000}
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+TopTenantsByNoOfEventsQuery: &TopTenantsByNoOfEventsQuery
+  aggregate: *Collection
+  pipeline:
+    [
+      {
+        "$match": {
+          "created_at": {"$gte": {"$date": "2020-03-09T01:18:32Z"}},
+          "resource": {"$nin": ["DashboardItem", "EmbeddedChart", "Error"]},
+          "metadata.target": {"$nin": [null]},
+          "metadata.tenant_id": {"$nin": [null]}
+        }
+      },
+      {
+        "$group": {
+          "_id": {"__alias_0": "$metadata.target", "__alias_1": "$metadata.tenant_id"},
+          "__alias_2": {"$sum": 1}
+        }
+      },
+      {
+        "$project": {
+          "_id": 0, "__alias_0": "$_id.__alias_0", "__alias_1": "$_id.__alias_1", "__alias_2": 1
+        }
+      },
+      {"$project": {"color": "$__alias_0", "x": "$__alias_2", "y": "$__alias_1", "_id": 0}},
+      {"$limit": 50000}
+    ]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+
+# Defines test operations.
+TestOperations: &TestOperations
+- OperationMetricsName: TotalTenantCreatedQuery
+  OperationName: RunCommand
+  OperationCommand: *TotalTenantCreatedQuery
+- OperationMetricsName: ActiveCloudUsersLastMonthQuery
+  OperationName: RunCommand
+  OperationCommand: *ActiveCloudUsersLastMonthQuery
+- OperationMetricsName: VersionsHistogramQuery
+  OperationName: RunCommand
+  OperationCommand: *VersionsHistogramQuery
+- OperationMetricsName: UniqueUsersPerMonthQuery
+  OperationName: RunCommand
+  OperationCommand: *UniqueUsersPerMonthQuery
+- OperationMetricsName: TopErrorsQuery
+  OperationName: RunCommand
+  OperationCommand: *TopErrorsQuery
+- OperationMetricsName: NumberOfChartsPerTypeQuery
+  OperationName: RunCommand
+  OperationCommand: *NumberOfChartsPerTypeQuery
+- OperationMetricsName: EventsByVersionQuery
+  OperationName: RunCommand
+  OperationCommand: *EventsByVersionQuery
+- OperationMetricsName: BrowserUsageByDistinctUserQuery
+  OperationName: RunCommand
+  OperationCommand: *BrowserUsageByDistinctUserQuery
+- OperationMetricsName: TopTenantsByNoOfEventsQuery
+  OperationName: RunCommand
+  OperationCommand: *TopTenantsByNoOfEventsQuery
+
+# Defines how many times each test operation is executed.
+TestRepeatCount: &TestRepeatCount 1
+
+Actors:
+# The 'WarmupCache1' actor warms up the buffer cache.
+- Name: WarmupCache1
+  Type: RunCommand
+  Database: *db
+  Thread: 1
+  Phases:
+  - Repeat: 1
+    Threads: 1
+    Database: *db
+    Operations: *TestOperations
+  - Phase: 1..4
+    Nop: true
+
+# The 'CollScan' actor measures the perf without columnar indexes.
+- Name: CollScan
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - &Nop {Nop: true}
+  - Repeat: *TestRepeatCount
+    Database: *db
+    Operations: *TestOperations
+  - Phase: 2..4
+    Nop: true
+
+# The 'CreateColumnstoreIndexes' actor create columnstore indexes.
+- Name: CreateColumnstoreIndexes
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+# The 'WarmupCache2' actor warms up the buffer cache for columnar indexes.
+- Name: WarmupCache2
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Threads: 1
+    Database: *db
+    Operations: *TestOperations
+  - *Nop
+
+# The 'ColumnstoreScan' actor measures the perf with columnar indexes.
+- Name: ColumnstoreScan
+  Type: RunCommand
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: *TestRepeatCount
+    Database: *db
+    Operations: *TestOperations
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone-all-feature-flags
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0
+      - v5.3
+      - v6.0

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -313,30 +313,30 @@ TestOperations: &TestOperations
 - OperationMetricsName: TotalTenantCreatedQuery
   OperationName: RunCommand
   OperationCommand: *TotalTenantCreatedQuery
-- OperationMetricsName: ActiveCloudUsersLastMonthQuery
-  OperationName: RunCommand
-  OperationCommand: *ActiveCloudUsersLastMonthQuery
-- OperationMetricsName: VersionsHistogramQuery
-  OperationName: RunCommand
-  OperationCommand: *VersionsHistogramQuery
-- OperationMetricsName: UniqueUsersPerMonthQuery
-  OperationName: RunCommand
-  OperationCommand: *UniqueUsersPerMonthQuery
-- OperationMetricsName: TopErrorsQuery
-  OperationName: RunCommand
-  OperationCommand: *TopErrorsQuery
-- OperationMetricsName: NumberOfChartsPerTypeQuery
-  OperationName: RunCommand
-  OperationCommand: *NumberOfChartsPerTypeQuery
-- OperationMetricsName: EventsByVersionQuery
-  OperationName: RunCommand
-  OperationCommand: *EventsByVersionQuery
-- OperationMetricsName: BrowserUsageByDistinctUserQuery
-  OperationName: RunCommand
-  OperationCommand: *BrowserUsageByDistinctUserQuery
-- OperationMetricsName: TopTenantsByNoOfEventsQuery
-  OperationName: RunCommand
-  OperationCommand: *TopTenantsByNoOfEventsQuery
+# - OperationMetricsName: ActiveCloudUsersLastMonthQuery
+#   OperationName: RunCommand
+#   OperationCommand: *ActiveCloudUsersLastMonthQuery
+# - OperationMetricsName: VersionsHistogramQuery
+#   OperationName: RunCommand
+#   OperationCommand: *VersionsHistogramQuery
+# - OperationMetricsName: UniqueUsersPerMonthQuery
+#   OperationName: RunCommand
+#   OperationCommand: *UniqueUsersPerMonthQuery
+# - OperationMetricsName: TopErrorsQuery
+#   OperationName: RunCommand
+#   OperationCommand: *TopErrorsQuery
+# - OperationMetricsName: NumberOfChartsPerTypeQuery
+#   OperationName: RunCommand
+#   OperationCommand: *NumberOfChartsPerTypeQuery
+# - OperationMetricsName: EventsByVersionQuery
+#   OperationName: RunCommand
+#   OperationCommand: *EventsByVersionQuery
+# - OperationMetricsName: BrowserUsageByDistinctUserQuery
+#   OperationName: RunCommand
+#   OperationCommand: *BrowserUsageByDistinctUserQuery
+# - OperationMetricsName: TopTenantsByNoOfEventsQuery
+#   OperationName: RunCommand
+#   OperationCommand: *TopTenantsByNoOfEventsQuery
 
 # Defines how many times each test operation is executed.
 TestRepeatCount: &TestRepeatCount 1
@@ -356,7 +356,7 @@ Actors:
     Nop: true
 
 # The 'CollScan' actor measures the perf without columnar indexes.
-- Name: CollScan
+- Name: ColumnstoreScan
   Type: RunCommand
   Database: *db
   Phases:
@@ -368,13 +368,20 @@ Actors:
     Nop: true
 
 # The 'CreateColumnstoreIndexes' actor create columnstore indexes.
-- Name: CreateColumnstoreIndexes
+- Name: DropColumnstoreIndex
   Type: RunCommand
   Database: *db
   Phases:
   - *Nop
   - *Nop
-  - *Nop
+  - Repeat: 1
+    Threads: 1
+    Database: *db
+    Operations:
+      - OperationName: RunCommand
+        OperationCommand:
+          dropIndexes: *Collection
+          index: $**_columnstore
   - *Nop
   - *Nop
 
@@ -393,7 +400,7 @@ Actors:
   - *Nop
 
 # The 'ColumnstoreScan' actor measures the perf with columnar indexes.
-- Name: ColumnstoreScan
+- Name: CollScan
   Type: RunCommand
   Database: *db
   Phases:

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -20,6 +20,34 @@ Database: &db charts-metrics
 # Defines the collection name.
 Collection: &Collection events
 
+DateFieldProjectionQuery: &DateFieldProjectionQuery
+  aggregate: *Collection
+  pipeline:
+    [{"$project": {"_id": 0, "created_at": 1}}]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+DistinctStringFieldProjectionQuery: &DistinctStringFieldProjectionQuery
+  aggregate: *Collection
+  pipeline:
+    [{"$project": {"_id": 0, "metadata.tenant_id": 1}}]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+DuplicatedStringFieldProjectionQuery: &DuplicatedStringFieldProjectionQuery
+  aggregate: *Collection
+  pipeline:
+    [{"$project": {"_id": 0, "action": 1}}]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
+CountPerActionQuery: &CountPerActionQuery
+  aggregate: *Collection
+  pipeline:
+    [{"$group": {"_id": "$action", o: {$sum: 1}}}]
+  allowDiskUse: true
+  cursor: {batchSize: 2000}
+
 TotalTenantCreatedQuery: &TotalTenantCreatedQuery
   aggregate: *Collection
   pipeline:
@@ -310,6 +338,18 @@ TopTenantsByNoOfEventsQuery: &TopTenantsByNoOfEventsQuery
 
 # Defines test operations.
 TestOperations: &TestOperations
+- OperationMetricsName: DateFieldProjectionQuery
+  OperationName: RunCommand
+  OperationCommand: *DateFieldProjectionQuery
+- OperationMetricsName: DistinctStringFieldProjectionQuery
+  OperationName: RunCommand
+  OperationCommand: *DistinctStringFieldProjectionQuery
+- OperationMetricsName: DuplicatedStringFieldProjectionQuery
+  OperationName: RunCommand
+  OperationCommand: *DuplicatedStringFieldProjectionQuery
+- OperationMetricsName: CountPerActionQuery
+  OperationName: RunCommand
+  OperationCommand: *CountPerActionQuery
 - OperationMetricsName: TotalTenantCreatedQuery
   OperationName: RunCommand
   OperationCommand: *TotalTenantCreatedQuery
@@ -339,7 +379,7 @@ TestOperations: &TestOperations
 #   OperationCommand: *TopTenantsByNoOfEventsQuery
 
 # Defines how many times each test operation is executed.
-TestRepeatCount: &TestRepeatCount 1
+TestRepeatCount: &TestRepeatCount 10
 
 Actors:
 # The 'WarmupCache1' actor warms up the buffer cache.

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -381,9 +381,32 @@ TestOperations: &TestOperations
 # Defines how many times each test operation is executed.
 TestRepeatCount: &TestRepeatCount 1
 
-MaxPhases: &MaxPhses 4
+SetupPhase: &SetupPhase 0
+WarmupCache1Phase: &WarmupCache1Phase 1
+ColumnstoreScanPhase: &ColumnstoreScanPhase 2
+DropColumnstoreIndexPhase: &DropColumnstoreIndexPhase 3
+WarmupCache2Phase: &WarmupCache2Phase 4
+CollScanPhase: &CollScanPhase 5
+MaxPhases: &MaxPhses 5
 
 Actors:
+- Name: Setup
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [*SetupPhase]
+      NopInPhasesUpTo: *MaxPhses
+      PhaseConfig:
+        Repeat: 1
+        Thread: 1
+        Database: admin
+        Operations:
+          OperationName: AdminCommand
+          OperationCommand:
+            setParameter: 1
+            internalQueryForceClassicEngine: false
+
 # The 'WarmupCache1' actor warms up the buffer cache.
 - Name: WarmupCache1
   Type: RunCommand
@@ -391,7 +414,7 @@ Actors:
   Thread: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [0]
+      Active: [*WarmupCache1Phase]
       NopInPhasesUpTo: *MaxPhses
       PhaseConfig:
         Repeat: 1
@@ -405,7 +428,7 @@ Actors:
   Database: *db
   Phases:
     OnlyActiveInPhases:
-      Active: [1]
+      Active: [*ColumnstoreScanPhase]
       NopInPhasesUpTo: *MaxPhses
       PhaseConfig:
         Repeat: *TestRepeatCount
@@ -418,7 +441,7 @@ Actors:
   Database: *db
   Phases:
     OnlyActiveInPhases:
-      Active: [2]
+      Active: [*DropColumnstoreIndexPhase]
       NopInPhasesUpTo: *MaxPhses
       PhaseConfig:
         Repeat: 1
@@ -436,7 +459,7 @@ Actors:
   Database: *db
   Phases:
     OnlyActiveInPhases:
-      Active: [3]
+      Active: [*WarmupCache2Phase]
       NopInPhasesUpTo: *MaxPhses
       PhaseConfig:
         Repeat: 1
@@ -450,7 +473,7 @@ Actors:
   Database: *db
   Phases:
     OnlyActiveInPhases:
-      Active: [4]
+      Active: [*CollScanPhase]
       NopInPhasesUpTo: *MaxPhses
       PhaseConfig:
         Repeat: *TestRepeatCount

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -22,8 +22,7 @@ Collection: &Collection events
 
 CountPerActionQuery: &CountPerActionQuery
   aggregate: *Collection
-  pipeline:
-          [{"$group": {"_id": "$action", o: {$sum: 1}}}, {"$limit": 5000}]
+  pipeline: [{"$group": {"_id": "$action", o: {$sum: 1}}}, {"$limit": 5000}]
   allowDiskUse: true
   cursor: {batchSize: 5000}
 

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -388,7 +388,7 @@ Actors:
   Database: *db
   Thread: 1
   Phases:
-  - Repeat: 1
+  - Repeat: 2
     Threads: 1
     Database: *db
     Operations: *TestOperations
@@ -433,7 +433,7 @@ Actors:
   - *Nop
   - *Nop
   - *Nop
-  - Repeat: 1
+  - Repeat: 2
     Threads: 1
     Database: *db
     Operations: *TestOperations

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -402,7 +402,7 @@ Actors:
         Thread: 1
         Database: admin
         Operations:
-          OperationName: AdminCommand
+        - OperationName: AdminCommand
           OperationCommand:
             setParameter: 1
             internalQueryForceClassicEngine: false

--- a/src/workloads/execution/ColumnstoreIndexes.yml
+++ b/src/workloads/execution/ColumnstoreIndexes.yml
@@ -69,7 +69,7 @@ ActiveCloudUsersLastMonthQuery: &ActiveCloudUsersLastMonthQuery
       {
         "$match": {
           "metadata.target": {"$in": ["cloud"]},
-          "created_at": {"$gte": {"$date": "2020-03-09T01:10:04Z"}},
+          "created_at": {"$gte": ISODate("2020-03-09T01:10:04Z")},
           "resource": {"$in": ["Dashboard"]}
         }
       },
@@ -88,7 +88,7 @@ VersionsHistogramQuery: &VersionsHistogramQuery
       {"$match": {"metadata.target": {"$exists": true}}},
       {
         "$match": {
-          "created_at": {"$gte": {"$date": "2020-04-02T01:10:52Z"}},
+          "created_at": {"$gte": ISODate("2020-04-02T01:10:52Z")},
           "metadata.version": {"$nin": [null]},
           "resource": {"$nin": ["Error"]}
         }
@@ -113,7 +113,7 @@ UniqueUsersPerMonthQuery: &UniqueUsersPerMonthQuery
       {
         "$match": {
           "resource": {"$in": ["Dashboard"]},
-          "created_at": {"$gte": {"$date": "2019-07-09T01:12:32Z"}},
+          "created_at": {"$gte": ISODate("2019-07-09T01:12:32Z")},
           "metadata.target": {"$nin": [null, ""]}
         }
       },
@@ -165,7 +165,7 @@ TopErrorsQuery: &TopErrorsQuery
     [
       {
         "$match": {
-          "created_at": {"$gte": {"$date": "2020-04-02T01:13:04Z"}},
+          "created_at": {"$gte": ISODate("2020-04-02T01:13:04Z")},
           "resource": {"$in": ["Error"]}
         }
       },
@@ -216,7 +216,7 @@ NumberOfChartsPerTypeQuery: &NumberOfChartsPerTypeQuery
           "resource": {"$in": ["DashboardItem"]},
           "action": {"$in": ["added"]},
           "metadata.version": {"$nin": [null, "0.0.0"]},
-          "created_at": {"$gte": {"$date": "2020-01-09T01:13:37Z"}}
+          "created_at": {"$gte": ISODate("2020-01-09T01:13:37Z")}
         }
       },
       {"$group": {"_id": {"__alias_0": "$metadata.chart_type"}, "__alias_1": {"$sum": 1}}},
@@ -234,7 +234,7 @@ EventsByVersionQuery: &EventsByVersionQuery
       {
         "$match": {
           "created_at": {
-            "$gte": {"$date": "2020-04-08T01:14:07Z"}, "$lte": { "$date": "2020-04-09T01:14:07Z"}
+            "$gte": ISODate("2020-04-08T01:14:07Z"), "$lte": ISODate("2020-04-09T01:14:07Z")
           },
           "resource": {"$nin": []},
           "metadata.version": {"$nin": [null]}
@@ -286,7 +286,7 @@ BrowserUsageByDistinctUserQuery: &BrowserUsageByDistinctUserQuery
       {
         "$match": {
           "metadata.browser_name": {"$nin": [null, "", "null"]},
-          "created_at": {"$gte": {"$date": "2020-03-10T01:17:41Z"}}
+          "created_at": {"$gte": ISODate("2020-03-10T01:17:41Z")}
         }
       },
       {
@@ -312,7 +312,7 @@ TopTenantsByNoOfEventsQuery: &TopTenantsByNoOfEventsQuery
     [
       {
         "$match": {
-          "created_at": {"$gte": {"$date": "2020-03-09T01:18:32Z"}},
+          "created_at": {"$gte": ISODate("2020-03-09T01:18:32Z")},
           "resource": {"$nin": ["DashboardItem", "EmbeddedChart", "Error"]},
           "metadata.target": {"$nin": [null]},
           "metadata.tenant_id": {"$nin": [null]}
@@ -379,7 +379,9 @@ TestOperations: &TestOperations
   OperationCommand: *TopTenantsByNoOfEventsQuery
 
 # Defines how many times each test operation is executed.
-TestRepeatCount: &TestRepeatCount 10
+TestRepeatCount: &TestRepeatCount 1
+
+MaxPhases: &MaxPhses 4
 
 Actors:
 # The 'WarmupCache1' actor warms up the buffer cache.
@@ -388,69 +390,72 @@ Actors:
   Database: *db
   Thread: 1
   Phases:
-  - Repeat: 2
-    Threads: 1
-    Database: *db
-    Operations: *TestOperations
-  - Phase: 1..4
-    Nop: true
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhses
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Database: *db
+        Operations: *TestOperations
 
 # The 'ColumnstoreScan' actor measures the perf with columnar indexes.
 - Name: ColumnstoreScan
   Type: RunCommand
   Database: *db
   Phases:
-  - &Nop {Nop: true}
-  - Repeat: *TestRepeatCount
-    Database: *db
-    Operations: *TestOperations
-  - Phase: 2..4
-    Nop: true
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhses
+      PhaseConfig:
+        Repeat: *TestRepeatCount
+        Database: *db
+        Operations: *TestOperations
 
 # The 'DropColumnstoreIndexes' actor drops columnstore indexes.
 - Name: DropColumnstoreIndex
   Type: RunCommand
   Database: *db
   Phases:
-  - *Nop
-  - *Nop
-  - Repeat: 1
-    Threads: 1
-    Database: *db
-    Operations:
-      - OperationName: RunCommand
-        OperationCommand:
-          dropIndexes: *Collection
-          index: $**_columnstore
-  - *Nop
-  - *Nop
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhses
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Database: *db
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            dropIndexes: *Collection
+            index: $**_columnstore
 
 # The 'WarmupCache2' actor warms up the buffer cache for a regular scan.
 - Name: WarmupCache2
   Type: RunCommand
   Database: *db
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - Repeat: 2
-    Threads: 1
-    Database: *db
-    Operations: *TestOperations
-  - *Nop
+    OnlyActiveInPhases:
+      Active: [3]
+      NopInPhasesUpTo: *MaxPhses
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Database: *db
+        Operations: *TestOperations
 
 # The 'CollScan' actor measures the perf without columnar indexes.
 - Name: CollScan
   Type: RunCommand
   Database: *db
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - Repeat: *TestRepeatCount
-    Database: *db
-    Operations: *TestOperations
+    OnlyActiveInPhases:
+      Active: [4]
+      NopInPhasesUpTo: *MaxPhses
+      PhaseConfig:
+        Repeat: *TestRepeatCount
+        Database: *db
+        Operations: *TestOperations
 
 AutoRun:
 - When:


### PR DESCRIPTION
This PR is to add a query workload for columnar indexes and a companion PR with other PRs which have been submitted separately.
- system_perf.yml changes: https://github.com/10gen/mongo/pull/5229
- DSI test_control: https://github.com/10gen/dsi/pull/1053

@jimoleary,
Decided to not measure either cold cache or warm cache scenarios but just measure hot cache scenarios after discussion with the team.

As of now, all queries in the workload can leverage columnar indexes except `TopErrorsQuery` which uses a regular scan even though there is a columnar index.

Evergreen patch build:
https://spruce.mongodb.com/version/627d69980ae6067da38f8de6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC