### PR TITLE
PERF-3364 Add Genny workloads to run QE performance tests

### DIFF
--- a/src/phases/encrypted/ContinuousWritesWithExponentialCompactTemplate.yml
+++ b/src/phases/encrypted/ContinuousWritesWithExponentialCompactTemplate.yml
@@ -126,7 +126,7 @@ Actors:
   ClientName: EncryptedPool
   Phases:
     OnlyActiveInPhases:
-      Active: [4,6]
+      Active: [4, 6]
       NopInPhasesUpTo: *max_phases
       PhaseConfig:
         Repeat: 1

--- a/src/phases/encrypted/ContinuousWritesWithExponentialCompactTemplate.yml
+++ b/src/phases/encrypted/ContinuousWritesWithExponentialCompactTemplate.yml
@@ -1,0 +1,139 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  With queryable encryption enabled, this workload runs alternating CRUD and compact phases,
+  where the total number of inserts & updates is increased on every CRUD+Compact cycle in order
+  to grow the ECOC collection to a size that is at least twice its pre-compaction size in
+  the previous cycle. This is meant to test how long compaction takes relative to ECOC size.
+  Parameters:
+    Database:             name of encrypted database
+    Collection:           name of encrypted collection
+    ClientName:           name of encrypted client pool
+    Namespace:            namespace of the encrypted collection
+    ShardCollectionPhase: must be set to {Nop: true} for unsharded tests
+
+GlobalDefaults:
+  # Parameters
+  Database: &encrypted_db {^Parameter: {Name: "Database", Default: ""}}
+  Collection: &encrypted_coll {^Parameter: {Name: "Collection", Default: "testcoll"}}
+  Namespace: &encrypted_ns {^Parameter: {Name: "Namespace", Default: ""}}
+  ClientName: &encrypted_pool {^Parameter: {Name: "ClientName", Default: "Default"}}
+  MaxPhases: &max_phases 6
+  ShardCollectionPhase: &shard_or_nop
+    ^Parameter:
+      Name: "ShardCollectionPhase"
+      Default:
+        Repeat: 1
+        Database: admin
+        Operations:
+        - OperationMetricsName: EnableSharding
+          OperationName: AdminCommand
+          OperationCommand:
+            enableSharding: *encrypted_db
+        - OperationMetricsName: ShardCollection
+          OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: *encrypted_ns
+            key: {field1: hashed}
+
+  # Constants
+  RandomPrimaryKey: &rand_primary_key {^FormatString: {"format": "%0100d", "withArgs": [{^RandomInt: {min: 1, max: 2048}}]}}
+  RandomSecondaryKey: &rand_secondary_key {^RandomInt: {min: 1, max: 2048}}
+  InsertOperation: &insert_one
+    OperationName: insertOne
+    OperationMetricsName: insert
+    OperationCommand:
+      Document:
+        field0: *rand_primary_key
+        field1: *rand_secondary_key
+  # Update operation that uses unencrypted field in filter is faster
+  # than one that queries on an encrypted field
+  FastUpdateOperation: &fast_update_one
+    OperationName: updateOne
+    OperationMetricsName: update
+    OperationCommand:
+      Filter:
+        field1: *rand_secondary_key
+      Update:
+        $set:
+          field0: *rand_primary_key
+
+Actors:
+- Name: IndexSecondaryKey
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *max_phases
+      PhaseConfig:
+        Repeat: 1
+        Database: *encrypted_db
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            createIndexes: *encrypted_coll
+            indexes:
+            - key:
+                field1: 1
+              name: field1
+
+- Name: ShardCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *max_phases
+      PhaseConfig: *shard_or_nop
+
+# This actor runs the inserts and updates to increase the size of the ECOC collection before
+# running compaction. On every phase, the number of iterations is roughly twice that of the
+# previous phase, so that the ECOC size is also doubled.
+- Name: ContinuousWrites
+  Type: CrudActor
+  Threads: 32
+  Database: *encrypted_db
+  ClientName: EncryptedPool
+  Phases:
+  # Phases 0 and 1 are reserved for indexes setup & sharding
+  - &Nop {Nop: true}
+  - *Nop
+  # Phase 2: Pre-load the collection. The insertions will add 32*2571*136 bytes = ~10.67 MB to the ECOC
+  - Repeat: 2571
+    Collection: *encrypted_coll
+    Operations:
+    - *insert_one
+  # Phase 3: Run updates to also populate the ECC. These will add approx 32*2571*136*2 = 21.34 MB
+  # to the ECOC. Bringing the total ECOC size to 32 MB before compaction.
+  - Repeat: 2571
+    Collection: *encrypted_coll
+    Operations:
+    - *fast_update_one
+  - *Nop
+  # Phase 5: ECOC ~64 MB after this phase
+  - Repeat: 3085
+    Collection: *encrypted_coll
+    Operations:
+    - *insert_one
+    - *fast_update_one
+    - *fast_update_one
+  - *Nop
+
+- Name: Compactor
+  Type: RunCommand
+  Threads: 1
+  ClientName: EncryptedPool
+  Phases:
+    OnlyActiveInPhases:
+      Active: [4,6]
+      NopInPhasesUpTo: *max_phases
+      PhaseConfig:
+        Repeat: 1
+        Database: *encrypted_db
+        MetricsName: "Compactor"
+        Operations:
+        - OperationName: RunCommand
+          OperationMetricsName: compact
+          OperationCommand:
+            compactStructuredEncryptionData: *encrypted_coll

