### PR TITLE
PERF-3470 Add range query on '_id' and 'a' to clustered collection workload

### DIFF
--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -15,20 +15,20 @@ GlobalDefaults:
   MaxPhases: &MaxPhases 9
 
 ValueGenerators:
-  SmallId: &SmallId {^Join: {array: [
-    { ^FormatString: {"format": "%07.0f", "withArgs": [
-      {^RandomDouble: {
-        min: 1,
-        max: {^NumExpr: {withExpression: "(2 * docCount) / 10", andValues: {docCount: *docCount}}}}}]}},
-    *PaddingGenerator]}}
-  BigId: &BigId {^Join: {array: [
-    { ^FormatString: {"format": "%07.0f", "withArgs": [
-      {^RandomDouble: {
-        min: {^NumExpr: {withExpression: "(8 * docCount) / 10", andValues: {docCount: *docCount}}},
-        max: *docCount}}]}},
-    *PaddingGenerator]}}
-  SmallSecondaryKey: &SmallSecondaryKey {^Join: {array: ["1", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}
-  BigSecondaryKey: &BigSecondaryKey {^Join: {array: ["8", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}
+- &SmallId {^Join: {array: [
+  { ^FormatString: {"format": "%07.0f", "withArgs": [
+    {^RandomDouble: {
+      min: 1,
+      max: {^NumExpr: {withExpression: "(2 * docCount) / 10", andValues: {docCount: *docCount}}}}}]}},
+  *PaddingGenerator]}}
+- &BigId {^Join: {array: [
+  { ^FormatString: {"format": "%07.0f", "withArgs": [
+    {^RandomDouble: {
+      min: {^NumExpr: {withExpression: "(8 * docCount) / 10", andValues: {docCount: *docCount}}},
+      max: *docCount}}]}},
+  *PaddingGenerator]}}
+- &SmallSecondaryKey {^Join: {array: ["1", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}
+- &BigSecondaryKey {^Join: {array: ["8", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}
 
 Actors:
 # Phase 0: create collection

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -13,6 +13,8 @@ GlobalDefaults:
   Namespace: &Namespace test.Collection0
   DocumentCount: &docCount 1000000
   MaxPhases: &MaxPhases 9
+
+ValueGenerators:
   SmallId: &SmallId {^Join: {array: [
     { ^FormatString: {"format": "%07.0f", "withArgs": [
       {^RandomDouble: {

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -12,7 +12,7 @@ GlobalDefaults:
   Collection: &Collection Collection0
   Namespace: &Namespace test.Collection0
   DocumentCount: &docCount 1000000
-  MaxPhases: &MaxPhases 8
+  MaxPhases: &MaxPhases 9
 
 
 Actors:
@@ -135,8 +135,8 @@ Actors:
           OperationCommand:
             Filter: {a: *RandomSecondaryKey}
 
-# Phase 6: Range lookup with both primary and secondary key
-- Name: RangeLookupByPrimaryAndSecondaryIndexes
+# Phase 6: Range lookup with both primary and secondary key. Primary key predicate is more selective.
+- Name: RangeLookupBySelectivePrimaryAndWideSecondaryIndexes
   Type: CrudActor
   Database: *Database
   Threads: 16
@@ -153,26 +153,66 @@ Actors:
             Filter: {
               _id: {^Choose: {
                 from: [
-                  {$gte: *RandomId},
-                  {$lte: *RandomId}
+                  {$gte: &BigId {^Join: {array: [
+                    { ^FormatString: {"format": "%07d", "withArgs": [
+                      {^RandomDouble: {
+                        min: {^NumExpr: {withExpression: "(8 * docCount) / 10", andValues: {docCount: *docCount}}},
+                        max: *docCount}}]}},
+                    *PaddingGenerator]}}},
+                  {$lte: &SmallId {^Join: {array: [
+                    { ^FormatString: {"format": "%07d", "withArgs": [
+                      {^RandomDouble: {
+                        min: 1,
+                        max: {^NumExpr: {withExpression: "(2 * docCount) / 10", andValues: {docCount: *docCount}}}}}]}},
+                    *PaddingGenerator]}}}
                 ]
               }},
               a: {^Choose: {
                 from: [
-                  {$gte: *RandomSecondaryKey},
-                  {$lte: *RandomSecondaryKey}
+                  {$gte: &SmallSecondaryKey {^Join: {array: ["1", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}},
+                  {$lte: &BigSecondaryKey {^Join: {array: ["8", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}}
                 ]
               }}
             }
 
-# Phase 7: Point deletion.
+# Phase 7: Range lookup with both primary and secondary key. Secondary key predicate is more selective.
+- Name: RangeLookupByWidePrimaryAndSelectiveSecondaryIndexes
+  Type: CrudActor
+  Database: *Database
+  Threads: 16
+  Phases:
+    OnlyActiveInPhases:
+      Active: [7]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: 1 minute
+        Collection: *Collection
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {
+              _id: {^Choose: {
+                from: [
+                  {$gte: *SmallId},
+                  {$lte: *BigId}
+                ]
+              }},
+              a: {^Choose: {
+                from: [
+                  {$gte: *BigSecondaryKey},
+                  {$lte: *SmallSecondaryKey}
+                ]
+              }}
+            }
+
+# Phase 8: Point deletion.
 - Name: PointDeleter
   Type: CrudActor
   Database: *Database
   Threads: &ThreadCount 16
   Phases:
     OnlyActiveInPhases:
-      Active: [7]
+      Active: [8]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: 3 minutes

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -14,17 +14,17 @@ GlobalDefaults:
   DocumentCount: &docCount 1000000
   MaxPhases: &MaxPhases 9
   SmallId: &SmallId {^Join: {array: [
-                    { ^FormatString: {"format": "%07.0f", "withArgs": [
-                      {^RandomDouble: {
-                        min: 1,
-                        max: {^NumExpr: {withExpression: "(2 * docCount) / 10", andValues: {docCount: *docCount}}}}}]}},
-                    *PaddingGenerator]}}
+    { ^FormatString: {"format": "%07.0f", "withArgs": [
+      {^RandomDouble: {
+        min: 1,
+        max: {^NumExpr: {withExpression: "(2 * docCount) / 10", andValues: {docCount: *docCount}}}}}]}},
+    *PaddingGenerator]}}
   BigId: &BigId {^Join: {array: [
-                    { ^FormatString: {"format": "%07.0f", "withArgs": [
-                      {^RandomDouble: {
-                        min: {^NumExpr: {withExpression: "(8 * docCount) / 10", andValues: {docCount: *docCount}}},
-                        max: *docCount}}]}},
-                    *PaddingGenerator]}}
+    { ^FormatString: {"format": "%07.0f", "withArgs": [
+      {^RandomDouble: {
+        min: {^NumExpr: {withExpression: "(8 * docCount) / 10", andValues: {docCount: *docCount}}},
+        max: *docCount}}]}},
+    *PaddingGenerator]}}
   SmallSecondaryKey: &SmallSecondaryKey {^Join: {array: ["1", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}
   BigSecondaryKey: &BigSecondaryKey {^Join: {array: ["8", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}
 

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -13,7 +13,20 @@ GlobalDefaults:
   Namespace: &Namespace test.Collection0
   DocumentCount: &docCount 1000000
   MaxPhases: &MaxPhases 9
-
+  SmallId: &SmallId {^Join: {array: [
+                    { ^FormatString: {"format": "%07.0f", "withArgs": [
+                      {^RandomDouble: {
+                        min: 1,
+                        max: {^NumExpr: {withExpression: "(2 * docCount) / 10", andValues: {docCount: *docCount}}}}}]}},
+                    *PaddingGenerator]}}
+  BigId: &BigId {^Join: {array: [
+                    { ^FormatString: {"format": "%07.0f", "withArgs": [
+                      {^RandomDouble: {
+                        min: {^NumExpr: {withExpression: "(8 * docCount) / 10", andValues: {docCount: *docCount}}},
+                        max: *docCount}}]}},
+                    *PaddingGenerator]}}
+  SmallSecondaryKey: &SmallSecondaryKey {^Join: {array: ["1", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}
+  BigSecondaryKey: &BigSecondaryKey {^Join: {array: ["8", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}
 
 Actors:
 # Phase 0: create collection
@@ -153,24 +166,14 @@ Actors:
             Filter: {
               _id: {^Choose: {
                 from: [
-                  {$gte: &BigId {^Join: {array: [
-                    { ^FormatString: {"format": "%07.0f", "withArgs": [
-                      {^RandomDouble: {
-                        min: {^NumExpr: {withExpression: "(8 * docCount) / 10", andValues: {docCount: *docCount}}},
-                        max: *docCount}}]}},
-                    *PaddingGenerator]}}},
-                  {$lte: &SmallId {^Join: {array: [
-                    { ^FormatString: {"format": "%07.0f", "withArgs": [
-                      {^RandomDouble: {
-                        min: 1,
-                        max: {^NumExpr: {withExpression: "(2 * docCount) / 10", andValues: {docCount: *docCount}}}}}]}},
-                    *PaddingGenerator]}}}
+                  {$gte: *BigId},
+                  {$lte: *SmallId}
                 ]
               }},
               a: {^Choose: {
                 from: [
-                  {$gte: &SmallSecondaryKey {^Join: {array: ["1", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}},
-                  {$lte: &BigSecondaryKey {^Join: {array: ["8", {^FastRandomString: {length: 5, alphabet: "0123456789"}}]}}}
+                  {$gte: *SmallSecondaryKey},
+                  {$lte: *BigSecondaryKey}
                 ]
               }}
             }

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -12,7 +12,7 @@ GlobalDefaults:
   Collection: &Collection Collection0
   Namespace: &Namespace test.Collection0
   DocumentCount: &docCount 1000000
-  MaxPhases: &MaxPhases 7
+  MaxPhases: &MaxPhases 8
 
 
 Actors:
@@ -109,7 +109,6 @@ Actors:
       PhaseConfig:
         Repeat: 1
         Database: *Database
-        Collection: *Collection
         Operations:
         - OperationName: RunCommand
           OperationCommand:
@@ -136,15 +135,41 @@ Actors:
           OperationCommand:
             Filter: {a: {^FastRandomString: {length: 6, alphabet: "0123456789"}}}
 
+# Phase 6: Range lookup with both primary and secondary key
+- Name: RangeLookupByPrimaryAndSecondaryIndexes
+  Type: CrudActor
+  Database: *Database
+  Threads: 16
+  Phases:
+    OnlyActiveInPhases:
+      Active: [6]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: 1 minute
+        Collection: *Collection
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {
+              _id: {
+                $gte: {^Join: {array: [{ ^FormatString: {"format": "%07d", "withArgs": [{^RandomInt: {min: 1, max: *docCount}}]}}, *PaddingGenerator]}}
+              },
+              a: {
+                $gte: {^Join: {array: [
+                  {^Choose: {from: ["49", "51"]}},
+                  {^FastRandomString: {length: 4, alphabet: "0123456789"}}
+                ]}}
+              }
+            }
 
-# Phase 6: Point deletion.
+# Phase 7: Point deletion.
 - Name: PointDeleter
   Type: CrudActor
   Database: *Database
   Threads: &ThreadCount 16
   Phases:
     OnlyActiveInPhases:
-      Active: [6]
+      Active: [7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: 3 minutes

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -148,8 +148,9 @@ Actors:
           OperationCommand:
             Filter: {a: *RandomSecondaryKey}
 
-# Phase 6: Range lookup with both primary and secondary key. Primary key predicate is more selective.
-- Name: RangeLookupBySelectivePrimaryAndWideSecondaryIndexes
+# Phase 6: Range query with both primary and secondary key. Primary key matches much less
+# documents, so primary index should be selected by the query planner.
+- Name: PrimaryIndexScanWithSecondaryKeyFilter
   Type: CrudActor
   Database: *Database
   Threads: 16
@@ -178,8 +179,9 @@ Actors:
               }}
             }
 
-# Phase 7: Range lookup with both primary and secondary key. Secondary key predicate is more selective.
-- Name: RangeLookupByWidePrimaryAndSelectiveSecondaryIndexes
+# Phase 7: Range query with both primary and secondary key. Secondary key matches much less
+# documents, so secondary index should be selected by the query planner.
+- Name: SecondaryIndexScanWithPrimaryKeyFilter
   Type: CrudActor
   Database: *Database
   Threads: 16

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -77,7 +77,7 @@ Actors:
           # Start from {_id: "0000001"} in order to be able to set the ^RandomInt max bound to *docCount
           # in the LookupByClusterKey phase. This works around TIG-3759.
           _id: {^Join: {array: [{ ^FormatString: {"format": "%07d", "withArgs": [{^Inc: {start: 1}}]}}, *PaddingGenerator]}}
-          a: {^FastRandomString: {length: 6, alphabet: "0123456789"}}
+          a: &RandomSecondaryKey {^FastRandomString: {length: 6, alphabet: "0123456789"}}
           b: {^FastRandomString: {length: 1024}}
 
 # Phase 3: Point _id lookups. TODO convert to range queries once TIG-3707 is implemented.
@@ -133,7 +133,7 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter: {a: {^FastRandomString: {length: 6, alphabet: "0123456789"}}}
+            Filter: {a: *RandomSecondaryKey}
 
 # Phase 6: Range lookup with both primary and secondary key
 - Name: RangeLookupByPrimaryAndSecondaryIndexes
@@ -151,15 +151,24 @@ Actors:
         - OperationName: find
           OperationCommand:
             Filter: {
-              _id: {
-                $gte: {^Join: {array: [{ ^FormatString: {"format": "%07d", "withArgs": [{^RandomInt: {min: 1, max: *docCount}}]}}, *PaddingGenerator]}}
-              },
-              a: {
-                $gte: {^Join: {array: [
-                  {^Choose: {from: ["49", "51"]}},
-                  {^FastRandomString: {length: 4, alphabet: "0123456789"}}
-                ]}}
-              }
+              _id: {^Choose: {
+                from: [
+                  {$gte: &RandomId {^Join: {array: [
+                    { ^FormatString: {
+                      "format": "%07d",
+                      "withArgs": [{^RandomInt: {min: 1, max: *docCount}}]
+                    }},
+                    *PaddingGenerator
+                  ]}}},
+                  {$lte: *RandomId}
+                ]
+              }},
+              a: {^Choose: {
+                from: [
+                  {$gte: *RandomSecondaryKey},
+                  {$lte: *RandomSecondaryKey}
+                ]
+              }}
             }
 
 # Phase 7: Point deletion.

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -154,13 +154,13 @@ Actors:
               _id: {^Choose: {
                 from: [
                   {$gte: &BigId {^Join: {array: [
-                    { ^FormatString: {"format": "%07d", "withArgs": [
+                    { ^FormatString: {"format": "%07.0f", "withArgs": [
                       {^RandomDouble: {
                         min: {^NumExpr: {withExpression: "(8 * docCount) / 10", andValues: {docCount: *docCount}}},
                         max: *docCount}}]}},
                     *PaddingGenerator]}}},
                   {$lte: &SmallId {^Join: {array: [
-                    { ^FormatString: {"format": "%07d", "withArgs": [
+                    { ^FormatString: {"format": "%07.0f", "withArgs": [
                       {^RandomDouble: {
                         min: 1,
                         max: {^NumExpr: {withExpression: "(2 * docCount) / 10", andValues: {docCount: *docCount}}}}}]}},

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -95,7 +95,7 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter: {_id: {^Join: {array: [{ ^FormatString: {"format": "%07d", "withArgs": [{^RandomInt: {min: 1, max: *docCount}}]}}, *PaddingGenerator]}}}
+            Filter: &RandomId {_id: {^Join: {array: [{ ^FormatString: {"format": "%07d", "withArgs": [{^RandomInt: {min: 1, max: *docCount}}]}}, *PaddingGenerator]}}}
 
 
 # Phase 4: Create a secondary index.
@@ -153,13 +153,7 @@ Actors:
             Filter: {
               _id: {^Choose: {
                 from: [
-                  {$gte: &RandomId {^Join: {array: [
-                    { ^FormatString: {
-                      "format": "%07d",
-                      "withArgs": [{^RandomInt: {min: 1, max: *docCount}}]
-                    }},
-                    *PaddingGenerator
-                  ]}}},
+                  {$gte: *RandomId},
                   {$lte: *RandomId}
                 ]
               }},


### PR DESCRIPTION
Added range queires on '_id' and 'a' to test if multi planner can efficiently choose between clustered index scan and secondary index scan