### PR TITLE
PERF-3040 Create a genny workload for measuring replication overhead

### DIFF
--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -1,0 +1,71 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/server-replication"
+Description: |
+  This workload loads a large number of small documents into a single collection, and then does a
+  small multi-update which touches all of them.  It is intended to measure the impact of the load of
+  replication of many oplog entries on the primary.  Number of documents should be significantly
+  greater than the maximum replication batch size of 5K (50K is a good minimum).
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 1000
+
+Actors:
+- Name: Setup
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: &DB test
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+  - &Nop {Nop: true}
+  - *Nop
+
+- Name: Loader
+  Type: Loader
+  Threads: 10
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *DB
+    CollectionCount: 1
+    Threads: 10
+    DocumentCount: 5e4
+    BatchSize: 1000
+    Document:  # Documents are approximately 100B in size
+      i: 0
+      string0: {^FastRandomString: {length: 100}}
+  - *Nop
+
+- Name: DocumentUpdater
+  Type: CrudActor
+  Threads: 1
+  Database: *DB
+  Phases:
+  - *Nop
+  - *Nop
+  - Duration: 1 minutes
+    MetricsName: Update
+    Collection: Collection0
+    Operations:
+    - OperationName: updateMany
+      OperationCommand:
+        Filter: {}
+        Update: {$inc: {i: 1}}
+        Options:
+          WriteConcern:
+            Level: 1
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - atlas
+      - replica
+      - replica-noflowcontrol
+      - replica-1dayhistory-15gbwtcache
+      - replica-all-feature-flags
+      - single-replica

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -15,6 +15,8 @@ Keywords:
 - CrudActor
 - updateMany
 - update
+- replication
+- oplogSourceOverhead
 
 Clients:
   Default:
@@ -42,7 +44,6 @@ Actors:
   - Repeat: 1
     Database: *DB
     CollectionCount: 1
-    Threads: 10
     MultipleThreadsPerCollection: true
     DocumentCount: 5e4
     BatchSize: 1000
@@ -58,7 +59,7 @@ Actors:
   Phases:
   - *Nop
   - *Nop
-  - Duration: 1 minutes
+  - Duration: 5 minutes
     MetricsName: Update
     Collection: Collection0
     Operations:

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -5,6 +5,16 @@ Description: |
   small multi-update which touches all of them.  It is intended to measure the impact of the load of
   replication of many oplog entries on the primary.  Number of documents should be significantly
   greater than the maximum replication batch size of 5K (50K is a good minimum).
+  We will run this against standalone nodes and single-node replica sets as well as 3-node replica
+  sets to determine if any performance changes are due to replication overhead changes (if only
+  3-node replica sets are affected) or some other reason.
+
+Keywords:
+- RunCommand
+- Loader
+- CrudActor
+- updateMany
+- update
 
 Clients:
   Default:
@@ -33,6 +43,7 @@ Actors:
     Database: *DB
     CollectionCount: 1
     Threads: 10
+    MultipleThreadsPerCollection: true
     DocumentCount: 5e4
     BatchSize: 1000
     Document:  # Documents are approximately 100B in size

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -45,7 +45,7 @@ Actors:
     Database: *DB
     CollectionCount: 1
     MultipleThreadsPerCollection: true
-    DocumentCount: 5e4
+    DocumentCount: 50000
     BatchSize: 1000
     Document:  # Documents are approximately 100B in size
       i: 0

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -69,3 +69,4 @@ AutoRun:
       - replica-1dayhistory-15gbwtcache
       - replica-all-feature-flags
       - single-replica
+      - standalone


### PR DESCRIPTION
This is a workload that just does a simple multi-update on a large number of documents.  This ends up measuring the impact of secondary replication on the primary.

@dalyd 

@mridul-augustine 
