### PR TITLE
PERF-3379 Make additional workloads run in SBE and classic build vari…

### DIFF
--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -129,8 +129,10 @@ AutoRun:
       $eq:
       - atlas
       - replica
-      - replica-noflowcontrol
       - replica-1dayhistory-15gbwtcache
       - replica-all-feature-flags
+      - replica-noflowcontrol
       - single-replica
       - standalone
+      - standalone-classic-query-engine
+      - standalone-sbe

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -90,7 +90,9 @@ AutoRun:
       - atlas
       - replica
       - replica-all-feature-flags
+      - shard
       - single-replica
       - single-replica-15gbwtcache
-      - shard
       - standalone
+      - standalone-classic-query-engine
+      - standalone-sbe

--- a/src/workloads/scale/MajorityReads10KThreads.yml
+++ b/src/workloads/scale/MajorityReads10KThreads.yml
@@ -22,3 +22,5 @@ AutoRun:
       $eq:
       - replica
       - replica-all-feature-flags
+      - single-replica-classic-query-engine
+      - single-replica-sbe

--- a/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
@@ -193,9 +193,11 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
+      - replica-1dayhistory-15gbwtcache
+      - replica-all-feature-flags
+      - replica-maintenance-events
+      - replica-noflowcontrol
       - single-replica
       - standalone
-      - replica-noflowcontrol
-      - replica-1dayhistory-15gbwtcache
-      - replica-maintenance-events
-      - replica-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-sbe

--- a/src/workloads/scale/ScanWithLongLived.yml
+++ b/src/workloads/scale/ScanWithLongLived.yml
@@ -101,5 +101,7 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - single-replica
       - replica-noflowcontrol
+      - single-replica
+      - single-replica-classic-query-engine
+      - single-replica-sbe

--- a/src/workloads/transactions/LLTMixed.yml
+++ b/src/workloads/transactions/LLTMixed.yml
@@ -577,6 +577,8 @@ AutoRun:
       - replica
       - replica-all-feature-flags
       - single-replica
+      - single-replica-classic-query-engine
+      - single-replica-sbe
     branch_name:
       $neq:
       - v4.0


### PR DESCRIPTION
…ants

Update the `AutoRun` sections of a few Genny workloads such that they run in the SBE/classic sys-perf build variants. We missed these workloads on our first pass because they aren't obviously query-related. However, I did an analysis which found that measurements associated with these tasks have historically had change points tied to SBE. This suggests that there is some value in including these benchmarks in our system to compare SBE performance against the classic baseline.

I'm open to suggestions from the performance team about what should or shouldn't be included. See [PERF-3379](https://jira.mongodb.org/browse/PERF-3379) and the [linked spreadsheet](https://docs.google.com/spreadsheets/d/17s3ep6fb6b00MHjSU2W9ai5sxq8YmiRNpaM16tq_SxY/edit) for a description of how I performed my audit.

There are a few workloads from my audit that Mihai and I considered including but I had second thoughts about. Please let me know whether you think we should try to include any of the following:

- big_update_10k
- mixed_workloads_genny_stress

Also note that we agreed to include `snapshot_reads`, but this needs to be done by modifying `system_perf.yml` in the mongodb/mongo repo, so I'll file a separate ticket for this.

I kicked off a sys-perf patch build in order to validate that the tests run correctly on the new build variants: https://spruce.mongodb.com/version/63373d43d6d80a2daf48627c/tasks