### PR TITLE
PERF-3093 Remove `AutoRun` configuration

### DIFF
--- a/src/workloads/execution/ColumnStoreIndex.yml
+++ b/src/workloads/execution/ColumnStoreIndex.yml
@@ -439,16 +439,19 @@ Actors:
         Database: *db
         Operations: *TestOperations
 
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone-all-feature-flags
-    branch_name:
-      $neq:
-      - v4.0
-      - v4.2
-      - v4.4
-      - v5.0
-      - v5.3
-      - v6.0
+# TODO PERF-3094: Revive 'AutoRun' configuration when the project is near to a closure.
+# AutoRun:
+# - When:
+#     mongodb_setup:
+#       $eq:
+#       - standalone-all-feature-flags
+#     branch_name:
+#       $neq:
+#       - v4.0
+#       - v4.2
+#       - v4.4
+#       - v5.0
+#       - v5.3
+#       - v6.0
+#     ThenRun:
+#     - test_control: charts_events_1G


### PR DESCRIPTION
This is to fix the perf BF: https://jira.mongodb.org/browse/BF-25436

The symptom is `{dropIndexes: "charts_metrics.events", indexes: ["$**_columstore"]}` command was failing due to non-existent namespace. Actually test_control.columnstore.yml file was restoring data into charts_metrics.events collection and creating a column store index. But somehow the test control file was not applied.

The culprit is `AutoRun` specification. If we want to run the columnstore genny workload as part of autorun tasks, it should have had the following specification.

```
AutoRun:
  ...
  ThenRun:
    test_control: columnstore 
```

Because the columnstore workload task has the separate test control file. Without {{ThenRun}} specification, autorun tasks does not apply the separate test control file.

For now, I will remove the ``AutoRun`` specification and revive it when the project is close to a closure.

I'm also modifying the task name with a prospect that we revive the `AutoRun` configuration when the project is near to a closure. There will be two more companion PRs.
- DSI: https://github.com/10gen/dsi/pull/1058
- Server system_perf.yml: https://github.com/10gen/mongo/pull/5780

Evergreen patch build:
https://spruce.mongodb.com/version/62a3a314d1fe07330206203a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC