### PR TITLE
SERVER-58712: Add UpdateWithSecondaryIndexes workload

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -264,7 +264,9 @@ struct UpdateManyOperation : public WriteOperation {
           _collection{std::move(collection)},
           _operation{operation},
           _filter{opNode["Filter"].to<DocumentGenerator>(context, id)},
-          _update{opNode["Update"].to<DocumentGenerator>(context, id)} {}
+          _update{opNode["Update"].to<DocumentGenerator>(context, id)},
+          _options{opNode["OperationOptions"].maybe<mongocxx::options::update>().value_or(
+              mongocxx::options::update{})} {}
 
     mongocxx::model::write getModel() override {
         auto filter = _filter();

--- a/src/phases/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/phases/execution/UpdateWithSecondaryIndexes.yml
@@ -1,0 +1,116 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/server-execution"
+Description: >
+  Runs a workload that updates a large range of documents.
+
+Keywords:
+- RunCommand
+- Loader
+- LoggingActor
+- CrudActor
+- insert
+- update
+- latency
+
+GlobalDefaults:
+  # Configurable parameters.
+  DocumentCount: &DocumentCount {^Parameter: {Name: "DocumentCount", Default: 50_000}}
+  # Insert same document for both default and with secondary indexes to remove one variable.
+  InsertDocument: &DocumentToInsert
+    a: "foo"
+    b: &rs {^FastRandomString: {length: 6, alphabet: "0123456789"}}
+    c: *rs
+
+# Constants.
+WriteRate: &WriteRate 1 per 500 microseconds  # 2000/second
+ConcurrentWritesColl: &ConcurrentWritesColl concurrentWritesColl
+
+Database: &Database test
+UpdateColl: &UpdateColl Collection0
+
+Actors:
+# Phase 1: Initialize the database.
+- Name: InitializeDatabase
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: *Database
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: {dropDatabase: 1}
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *UpdateColl 
+        indexes:
+          - key: {a: 1, b: 1}
+          name: a_1_b_1
+          - key: {a: 1, c: 1}
+          name: a_1_c_1
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+# Phase 2: Populate the collection for mass update.
+- Name: PopulateInitialData
+  Type: Loader
+  Threads: 4
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: *Database
+    MultipleThreadsPerCollection: true
+    CollectionCount: 1
+    DocumentCount: *DocumentCount
+    BatchSize: 1_000
+    Document:
+      *DocumentToInsert
+  - *Nop
+  - *Nop
+  - *Nop
+
+# Phase 3: Issue a large update without a hint.
+- Name: LargeMultiUpdate
+  Type: CrudActor
+  Database: *Database
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: *Database
+    Collection: *UpdateColl
+
+    Operation:
+      OperationName: multiUpdateWithoutHint
+      OperationCommand:
+        Filter: { a: "foo" }
+        Update: { $set: { a: "bar" } }
+  - *Nop
+  - *Nop
+
+# Phase 4: Issue a large update without a hint.
+- Name: LargeMultiUpdate
+  Type: CrudActor
+  Database: *Database
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - Repeat: 1
+    Database: *Database
+    Collection: *UpdateColl
+
+    Operation:
+      OperationName: multiUpdateWithHint
+      OperationCommand:
+      OperationCommand:
+        Filter: { a: "bar" }
+        Update: { $set: { a: "foo" } }
+        OperationOptions:
+          Hint: a_1_b_1
+  - *Nop

--- a/src/phases/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/phases/execution/UpdateWithSecondaryIndexes.yml
@@ -16,7 +16,7 @@ Keywords:
 
 GlobalDefaults:
   # Configurable parameters.
-  DocumentCount: &DocumentCount {^Parameter: {Name: "DocumentCount", Default: 50_000}}
+  DocumentCount: &DocumentCount {^Parameter: {Name: "DocumentCount", Default: 500_000}}
   # Insert same document for both default and with secondary indexes to remove one variable.
   InsertDocument: &DocumentToInsert
     a: "foo"
@@ -24,7 +24,6 @@ GlobalDefaults:
     c: *rs
 
 # Constants.
-WriteRate: &WriteRate 1 per 500 microseconds  # 2000/second
 ConcurrentWritesColl: &ConcurrentWritesColl concurrentWritesColl
 
 Database: &Database test

--- a/src/phases/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/phases/execution/UpdateWithSecondaryIndexes.yml
@@ -11,7 +11,7 @@ Keywords:
 - LoggingActor
 - CrudActor
 - insert
-- updateMany
+- update
 - latency
 
 GlobalDefaults:

--- a/src/phases/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/phases/execution/UpdateWithSecondaryIndexes.yml
@@ -11,7 +11,7 @@ Keywords:
 - LoggingActor
 - CrudActor
 - insert
-- update
+- updateMany
 - latency
 
 GlobalDefaults:

--- a/src/phases/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/phases/execution/UpdateWithSecondaryIndexes.yml
@@ -2,6 +2,8 @@ SchemaVersion: 2018-07-01
 Owner: "@mongodb/server-execution"
 Description: >
   Runs a workload that updates a large range of documents.
+  Multiple secondary indexes are present.
+  Update performed with and without a hint.
 
 Keywords:
 - RunCommand
@@ -41,11 +43,11 @@ Actors:
       OperationCommand: {dropDatabase: 1}
     - OperationName: RunCommand
       OperationCommand:
-        createIndexes: *UpdateColl 
+        createIndexes: *UpdateColl
         indexes:
-          - key: {a: 1, b: 1}
+        - key: {a: 1, b: 1}
           name: a_1_b_1
-          - key: {a: 1, c: 1}
+        - key: {a: 1, c: 1}
           name: a_1_c_1
   - &Nop {Nop: true}
   - *Nop
@@ -83,9 +85,9 @@ Actors:
   - Repeat: 1
     Database: *Database
     Collection: *UpdateColl
-
     Operation:
-      OperationName: multiUpdateWithoutHint
+      OperationName: updateMany
+      OperationMetricsName: UpdateManyWithoutHint
       OperationCommand:
         Filter: { a: "foo" }
         Update: { $set: { a: "bar" } }
@@ -104,10 +106,9 @@ Actors:
   - Repeat: 1
     Database: *Database
     Collection: *UpdateColl
-
     Operation:
-      OperationName: multiUpdateWithHint
-      OperationCommand:
+      OperationName: updateMany
+      OperationMetricsName: UpdateManyWithHint
       OperationCommand:
         Filter: { a: "bar" }
         Update: { $set: { a: "foo" } }

--- a/src/phases/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/phases/execution/UpdateWithSecondaryIndexes.yml
@@ -93,7 +93,7 @@ Actors:
   - *Nop
   - *Nop
 
-# Phase 4: Issue a large update without a hint.
+# Phase 4: Issue a large update with a hint.
 - Name: LargeMultiUpdate
   Type: CrudActor
   Database: *Database

--- a/src/workloads/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/workloads/execution/UpdateWithSecondaryIndexes.yml
@@ -23,7 +23,6 @@ Clients:
 LoadConfig:
   Path: "../../phases/execution/UpdateWithSecondaryIndexes.yml"
 
-# Uncomment AutoRun to enable this test in evergreen patches
 AutoRun:
 - When:
     mongodb_setup:

--- a/src/workloads/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/workloads/execution/UpdateWithSecondaryIndexes.yml
@@ -1,9 +1,9 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/server-execution"
 Description: >
-  Updates a range of documents in the collection.
-  Secondary indexes are created to see how they might affect performance.
-  Documents are approximately of size ~1KB.
+  Updates a large range of documents in the collection.
+  Multiple secondary indexes are present.
+  Update performed with and without a hint.
 
 Keywords:
 - RunCommand

--- a/src/workloads/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/workloads/execution/UpdateWithSecondaryIndexes.yml
@@ -1,0 +1,34 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/server-execution"
+Description: >
+  Updates a range of documents in the collection.
+  Secondary indexes are created to see how they might affect performance.
+  Documents are approximately of size ~1KB.
+
+Keywords:
+- RunCommand
+- Loader
+- LoggingActor
+- CrudActor
+- insert
+- update
+- latency
+- secondary indexes
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: 3_600_000  # = 1 hour
+
+LoadConfig:
+  Path: "../../phases/execution/UpdateWithSecondaryIndexes.yml"
+
+# Uncomment AutoRun to enable this test in evergreen patches
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - replica
+      - replica-all-feature-flags
+      - standalone
+      - standalone-all-feature-flags


### PR DESCRIPTION
Add UpdateWithSecondaryIndexes workload:
```
  Updates a large range of documents in the collection.
  Multiple secondary indexes are present.
  Update performed with and without a hint.
```
Fixed a bug that prevented update option from actually affecting updateMany operations.