### PR TITLE
PERF-3420 Add workload for background index build impact

### DIFF
--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -1,8 +1,14 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/server-execution"
 Description: |
-   This workload tests the performance of creating indexes on a collection large enough that the external
-   sorter must spill to disk. This can happen when the keys are larger than maxIndexBuildMemoryUsageMegabytes.
+  This workload tests the write performance impact of creating indexes on a very large collection.
+  It synthetically lowers the number of concurrent operations allowed to represent a saturated
+  server.
+
+Keywords:
+- stress
+- indexes
+- InsertRemove
 
 Clients:
   Default:
@@ -64,7 +70,7 @@ Actors:
   - *Nop
   - *Nop
   # Build an index on an integer field.
-  - Repeat: 10
+  - Repeat: 5
     Database: *db
     Operations:
     - OperationMetricsName: CreateIndexInt
@@ -81,7 +87,7 @@ Actors:
         dropIndexes: *coll
         index: random_int
   # Build an index on a string field.
-  - Repeat: 10
+  - Repeat: 5
     Database: *db
     Operations:
     - OperationMetricsName: CreateIndexString
@@ -104,11 +110,11 @@ Actors:
   Phases:
   - *Nop
   - *Nop
-  # Build an index on an integer field.
+  # Execute while building an index on an integer field.
   - Blocking: None
     Database: *db
     Collection: &otherColl Collection1  # Work on a different collection to avoid overloading the index target
-  # Build an index on a string field.
+  # Execute while building an index on a string field.
   - Blocking: None
     Database: *db
     Collection: *otherColl

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -70,7 +70,7 @@ Actors:
   - *Nop
   - *Nop
   # Build an index on an integer field.
-  - Repeat: 5
+  - Repeat: 2
     Database: *db
     Operations:
     - OperationMetricsName: CreateIndexInt
@@ -87,7 +87,7 @@ Actors:
         dropIndexes: *coll
         index: random_int
   # Build an index on a string field.
-  - Repeat: 5
+  - Repeat: 2
     Database: *db
     Operations:
     - OperationMetricsName: CreateIndexString

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -13,7 +13,7 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 260
+      maxPoolSize: 512
       socketTimeoutMS: 3600000  # = 1 hour
 
 Actors:
@@ -132,6 +132,16 @@ Actors:
   - Blocking: None
     Database: *db
     Collection: *otherColl
+  - *Nop
+
+- Name: BackgroundSideWrites
+  Type: InsertRemove
+  Threads: 128
+  Phases:
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
   - Blocking: None
     Database: *db
     Collection: *coll  # Work on the same collection to excercise the side-writes.

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -20,7 +20,7 @@ Clients:
   Default:
     QueryOptions:
       maxPoolSize: 1024
-      socketTimeoutMS: 21600000  # = 6 hours
+      socketTimeoutMS: 7200000  # = 2 hours
 
 Actors:
 # Phase 1: Insert enough data to ensure than an index build on each field spills to disk with a
@@ -33,13 +33,12 @@ Actors:
     Database: &db test
     Threads: 1
     CollectionCount: 1
-    DocumentCount: 10000000
+    DocumentCount: 10_000_000
     BatchSize: 1000
     Document:
       randomInt: {^RandomInt: {min: -10000000, max: 10000000}}
       randomString: {^RandomString: {length: 16}}
   - &Nop {Nop: true}
-  - *Nop
   - *Nop
   - *Nop
 
@@ -66,7 +65,6 @@ Actors:
       OperationCommand:
         setParameter: 1
         maxIndexBuildMemoryUsageMegabytes: 100
-  - *Nop
   - *Nop
   - *Nop
 
@@ -111,18 +109,6 @@ Actors:
       OperationCommand:
         dropIndexes: *coll
         index: random_string
-  # Build an index on an integer field while side-writes are occurring.
-  - Repeat: 1
-    Database: *db
-    Operations:
-    - OperationMetricsName: CreateIndexIntegerSideWrites
-      OperationName: RunCommand
-      OperationCommand:
-        createIndexes: *coll
-        indexes:
-        - key:
-            randomInt: 1
-          name: random_int_side_writes
 
 - Name: BackgroundWrites
   Type: InsertRemove
