### PR TITLE
SERVER-68113 Drop all indexes after creating timeseries collection in TimeSeriesSort

### DIFF
--- a/src/workloads/execution/TimeSeriesSort.yml
+++ b/src/workloads/execution/TimeSeriesSort.yml
@@ -38,7 +38,14 @@ Actors:
       OperationCommand:
         {create: &coll Collection0, timeseries: {timeField: "t", metaField: "m"}}
   - *Nop
-  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationMetricsName: DropAllIndexesUponCreation
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: *coll
+        index: "*"
   - *Nop
   - *Nop
   - *Nop


### PR DESCRIPTION
Hey, I didn't know of a way to check if the feature flag was enabled or if there was an existing meta x time index, so I believe dropping all indexes (aside from the _id index) will be a suitable solution. The indexes will be dropped right after creating the timeseries collection. 

I am not very familiar with modifying workloads but I put up a [patch on evergreen](https://spruce.mongodb.com/version/633258b03066155c6b42b277/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Elinux-3-node-replSet-disabled-feature-flags%24) and it looks good.