### PR TITLE
PERF-3660 Remove standalone build variant and 6.0 testing

### DIFF
--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -154,10 +154,9 @@ AutoRun:
       $eq:
       - replica
       - replica-all-feature-flags
-      - standalone
-      - standalone-all-feature-flags
     branch_name:
       $neq:
       - v4.2
       - v4.4
       - v5.0
+      - v6.0


### PR DESCRIPTION
This PR removes standalone variant and 6.0 testing since the meaningful results are only present in master right now