### PR TITLE
Comment out macos temporarily

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -122,13 +122,13 @@ buildvariants:
   tasks:
   - name: tg_compile
 
-    # - name: macos-1014
-    #   display_name: macOS Mojave
-    #   modules: [mongo]
-    #   run_on:
-    #   - macos-1014
-    #   tasks:
-    #   - name: tg_compile
+# - name: macos-1014
+#   display_name: macOS Mojave
+#   modules: [mongo]
+#   run_on:
+#   - macos-1014
+#   tasks:
+#   - name: tg_compile
 
 # - name: centos6-perf
 #   display_name: CentOS 6 for Performance

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -122,13 +122,13 @@ buildvariants:
   tasks:
   - name: tg_compile
 
-- name: macos-1014
-  display_name: macOS Mojave
-  modules: [mongo]
-  run_on:
-  - macos-1014
-  tasks:
-  - name: tg_compile
+    # - name: macos-1014
+    #   display_name: macOS Mojave
+    #   modules: [mongo]
+    #   run_on:
+    #   - macos-1014
+    #   tasks:
+    #   - name: tg_compile
 
 # - name: centos6-perf
 #   display_name: CentOS 6 for Performance


### PR DESCRIPTION
Until we pull in the ticket, we can comment this out. The test is just noise at this point and makes people merge past the commit queue.