### PR TITLE
PERF-3187 - Extend Genny to add queryable encryption support

### DIFF
--- a/src/gennylib/include/gennylib/v1/PoolManager.hpp
+++ b/src/gennylib/include/gennylib/v1/PoolManager.hpp
@@ -71,6 +71,7 @@ public:
 
     bsoncxx::document::value generateKMSProvidersDoc() const;
     bsoncxx::document::value generateSchemaMapDoc() const;
+    bsoncxx::document::value generateEncryptedFieldsMapDoc() const;
     bsoncxx::document::value generateExtraOptionsDoc() const;
 
     bool hasEncryptedCollections() const;

--- a/src/gennylib/src/encryption.cpp
+++ b/src/gennylib/src/encryption.cpp
@@ -453,6 +453,7 @@ void QueryableEncryptedCollection::createCollection(const mongocxx::client& clie
 }
 
 void QueryableEncryptedCollection::dropCollection(const mongocxx::client& client) const {
+    // TODO: PERF-3306 remove this loop once CXX driver supports queryable-encryption
     for (auto& suffix : {".esc", ".ecc", ".ecoc"}) {
         std::string stateCollName = "enxcol_." + _collection + suffix;
         client[_database][stateCollName].drop();

--- a/src/gennylib/src/encryption.cpp
+++ b/src/gennylib/src/encryption.cpp
@@ -438,8 +438,9 @@ void QueryableEncryptedCollection::appendEncryptedFieldConfig(sub_document subdo
         return;
     }
     subdoc.append(kvp("fields", [&](sub_array fieldsArray) {
-        for (const auto& [_, field] : _fields) {
-            fieldsArray.append([&](sub_document fieldDoc) { field.appendEncryptInfo(fieldDoc); });
+        for (const auto& fieldPair : _fields) {
+            fieldsArray.append(
+                [&](sub_document fieldDoc) { fieldPair.second.appendEncryptInfo(fieldDoc); });
         }
     }));
 }

--- a/src/workloads/docs/CrudActorEncrypted.yml
+++ b/src/workloads/docs/CrudActorEncrypted.yml
@@ -87,11 +87,11 @@ Encryption:
       bio.birthplace.country: { type: "string", algorithm: "deterministic" }
   - Database: *encrypted_db
     Collection: "medical"
-    EncryptionType: "fle"
-    FLEEncryptedFields:
-      patient_id: { type: "string", algorithm: "deterministic" }
-      insurance: { type: "string", algorithm: "random" }
-      conditions: { type: "array", algorithm: "random" }
+    EncryptionType: "queryable"
+    QueryableEncryptedFields:
+      patient_id: { type: "string", queries: [{queryType: "equality"}] }
+      insurance: { type: "string", queries: [{queryType: "equality", contention: 16}] }
+      a1c: { type: "long", queries: [{queryType: "equality", contention: 10}] }
 
 Clients:
   Default:
@@ -170,6 +170,7 @@ Actors:
       OperationCommand:
         Filter: {pii.ssn: "111-11-1111"}
         Update: {$set: {surname: "Bacon", pii.ssn: "222-22-2222"}}
+  - &nop {Nop: true}
 
 - Name: Accounts_SecondPool
   Type: CrudActor
@@ -177,7 +178,7 @@ Actors:
   Database: *encrypted_db
   ClientName: SecondEncryptedPool  # Use encryption-enabled pool
   Phases:
-  - &Nop {Nop: true}
+  - *nop
   - Repeat: 1
     Collection: accounts
     Operations:
@@ -186,6 +187,7 @@ Actors:
         # Query on deterministically-encrypted field
         Filter: {bio.birthplace.country: "USA"}
         Update: {$set: {bio.birthplace.country: "New Zealand", updated_by: "SecondEncryptedPool"}}
+  - *nop
 
 - Name: Medical
   Type: CrudActor
@@ -201,7 +203,7 @@ Actors:
         Document:
           patient_id: {^Join: {array: ["Patient-", {^ActorIdString: {}}]}}
           patient_id_plain: {^Join: {array: ["Patient-", {^ActorIdString: {}}]}}
-          conditions: {^Array: {of: 1, number: 10}}
+          a1c: {^RandomInt: {min: 2, max: 12}}
           _id: {^Inc: {start: -10, multiplier: 10}}
   - Repeat: 10
     Collection: medical
@@ -212,6 +214,19 @@ Actors:
         Update:
           $set:
             insurance: "none"
-            patient_id: {^Join: {array: ["UpdatedPatient-", {^ActorIdString: {}}]}}
-            physician: {^Join: {array: ["Dr.", {^RandomString: {length: 10}}]}}
-            conditions: ["dysphagia", "arrythmia", "hemiparesis"]
+            a1c: {^RandomInt: {min: 2, max: 12}}
+  - *nop
+
+- Name: Compactor
+  Type: RunCommand
+  Threads: 1
+  ClientName: EncryptedPool
+  Phases:
+  - *nop
+  - *nop
+  - Repeat: 1
+    Database: *encrypted_db
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        compactStructuredEncryptionData: medical


### PR DESCRIPTION
This patch builds on top of this patch: https://github.com/mongodb/genny/pull/726 to add QE support.