@@ -138,27 +124,14 @@ Actors:
   - Blocking: None
     Database: *db
     Collection: *otherColl
-  - *Nop
-
-- Name: BackgroundSideWrites
-  Type: InsertRemove
-  Threads: 256
-  Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  - *Nop
-  - Blocking: None
-    Database: *db
-    Collection: *coll  # Work on the same collection to excercise the side-writes.
 
 - Name: LoggingActor
   Type: LoggingActor
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [3, 4, 5]
-      NopInPhasesUpTo: 5
+      Active: [2, 3]
+      NopInPhasesUpTo: 4
       PhaseConfig:
         LogEvery: 10 minutes
         Blocking: None

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -14,7 +14,7 @@ Clients:
   Default:
     QueryOptions:
       maxPoolSize: 1024
-      socketTimeoutMS: 3600000  # = 1 hour
+      socketTimeoutMS: 21600000  # = 6 hours
 
 Actors:
 # Phase 1: Insert enough data to ensure than an index build on each field spills to disk with a
@@ -145,6 +145,17 @@ Actors:
   - Blocking: None
     Database: *db
     Collection: *coll  # Work on the same collection to excercise the side-writes.
+
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3, 4, 5]
+      NopInPhasesUpTo: 5
+      PhaseConfig:
+        LogEvery: 10 minutes
+        Blocking: None
 
 AutoRun:
 - When:

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -8,6 +8,7 @@ Clients:
   Default:
     QueryOptions:
       maxPoolSize: 260
+      socketTimeoutMS: 3600000  # = 1 hour
 
 Actors:
 # Phase 1: Insert enough data to ensure than an index build on each field spills to disk with a
@@ -63,7 +64,7 @@ Actors:
   - *Nop
   - *Nop
   # Build an index on an integer field.
-  - Repeat: 20
+  - Repeat: 10
     Database: *db
     Operations:
     - OperationMetricsName: CreateIndexInt
@@ -80,7 +81,7 @@ Actors:
         dropIndexes: *coll
         index: random_int
   # Build an index on a string field.
-  - Repeat: 20
+  - Repeat: 10
     Database: *db
     Operations:
     - OperationMetricsName: CreateIndexString

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -13,7 +13,7 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 512
+      maxPoolSize: 1024
       socketTimeoutMS: 3600000  # = 1 hour
 
 Actors:
@@ -136,7 +136,7 @@ Actors:
 
 - Name: BackgroundSideWrites
   Type: InsertRemove
-  Threads: 128
+  Threads: 256
   Phases:
   - *Nop
   - *Nop

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -49,7 +49,6 @@ Actors:
   Threads: 1
   Phases:
   - *Nop
-  - *Nop
   - Repeat: 1
     Database: admin
     Operations:
@@ -64,7 +63,9 @@ Actors:
         maxIndexBuildMemoryUsageMegabytes: 100
   - *Nop
   - *Nop
+  - *Nop
 
+# Phase 3: Quiesce the system
 - Name: QuiesceActor
   Type: QuiesceActor
   # Using multiple threads will result in an error.
@@ -76,7 +77,8 @@ Actors:
   - Repeat: 1
   - *Nop
   - *Nop
-# Phases 3+: Build indexes on each field.
+
+# Phases 4, 5: Build indexes on each field.
 - Name: IndexCollection
   Type: RunCommand
   Threads: 1

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -35,6 +35,7 @@ Actors:
   - &Nop {Nop: true}
   - *Nop
   - *Nop
+  - *Nop
 
 # Phase 2: Lower the memory limit for spilling to disk so that it occurs more often.
 - Name: Setup
@@ -61,6 +62,7 @@ Actors:
         maxIndexBuildMemoryUsageMegabytes: 100
   - *Nop
   - *Nop
