### PR TITLE
Update python deps; don't rely on /data for run-genny

### DIFF
--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -1,4 +1,4 @@
-wheel==0.36.2
+wheel==0.37.1
 pymongo>=3.9
 click==7.1.2
 click-option-group==0.5.2
@@ -15,7 +15,7 @@ pytest==6.0.2
 
 # Force a binary distribution of numpy on macOS:
 # https://github.com/numpy/numpy/issues/15947
-numpy==1.20.1 --only-binary=numpy; platform_system == 'darwin'
-numpy==1.20.1;                     platform_system != 'darwin'
+numpy==1.23.1 --only-binary=numpy; platform_system == 'darwin'
+numpy==1.23.1;                     platform_system != 'darwin'
 
-numexpr==2.8.1
+numexpr==2.8.3

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -164,7 +164,7 @@ class ToolchainDownloader(Downloader):
 
     TOOLCHAIN_BUILD_ID = "fc5ec55493f12c0791739e66bd9ffc6db78468e1_22_01_31_16_45_23"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
-    TOOLCHAIN_ROOT = "/data/mci"  # TODO BUILD-7624 change this to /opt.
+    # TOOLCHAIN_ROOT = "/data/mci"  # TODO BUILD-7624 change this to /opt.
 
     def __init__(
         self,
@@ -179,7 +179,7 @@ class ToolchainDownloader(Downloader):
             workspace_root=workspace_root,
             os_family=os_family,
             linux_distro=linux_distro,
-            install_dir=ToolchainDownloader.TOOLCHAIN_ROOT,
+            install_dir=os.path.join(workspace_root, "build", "toolchain"),
             name="gennytoolchain",
         )
         self.ignore_toolchain_version = ignore_toolchain_version

--- a/src/third_party/cppcodec/CMakeLists.txt
+++ b/src/third_party/cppcodec/CMakeLists.txt
@@ -66,9 +66,9 @@ set_target_properties(cppcodec PROPERTIES LINKER_LANGUAGE CXX)
 add_subdirectory(tool)
 add_subdirectory(example)
 
-if (BUILD_TESTING)
-    add_subdirectory(test)
-endif()
+# if (BUILD_TESTING)
+#     add_subdirectory(test)
+# endif()
 
 foreach(h ${PUBLIC_HEADERS})
     get_filename_component(FINAL_PATH ${h} PATH) # use DIRECTORY instead of PATH once requiring CMake 3.0


### PR DESCRIPTION
WIP. We had an assumption that the toolchain was not relocatable, but I think that is wrong. That means we no longer have to fear latest macOS which doesn't let us write to `/data`.

Also

1. updated to later versions of a few python deps that don't install on M1.
2. don't build cppcodec's tests which don't compile on M1 (maybe Monterey?) due to (vendored) catch2 things