--- a/src/phases/encrypted/YCSBLikeActorTemplate.yml
+++ b/src/phases/encrypted/YCSBLikeActorTemplate.yml
@@ -1,0 +1,119 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Phase definitions for encrypted YCSB-like workloads. This defines the YCSBLikeActor
+  that emulates the MongoDB YCSB workloads.
+  Parameters:
+    Database:             name of encrypted database
+    Collection:           name of encrypted collection
+    ClientName:           name of encrypted client pool
+    Threads:              number of client threads for the CrudActor
+    Filter:               filter document to use for find and update operations
+    UpdateDocument:       document used in the $set field of an update operation
+    InsertDocument:       document to insert during the load phase
+    100ReadRepeat:        how many iterations of the 100% read phase to run per thread
+    95Read5UpdateRepeat:  how many iterations of the 95/5 phase to run per thread
+    100UpdateRepeat:      how many iterations of the 100% update phase to run per thread
+    50Read50UpdateRepeat: how many iterations of the 50/50 phase to run per thread
+
+# Variables
+RandomString: &rand_string {^FastRandomString: {length: 100}}
+DefaultDocument: &default_doc
+  field0: *rand_string
+  field1: *rand_string
+  field2: *rand_string
+  field3: *rand_string
+  field4: *rand_string
+  field5: *rand_string
+  field6: *rand_string
+  field7: *rand_string
+  field8: *rand_string
+  field9: *rand_string
+
+# Parameterized operations
+FindOneOperation: &find_op
+  OperationName: findOne
+  OperationMetricsName: reads
+  OperationCommand:
+    Filter: &filter_param {^Parameter: {Name: "Filter", Default: ""}}
+UpdateOneOperation: &update_op
+  OperationName: updateOne
+  OperationMetricsName: writes
+  OperationCommand:
+    Filter: *filter_param
+    Update: {$set: {^Parameter: {Name: "UpdateDocument", Default: *default_doc}}}
+
+# Parameterized phase definitions
+LoadPhase: &load_phase
+  Repeat: {^Parameter: {Name: "LoadRepeat", Default: 3125}}
+  Collection: &collection_param {^Parameter: {Name: "Collection", Default: "testcoll"}}
+  MetricsName: "load"
+  Operations:
+  - OperationName: insertOne
+    OperationMetricsName: inserts
+    OperationCommand:
+      Document: {^Parameter: {Name: "InsertDocument", Default: *default_doc}}
+
+100ReadPhase: &100read_phase
+  Repeat: {^Parameter: {Name: "100ReadRepeat", Default: 3125}}
+  Collection: *collection_param
+  MetricsName: "100read"
+  Operations:
+  - *find_op
+
+95Read5UpdatePhase: &95read5update_phase
+  Repeat: {^Parameter: {Name: "95Read5UpdateRepeat", Default: 157}}
+  Collection: *collection_param
+  MetricsName: "95read5update"
+  Operations:
+  - *update_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+  - *find_op
+
+50Read50UpdatePhase: &50read50update_phase
+  Repeat: {^Parameter: {Name: "50Read50UpdateRepeat", Default: 1563}}
+  Collection: *collection_param
+  MetricsName: "50read50update"
+  Operations:
+  - *find_op
+  - *update_op
+
+100UpdatePhase: &100update_phase
+  Repeat: {^Parameter: {Name: "100UpdateRepeat", Default: 3125}}
+  Collection: *collection_param
+  MetricsName: "100update"
+  Operations:
+  - *update_op
+
+# Parameterized Actor
+YCSBLikeActor:
+  Name: YCSBLike
+  Type: CrudActor
+  Threads: {^Parameter: {Name: "Threads", Default: 32}}
+  Database: {^Parameter: {Name: "Database", Default: ""}}
+  ClientName: {^Parameter: {Name: "ClientName", Default: "Default"}}
+  Phases:
+  - {Nop: true}
+  - {Nop: true}
+  - *load_phase
+  - *100read_phase
+  - *95read5update_phase
+  - *100update_phase
+  - *50read50update_phase