+  - *Nop
 
 # Phases 3+: Build indexes on each field.
 - Name: IndexCollection
@@ -70,7 +72,7 @@ Actors:
   - *Nop
   - *Nop
   # Build an index on an integer field.
-  - Repeat: 2
+  - Repeat: 1
     Database: *db
     Operations:
     - OperationMetricsName: CreateIndexInt
@@ -87,7 +89,7 @@ Actors:
         dropIndexes: *coll
         index: random_int
   # Build an index on a string field.
-  - Repeat: 2
+  - Repeat: 1
     Database: *db
     Operations:
     - OperationMetricsName: CreateIndexString
@@ -103,6 +105,18 @@ Actors:
       OperationCommand:
         dropIndexes: *coll
         index: random_string
+    # Build an index on an integer field while side-writes are occurring.
+    - Repeat: 1
+      Database: *db
+      Operations:
+      - OperationMetricsName: CreateIndexIntegerSideWrites
+        OperationName: RunCommand
+        OperationCommand:
+          createIndexes: *coll
+          indexes:
+          - key:
+              randomInt: 1
+            name: random_int_side_writes
 
 - Name: BackgroundWrites
   Type: InsertRemove
@@ -113,11 +127,14 @@ Actors:
   # Execute while building an index on an integer field.
   - Blocking: None
     Database: *db
-    Collection: &otherColl Collection1  # Work on a different collection to avoid overloading the index target
+    Collection: &otherColl Collection1  # Work on a different collection to avoid overloading the index target.
   # Execute while building an index on a string field.
   - Blocking: None
     Database: *db
     Collection: *otherColl
+  - Blocking: None
+    Database: *db
+    Collection: *coll  # Work on the same collection to excercise the side-writes.
 
 AutoRun:
 - When:

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -106,17 +106,17 @@ Actors:
         dropIndexes: *coll
         index: random_string
     # Build an index on an integer field while side-writes are occurring.
-    - Repeat: 1
-      Database: *db
-      Operations:
-      - OperationMetricsName: CreateIndexIntegerSideWrites
-        OperationName: RunCommand
-        OperationCommand:
-          createIndexes: *coll
-          indexes:
-          - key:
-              randomInt: 1
-            name: random_int_side_writes
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateIndexIntegerSideWrites
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key:
+            randomInt: 1
+          name: random_int_side_writes
 
 - Name: BackgroundWrites
   Type: InsertRemove

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -105,7 +105,7 @@ Actors:
       OperationCommand:
         dropIndexes: *coll
         index: random_string
-    # Build an index on an integer field while side-writes are occurring.
+  # Build an index on an integer field while side-writes are occurring.
   - Repeat: 1
     Database: *db
     Operations:

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -2,8 +2,14 @@ SchemaVersion: 2018-07-01
 Owner: "@mongodb/server-execution"
 Description: |
   This workload tests the write performance impact of creating indexes on a very large collection.
