### PR TITLE
PERF-2738 fixed unit <-> units bug that caused incorrect phase transition timings

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -1215,7 +1215,7 @@ class Delay {
 public:
     Delay(const Node& node, GeneratorArgs args)
         : numberGenerator{makeDoubleGenerator(node["^TimeSpec"]["value"], args)} {
-        auto unitString = node["^TimeSpec"]["units"].maybe<std::string>().value_or("seconds");
+        auto unitString = node["^TimeSpec"]["unit"];
 
         // Use string::find here so plurals get parsed correctly.
         if (unitString.find("nanosecond") == 0) {

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -1215,7 +1215,11 @@ class Delay {
 public:
     Delay(const Node& node, GeneratorArgs args)
         : numberGenerator{makeDoubleGenerator(node["^TimeSpec"]["value"], args)} {
-        auto unitString = node["^TimeSpec"]["unit"].toString();
+        if (!node["^TimeSpec"]["unit"]) {
+            BOOST_THROW_EXCEPTION(InvalidConfigurationException(
+                "Each TimeSpec needs a unit declaration."));
+        }
+        auto unitString = node["^TimeSpec"]["unit"].to<std::string>()
 
         // Use string::find here so plurals get parsed correctly.
         if (unitString.find("nanosecond") == 0) {

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -1215,7 +1215,7 @@ class Delay {
 public:
     Delay(const Node& node, GeneratorArgs args)
         : numberGenerator{makeDoubleGenerator(node["^TimeSpec"]["value"], args)} {
-        auto unitString = node["^TimeSpec"]["unit"];
+        auto unitString = node["^TimeSpec"]["unit"].toString();
 
         // Use string::find here so plurals get parsed correctly.
         if (unitString.find("nanosecond") == 0) {

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -1219,7 +1219,7 @@ public:
             BOOST_THROW_EXCEPTION(InvalidConfigurationException(
                 "Each TimeSpec needs a unit declaration."));
         }
-        auto unitString = node["^TimeSpec"]["unit"].to<std::string>()
+        auto unitString = node["^TimeSpec"]["unit"].to<std::string>();
 
         // Use string::find here so plurals get parsed correctly.
         if (unitString.find("nanosecond") == 0) {


### PR DESCRIPTION
All tests using this and the documentation use the `unit` key, but the implementation looks for `units` and otherwise defaults to seconds.

This PR aligns the implementation and tests/documentation to all use `unit` and further removes the default to avoid this issue from flying under the surface again.