### PR TITLE
PERF-3268: Automate multiple mongosync use-case

### DIFF
--- a/src/cast_core/include/cast_core/actors/ExternalScriptRunner.hpp
+++ b/src/cast_core/include/cast_core/actors/ExternalScriptRunner.hpp
@@ -42,8 +42,6 @@ public:
 
     void run() override;
 
-    std::string exec(const char* cmd);
-
     static std::string_view defaultName() {
         return "ExternalScriptRunner";
     }
@@ -54,6 +52,7 @@ private:
     struct PhaseConfig;
     PhaseLoop<PhaseConfig> _loop;
     std::string _command;
+    std::unordered_map<std::string, std::string> _environmentVariables;
 };
 
 }  // namespace genny::actor

--- a/src/workloads/c2c/ChangeEventApplication.yml
+++ b/src/workloads/c2c/ChangeEventApplication.yml
@@ -13,6 +13,9 @@ Keywords:
 - change event application
 - CEA
 
+EnvironmentVariables:
+  MongosyncConnectionUrls: http://localhost:27182
+
 Clients:
   Default:
     QueryOptions:
@@ -21,17 +24,52 @@ Clients:
 ScriptsPath: &scriptsPath ./MongosyncScripts.yml
 
 Actors:
+
+- Name: SetupSharding
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: admin
+    # We also run this on replica sets and so we
+    # ignore if this command fails
+    ThrowOnFailure: false
+    Operations:
+    - OperationMetricsName: EnableShardingMetrics
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: db
+
+  - Repeat: 1
+    Database: admin
+    ThrowOnFailure: false
+    Operations:
+    - OperationMetricsName: ShardCollectionMetrics
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: db.Collection0
+        key:
+          _id: hashed
+  - &nop {Nop: true}
+  - *nop
+  - *nop
+  - *nop
+  - *nop
+  - *nop
+
 - Name: Mongosync
   Type: ExternalScriptRunner
   Threads: 1
   Phases:
+  - *nop
+  - *nop
   - LoadConfig:
       Path: *scriptsPath
       Key: StartMongosync
   - LoadConfig:
       Path: *scriptsPath
       Key: PollForCEA
-  - &nop {Nop: true}
+  - *nop
   - LoadConfig:
       Path: *scriptsPath
       Key: DrainWrites
@@ -48,10 +86,12 @@ Actors:
   Phases:
   - *nop
   - *nop
+  - *nop
+  - *nop
   - Repeat: 1
     BatchSize: 100
     Threads: 1
-    DocumentCount: 1000000
+    DocumentCount: 500000
     Database: db
 
     # Note the document shape and number of collections doesn't
@@ -60,7 +100,7 @@ Actors:
     # insert workload
     CollectionCount: 1
     Document:
-      a: {^RandomInt: {min: 0, max: 1000000}}
+      a: {^RandomInt: {min: 0, max: 500000}}
       b: {^RandomString: {length: 8}}
       c: {^RandomString: {length: 20}}
   - *nop

--- a/src/workloads/c2c/MongosyncScripts.yml
+++ b/src/workloads/c2c/MongosyncScripts.yml
@@ -12,85 +12,32 @@ Description: |
         Path: ./MongosyncScripts.yml
         Key: StartMongosync
 
-  Note that the polling scripts start with set -eou pipefail so that any
-  subcommand run during the script failing will cause the entire script to fail.
-  This way if mongosync crashes during the test, it will stop the test execution
-  immediately and genny will bubble up the error and fail the test
-
-  For curl commands we pass -s and -S so that an errors are still reported (-S)
-  but download progress stats are not logged to stderr
-
 StartMongosync:
   Repeat: 1
-  Command: sh
+  Command: python3
   MetricsName: StartMongosync
-  Script: |
-    curl -s -S -X POST http://10.2.0.160:27182/api/v1/start \
-      -H 'Content-Type: application/json' \
-      -d '{"Source": "cluster0", "Destination": "cluster1"}'
+  ScriptPath: ./src/genny/src/workloads/c2c/mongosync_helpers.py -m start
 
 PollForCEA:
   Repeat: 1
-  Command: sh
+  Command: python3
   MetricsName: PollForCEA
-  Script: |
-    set -eou pipefail
-
-    getState() {
-      curl -s -S http://10.2.0.160:27182/api/v1/progress | jq '.progress.info' --raw-output
-    }
-
-    state=$(getState)
-    while [ "$state" != "change event application" ]
-    do
-      echo "Polling for change event application, current state=$state"
-      sleep 1;
-      state=$(getState)
-    done
+  ScriptPath: ./src/genny/src/workloads/c2c/mongosync_helpers.py -m poll_for_cea
 
 DrainWrites:
   Repeat: 1
-  Command: sh
+  Command: python3
   MetricsName: DrainWrites
-  Script: |
-    set -eou pipefail
-
-    getLag () {
-      curl -s -S http://10.2.0.160:27182/api/v1/progress | jq '.progress.lagTimeSeconds'
-    }
-
-    lagTime=$(getLag)
-    while [ $lagTime -gt 0 ];
-    do
-      echo "Waiting for writes to drain, currentLag=$lagTime"
-      sleep 1;
-      lagTime=$(getLag)
-    done
+  ScriptPath: ./src/genny/src/workloads/c2c/mongosync_helpers.py -m drain_writes
 
 Commit:
   Repeat: 1
-  Command: sh
+  Command: python3
   MetricsName: Commit
