### PR TITLE
PERF-3053 Deploy Sharded stress testing conn pool workload

### DIFF
--- a/src/workloads/issues/ConnectionPoolStress.yml
+++ b/src/workloads/issues/ConnectionPoolStress.yml
@@ -6,25 +6,25 @@ Description: |
   for this workload are the latencies and more specifically the Latency90thPercentile to Latency99thPercentile metrics.
 
 Keywords:
-  - reproducer
-  - connections
-  - secondaryPreferred
-  - sharding
-  - latency
+- reproducer
+- connections
+- secondaryPreferred
+- sharding
+- latency
 
 Parameters:
-  - ConnectionThreads: &GlobalConnectionThreads 8000
-  - ConnectionDuration: &GlobalConnectionDuration 600 seconds
-  - ShardingTaskExecutorPoolMaxSize: &GlobalShardingTaskExecutorPoolMaxSize 32767 # Essentially a noop as this is the default.
-  - ShardingTaskExecutorPoolMinSize: &GlobalShardingTaskExecutorPoolMinSize     1  # Essentially a noop as this is the default.
-  - ReadMode: &GlobalReadMode secondaryPreferred
-  - ClientPerThread: &GlobalSetClientPerThread false
-  - MaxPoolSize: &GlobalMaxPoolSize 15000
+- ConnectionThreads: &GlobalConnectionThreads 8000
+- ConnectionDuration: &GlobalConnectionDuration 600 seconds
+- ShardingTaskExecutorPoolMaxSize: &GlobalShardingTaskExecutorPoolMaxSize 32767  # Essentially a noop as this is the default.
+- ShardingTaskExecutorPoolMinSize: &GlobalShardingTaskExecutorPoolMinSize     1  # Essentially a noop as this is the default.
+- ReadMode: &GlobalReadMode secondaryPreferred
+- ClientPerThread: &GlobalSetClientPerThread false
+- MaxPoolSize: &GlobalMaxPoolSize 15000
 
 Constants:
-  - &MaxPhases 1
-  - Database: &Database test
-  - Collection: &Collection Collection0
+- &MaxPhases 1
+- Database: &Database test
+- Collection: &Collection Collection0
 
 Clients:
   Default:
@@ -48,11 +48,11 @@ Actors:
         Database: *Database
         Collection: *Collection
         Operations:
-          - OperationName: updateOne
-            OperationCommand:
-              Filter: {_id: 0}
-              Update: {}
-              OperationOptions: {Upsert: true}
+        - OperationName: updateOne
+          OperationCommand:
+            Filter: {_id: 0}
+            Update: {}
+            OperationOptions: {Upsert: true}
 
 - Name: ShardingTaskExecutorPoolMaxSize
   Type: AdminCommand
@@ -100,12 +100,12 @@ Actors:
         Duration: *GlobalConnectionDuration
         Collection: *Collection
         Operations:
-          - OperationName: find
-            OperationCommand:
-              Filter: {_id: 0}
-              Options:
-                ReadPreference:
-                  ReadMode: *GlobalReadMode
+        - OperationName: find
+          OperationCommand:
+            Filter: {_id: 0}
+            Options:
+              ReadPreference:
+              ReadMode: *GlobalReadMode
 
 
 # to avoid connection closing
@@ -120,6 +120,6 @@ Actors:
 
 
 AutoRun:
-  - When:
-      mongodb_setup:
-        $eq: shard-single
+- When:
+    mongodb_setup:
+      $eq: shard-single

--- a/src/workloads/issues/ConnectionPoolStress.yml
+++ b/src/workloads/issues/ConnectionPoolStress.yml
@@ -105,7 +105,7 @@ Actors:
             Filter: {_id: 0}
             Options:
               ReadPreference:
-              ReadMode: *GlobalReadMode
+                ReadMode: *GlobalReadMode
 
 
 # to avoid connection closing

--- a/src/workloads/issues/ConnectionPoolStress.yml
+++ b/src/workloads/issues/ConnectionPoolStress.yml
@@ -120,4 +120,6 @@ Actors:
 AutoRun:
 - When:
     mongodb_setup:
-      $eq: shard-single
+      $eq:
+      - shard-single
+      - replica

