### PR TITLE
PERF-2990 Test time to first batch for BUS

### DIFF
--- a/src/phases/execution/TimeSeriesSortCommands.yml
+++ b/src/phases/execution/TimeSeriesSortCommands.yml
@@ -14,3 +14,8 @@ SortFirstResultCmdTemplate:
   pipeline: [{$sort: {t: 1}}, {$_internalInhibitOptimization: {}}, {$limit: 1}]
   cursor: {batchSize: {^Parameter: {Name: "batchSize", Default: 30000}}}
   allowDiskUse: true
+
+SortFirstBatchCmdTemplate:
+  aggregate: {^Parameter: {Name: "coll", Default: Collection0}}
+  pipeline: [{$sort: {t: 1}}]
+  cursor: {batchSize: {^Parameter: {Name: "batchSize", Default: 30000}}}

--- a/src/workloads/execution/TimeSeriesSortFirstBatch.yml
+++ b/src/workloads/execution/TimeSeriesSortFirstBatch.yml
@@ -1,0 +1,108 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test compares the performance of the bounded sorter and blocking sort, time to first batch.
+
+GlobalDefaults:
+  dbname: &db test
+  coll: &coll Collection0
+  batchSize: &batchSize 101 # default initial batch size: https://www.mongodb.com/docs/manual/tutorial/iterate-a-cursor/
+  fieldName: &field "numeric"
+  nop: &Nop {Nop: true}
+
+SortCmd: &SortCmd
+  LoadConfig:
+    Path: "../../phases/execution/TimeSeriesSortCommands.yml"
+    Key: SortFirstBatchCmdTemplate
+    Parameters:
+      coll: *coll
+      batchSize: *batchSize
+
+Actors:
+- Name: CreateTimeSeriesCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: *db
+    Operation:
+      OperationMetricsName: CreateTimeSeriesCollection
+      OperationName: RunCommand
+      OperationCommand:
+        {create: *coll, timeseries: {timeField: "t", metaField: "m"}}
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+  - *Nop
+  - Repeat: 1
+  - *Nop
+
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Threads: 1
+    CollectionCount: 1
+    DocumentCount: 10e6
+    BatchSize: *batchSize
+    Document:
+      t: {^IncDate: {start: "2014-01-01", step: 400}}
+      m: {^RandomInt: {min: 0, max: 1000}}
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: Queries
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 50
+    Database: *db
+    Operations:
+    - OperationMetricsName: BoundedSortFirstBatch
+      OperationName: RunCommand
+      OperationCommand: *SortCmd
+  - *Nop
+  - Repeat: 50
+    Database: *db
+    Operations:
+    - OperationMetricsName: BlockingSortFirstBatch
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: {^Parameter: {Name: "coll", Default: Collection0}}
+        pipeline: [{$_internalInhibitOptimization: {}}, {$sort: {t: 1}}]
+        cursor: {batchSize: *batchSize}
+        allowDiskUse: true
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - replica
+      - replica-all-feature-flags
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0
+      - v5.1
+      - v5.2
+      - v5.3

--- a/src/workloads/execution/TimeSeriesSortFirstBatch.yml
+++ b/src/workloads/execution/TimeSeriesSortFirstBatch.yml
@@ -6,7 +6,7 @@ Description: |
 GlobalDefaults:
   dbname: &db test
   coll: &coll Collection0
-  batchSize: &batchSize 101 # default initial batch size: https://www.mongodb.com/docs/manual/tutorial/iterate-a-cursor/
+  batchSize: &batchSize 101  # default initial batch size: https://www.mongodb.com/docs/manual/tutorial/iterate-a-cursor/
   nop: &Nop {Nop: true}
 
 BoundedSortCmd: &BoundedSortCmd

--- a/src/workloads/execution/TimeSeriesSortFirstBatch.yml
+++ b/src/workloads/execution/TimeSeriesSortFirstBatch.yml
@@ -7,10 +7,9 @@ GlobalDefaults:
   dbname: &db test
   coll: &coll Collection0
   batchSize: &batchSize 101 # default initial batch size: https://www.mongodb.com/docs/manual/tutorial/iterate-a-cursor/
-  fieldName: &field "numeric"
   nop: &Nop {Nop: true}
 
-SortCmd: &SortCmd
+BoundedSortCmd: &BoundedSortCmd
   LoadConfig:
     Path: "../../phases/execution/TimeSeriesSortCommands.yml"
     Key: SortFirstBatchCmdTemplate
@@ -65,6 +64,7 @@ Actors:
   - *Nop
   - *Nop
   - *Nop
+  - *Nop
 
 - Name: Queries
   Type: RunCommand
@@ -78,7 +78,7 @@ Actors:
     Operations:
     - OperationMetricsName: BoundedSortFirstBatch
       OperationName: RunCommand
-      OperationCommand: *SortCmd
+      OperationCommand: *BoundedSortCmd
   - *Nop
   - Repeat: 50
     Database: *db


### PR DESCRIPTION
This is very similar to [TimeSeriesSortScale.yml](https://github.com/mongodb/genny/blob/master/src/workloads/scale/TimeSeriesSortScale.yml), essentially I just changed the pipeline so only one batch is sent, and also added a blocking sort in addition to the bounded.

I've also checked the explains to make sure we get the expected sorts