### PR TITLE
EVG-18665: Upgrade patch version of numexpr.

### DIFF
--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -16,4 +16,4 @@ progressbar==2.5
 
 numpy==1.23.5
 
-numexpr==2.8.1
+numexpr==2.8.4


### PR DESCRIPTION
This avoids needing to build a binary wheel for Linux arm64, so instead we can just download it.