### PR TITLE
TIG-2766 Genny warn on unused yaml

### DIFF
--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -90,6 +90,10 @@ void reportMetrics(genny::metrics::Registry& metrics,
 
 /**
  * Filter to remove any nodes inside dedicated "ignore" values.
+ *
+ * Basically re-implementing the following python logic:
+ *  ignored = set("foo","bar")
+ *  return [u for u in unused if not any(ignore in u for ignore in ignored)]
  */
 UnusedNodes removeIgnored(const UnusedNodes& unused, const std::vector<std::string>& ignored) {
     UnusedNodes out{};

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -131,6 +131,9 @@ void reportUnused(const NodeSource& nodeSource, const bool dryrun) {
         message << "All YAML structures appear to have been used when " << action
                 << " this workload." << std::endl;
     }
+    message << "The following nodes were ignored in this analysis:" << std::endl;
+    message << "\n\t" << boost::algorithm::join(ignored, "\n\t") << std::endl;
+
     message << "Incorrect results are possible. "
             << "Please file a TIG ticket on the TIPS backlog, or otherwise let us know in the "
             << "#performance-tooling-users slack channel if this looks wrong." << std::endl;

--- a/src/driver/src/DefaultDriver.cpp
+++ b/src/driver/src/DefaultDriver.cpp
@@ -113,7 +113,7 @@ UnusedNodes removeIgnored(const UnusedNodes& unused, const std::vector<std::stri
 void reportUnused(const NodeSource& nodeSource, const bool dryrun) {
     auto raw = nodeSource.unused();
 
-    std::vector<std::string> ignored{".yml/Description", ".yml/Owner", ".yml/AutoRun", ".yml/Keywords"};
+    std::vector<std::string> ignored{".yml/Description", ".yml/Owner", ".yml/AutoRun", ".yml/Keywords", ".yml/Clients"};
     if (dryrun) {
         ignored.push_back(".yml/Clients");
     }

--- a/src/gennylib/include/gennylib/Node.hpp
+++ b/src/gennylib/include/gennylib/Node.hpp
@@ -21,6 +21,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
+#include <typeinfo>
 
 #include <boost/exception/all.hpp>
 #include <boost/exception/error_info.hpp>
@@ -31,6 +32,8 @@
 #include <yaml-cpp/yaml.h>
 
 namespace genny {
+
+using UnusedNodes = std::vector<std::string>;
 
 /**
  * Source of all `genny::Node` instances.
@@ -59,6 +62,8 @@ public:
      *   Likely a file-path from where the yaml was loaded.
      */
     NodeSource(std::string yaml, std::string path);
+
+    UnusedNodes unused() const;
 
 private:
     const YAML::Node _yaml;
@@ -453,6 +458,7 @@ public:
         if (!*this) {
             return std::nullopt;
         }
+
         try {
             return _maybeImpl<O, Args...>(std::forward<Args>(args)...);
         } catch (const YAML::BadConversion& x) {
@@ -557,6 +563,8 @@ public:
 
     // Only intended to be used internally
     explicit Node(const v1::NodeKey::Path& path, const YAML::Node yaml);
+
+    UnusedNodes unused() const;
 
 private:
     friend class NodeImpl;

--- a/src/gennylib/include/gennylib/Node.hpp
+++ b/src/gennylib/include/gennylib/Node.hpp
@@ -21,7 +21,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <typeinfo>
 
 #include <boost/exception/all.hpp>
 #include <boost/exception/error_info.hpp>

--- a/src/gennylib/src/Node.cpp
+++ b/src/gennylib/src/Node.cpp
@@ -65,6 +65,10 @@ NodeSource::NodeSource(std::string yaml, std::string path)
 
 NodeSource::~NodeSource() = default;
 
+UnusedNodes NodeSource::unused() const {
+    return this->_root->unused();
+}
+
 
 //
 // v1::NodeKey
@@ -161,7 +165,33 @@ public:
     }
 
     const YAML::Node yaml() const {
+        this->_used = true;
         return _yaml;
+    }
+
+    UnusedNodes unused() const {
+
+        // Ignore cases where we did something like node["does not exist"].maybe<int>()
+        // since technically there is a "zombie" node that the yaml-cpp internals creates.
+        if (_self->_impl->_yaml == _zombie) {
+            return {};
+        }
+
+        // Depth-first.
+        UnusedNodes out{};
+        for (auto&& [_, child] : this->_children) {
+            const auto childUnused = child->unused();
+            for (auto&& u : childUnused) {
+                out.push_back(u);
+            }
+        }
+
+        // Base-case: no children and unused.
+        if (this->_children.empty() && !this->_used) {
+            out.push_back(this->path());
+        }
+
+        return out;
     }
 
     Node::Type type() const {
@@ -252,6 +282,8 @@ private:
     // these 2 need to be mutable to generate placeholder nodes for non-existent keys.
     mutable ChildKeys _keyOrder;  // maintain insertion-order
     mutable Children _children;
+    // Atomic since yaml may see multi-threaded access during actor init.
+    mutable std::atomic_bool _used = false;
     const YAML::Node _yaml;
     const v1::NodeKey::Path _path;
 };
@@ -310,6 +342,10 @@ size_t Node::size() const {
 
 const YAML::Node Node::yaml() const {
     return _impl->yaml();
+}
+
+UnusedNodes Node::unused() const {
+    return _impl->unused();
 }
 
 Node::operator bool() const {

--- a/src/gennylib/src/Node.cpp
+++ b/src/gennylib/src/Node.cpp
@@ -1,6 +1,7 @@
 #include <utility>
 
 #include <map>
+#include <atomic>
 
 #include <gennylib/Node.hpp>
 

--- a/src/gennylib/test/Node_test.cpp
+++ b/src/gennylib/test/Node_test.cpp
@@ -36,6 +36,132 @@ struct HasConversionSpecialization {
 
 // namespace genny {
 
+TEST_CASE("Unused Values") {
+    const NodeSource n{R"(
+a: [1, 2, 3]
+b: false
+c: []
+n: { ested: [v, alue] }
+t: { value: 11 }
+)", ""};
+    const auto& r = n.root();
+
+    const auto noneUsed = UnusedNodes{// We do depth-first.
+        "/a/0", "/a/1", "/a/2", "/b", "/c", "/n/ested/0", "/n/ested/1", "/t/value"
+    };
+
+    const auto onlyUsed = [=](std::initializer_list<std::string> ks) -> UnusedNodes {
+        auto out = noneUsed;
+        for (auto&& k : ks) {
+            out.erase(std::remove_if(
+                          out.begin(), out.end(), [&](const std::string& c) { return c == k; }),
+                      out.end());
+        }
+        return out;
+    };
+
+    SECTION("Only Root Used") {
+        REQUIRE(n.unused() == noneUsed);
+    }
+    SECTION("List used but no items used") {
+        REQUIRE(r["a"]);
+        REQUIRE(n.unused() == noneUsed);
+    }
+    SECTION("List of ints used via convert structs only uses the list not the items") {
+        // This is arguably a bug, but working around it is tedious.
+        //
+        // In the case of .to<X>, yaml-cpp's built-in conversions
+        // for std containers doesn't consult with genny::Node.
+        REQUIRE(r["a"].to<std::vector<int>>() == std::vector<int>{1, 2, 3});
+        // We'd really like this to be the same REQUIRE as in the "All items in a list used" case.
+        REQUIRE(n.unused() == onlyUsed({"/a"}));
+    }
+    SECTION("Multiple items in a list used") {
+        REQUIRE(r["a"][0].to<int>() == 1);
+        REQUIRE(r["a"][1].to<int>() == 2);
+        // Note we still didn't use "/a" despite using some of its children
+        REQUIRE(n.unused() == onlyUsed({"/a/0", "/a/1"}));
+    }
+    SECTION("All items in a list used") {
+        REQUIRE(r["a"][0].to<int>() == 1);
+        REQUIRE(r["a"][1].to<int>() == 2);
+        REQUIRE(r["a"][2].to<int>() == 3);
+        // We used all the children so we used "a" as well.
+        REQUIRE(n.unused() == onlyUsed({"/a/0", "/a/1", "/a/2", "/a"}));
+    }
+    SECTION("Use a false value") {
+        REQUIRE(r["b"].to<bool>() == false);
+        REQUIRE(n.unused() == onlyUsed({"/b"}));
+    }
+    SECTION("Use an empty list") {
+        REQUIRE(r["c"].to<std::vector<int>>().empty());
+        REQUIRE(n.unused() == onlyUsed({"/c"}));
+    }
+    SECTION("Use one nested value") {
+        REQUIRE(r["n"]["ested"][1].to<std::string>() == "alue");
+        REQUIRE(n.unused() == onlyUsed({"/n/ested/1"}));
+    }
+    SECTION("Use all nested values") {
+        REQUIRE(r["n"]["ested"][0].to<std::string>() == "v");
+        REQUIRE(r["n"]["ested"][1].to<std::string>() == "alue");
+        REQUIRE(n.unused() == onlyUsed({"/n/ested/0", "/n/ested/1", "/n/ested", "/n"}));
+    }
+    SECTION("Use entire doc") {
+        REQUIRE(r["a"][0].to<int>() == 1);
+        REQUIRE(r["a"][1].to<int>() == 2);
+        REQUIRE(r["a"][2].to<int>() == 3);
+        REQUIRE(r["b"].to<bool>() == false);
+        REQUIRE(r["c"].to<std::vector<int>>().empty());
+        REQUIRE(r["n"]["ested"][0].to<std::string>() == "v");
+        REQUIRE(r["n"]["ested"][1].to<std::string>() == "alue");
+        REQUIRE(r["t"]["value"].to<int>() == 11);
+        REQUIRE(r.unused().empty());
+    }
+    SECTION("Non-existent key used") {
+        auto m = r["does not exist"].maybe<int>();
+        REQUIRE(!m);
+        REQUIRE(n.unused() == noneUsed);
+    }
+    SECTION("Non-existent nested key used") {
+        auto m = r["does"]["not"]["ex"][1]["st"].maybe<int>();
+        REQUIRE(!m);
+        REQUIRE(n.unused() == noneUsed);
+    }
+    SECTION("Not unwrapping a maybe is fine.") {
+        auto m = r["b"].maybe<bool>();
+        REQUIRE(m);
+        REQUIRE(n.unused() == onlyUsed({"/b"}));
+    }
+    struct MyType {
+        int value;
+        explicit MyType(const Node& n, int mult = 1)
+            : value{(n["value"].maybe<int>().value_or(93) + 7) * mult} {}
+    };
+    SECTION("Using custom conversion counts as being used") {
+        auto t = r["t"].to<MyType>(3);
+        REQUIRE(t.value == 54);  // (11 + 7) * 3
+        REQUIRE(n.unused() == onlyUsed({"/t/value", "/t"}));
+    }
+    SECTION("Maybes also work") {
+        auto t = r["t"].maybe<MyType>(3);
+        REQUIRE(t->value == 54);  // (11 + 7) * 3
+        REQUIRE(n.unused() == onlyUsed({"/t/value", "/t"}));
+    }
+
+    SECTION("Maybes also work pt2") {
+        auto t = r["t"].maybe<MyType>();
+        REQUIRE(t->value == 18);  // (11 + 7) * (mult=1)
+        REQUIRE(n.unused() == onlyUsed({"/t/value", "/t"}));
+    }
+    SECTION("Maybes that fail to use the value don't use the value") {
+        // Use the 'n' structure (n:{ested:[v,alue]}) which doesn't have
+        // the "value" key that MyStruct wants to see.
+        auto t = r["n"].maybe<MyType>(5);
+        REQUIRE(t->value == 500);  // (93 + 7) * (mult=5)
+        REQUIRE(n.unused() == noneUsed);
+    }
+}
+
 TEST_CASE("Nested sequence like map") {
     NodeSource nodeSource("a: []", "");
     const auto& yaml = nodeSource.root();


### PR DESCRIPTION
Almost verbatim the main parts from @rtimmons 's PR (#424), with a more recent commit / some line noise removed. Spent a bit of time trying to get this to work with the STL containers but got a bit tangled up in templates, so agree with pushing this out for now and filing a separate bug ticket to catch it later, and maybe a separate ticket to make it barf explicitly.

Fwiw, I think the stl containers don't see a ton of use extracted from YAML like that in actor code.

Right now it's always on by default in dry runs and workload runs, with warning verbosity if there's anything caught by it. Hopefully people won't find that too annoying.

Patch: https://spruce.mongodb.com/version/62d1afc5c9ec4462ba43fdba/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Updated patch: https://spruce.mongodb.com/version/62e93199c9ec445a8443bdb5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Updated updated patch: https://spruce.mongodb.com/version/62eed22bc9ec443061c7d57e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC