### PR TITLE
PERF-3654 Enhance Genny to support FrequencyLists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ genny.egg-info
 curator
 .ccls-cache
 .vscode
+# clangd
+.cache

--- a/src/value_generators/include/value_generators/FrequencyMap.hpp
+++ b/src/value_generators/include/value_generators/FrequencyMap.hpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#ifndef HEADER_0BC4D6BC_FC92_4F1C_BAEA_26A633807830_INCLUDE
+#define HEADER_0BC4D6BC_FC92_4F1C_BAEA_26A633807830_INCLUDE
 
 #include <cstdint>
 #include <exception>
@@ -21,7 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace genny {
+namespace genny::v1 {
 
 /**
  * Genny frequency map. A list of pairs <string, count>
@@ -85,4 +86,6 @@ private:
     std::vector<std::pair<std::string, uint64_t>> _list;
 };
 
-}  // namespace genny
+}  // namespace genny::v1
+
+#endif

--- a/src/value_generators/include/value_generators/FrequencyMap.hpp
+++ b/src/value_generators/include/value_generators/FrequencyMap.hpp
@@ -1,0 +1,88 @@
+// Copyright 2022-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace genny {
+
+/**
+ * Genny frequency map. A list of pairs <string, count>
+ *
+ * The list is unsorted.
+ */
+class FrequencyMap {
+public:
+    /**
+     * Add an item and a count to the back of the list of items in the map.
+     */
+    void push_back(std::string name, size_t count) {
+        _list.push_back({name, count});
+    }
+
+    /**
+     * Take a instance of one of the items, decrements the count.
+     *
+     * It the count for the item goes to zero, it removes the item.
+     *
+     * Throws an error if there are no items in the map.
+     */
+    std::string take(size_t index) {
+        if (index >= _list.size()) {
+            throw std::range_error("Out of bounds of frequency map");
+        }
+
+        auto& pair = _list[index];
+        auto ret = pair.first;
+        pair.second--;
+
+        // We have taken all the entries for this element
+        if (pair.second == 0) {
+            _list.erase(_list.begin() + index);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Returns the number of elements with counts
+     */
+    size_t size() const {
+        return _list.size();
+    }
+
+    /**
+     * Returns a total size of the frequency map
+     */
+    size_t total_count() const {
+        size_t total_count = 0;
+
+        for (const auto& p : _list) {
+            total_count += p.second;
+        }
+
+        return total_count;
+    }
+
+private:
+    std::vector<std::pair<std::string, uint64_t>> _list;
+};
+
+}  // namespace genny

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -618,7 +618,7 @@ public:
         }
 
         for (const auto&& [k, v] : node["from"]) {
-            _map.push_back(v.key(), static_cast<size_t>(v.maybe<std::int64_t>().value()));
+            _map.push_back(v.key(), v.to<std::size_t>());
         }
     }
 
@@ -635,7 +635,7 @@ public:
 
 private:
     DefaultRandom& _rng;
-    FrequencyMap _map;
+    v1::FrequencyMap _map;
 };
 
 /**
@@ -1386,7 +1386,7 @@ protected:
     std::vector<UniqueGenerator<bsoncxx::array::value>> _parts;
 };
 
-/** 
+/**
  * `{^Object: {withNEntries: 10, havingKeys: {^Foo}, andValues: {^Bar}, allowDuplicateKeys: bool}`
  */
 class ObjectGenerator : public Generator<bsoncxx::document::value> {

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -655,8 +655,8 @@ Tests:
   - Name: Join With Deterministic Choose
     GivenTemplate:
       a: {^Object: {
-        withNEntries: 4, 
-        havingKeys: {^Join: {array: ["a", {^Choose: {from: ["1", "2"], deterministic: true}}], sep: ""}}, 
+        withNEntries: 4,
+        havingKeys: {^Join: {array: ["a", {^Choose: {from: ["1", "2"], deterministic: true}}], sep: ""}},
         andValues: 1,
         duplicatedKeys: insert
       }}
@@ -670,12 +670,12 @@ Tests:
         a1: 1
         a2: 1
         a1: 1
-        a2: 1 
+        a2: 1
     - a:
         a1: 1
         a2: 1
         a1: 1
-        a2: 1 
+        a2: 1
 
   - Name: Concat two singletons
     GivenTemplate:
@@ -1364,3 +1364,34 @@ Tests:
       - { "a" : [3.9359523367534210436, 105.26147012586838514] }
       - { "a" : [3.8554769964739108445, 105.32083105246911714] }
       - { "a" : [3.7750016561944006455, 105.38019197906984914] }
+
+  - Name: TakeTest
+    GivenTemplate:
+        foo:
+          ^TakeRandomStringFromFrequencyMap:
+            from:
+              v1: 1
+              v2: 2
+              v3: 2
+    ThenReturns:
+        - foo : v1
+        - foo : v2
+        - foo : v2
+        - foo : v3
+        - foo : v3
+
+  - Name: TakeSingletonTest
+    GivenTemplate:
+        foo:
+          ^TakeRandomStringFromFrequencyMapSingleton:
+            id: foo1
+            from:
+              v1: 1
+              v2: 2
+              v3: 2
+    ThenReturns:
+        - foo : v1
+        - foo : v2
+        - foo : v2
+        - foo : v3
+        - foo : v3

--- a/src/value_generators/test/FrequencyMap_test.cpp
+++ b/src/value_generators/test/FrequencyMap_test.cpp
@@ -26,7 +26,7 @@ namespace {
 TEST_CASE("genny frequencyMap") {
 
     SECTION("Basic") {
-        FrequencyMap map;
+        v1::FrequencyMap map;
 
         // Load Map
         map.push_back("a", 1);

--- a/src/value_generators/test/FrequencyMap_test.cpp
+++ b/src/value_generators/test/FrequencyMap_test.cpp
@@ -1,0 +1,68 @@
+// Copyright 2023-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <algorithm>
+#include <iostream>
+
+#include <catch2/catch_all.hpp>
+
+#include <value_generators/FrequencyMap.hpp>
+
+namespace genny {
+namespace {
+
+TEST_CASE("genny frequencyMap") {
+
+    SECTION("Basic") {
+        FrequencyMap map;
+
+        // Load Map
+        map.push_back("a", 1);
+
+        REQUIRE(map.size() == 1);
+        REQUIRE(map.total_count() == 1);
+
+        map.push_back("b", 3);
+
+        REQUIRE(map.size() == 2);
+        REQUIRE(map.total_count() == 4);
+
+        map.push_back("c", 5);
+
+        REQUIRE(map.size() == 3);
+        REQUIRE(map.total_count() == 9);
+
+        // Read from map
+        auto b1 = map.take(1);
+        REQUIRE(b1 == "b");
+
+        REQUIRE(map.size() == 3);
+        REQUIRE(map.total_count() == 8);
+
+        auto b2 = map.take(1);
+        REQUIRE(b2 == "b");
+
+        REQUIRE(map.size() == 3);
+        REQUIRE(map.total_count() == 7);
+        auto b3 = map.take(1);
+        REQUIRE(b3 == "b");
+
+        REQUIRE(map.size() == 2);
+        REQUIRE(map.total_count() == 6);
+    }
+}
+
+}  // namespace
+}  // namespace genny

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -307,13 +307,13 @@ Actors:
             # A list of {string, count} pairs.
             # An item will be pulled from a random bucket and its count will be decremented. If all buckets are empty, the generator throws an error.
             #
-            freqmap: { ^TakeRandomStringFromFrequencyMap: { from: [ "string1":1, "string2":2 ] } }
+            freqmap: { ^TakeRandomStringFromFrequencyMap: { from: { "string1":100, "string2":200 } } }
 
             # TakeRandomStringFromFrequencyMapSingleton keep singletons shared frequency maps shared across threads.
             # This can be used to ensure the distribution across threads matches exactly. This is important if you want a single value for given thread,
             # but use multiple threads to load the data.
             # Maps are identified by their "id" are shared.
-            freqmap_singleton: { ^TakeRandomStringFromFrequencyMapSingleton: { id: "some_string", from: [ "string1":1, "string2":2 ] } }
+            freqmap_singleton: { ^TakeRandomStringFromFrequencyMapSingleton: { id: "some_string", from: { "string3":100, "string4":200 } } }
 
 
   # 10% of the findOnes will introduce a 60-second sleep.

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -303,6 +303,18 @@ Actors:
             # Next OID
             noid: {^ObjectId: ""}
 
+            # FrequencyMaps
+            # A list of {string, count} pairs.
+            # An item will be pulled from a random bucket and its count will be decremented. If all buckets are empty, the generator throws an error.
+            #
+            freqmap: { ^TakeRandomStringFromFrequencyMap: { from: [ "string1":1, "string2":2 ] } }
+
+            # TakeRandomStringFromFrequencyMapSingleton keep singletons shared frequency maps shared across threads.
+            # This can be used to ensure the distribution across threads matches exactly. This is important if you want a single value for given thread,
+            # but use multiple threads to load the data.
+            # Maps are identified by their "id" are shared.
+            freqmap_singleton: { ^TakeRandomStringFromFrequencyMapSingleton: { id: "some_string", from: [ "string1":1, "string2":2 ] } }
+
 
   # 10% of the findOnes will introduce a 60-second sleep.
   - Duration: 1 minutes


### PR DESCRIPTION
QE tests require a precise distribution of data. The data distributions are generated offline and then fed into the workload.yml files. See https://github.com/markbenvenuto/genny/blob/frequency_map/src/phases/encrypted2/maps_pbl.yml for an example of a real example of how this is used.

A new generator `TakeRandomStringFromFrequencyMap` is added to read from these list of data distributions.
```
        foo:
          ^TakeRandomStringFromFrequencyMap:
            from:
              v1: 1
              v2: 2
              v3: 2
```
This generator will generate "v1" once, "v2" twice and "v3" thrice in a random order. If you ask for 7 values, it will throw an error.

To enable us to use this across multiple actors threads, there is a version called `^TakeRandomStringFromFrequencyMapSingleton` which creates a singleton of each map to ensure distribution is followed exactly (i.e. if the distribution says insert something once, it is inserted once overall, not once per thread).