### PR TITLE
EVG-18233 Set isQuiet=true as default for RunCommand actor

### DIFF
--- a/src/cast_core/src/RunCommand.cpp
+++ b/src/cast_core/src/RunCommand.cpp
@@ -89,7 +89,7 @@ void runThenAwaitStepdown(mongocxx::database& database, bsoncxx::document::view&
 struct RunCommandOperationConfig {
     explicit RunCommandOperationConfig(const genny::Node& node)
         : metricsName{node["OperationMetricsName"].maybe<std::string>().value_or("")},
-          isQuiet{node["OperationIsQuiet"].maybe<bool>().value_or(false)},
+          isQuiet{node["OperationIsQuiet"].maybe<bool>().value_or(true)},
           logResult{node["OperationLogsResult"].maybe<bool>().value_or(false)},
           awaitStepdown{node["OperationAwaitStepdown"].maybe<bool>().value_or(false)} {
         if (auto opName = node["OperationName"].maybe<std::string>();
@@ -102,7 +102,7 @@ struct RunCommandOperationConfig {
     explicit RunCommandOperationConfig() {}
 
     const std::string metricsName = "";
-    const bool isQuiet = false;
+    const bool isQuiet = true;
     const bool logResult = false;
     const bool awaitStepdown = false;
 };

--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -19,7 +19,6 @@ Actors:
     Database: test
     Operations:
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         insert: myCollection
         documents: &Doc [{a: {^FastRandomString: {length: 1000}}}]
@@ -31,7 +30,6 @@ Actors:
     Database: test
     Operations:
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         insert: myCollection
         documents: *Doc
@@ -43,7 +41,6 @@ Actors:
     Database: test
     Operations:
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         insert: myCollection
         documents: *Doc
@@ -55,7 +52,6 @@ Actors:
     Database: test
     Operations:
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         insert: myCollection
         documents: *Doc

--- a/src/workloads/execution/UserAcquisition.yml
+++ b/src/workloads/execution/UserAcquisition.yml
@@ -28,7 +28,6 @@ Actors:
 
     # Simple leaf roles
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleA'
         roles: ['backup']
@@ -37,7 +36,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleB'
         roles: ['backup']
@@ -46,7 +44,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleC'
         roles: ['backup']
@@ -55,7 +52,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleD'
         roles: ['backup']
@@ -65,7 +61,6 @@ Actors:
 
     # First degree inheritors
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleAB'
         roles:
@@ -76,7 +71,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleBC'
         roles:
@@ -87,7 +81,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleCD'
         roles:
@@ -98,7 +91,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleDA'
         roles:
@@ -110,7 +102,6 @@ Actors:
 
     # 2nd degree inheritors
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleABCD'
         roles:
@@ -121,7 +112,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleBCDA'
         roles:
@@ -132,7 +122,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleCDAB'
         roles:
@@ -143,7 +132,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleDABC'
         roles:
@@ -155,7 +143,6 @@ Actors:
 
     # Composite of 2nd degree inheritors
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createRole: 'userAcquisitionRoleAll'
         roles:
@@ -168,7 +155,6 @@ Actors:
           actions: ['insert']
 
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         createUser: 'testUserAcquisition'
         pwd: 'pwd'
@@ -181,12 +167,10 @@ Actors:
     Operations:
     # Make sure the user is ejected from the read-through cache.
     - OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand: {invalidateUserCache: 1}
 
       # Pull the user definition from the underlying store
     - OperationMetricsName: UserInfoExactUser
-      OperationIsQuiet: true
       OperationName: RunCommand
       OperationCommand:
         usersInfo: {user: "testUserAcquisition", db: "admin"}

--- a/src/workloads/networking/SecondaryAllowed.yml
+++ b/src/workloads/networking/SecondaryAllowed.yml
@@ -47,7 +47,6 @@ Actors:
     Operation: &find_one
       OperationMetricsName: "Find"
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         find: Collection0
         readConcern: {level: local}

--- a/src/workloads/networking/ServiceArchitectureWorkloads.yml
+++ b/src/workloads/networking/ServiceArchitectureWorkloads.yml
@@ -50,7 +50,6 @@ Actors:
     Operation: &find_one
       OperationMetricsName: "Find"
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         find: Collection0
         readConcern: {level: local}

--- a/src/workloads/networking/TransportLayerConnectTiming.yml
+++ b/src/workloads/networking/TransportLayerConnectTiming.yml
@@ -22,7 +22,6 @@ Actors:
     Operation:
       OperationMetricsName: Connection
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         replSetTestEgress: 1
 

--- a/src/workloads/query/PipelineUpdate.yml
+++ b/src/workloads/query/PipelineUpdate.yml
@@ -76,49 +76,42 @@ Actors:
     Operations:
     - OperationMetricsName: ClassicUpdateAddFieldsSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: {$set: {newStr: *string}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateModifyFieldsSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: {$set: {int: *integer}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateAddElementToArraySmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: {$push: {nestedObj.arr: *integer}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateTruncateArraySmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: {$pop: {nestedObj.arr: 1}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateUnsetTopLevelFieldsSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: {$unset: {int: "", str: ""}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateUnsetNestedFieldsSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: {$unset: {nestedObj.str: ""}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateReplaceDocumentSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: *smallDocument, multi: false}]
@@ -130,49 +123,42 @@ Actors:
     Operations:
     - OperationMetricsName: ClassicUpdateAddFieldsLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: {$set: {newStr: *string}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateModifyFieldsLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: {$set: {int: *integer}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateAddElementToArrayLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: {$push: {nestedObj.arr: *integer}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateTruncateArrayLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: {$pop: {nestedObj.arr: 1}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateUnsetTopLevelFieldsLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: {$unset: {int: "", str: ""}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateUnsetNestedFieldsLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: {$unset: {nestedObj.str: ""}}, multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: ClassicUpdateReplaceDocumentLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: *largeDocument, multi: false}]
@@ -184,21 +170,18 @@ Actors:
     Operations:
     - OperationMetricsName: PipelineUpdateAddFieldsSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: [{$addFields: {newStr: *string}}], multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateModifyFieldsSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: [{$addFields: {int: *integer}}], multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateAddElementToArraySmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: [
@@ -206,7 +189,6 @@ Actors:
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateTruncateArraySmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: [
@@ -214,21 +196,18 @@ Actors:
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateUnsetTopLevelFieldsSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: [{$unset: [int, str]}], multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateUnsetNestedFieldsSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: [{$unset: [nestedObj.str]}], multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateReplaceDocumentSmallDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDSmall}, u: [{$replaceWith: *smallDocument}], multi: false}]
@@ -240,21 +219,18 @@ Actors:
     Operations:
     - OperationMetricsName: PipelineUpdateAddFieldsLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: [{$addFields: {newStr: *string}}], multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateModifyFieldsLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: [{$addFields: {int: *integer}}], multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateAddElementToArrayLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: [
@@ -262,7 +238,6 @@ Actors:
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateTruncateArrayLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: [
@@ -270,21 +245,18 @@ Actors:
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateUnsetTopLevelFieldsLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: [{$unset: [int, str]}], multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateUnsetNestedFieldsLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: [{$unset: [nestedObj.str]}], multi: true}]
         writeConcern: {w: majority}
     - OperationMetricsName: PipelineUpdateReplaceDocumentLargeDoc
       OperationName: RunCommand
-      OperationIsQuiet: true
       OperationCommand:
         update: Collection0
         updates: [{q: {t: *partitionIDLarge}, u: [{$replaceWith: *largeDocument}], multi: false}]

--- a/src/workloads/scale/CreateDropView.yml
+++ b/src/workloads/scale/CreateDropView.yml
@@ -53,13 +53,11 @@ Actors:
     Database: *dbname
     Operations:
     - OperationMetricsName: CreateViewMetric
-      OperationIsQuiet: true
       OperationName: RunCommand
       OperationCommand:
         {create: myView, viewOn: Collection0, pipeline: [{$match: {id: {$lt: 10}}}]}
     - OperationName: RunCommand
       OperationMetricsName: DropViewMetric
-      OperationIsQuiet: true
       OperationCommand:
         drop: myView
   - Nop: true

--- a/src/workloads/sharding/MongosMerging.yml
+++ b/src/workloads/sharding/MongosMerging.yml
@@ -43,7 +43,6 @@ ActorTemplates:
           Operations:
           - OperationMetricsName: AggregationPipeline
             OperationName: RunCommand
-            OperationIsQuiet: true
             OperationCommand:
               aggregate: Collection0
               pipeline: {^Parameter: {Name: "Pipeline", Default: []}}


### PR DESCRIPTION
This PR makes isQuiet=true the default for the RunCommand actor as printing every command can generate quite log files (e.g., PipelineUpdate, ServiceArchitectureWorkloads, ParallelInsert) and in extreme cases even bottleneck the test on the client side (PipelineUpdate).

With isQuiet=true being the new default, this PR also removes all existing occurrences of isQuiet:true in existing tests.

This PR does not update any documentation as this was split of into [EVG-18383](https://jira.mongodb.org/browse/EVG-18383).