--- a/src/phases/encrypted/YCSBLikeEncryptedTemplate.yml
+++ b/src/phases/encrypted/YCSBLikeEncryptedTemplate.yml
@@ -1,0 +1,138 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Template for encryption-enabled workloads that emulate a YCSB workload.
+  Performs queries on an encrypted field, instead of _id, during the read/update phase.
+  Parameters:
+    Database:             name of encrypted database
+    Collection:           name of encrypted collection
+    ClientName:           name of encrypted client pool
+    Field<n>Value:        value of the nth field (n is 1..8)
+    ShardCollectionPhase: must be set to {Nop: true} for unsharded tests
+
+GlobalDefaults:
+  Database: &encrypted_db {^Parameter: {Name: "Database", Default: ""}}
+  Collection: &encrypted_coll {^Parameter: {Name: "Collection", Default: "testcoll"}}
+  Namespace: &encrypted_ns {^Parameter: {Name: "Namespace", Default: ""}}
+  ClientName: &encrypted_pool {^Parameter: {Name: "ClientName", Default: "Default"}}
+
+  # 8 threads, 100,000 documents, ~10,000 operations
+  ThreadCount: &thread_count 8
+  # 100k documents / 8 threads = 12.5k inserts per thread
+  InsertIterations: &insert_iterations 12500
+  # 10k operations / 1 op per iteration / 8 threads = 1250 iterations per thread
+  1OpPerThreadIterations: &1op_per_thread_iterations 1250
+  # 10k operations / 2 ops per iteration / 8 threads = 625 iterations per thread
+  2OpsPerThreadIterations: &2op_per_thread_iterations 625
+  # 10k operations / 20 ops per iteration / 8 threads = 62.5 iterations per thread
+  # Real op count is 10080 ops due to round-up.
+  20OpsPerThreadIterations: &20op_per_thread_iterations 63
+  # Encrypted values are 0-padded strings of length 100 with values uniformly
+  # selected between 1-100. ie. cardinality of each encrypted field is 100.
+  # With 100k documents, ~1000 documents (1%) will have the same encrypted key.
+  #
+  # Each document is queried using two keys. An encrypted primary key (field0) with,
+  # on average, 1000 documents per unique value; and an unencrypted secondary key,
+  # randomly selected value between 1 to 10, which is used to narrow down the set
+  # of documents that each query operation targets.
+  RandomPrimaryKey: &rand_primary_key {^RandomInt: {min: 1, max: 100}}
+  RandomSecondaryKey: &rand_secondary_key {^RandomInt: {min: 1, max: 10}}
+  RandomString: &rand_string {^FastRandomString: {length: 100}}
+  InsertDocument: &insert_doc
+    field0: {^FormatString: {"format": "%0100d", "withArgs": [*rand_primary_key]}}
+    field1: {^Parameter: {Name: "Field1Value", Default: *rand_string}}
+    field2: {^Parameter: {Name: "Field2Value", Default: *rand_string}}
+    field3: {^Parameter: {Name: "Field3Value", Default: *rand_string}}
+    field4: {^Parameter: {Name: "Field4Value", Default: *rand_string}}
+    field5: {^Parameter: {Name: "Field5Value", Default: *rand_string}}
+    field6: {^Parameter: {Name: "Field6Value", Default: *rand_string}}
+    field7: {^Parameter: {Name: "Field7Value", Default: *rand_string}}
+    field8: {^Parameter: {Name: "Field8Value", Default: *rand_string}}
+    field9: {^FormatString: {"format": "%0100d", "withArgs": [*rand_secondary_key]}}
+  UpdateDocument: &update_doc
+    field0: {^FormatString: {"format": "%0100d", "withArgs": [*rand_primary_key]}}
+    field1: {^Parameter: {Name: "Field1Value", Default: *rand_string}}
+    field2: {^Parameter: {Name: "Field2Value", Default: *rand_string}}
+    field3: {^Parameter: {Name: "Field3Value", Default: *rand_string}}
+    field4: {^Parameter: {Name: "Field4Value", Default: *rand_string}}
+    field5: {^Parameter: {Name: "Field5Value", Default: *rand_string}}
+    field6: {^Parameter: {Name: "Field6Value", Default: *rand_string}}
+    field7: {^Parameter: {Name: "Field7Value", Default: *rand_string}}
+    field8: {^Parameter: {Name: "Field8Value", Default: *rand_string}}
+  ShardCollectionPhase: &shard_or_nop
+    ^Parameter:
+      Name: "ShardCollectionPhase"
+      Default:
+        Repeat: 1
+        Database: admin
+        Operations:
+        - OperationMetricsName: EnableSharding
+          OperationName: AdminCommand
+          OperationCommand:
+            enableSharding: *encrypted_db
+        - OperationMetricsName: ShardCollection
+          OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: *encrypted_ns
+            key: {field9: hashed}
+
+Actors:
+- LoadConfig:
+    Path: ../../phases/encrypted/YCSBLikeActorTemplate.yml
+    Key: YCSBLikeActor
+    Parameters:
+      Threads: *thread_count
+      Database: *encrypted_db
+      Collection: *encrypted_coll
+      ClientName: *encrypted_pool
+      # The load, 100read, & 100update phases do 1 op per thread,
+      # so the total opcount = thread_count * 1 op * iter_count
+      LoadRepeat: *insert_iterations
+      100ReadRepeat: *1op_per_thread_iterations
+      100UpdateRepeat: *1op_per_thread_iterations
+      # The 50/50 phase does 2 ops per thread,
+      # so the total opcount = thread_count * 2 ops * iter_count
+      50Read50UpdateRepeat: *2op_per_thread_iterations
+      # The 95/5 phase does 20 ops per thread,
+      # so the total opcount = thread_count * 20 ops * iter_count
+      95Read5UpdateRepeat: *20op_per_thread_iterations
+      InsertDocument: *insert_doc
+      Filter:
+        $and:
+        - {field0: {^FormatString: {"format": "%0100d", "withArgs": [*rand_primary_key]}}}
+        - {field9: {^FormatString: {"format": "%0100d", "withArgs": [*rand_secondary_key]}}}
+      UpdateDocument: *update_doc
+
+- Name: IndexSecondaryKey
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: *encrypted_db
+    MetricsName: "indexSecondary"
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *encrypted_coll
+        indexes:
+        - key:
+            field9: 1
+          name: field9
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: ShardCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *shard_or_nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop

