### PR TITLE
Correct evergreen patch command

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -443,7 +443,7 @@ If you are running Genny through DSI in Evergreen, the FTDC contents are rolled 
 	cd ~/[path_to_evg_project_repo]
 	evergreen patch -p [evg_project]
 	cd ~/[path_to_genny]/genny
-	evergreen patch-set-module -i [patch_id_number] genny
+	evergreen patch-set-module -i [patch_id_number] -m genny
 	```
     
     You can then select `schedule_patch_auto_tasks` on a variant to schedule any modified or new Genny tasks created by AutoRun. Alternatively, you could select `schedule_variant_auto_tasks` to schedule all Genny tasks on that variant.


### PR DESCRIPTION
Evergreen help text:
```
> evergreen patch-set-module -h
NAME:
   evergreen patch-set-module - update or add module to an existing patch

USAGE:
   evergreen patch-set-module [command options] [arguments...]

OPTIONS:
   --module value, -m value             the name of a module in the project configuration
   --skip_confirm, --yes, -y            skip confirmation text
   --ref REF                            diff with REF (default: "HEAD")
   --uncommitted, -u                    include uncommitted changes
   --finalize, -f                       schedule tasks immediately
   --large                              enable submitting larger patches (>16MB)
   --patch value, --id value, -i value  specify the ID of a patch (defaults to user's latest submitted patch)
   --preserve-commits                   preserve separate commits when enqueueing to the commit queue

```