### PR TITLE
PERF-3199 Add workloads based on cost-based access path selection issues

### DIFF
--- a/src/workloads/query/PlanSelection.yml
+++ b/src/workloads/query/PlanSelection.yml
@@ -5,10 +5,16 @@ Description: |
   First, it inserts 1000 documents with 2 uniformly distributed fields, and creates indexes on
   both fields. Then it runs several pipelines, which will be slow due to incorrect plan selection.
 
+Keywords:
+ - plan
+ - ranking
+ - selection
+ - indexes
+
 GlobalDefaults:
-  Database: &Database planselection
+  Database: &Database PlanSelection
   Collection: &Collection Collection0
-  DocumentCount: &docCount 1000
+  DocumentCount: &docCount 1000000
   Nop: &Nop {Nop: true}
 
 Actors:

--- a/src/workloads/query/PlanSelection.yml
+++ b/src/workloads/query/PlanSelection.yml
@@ -1,0 +1,91 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload was created to reproduce various plan selection issues.
+  First, it inserts 1000 documents with 2 uniformly distributed fields, and creates indexes on
+  both fields. Then it runs several pipelines, which will be slow due to incorrect plan selection.
+
+GlobalDefaults:
+  Database: &Database planselection
+  Collection: &Collection Collection0
+  DocumentCount: &docCount 1000
+  Nop: &Nop {Nop: true}
+
+Actors:
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: *Database
+    CollectionCount: 1
+    Threads: 1
+    DocumentCount: *docCount
+    BatchSize: 1000
+    Indexes:
+    - keys: {a: 1}
+    - keys: {b: 1}
+    Document:
+      a: {^Inc: {start: 0}}
+      b: {^Cycle: {ofLength: 10, fromGenerator: {^Inc: {start: 0}}}}
+  - *Nop
+  - *Nop
+  - *Nop
+
+
+- Name: SelectiveIndex
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 500
+    Database: *Database
+    Operations:
+    - OperationMetricsName: SelectiveIndexQuery
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: *Collection
+        pipeline: [
+          {$match: {'a': {$eq: 0}, 'b': {$eq: 0}}}
+        ]
+        cursor: {}
+  - *Nop
+  - *Nop
+
+- Name: NonSelectiveIndex
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 500
+    Database: *Database
+    Operations:
+    - OperationMetricsName: NonSelectiveIndexQuery
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: *Collection
+        pipeline: [
+          {$match: {a: {$gte: 0}}}
+        ]
+        cursor: {}
+  - *Nop
+
+- Name: SortMatch
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 500
+    Database: *Database
+    Operations:
+    - OperationMetricsName: SortMatchQuery
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: *Collection
+        pipeline: [
+          {$sort: {b: 1}}, {$match: {a: {$eq: 0}}}
+        ]
+        cursor: {}

--- a/src/workloads/query/ResidualPredCosting.yml
+++ b/src/workloads/query/ResidualPredCosting.yml
@@ -1,0 +1,52 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload was created to reproduce SERVER-21697 - Plan ranking should take query and index
+  keys into consideration for breaking ties. First, it inserts 1000 documents with 4 uniformly
+  distributed fields, and creates several compound indexes. Then it runs a pipeline, which will be
+  slow due to incorrect plan selection.
+
+GlobalDefaults:
+  Database: &Database residualpredcosting
+  Collection: &Collection Collection0
+  DocumentCount: &docCount 1000
+  Nop: &Nop {Nop: true}
+
+Actors:
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: *Database
+    CollectionCount: 1
+    Threads: 1
+    DocumentCount: *docCount
+    BatchSize: 1000
+    Indexes:
+    - keys: {a: 1, b: 1, c: 1, d: 1}
+    - keys: {a: 1, b: 1, d: 1}
+    - keys: {a: 1, d: 1}
+    Document:
+      a: {^Cycle: {ofLength: 10, fromGenerator: {^Inc: {start: 0}}}}
+      b: {^Cycle: {ofLength: 10, fromGenerator: {^Inc: {start: 0}}}}
+      c: {^Cycle: {ofLength: 10, fromGenerator: {^Inc: {start: 0}}}}
+      d: {^Cycle: {ofLength: 10, fromGenerator: {^Inc: {start: 0}}}}
+  - *Nop
+
+- Name: Match
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 500
+    Database: *Database
+    Operations:
+    - OperationMetricsName: MatchQuery
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: *Collection
+        pipeline: [
+          {$match: {a: {$eq: 0}, b: {$eq: 0}, c: {$eq: 0}}}, {$sort: {d: 1}}
+        ]
+        cursor: {}

--- a/src/workloads/query/ResidualPredCosting.yml
+++ b/src/workloads/query/ResidualPredCosting.yml
@@ -6,10 +6,17 @@ Description: |
   distributed fields, and creates several compound indexes. Then it runs a pipeline, which will be
   slow due to incorrect plan selection.
 
+Keywords:
+ - plan
+ - ranking
+ - selection
+ - indexes
+ - compound
+
 GlobalDefaults:
-  Database: &Database residualpredcosting
+  Database: &Database ResidualPredCosting
   Collection: &Collection Collection0
-  DocumentCount: &docCount 1000
+  DocumentCount: &docCount 1000000
   Nop: &Nop {Nop: true}
 
 Actors:


### PR DESCRIPTION
[Evergreen patch](https://spruce.mongodb.com/version/62eae4cf2fbabe458c79a9f6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

These workloads are based on the repro tests for:
[SERVER-20616](https://jira.mongodb.org/browse/SERVER-20616) Plan ranker sampling from the beginning of a query's execution can result in poor plan selection
[SERVER-21697](https://jira.mongodb.org/browse/SERVER-21697) Plan ranking should take query and index keys into consideration for breaking ties
[SERVER-12923](https://jira.mongodb.org/browse/SERVER-12923) Plan ranking is bad or plans with blocking stages
[SERVER-13211](https://jira.mongodb.org/browse/SERVER-13211) Optimal index not chosen for query plan when many indexes match same prefix