### PR TITLE
Remove spurious autorun

### DIFF
--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -157,10 +157,3 @@ Actors:
               # If there are N threads created before the PointDeleter, the first N documents will
               # not be deleted. See TIG-4057
               {_id: {^Join: {array: [{ ^FormatString: {"format": "%07d", "withArgs": [{^Inc: {start: 0, multiplier: 1, step: *ThreadCount}}]}}, *PaddingGenerator]}}}
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - replica-all-feature-flags
-      - shard-lite-all-feature-flags


### PR DESCRIPTION
Genny ignores autorun in the phases directory. This definition has one, and it's surprising and confusing. This change removes it. 

The workload itself still runs. The workload is defined in the workloads directory and uses LoadConfig to load this whole file. 