-  It synthetically lowers the number of concurrent operations allowed to represent a saturated
-  server.
+  For this workload we perform an index build in parallel with a write workload.
+  
+  We measure and care about the index creation time and throughput/latency of write operation
+  (inserts, deletes). Usually we'll see trade-offs in favour of either background index build time
+  or write operations.
+  
+  This test synthetically lowers the number of concurrent operations allowed to represent a
+  saturated server.
 
 Keywords:
 - stress

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -1,0 +1,122 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/server-execution"
+Description: |
+   This workload tests the performance of creating indexes on a collection large enough that the external
+   sorter must spill to disk. This can happen when the keys are larger than maxIndexBuildMemoryUsageMegabytes.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 260
+
+Actors:
+# Phase 1: Insert enough data to ensure than an index build on each field spills to disk with a
+# memory limit of 100MB.
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: &db test
+    Threads: 1
+    CollectionCount: 1
+    DocumentCount: 10000000
+    BatchSize: 1000
+    Document:
+      randomInt: {^RandomInt: {min: -10000000, max: 10000000}}
+      randomString: {^RandomString: {length: 16}}
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+
+# Phase 2: Lower the memory limit for spilling to disk so that it occurs more often.
+- Name: Setup
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    # Fsync to force a checkpoint and quiesce the system.
+    - OperationMetricsName: FsyncCommand
+      OperationName: AdminCommand
+      OperationCommand:
+        fsync: 1
+    - OperationName: AdminCommand
+      OperationCommand:
+        setParameter: 1
+        storageEngineConcurrentWriteTransactions: 5
+    - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
+      OperationName: RunCommand
+      OperationCommand:
+        setParameter: 1
+        maxIndexBuildMemoryUsageMegabytes: 100
+  - *Nop
+  - *Nop
+
+# Phases 3+: Build indexes on each field.
+- Name: IndexCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  # Build an index on an integer field.
+  - Repeat: 20
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateIndexInt
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: &coll Collection0
+        indexes:
+        - key:
+            randomInt: 1
+          name: random_int
+    - OperationMetricsName: DropIndexInt
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: *coll
+        index: random_int
+  # Build an index on a string field.
+  - Repeat: 20
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateIndexString
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key:
+            randomString: 1
+          name: random_string
+    - OperationMetricsName: DropIndexString
+      OperationName: RunCommand
+      OperationCommand:
+        dropIndexes: *coll
+        index: random_string
+
+- Name: BackgroundWrites
+  Type: InsertRemove
+  Threads: 256
+  Phases:
+  - *Nop
+  - *Nop
+  # Build an index on an integer field.
+  - Blocking: None
+    Database: *db
+    Collection: &otherColl Collection1  # Work on a different collection to avoid overloading the index target
+  # Build an index on a string field.
+  - Blocking: None
+    Database: *db
+    Collection: *otherColl
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - replica
+      - replica-all-feature-flags
+      - standalone
+      - standalone-all-feature-flags

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -41,6 +41,7 @@ Actors:
   - &Nop {Nop: true}
   - *Nop
   - *Nop
+  - *Nop
 
 # Phase 2: Lower the memory limit for spilling to disk so that it occurs more often.
 - Name: Setup
@@ -48,14 +49,10 @@ Actors:
   Threads: 1
   Phases:
   - *Nop
+  - *Nop
   - Repeat: 1
     Database: admin
     Operations:
-    # Fsync to force a checkpoint and quiesce the system.
-    - OperationMetricsName: FsyncCommand
-      OperationName: AdminCommand
-      OperationCommand:
-        fsync: 1
     - OperationName: AdminCommand
       OperationCommand:
         setParameter: 1
@@ -68,11 +65,23 @@ Actors:
   - *Nop
   - *Nop
 
+- Name: QuiesceActor
+  Type: QuiesceActor
+  # Using multiple threads will result in an error.
+  Threads: 1
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1
+  - *Nop
+  - *Nop
 # Phases 3+: Build indexes on each field.
 - Name: IndexCollection
   Type: RunCommand
   Threads: 1
   Phases:
+  - *Nop
   - *Nop
   - *Nop
   # Build an index on an integer field.
@@ -116,6 +125,7 @@ Actors:
   Phases:
   - *Nop
   - *Nop
+  - *Nop
   # Execute while building an index on an integer field.
   - Blocking: None
     Database: *db
@@ -130,7 +140,7 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [2, 3]
+      Active: [3, 4]
       NopInPhasesUpTo: 4
       PhaseConfig:
         LogEvery: 10 minutes

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -3,11 +3,11 @@ Owner: "@mongodb/server-execution"
 Description: |
   This workload tests the write performance impact of creating indexes on a very large collection.
   For this workload we perform an index build in parallel with a write workload.
-  
+
   We measure and care about the index creation time and throughput/latency of write operation
   (inserts, deletes). Usually we'll see trade-offs in favour of either background index build time
   or write operations.
-  
+
   This test synthetically lowers the number of concurrent operations allowed to represent a
   saturated server.
 


### PR DESCRIPTION
This workload is to test the impact of background index builds on a populated dataset while writes are occurring simultaneously.