### PR TITLE
PERF-3485 Extend 'CrudActor' to support the aggregate command

### DIFF
--- a/src/cast_core/test/CrudActorYamlTestRunner.cpp
+++ b/src/cast_core/test/CrudActorYamlTestRunner.cpp
@@ -130,6 +130,9 @@ void requireEvent(ApmEvent& event, YAML::Node requirements) {
         REQUIRE(event.command["$readPreference"]["maxStalenessSeconds"].get_int64() ==
                 staleness.as<int64_t>());
     }
+    if (auto allowDiskUse = requirements["allowDiskUse"]) {
+        REQUIRE(event.command["allowDiskUse"].get_bool() == allowDiskUse.as<bool>());
+    }
 }
 
 void requireAllEvents(mongocxx::pool::entry& client, ApmEvents events, YAML::Node requirements) {

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -685,6 +685,14 @@ Tests:
               Document: { a: "foo", b: 4 }
       - OperationName: aggregate
         OperationCommand:
+            # In order to test that the pipeline produces the correct results, we use $out to
+            # persist the result of the query to the "test" collection. The contents of the
+            # collection are subsequently validated using 'OutcomeData'.
+            #
+            # The test is written this way because the 'CrudActor' iterates the agg cursor and
+            # throws out the query results, without providing an easy way to validate that the
+            # contents of the cursor are as expected. (Although this is something that we could
+            # potentially add support for in the future.)
             Pipeline: [{$group: {_id: "$a", sum: {$sum: "$b"}}}, {$out: "test"}]
     OutcomeData:
         - {_id: "foo", sum: 7}
@@ -700,3 +708,11 @@ Tests:
     ExpectAllEvents:
       allowDiskUse: false
       bypassDocumentValidation: true
+
+  - Description: Test that an error is thrown when the pipeline is not an array.
+    Operations:
+      - OperationName: aggregate
+        OperationCommand:
+            Pipeline: {$group: {_id: "$a", sum: {$sum: "$b"}}}
+    Error: |
+      .*'Pipeline' must be an array.*

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -686,9 +686,6 @@ Tests:
       - OperationName: aggregate
         OperationCommand:
             Pipeline: [{$group: {_id: "$a", sum: {$sum: "$b"}}}, {$out: "test"}]
-            Options:
-              AllowDiskUse: false
-              BypassDocumentValidation: true
     OutcomeData:
         - {_id: "foo", sum: 7}
 

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -673,3 +673,33 @@ Tests:
     OutcomeData:
       - {a: 2}
     AssertNumTransactionsCommitted: 1
+
+  - Description: Test that an aggregate command with $out produces the expected data.
+    Operations:
+      - OperationName: bulkWrite
+        OperationCommand:
+          WriteOperations:
+            - WriteCommand: insertOne
+              Document: { a: "foo", b: 3 }
+            - WriteCommand: insertOne
+              Document: { a: "foo", b: 4 }
+      - OperationName: aggregate
+        OperationCommand:
+            Pipeline: [{$group: {_id: "$a", sum: {$sum: "$b"}}}, {$out: "test"}]
+            Options:
+              AllowDiskUse: false
+              BypassDocumentValidation: true
+    OutcomeData:
+        - {_id: "foo", sum: 7}
+
+  - Description: Test that an aggregate command passes through its command options.
+    Operations:
+      - OperationName: aggregate
+        OperationCommand:
+            Pipeline: [{$group: {_id: "$a", sum: {$sum: "$b"}}}, {$out: "test"}]
+            Options:
+              AllowDiskUse: false
+              BypassDocumentValidation: true
+    ExpectAllEvents:
+      allowDiskUse: false
+      bypassDocumentValidation: true

--- a/src/workloads/docs/CrudActorAggregate.yml
+++ b/src/workloads/docs/CrudActorAggregate.yml
@@ -1,0 +1,29 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload demonstrates using the CrudActor to run an aggregate command. Like find operations,
+  genny will exhaust the cursor, measuring the initial aggregate command and all subsequent getMore
+  operations.
+
+Actors:
+- Name: CrudActorAggregateExample
+  Type: CrudActor
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: test
+    Collection: crud_actor_aggregate
+    Operations:
+    - OperationMetricsName: PipelineWithoutOptions
+      OperationName: aggregate
+      OperationCommand:
+          Pipeline: [{$match: {x: 42}}, {$group: {_id: "$y", sum: {$sum: "$z"}}}]
+    - OperationMetricsName: PipelineWithOptions
+      OperationName: aggregate
+      OperationCommand:
+          Pipeline: [{$match: {x: 42}}, {$group: {_id: "$y", sum: {$sum: "$z"}}}]
+          # For a complete list of available options, see OptionsConversion.hpp.
+          Options:
+            AllowDiskUse: true
+            BatchSize: 1000
+            MaxTime: 5 minute

--- a/src/workloads/docs/CrudActorAggregate.yml
+++ b/src/workloads/docs/CrudActorAggregate.yml
@@ -17,13 +17,13 @@ Actors:
     - OperationMetricsName: PipelineWithoutOptions
       OperationName: aggregate
       OperationCommand:
-          Pipeline: [{$match: {x: 42}}, {$group: {_id: "$y", sum: {$sum: "$z"}}}]
+        Pipeline: [{$match: {x: 42}}, {$group: {_id: "$y", sum: {$sum: "$z"}}}]
     - OperationMetricsName: PipelineWithOptions
       OperationName: aggregate
       OperationCommand:
-          Pipeline: [{$match: {x: 42}}, {$group: {_id: "$y", sum: {$sum: "$z"}}}]
-          # For a complete list of available options, see OptionsConversion.hpp.
-          Options:
-            AllowDiskUse: true
-            BatchSize: 1000
-            MaxTime: 5 minute
+        Pipeline: [{$match: {x: 42}}, {$group: {_id: "$y", sum: {$sum: "$z"}}}]
+        # For a complete list of available options, see OptionsConversion.hpp.
+        Options:
+          AllowDiskUse: true
+          BatchSize: 1000
+          MaxTime: 5 minute


### PR DESCRIPTION
Proposed detailed commit message:

> Aggregate, like find, returns a cursor. We often want to measure the time taken to fully iterate the cursor, including the time to process the initial request as well as any subsequent getMore commands. Past workarounds obviated by this change include using manipulating the batchSize to ensure that the complete reply fits in a single batch, or using explain with "executionStats" verbosity.

This is depended on by [PERF-3476](https://jira.mongodb.org/browse/PERF-3476) (see https://github.com/mongodb/genny/pull/757).