--- a/src/workloads/issues/ConnectionPoolStress.yml
+++ b/src/workloads/issues/ConnectionPoolStress.yml
@@ -23,8 +23,6 @@ Keywords:
 Parameters:
 - ConnectionThreads: &GlobalConnectionThreads 8000
 - ConnectionDuration: &GlobalConnectionDuration 600 seconds
-- ShardingTaskExecutorPoolMaxSize: &GlobalShardingTaskExecutorPoolMaxSize 32767  # Essentially a noop as this is the default.
-- ShardingTaskExecutorPoolMinSize: &GlobalShardingTaskExecutorPoolMinSize     1  # Essentially a noop as this is the default.
 - ReadMode: &GlobalReadMode secondaryPreferred
 - MaxPoolSize: &GlobalMaxPoolSize 15000
 
@@ -62,28 +60,6 @@ Actors:
             # Upsert means that this workload doesn't need to be reset when running locally.
             # This is very situational.
             OperationOptions: {Upsert: true}
-
-- Name: ShardingTaskExecutorPoolSizes
-  Type: AdminCommand
-  Threads: 1
-  Phases:
-    OnlyActiveInPhases:
-      Active: [0]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Repeat: 1
-        ThrowOnFailure: false
-        Operations:
-        - OperationMetricsName: ShardingTaskExecutorPoolMaxSize
-          OperationName: AdminCommand
-          OperationCommand:
-            setParameter: 1
-            ShardingTaskExecutorPoolMaxSize: *GlobalShardingTaskExecutorPoolMaxSize
-        - OperationMetricsName: ShardingTaskExecutorPoolMinSize
-          OperationName: AdminCommand
-          OperationCommand:
-            setParameter: 1
-            ShardingTaskExecutorPoolMinSize: *GlobalShardingTaskExecutorPoolMinSize
 
 - Name: ConnectionPoolStress
   Type: CrudActor

--- a/src/workloads/issues/ConnectionPoolStress.yml
+++ b/src/workloads/issues/ConnectionPoolStress.yml
@@ -5,6 +5,14 @@ Description: |
   low performance, spikes in latency and excessive connection creation (on mongos processes). The metrics to look at
   for this workload are the latencies and more specifically the Latency90thPercentile to Latency99thPercentile metrics.
 
+  The workload performs the following steps:
+    - Phase 0
+      - Upsert a Single Document in the collection
+      - set ShardingTaskExecutorPoolMaxSize
+      - set ShardingTaskExecutorPoolMinSize
+    - Phase 1
+      - Execute a find command for GlobalConnectionDuration seconds in GlobalConnectionThreads threads.
+
 Keywords:
 - reproducer
 - connections
@@ -18,7 +26,6 @@ Parameters:
 - ShardingTaskExecutorPoolMaxSize: &GlobalShardingTaskExecutorPoolMaxSize 32767  # Essentially a noop as this is the default.
 - ShardingTaskExecutorPoolMinSize: &GlobalShardingTaskExecutorPoolMinSize     1  # Essentially a noop as this is the default.
 - ReadMode: &GlobalReadMode secondaryPreferred
-- ClientPerThread: &GlobalSetClientPerThread false
 - MaxPoolSize: &GlobalMaxPoolSize 15000
 
 Constants:
@@ -52,9 +59,11 @@ Actors:
           OperationCommand:
             Filter: {_id: 0}
             Update: {}
+            # Upsert means that this workload doesn't need to be reset when running locally.
+            # This is very situational.
             OperationOptions: {Upsert: true}
 
-- Name: ShardingTaskExecutorPoolMaxSize
+- Name: ShardingTaskExecutorPoolSizes
   Type: AdminCommand
   Threads: 1
   Phases:
@@ -64,24 +73,14 @@ Actors:
       PhaseConfig:
         Repeat: 1
         ThrowOnFailure: false
-        Operation:
-          OperationName: RunCommand
+        Operations:
+        - OperationMetricsName: ShardingTaskExecutorPoolMaxSize
+          OperationName: AdminCommand
           OperationCommand:
             setParameter: 1
             ShardingTaskExecutorPoolMaxSize: *GlobalShardingTaskExecutorPoolMaxSize