--- a/src/workloads/encrypted/ExponentialCompact.yml
+++ b/src/workloads/encrypted/ExponentialCompact.yml
@@ -1,0 +1,50 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  With queryable encryption enabled, this workload runs alternating CRUD and compact phases,
+  where the total number of inserts & updates is increased on every CRUD+Compact cycle in order
+  to grow the ECOC collection to a size that is at least twice its pre-compaction size in
+  the previous cycle. This is meant to test how long compaction takes relative to ECOC size.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: { type: "string", queries: [{queryType: "equality"}] }
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+      socketTimeoutMS: -1
+    # Comment this section out to disable encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/ContinuousWritesWithExponentialCompactTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    ShardCollectionPhase: {Nop: true}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - single-replica-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16.yml
@@ -1,0 +1,47 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: { type: "string", queries: [{queryType: "equality", contention: 16}] }
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to disable encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    ShardCollectionPhase: {Nop: true}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - single-replica-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16Sharded.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16Sharded.yml
@@ -1,0 +1,46 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: { type: "string", queries: [{queryType: "equality", contention: 16}] }
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to disable encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard-lite-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32.yml
@@ -1,0 +1,47 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: { type: "string", queries: [{queryType: "equality", contention: 32}] }
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to disable encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    ShardCollectionPhase: {Nop: true}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - single-replica-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32Sharded.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32Sharded.yml
@@ -1,0 +1,46 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: { type: "string", queries: [{queryType: "equality", contention: 32}] }
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to disable encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard-lite-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cfdefault.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cfdefault.yml
@@ -1,0 +1,47 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: { type: "string", queries: [{queryType: "equality"}] }
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to disable encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    ShardCollectionPhase: {Nop: true}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - single-replica-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt1CfdefaultSharded.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt1CfdefaultSharded.yml
@@ -1,0 +1,46 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: { type: "string", queries: [{queryType: "equality"}] }
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to disable encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard-lite-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16.yml
@@ -1,0 +1,55 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: &field_schema { type: "string", queries: [{queryType: "equality", contention: 16}] }
+      field1: *field_schema
+      field2: *field_schema
+      field3: *field_schema
+      field4: *field_schema
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to run without encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    ShardCollectionPhase: {Nop: true}
+    Field1Value: &100unique_values {^FormatString: {"format": "%0100d", "withArgs": [{^RandomInt: {min: 1, max: 100}}]}}
+    Field2Value: *100unique_values
+    Field3Value: *100unique_values
+    Field4Value: *100unique_values
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - single-replica-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16Sharded.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16Sharded.yml
@@ -1,0 +1,54 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: &field_schema { type: "string", queries: [{queryType: "equality", contention: 16}] }
+      field1: *field_schema
+      field2: *field_schema
+      field3: *field_schema
+      field4: *field_schema
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to run without encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    Field1Value: &100unique_values {^FormatString: {"format": "%0100d", "withArgs": [{^RandomInt: {min: 1, max: 100}}]}}
+    Field2Value: *100unique_values
+    Field3Value: *100unique_values
+    Field4Value: *100unique_values
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard-lite-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32.yml
@@ -1,0 +1,55 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: &field_schema { type: "string", queries: [{queryType: "equality", contention: 32}] }
+      field1: *field_schema
+      field2: *field_schema
+      field3: *field_schema
+      field4: *field_schema
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to run without encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    ShardCollectionPhase: {Nop: true}
+    Field1Value: &100unique_values {^FormatString: {"format": "%0100d", "withArgs": [{^RandomInt: {min: 1, max: 100}}]}}
+    Field2Value: *100unique_values
+    Field3Value: *100unique_values
+    Field4Value: *100unique_values
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - single-replica-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32Sharded.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32Sharded.yml
@@ -1,0 +1,54 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: &field_schema { type: "string", queries: [{queryType: "equality", contention: 32}] }
+      field1: *field_schema
+      field2: *field_schema
+      field3: *field_schema
+      field4: *field_schema
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to run without encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    Field1Value: &100unique_values {^FormatString: {"format": "%0100d", "withArgs": [{^RandomInt: {min: 1, max: 100}}]}}
+    Field2Value: *100unique_values
+    Field3Value: *100unique_values
+    Field4Value: *100unique_values
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard-lite-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cfdefault.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cfdefault.yml
@@ -1,0 +1,55 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: &field_schema { type: "string", queries: [{queryType: "equality"}] }
+      field1: *field_schema
+      field2: *field_schema
+      field3: *field_schema
+      field4: *field_schema
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to run without encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    ShardCollectionPhase: {Nop: true}
+    Field1Value: &100unique_values {^FormatString: {"format": "%0100d", "withArgs": [{^RandomInt: {min: 1, max: 100}}]}}
+    Field2Value: *100unique_values
+    Field3Value: *100unique_values
+    Field4Value: *100unique_values
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - single-replica-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/workloads/encrypted/YCSBLikeQueryableEncrypt5CfdefaultSharded.yml
+++ b/src/workloads/encrypted/YCSBLikeQueryableEncrypt5CfdefaultSharded.yml
@@ -1,0 +1,54 @@
+SchemaVersion: 2018-07-01
+Owner: "@10gen/server-security"
+Description: |
+  Mimics a YCSB workload, with queryable encryption enabled. Performs queries on an encrypted
+  field, instead of _id, during the read/update phase.
+
+Encryption:
+  UseCryptSharedLib: true
+  CryptSharedLibPath: /data/workdir/mongocrypt/lib/mongo_crypt_v1.so
+  EncryptedCollections:
+  - Database: genny_qebench
+    Collection: testcoll
+    EncryptionType: queryable
+    QueryableEncryptedFields:
+      field0: &field_schema { type: "string", queries: [{queryType: "equality"}] }
+      field1: *field_schema
+      field2: *field_schema
+      field3: *field_schema
+      field4: *field_schema
+
+Clients:
+  EncryptedPool:
+    QueryOptions:
+      maxPoolSize: 400
+    # Comment this section out to run without encryption
+    EncryptionOptions:
+      KeyVaultDatabase: "keyvault"
+      KeyVaultCollection: "datakeys"
+      EncryptedCollections:
+      - genny_qebench.testcoll
+
+LoadConfig:
+  Path: ../../phases/encrypted/YCSBLikeEncryptedTemplate.yml
+  Parameters:
+    Database: genny_qebench
+    Collection: testcoll
+    Namespace: genny_qebench.testcoll
+    ClientName: EncryptedPool
+    Field1Value: &100unique_values {^FormatString: {"format": "%0100d", "withArgs": [{^RandomInt: {min: 1, max: 100}}]}}
+    Field2Value: *100unique_values
+    Field3Value: *100unique_values
+    Field4Value: *100unique_values
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard-lite-fle
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0


### PR DESCRIPTION
This adds a subset of the tests performed in the PM-2759 QE performance project, but with reduced number of iterations so that it does not take more than a few hours to run on DSI.

There are two types of workloads:
1. the YCSB-like workloads that try to emulate a YCSB workload, but with queries on encrypted fields, as opposed to simply the '_id' field. These workloads are meant to test the performance of encrypted finds and update, for various contention factor settings and various number of encrypted fields.
2. the exponential compact workload, which tests the latency of a compaction operation relative to the size of the ECOC collection.

evg: https://spruce.mongodb.com/version/637557d3d1fe072d1a4f7ab8/tasks
