### PR TITLE
PERF-3379 Maked mixed_workloads_genny_rate_limited run in 1-node repl…

### DIFF
--- a/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
@@ -198,6 +198,6 @@ AutoRun:
       - replica-maintenance-events
       - replica-noflowcontrol
       - single-replica
+      - single-replica-classic-query-engine
+      - single-replica-sbe
       - standalone
-      - standalone-classic-query-engine
-      - standalone-sbe


### PR DESCRIPTION
…set SBE/classic configurations

The related mixed_workloads_genny workload is already running in the 1-node replset variants rather than standalone. These two workloads should be running in the same place.