-
-- Name: ShardingTaskExecutorPoolMinSize
-  Type: AdminCommand
-  Threads: 1
-  Phases:
-    OnlyActiveInPhases:
-      Active: [0]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Repeat: 1
-        ThrowOnFailure: false
-        Operation:
-          OperationName: RunCommand
+        - OperationMetricsName: ShardingTaskExecutorPoolMinSize
+          OperationName: AdminCommand
           OperationCommand:
             setParameter: 1
             ShardingTaskExecutorPoolMinSize: *GlobalShardingTaskExecutorPoolMinSize
@@ -89,7 +88,6 @@ Actors:
 - Name: ConnectionPoolStress
   Type: CrudActor
   ClientName: PerThread
-  ClientPerThread: *GlobalSetClientPerThread
   Database: *Database
   Threads: *GlobalConnectionThreads
   Phases:

--- a/src/workloads/issues/ConnectionPoolStress.yml
+++ b/src/workloads/issues/ConnectionPoolStress.yml
@@ -1,0 +1,125 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  This workload was created to reproduce issues discovered during sharded stress testing. The workload can cause
+  low performance, spikes in latency and excessive connection creation (on mongos processes). The metrics to look at
+  for this workload are the latencies and more specifically the Latency90thPercentile to Latency99thPercentile metrics.
+
+Keywords:
+  - reproducer
+  - connections
+  - secondaryPreferred
+  - sharding
+  - latency
+
+Parameters:
+  - ConnectionThreads: &GlobalConnectionThreads 8000
+  - ConnectionDuration: &GlobalConnectionDuration 600 seconds
+  - ShardingTaskExecutorPoolMaxSize: &GlobalShardingTaskExecutorPoolMaxSize 32767 # Essentially a noop as this is the default.
+  - ShardingTaskExecutorPoolMinSize: &GlobalShardingTaskExecutorPoolMinSize     1  # Essentially a noop as this is the default.
+  - ReadMode: &GlobalReadMode secondaryPreferred
+  - ClientPerThread: &GlobalSetClientPerThread false
+  - MaxPoolSize: &GlobalMaxPoolSize 15000
+
+Constants:
+  - &MaxPhases 1
+  - Database: &Database test
+  - Collection: &Collection Collection0
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: *GlobalMaxPoolSize
+  PerThread:
+    QueryOptions:
+      maxPoolSize: *GlobalMaxPoolSize
+
+Actors:
+- Name: InsertData
+  Type: CrudActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Database: *Database
+        Collection: *Collection
+        Operations:
+          - OperationName: updateOne
+            OperationCommand:
+              Filter: {_id: 0}
+              Update: {}
+              OperationOptions: {Upsert: true}
+
+- Name: ShardingTaskExecutorPoolMaxSize
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        ThrowOnFailure: false
+        Operation:
+          OperationName: RunCommand
+          OperationCommand:
+            setParameter: 1
+            ShardingTaskExecutorPoolMaxSize: *GlobalShardingTaskExecutorPoolMaxSize
+
+- Name: ShardingTaskExecutorPoolMinSize
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        ThrowOnFailure: false
+        Operation:
+          OperationName: RunCommand
+          OperationCommand:
+            setParameter: 1
+            ShardingTaskExecutorPoolMinSize: *GlobalShardingTaskExecutorPoolMinSize
+
+- Name: ConnectionPoolStress
+  Type: CrudActor
+  ClientName: PerThread
+  ClientPerThread: *GlobalSetClientPerThread
+  Database: *Database
+  Threads: *GlobalConnectionThreads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *GlobalConnectionDuration
+        Collection: *Collection
+        Operations:
+          - OperationName: find
+            OperationCommand:
+              Filter: {_id: 0}
+              Options:
+                ReadPreference:
+                  ReadMode: *GlobalReadMode
+
+
+# to avoid connection closing
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1  # must be 1
+  Phases:
+  - LogEvery: 10 second  # TimeSpec
+    Blocking: None  # must be Blocking:None
+  - LogEvery: 10 second  # TimeSpec
+    Blocking: None  # must be Blocking:None
+
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq: shard-single


### PR DESCRIPTION
Patch: [single shard](https://spruce.mongodb.com/version/628c9f8a2fbabe7a3e6cb567/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)