### PR TITLE
PERF-3062: Change test data in DensifyTimeSeriesCollection to have more than one document per bucket

### DIFF
--- a/src/workloads/execution/DensifyTimeseriesCollection.yml
+++ b/src/workloads/execution/DensifyTimeseriesCollection.yml
@@ -83,7 +83,7 @@ Actors:
     Collection: *coll
     Threads: 1
     CollectionCount: 1
-    DocumentCount: 10000
+    DocumentCount: 100000
     BatchSize: *batchSize
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}

--- a/src/workloads/execution/DensifyTimeseriesCollection.yml
+++ b/src/workloads/execution/DensifyTimeseriesCollection.yml
@@ -87,7 +87,7 @@ Actors:
     BatchSize: *batchSize
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
-      timestamp: {^RandomDate: {min: "2021-01-01T00:00:00.000", max: "2021-01-01T00:01:00.000"}}
+      timestamp: {^IncDate: {start: "2021-01-01T00:00:00.000", step: 400}}
       # Test a subset of units that have different characteristics.
       numeric: {^RandomInt: {min: 0, max: 100}}  # Separate codepath for numeric DensifyValues.
     # $densify stages always add a $sort on the field that is being densified, so this phase adds

--- a/src/workloads/execution/DensifyTimeseriesCollection.yml
+++ b/src/workloads/execution/DensifyTimeseriesCollection.yml
@@ -87,9 +87,9 @@ Actors:
     BatchSize: *batchSize
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
-      timestamp: {^RandomDate: {min: "2021-01-01", max: "2023-01-01"}}
+      timestamp: {^RandomDate: {min: "2021-01-01T00:00:00.000", max: "2021-01-01T00:01:00.000"}}
       # Test a subset of units that have different characteristics.
-      numeric: {^RandomInt: {min: 0, max: 20000}}  # Seperate codepath for numeric DensifyValues.
+      numeric: {^RandomInt: {min: 0, max: 100}}  # Separate codepath for numeric DensifyValues.
     # $densify stages always add a $sort on the field that is being densified, so this phase adds
     # indexes on the date/number fields so that we aren't performing an in-memory sort.
     Indexes:


### PR DESCRIPTION
This change will create a pretty diverse set of buckets. We'll have buckets that close, buckets with a small amount of documents due to the previous bucket containing the meta/time range being full. Then we'll have buckets that have close to 1000 documents and are still open.

[patch](https://spruce.mongodb.com/version/62964f852a60ed2b207ddc7a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)