-  Script: |
-    curl -s -S -X POST http://10.2.0.160:27182/api/v1/commit \
-      -H 'Content-Type: application/json' \
-      -d '{}'
+  ScriptPath: ./src/genny/src/workloads/c2c/mongosync_helpers.py -m commit
 
 WaitForCommit:
   Repeat: 1
-  Command: sh
+  Command: python3
   MetricsName: WaitForCommit
-  Script: |
-    set -eou pipefail
-
-    getState() {
-      curl -s -S http://10.2.0.160:27182/api/v1/progress | jq '.progress.state' --raw-output
-    }
-
-    state=$(getState)
-    while [ $state != "COMMITTED" ]
-    do
-      echo "Waiting for commit to finish, state=$state"
-      sleep 1;
-      state=$(getState)
-    done
+  ScriptPath: ./src/genny/src/workloads/c2c/mongosync_helpers.py -m wait_for_commit

--- a/src/workloads/c2c/mongosync_helpers.py
+++ b/src/workloads/c2c/mongosync_helpers.py
@@ -1,0 +1,117 @@
+import argparse
+import os
+import time
+import requests
+import functools
+from concurrent.futures import ThreadPoolExecutor
+
+
+def poll_mongosync(connection_urls, predicate, key):
+    """
+    Wait for all mongosyncs to reach a certain state (e.g. predicate returns False)
+    based on a value returned by the /progress endpoint
+    """
+
+    def get_progress():
+        res = requests.get(f"{url}/api/v1/progress")
+        return res.json()["progress"][key]
+
+    for url in connection_urls:
+        info = get_progress()
+        while predicate(info):
+            time.sleep(1)
+            print(f"Polling {url} for {key}, current value = {info}", flush=True)
+            info = get_progress()
+
+
+def change_one_mongosync_state(route, body, url):
+    """
+    Change state of a given mongosync running at the provided url
+    """
+    resp = requests.post(
+        f"{url}{route}", json=body
+    )
+    print(resp.json(), flush=True)
+    success = resp.json()["success"]
+    if not success:
+        raise Exception(f"State change failed at route {route}")
+    return success
+
+
+def change_mongosync_state(connection_urls, route, body):
+    """
+    Helper function to change state of mongosync. This must
+    send all requests in parallel, as some commands block until
+    all instances recieve them
+    """
+    fn = functools.partial(change_one_mongosync_state, route, body)
+    with ThreadPoolExecutor() as executor:
+        futures = []
+        # Using executor.map swallows exceptions from the task,
+        # using .submit and then accessing the future's .result
+        # will cause exceptions to be rethrown
+        for url in connection_urls:
+            futures.append(executor.submit(fn, url))
+        for f in futures:
+            f.result()
+
+def start_mongosync(connection_urls):
+    """
+    Start all mongosyncs
+    """
+    change_mongosync_state(connection_urls,
+        "/api/v1/start",
+        {"Source": "cluster0", "Destination": "cluster1"})
+
+def poll_for_cea(connection_urls):
+    """
+    Poll until mongosync reaches the CEA state
+    """
+    poll_mongosync(connection_urls, lambda x: x != "change event application", "info")
+
+
+def drain_writes(connection_urls):
+    """
+    Wait for mongosync to drain all writes, continuing to poll
+    while lag is greater than 5s
+    """
+    poll_mongosync(connection_urls, lambda x: int(x) > 5, "lagTimeSeconds")
+
+
+def wait_for_commit(connection_urls):
+    """
+    Wait until all mongosyncs have reached the COMMITED state
+    """
+    poll_mongosync(connection_urls, lambda x: x != "COMMITTED", "state")
+
+
+def commit(connection_urls):
+    """
+    Commit the migration for all mongosyncs
+    """
+    change_mongosync_state(connection_urls, "/api/v1/commit", {})
+
+
+def main (args):
+    lookup = {
+        "start": start_mongosync,
+        "poll_for_cea": poll_for_cea,
+        "drain_writes": drain_writes,
+        "wait_for_commit": wait_for_commit,
+        "commit": commit,
+    }
+
+    if args.mode in lookup:
+        mongosync_connection_var = "MongosyncConnectionUrls"
+        connection_urls = os.environ.get(mongosync_connection_var)
+        if not connection_urls:
+            raise Exception(f"The environment variable \"{mongosync_connection_var}\" must be set to use this script")
+        connection_urls = connection_urls.split(" ")
+        lookup[args.mode](connection_urls)
+    else:
+        raise Exception(f"Unknown mode {args.mode}")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-m", "--mode", help="Which mongosync helper to run")
+args = parser.parse_args()
+main(args)

--- a/src/workloads/docs/ExternalScriptActor.yml
+++ b/src/workloads/docs/ExternalScriptActor.yml
@@ -4,6 +4,7 @@ Description: |
   This workload was created to test an external script runner as per PERF-3198.
   The execution stats of the script will be collected with metrics name "ExternalScript"
   If the script writes and only writes an integer to stdout as result, the result will be collected to the specified metrics name (DefaultMetricsName as default)
+
 Actors:
 # Run JS script without connecting to a mongo db server
 - Name: MongoshScriptRunner


### PR DESCRIPTION
This adds sharding support to the mongosync workloads and refactors the external script actor so that we can pass in environment variables. This allows us to pass in the mongosync connection strings so they aren't hardcoded. I also ported the mongosync scripts to python since they were becoming more complex and needed threading support.