### PR TITLE
PERF-2891: Adding workload for measuring create / drop time for views.

### DIFF
--- a/src/workloads/scale/CreateDropView.yml
+++ b/src/workloads/scale/CreateDropView.yml
@@ -68,4 +68,5 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - single-replica
+      - replica
+      - shard-lite

--- a/src/workloads/scale/CreateDropView.yml
+++ b/src/workloads/scale/CreateDropView.yml
@@ -1,0 +1,81 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  This workload loads a collection with documents and then repeatedly 
+  create and drops a view on that collection.
+Keywords:
+- view
+- create
+- drop
+
+dbname: &dbname viewDB
+DocumentCount: &NumDocs 100000
+CollectionCount: &NumColls 1
+
+
+Actors:
+- Name: Setup
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    BatchSize: 100
+    Threads: 1
+    DocumentCount: *NumDocs
+    Database: *dbname
+    CollectionCount: *NumColls
+    Document: &doc
+      id: {^RandomInt: {min: 0, max: *NumDocs}}
+      a: {^RandomInt: {min: 0, max: *NumDocs}}
+      c: &string {^RandomString: {length: 50}}  # Adjust this so the doc comes out as 100 B.
+    Indexes:
+    - keys: {id: 1}
+    - keys: {a: 1}
+  - Phase: 1..3
+    Nop: true
+
+- Name: QuiesceBetweenLevels
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - &nop {Nop: true}
+  - &quiesce
+    Repeat: 1
+    Database: admin
+    Operations:
+    # Fsync to force a checkpoint and quiesce the system.
+    - OperationMetricsName: FsyncCommand
+      OperationName: AdminCommand
+      OperationCommand:
+        fsync: 1
+  - *nop
+  - *quiesce
+
+#This actor repeatedly creates and then drops a view
+- Name: ViewCreateDrop
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Nop: true
+  - Nop: true 
+  - &toggleView1
+    Repeat: 100000
+    Database: *dbname
+    Operations:
+    - OperationMetricsName: CreateViewMetric
+      OperationIsQuiet: true
+      OperationName: RunCommand
+      OperationCommand:
+        {create: myView, viewOn: Collection0, pipeline: [ { $match: { id: { $lt: 10 } } } ]}
+    - OperationName: RunCommand
+      OperationMetricsName: DropViewMetric
+      OperationIsQuiet: true
+      OperationCommand:
+        drop: myView
+  - Nop: true        
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - single-replica

--- a/src/workloads/scale/CreateDropView.yml
+++ b/src/workloads/scale/CreateDropView.yml
@@ -27,29 +27,20 @@ Actors:
     Document: &doc
       id: {^RandomInt: {min: 0, max: *NumDocs}}
       a: {^RandomInt: {min: 0, max: *NumDocs}}
-      c: &string {^RandomString: {length: 50}}  # Adjust this so the doc comes out as 100 B.
-    Indexes:
-    - keys: {id: 1}
-    - keys: {a: 1}
+      c: &string {^RandomString: {length: 50}}
   - Phase: 1..3
     Nop: true
 
-- Name: QuiesceBetweenLevels
-  Type: RunCommand
+- Name: QuiesceActor
+  Type: QuiesceActor
   Threads: 1
+  Database: dbname
   Phases:
-  - &nop {Nop: true}
-  - &quiesce
-    Repeat: 1
-    Database: admin
-    Operations:
-    # Fsync to force a checkpoint and quiesce the system.
-    - OperationMetricsName: FsyncCommand
-      OperationName: AdminCommand
-      OperationCommand:
-        fsync: 1
-  - *nop
-  - *quiesce
+  - Nop: true
+  - Repeat: 1
+  - Nop: true
+  - Repeat: 1
+
 
 # This actor repeatedly creates and then drops a view
 - Name: ViewCreateDrop
@@ -58,8 +49,7 @@ Actors:
   Phases:
   - Nop: true
   - Nop: true
-  - &toggleView1
-    Repeat: 100000
+  - Repeat: 100000
     Database: *dbname
     Operations:
     - OperationMetricsName: CreateViewMetric

--- a/src/workloads/scale/CreateDropView.yml
+++ b/src/workloads/scale/CreateDropView.yml
@@ -1,7 +1,7 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  This workload loads a collection with documents and then repeatedly 
+  This workload loads a collection with documents and then repeatedly
   create and drops a view on that collection.
 Keywords:
 - view
@@ -51,13 +51,13 @@ Actors:
   - *nop
   - *quiesce
 
-#This actor repeatedly creates and then drops a view
+# This actor repeatedly creates and then drops a view
 - Name: ViewCreateDrop
   Type: RunCommand
   Threads: 1
   Phases:
   - Nop: true
-  - Nop: true 
+  - Nop: true
   - &toggleView1
     Repeat: 100000
     Database: *dbname
@@ -66,13 +66,13 @@ Actors:
       OperationIsQuiet: true
       OperationName: RunCommand
       OperationCommand:
-        {create: myView, viewOn: Collection0, pipeline: [ { $match: { id: { $lt: 10 } } } ]}
+        {create: myView, viewOn: Collection0, pipeline: [{$match: {id: {$lt: 10}}}]}
     - OperationName: RunCommand
       OperationMetricsName: DropViewMetric
       OperationIsQuiet: true
       OperationCommand:
         drop: myView
-  - Nop: true        
+  - Nop: true
 
 AutoRun:
 - When:


### PR DESCRIPTION
@dalyd I was hoping to get your thoughts on this workload related to [PERF-2891](https://jira.mongodb.org/browse/PERF-2891). 
Do you think this provides enough value to be added? 
It takes less than a minute to run, and would monitor the duration of time for views to be created and deleted (averages are around 400,000 ns). 
I'm not particularly attached to it, and am fine just documenting having looked at this. 

I previous tested a different [view create / drop workload](https://github.com/mongodb/genny/compare/master...PERF-2891-create_view#diff-425cec6331df008a5d898ac29ac1757e5a3711f6c89710b182ad69fd0b19e8e8R112) (64 threads with 10,000 repeated create / drop views each) for an hour alongside mixed CRUD actors, and the server did seem to queue up the commands, create / drop view latency increased cyclically but dropped off, and the server managed well. Based on the servers behavior, I didn't see the need to add this kind of workload 