### PR TITLE
PERF-3305 Update AutoRun config to account for SBE build variants

### DIFF
--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -33,5 +33,6 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - standalone-dsi-integration-test
       - standalone-classic-query-engine
+      - standalone-dsi-integration-test
+      - standalone-sbe

--- a/src/workloads/execution/ConstantFoldArithmetic.yml
+++ b/src/workloads/execution/ConstantFoldArithmetic.yml
@@ -112,3 +112,4 @@ AutoRun:
       $eq:
       - replica
       - single-replica-classic-query-engine
+      - single-replica-sbe

--- a/src/workloads/execution/ExpressiveQueries.yml
+++ b/src/workloads/execution/ExpressiveQueries.yml
@@ -192,6 +192,7 @@ AutoRun:
       - single-replica
       - standalone
       - standalone-classic-query-engine
+      - standalone-sbe
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/execution/ExternalSort.yml
+++ b/src/workloads/execution/ExternalSort.yml
@@ -108,6 +108,7 @@ AutoRun:
       $eq:
       - standalone
       - standalone-classic-query-engine
+      - standalone-sbe
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/execution/GraphLookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/execution/GraphLookupWithOnlyUnshardedColls.yml
@@ -105,3 +105,4 @@ AutoRun:
       - shard-lite
       - shard-lite-all-feature-flags
       - single-replica-classic-query-engine
+      - single-replica-sbe

--- a/src/workloads/execution/LookupSBEPushdown.yml
+++ b/src/workloads/execution/LookupSBEPushdown.yml
@@ -437,6 +437,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-sbe
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/execution/LookupSBEPushdownINLJMisc.yml
@@ -386,6 +386,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-sbe
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/execution/LookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/execution/LookupWithOnlyUnshardedColls.yml
@@ -114,3 +114,4 @@ AutoRun:
       - shard-lite
       - shard-lite-all-feature-flags
       - single-replica-classic-query-engine
+      - single-replica-sbe

--- a/src/workloads/execution/UnionWith.yml
+++ b/src/workloads/execution/UnionWith.yml
@@ -267,6 +267,7 @@ AutoRun:
       - shard-lite
       - standalone
       - standalone-classic-query-engine
+      - standalone-sbe
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/scale/LargeIndexedIns.yml
+++ b/src/workloads/scale/LargeIndexedIns.yml
@@ -65,3 +65,4 @@ AutoRun:
       $eq:
       - replica
       - single-replica-classic-query-engine
+      - single-replica-sbe

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -310,10 +310,11 @@ AutoRun:
       $eq:
       - atlas
       - replica
-      - single-replica
-      - standalone
-      - replica-noflowcontrol
       - replica-1dayhistory-15gbwtcache
-      - replica-maintenance-events
       - replica-all-feature-flags
+      - replica-maintenance-events
+      - replica-noflowcontrol
+      - single-replica
       - single-replica-classic-query-engine
+      - single-replica-sbe
+      - standalone


### PR DESCRIPTION
This proposed `genny` change goes together with the following 10gen/mongo and 10gen/dsi PRs:

- https://github.com/10gen/mongo/pull/7536
- https://github.com/10gen/dsi/pull/1095

I suggest reading the 10gen/mongo patch first, followed by the 10gen/dsi patch, followed by this patch.