### PR TITLE
PERF-3746 Rewrite BackgroundIndexConstruction workload

### DIFF
--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -37,17 +37,17 @@ Actors:
   Type: Loader
   Threads: 1
   Phases:
-  - Repeat: 1
-    Database: &db test
-    Threads: 1
-    CollectionCount: &CollCount 1
-    DocumentCount: 10_000_000
-    BatchSize: 1000
-    Document: *SmallDoc
-  - &Nop {Nop: true}
-  - *Nop
-  - *Nop
-  - *Nop
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: &db test
+        Threads: 1
+        CollectionCount: 1
+        DocumentCount: 10_000_000
+        BatchSize: 1000
+        Document: *SmallDoc
 
 - Name: InsertIntoOtherColl
   Type: MonotonicSingleLoader
@@ -87,22 +87,22 @@ Actors:
   Type: RunCommand
   Threads: 1
   Phases:
-  - *Nop
-  - Repeat: 1
-    Database: admin
-    Operations:
-    - OperationName: AdminCommand
-      OperationCommand:
-        setParameter: 1
-        storageEngineConcurrentWriteTransactions: 32
-    - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
-      OperationName: RunCommand
-      OperationCommand:
-        setParameter: 1
-        maxIndexBuildMemoryUsageMegabytes: 100
-  - *Nop
-  - *Nop
-  - *Nop
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: admin
+        Operations:
+        - OperationName: AdminCommand
+          OperationCommand:
+            setParameter: 1
+            storageEngineConcurrentWriteTransactions: 32
+        - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
+          OperationName: RunCommand
+          OperationCommand:
+            setParameter: 1
+            maxIndexBuildMemoryUsageMegabytes: 100
 
 # Phase 2: Quiesce the system
 - Name: QuiesceActor
@@ -111,11 +111,11 @@ Actors:
   Threads: 1
   Database: *db
   Phases:
-  - *Nop
-  - *Nop
-  - Repeat: 1
-  - *Nop
-  - *Nop
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
 
 # Phases 3, 4: Build indexes on a collection that has no concurrent writes and a collection with concurrent writes.
 - Name: IndexCollection

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -31,7 +31,7 @@ SmallDoc: &SmallDoc
 NumPhases: &NumPhases 4
 
 Actors:
-# Phase 1: Insert enough data to ensure than an index build on each field spills to disk with a
+# Phase 0: Insert enough data to ensure than an index build on each field spills to disk with a
 # memory limit of 100MB.
 - Name: LoadSmallData
   Type: Loader
@@ -82,7 +82,7 @@ Actors:
             - key: {numField: 1}
               name: numField_1
 
-# Phase 2: Lower the memory limit for spilling to disk so that it occurs more often. Also lower tickets to emulate an overloaded server.
+# Phase 1: Lower the memory limit for spilling to disk so that it occurs more often. Also lower tickets to emulate an overloaded server.
 - Name: Setup
   Type: RunCommand
   Threads: 1
@@ -104,7 +104,7 @@ Actors:
   - *Nop
   - *Nop
 
-# Phase 3: Quiesce the system
+# Phase 2: Quiesce the system
 - Name: QuiesceActor
   Type: QuiesceActor
   # Using multiple threads will result in an error.
@@ -117,7 +117,7 @@ Actors:
   - *Nop
   - *Nop
 
-# Phases 4, 5: Build indexes on a collection that has no concurrent writes and a collection with concurrent writes.
+# Phases 3, 4: Build indexes on a collection that has no concurrent writes and a collection with concurrent writes.
 - Name: IndexCollection
   Type: RunCommand
   Threads: 1
@@ -125,8 +125,8 @@ Actors:
   - *Nop
   - *Nop
   - *Nop
-  # Build an index on an integer field.
-  - Repeat: &numRepetitions 5  # Repeat 5 times to get more stable times
+  # Build an index on a collection with a noisy neighbor.
+  - Repeat: &numRepetitions 5  # Repeat 5 times to get more stable latencies
     Database: *db
     Operations:
     - OperationMetricsName: CreateIndex

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -122,7 +122,7 @@ Actors:
   Type: RunCommand
   Threads: 1
   Phases:
-  - *Nop
+  - &Nop {Nop: true}
   - *Nop
   - *Nop
   # Build an index on a collection with a noisy neighbor.

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -19,31 +19,70 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 1024
-      socketTimeoutMS: 7200000  # = 2 hours
+      maxPoolSize: 10000
+      socketTimeoutMS: 7_200_000  # = 2 hours
+
+SmallDoc: &SmallDoc
+  randomString: {^FastRandomString: {length: 123}}
+  randomInt: {^RandomInt: {min: -1_000_000, max: 1_000_000}}
+  numField: &numField {^RandomInt: {min: 0, max: 1_000}}
+  counter: 0
+
+NumPhases: &NumPhases 4
 
 Actors:
 # Phase 1: Insert enough data to ensure than an index build on each field spills to disk with a
 # memory limit of 100MB.
-- Name: InsertData
+- Name: LoadSmallData
   Type: Loader
   Threads: 1
   Phases:
   - Repeat: 1
     Database: &db test
     Threads: 1
-    CollectionCount: 1
+    CollectionCount: &CollCount 1
     DocumentCount: 10_000_000
     BatchSize: 1000
-    Document:
-      randomInt: {^RandomInt: {min: -10000000, max: 10000000}}
-      randomString: {^RandomString: {length: 16}}
+    Document: *SmallDoc
   - &Nop {Nop: true}
   - *Nop
   - *Nop
   - *Nop
 
-# Phase 2: Lower the memory limit for spilling to disk so that it occurs more often.
+- Name: InsertIntoOtherColl
+  Type: MonotonicSingleLoader
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        DocumentCount: 5_000_000
+        BatchSize: 1_000
+        Collection: &otherColl otherColl
+        Database: *db
+        Document: *SmallDoc
+
+- Name: CreateIndexesOtherColl
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *db
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            createIndexes: *otherColl
+            indexes:
+            - key: {numField: 1}
+              name: numField_1
+
+# Phase 2: Lower the memory limit for spilling to disk so that it occurs more often. Also lower tickets to emulate an overloaded server.
 - Name: Setup
   Type: RunCommand
   Threads: 1
@@ -55,7 +94,7 @@ Actors:
     - OperationName: AdminCommand
       OperationCommand:
         setParameter: 1
-        storageEngineConcurrentWriteTransactions: 5
+        storageEngineConcurrentWriteTransactions: 32
     - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
       OperationName: RunCommand
       OperationCommand:
@@ -78,7 +117,7 @@ Actors:
   - *Nop
   - *Nop
 
-# Phases 4, 5: Build indexes on each field.
+# Phases 4, 5: Build indexes on a collection that has no concurrent writes and a collection with concurrent writes.
 - Name: IndexCollection
   Type: RunCommand
   Threads: 1
@@ -87,10 +126,10 @@ Actors:
   - *Nop
   - *Nop
   # Build an index on an integer field.
-  - Repeat: 1
+  - Repeat: &numRepetitions 5  # Repeat 5 times to get more stable times
     Database: *db
     Operations:
-    - OperationMetricsName: CreateIndexInt
+    - OperationMetricsName: CreateIndex
       OperationName: RunCommand
       OperationCommand:
         createIndexes: &coll Collection0
@@ -98,44 +137,79 @@ Actors:
         - key:
             randomInt: 1
           name: random_int
-    - OperationMetricsName: DropIndexInt
+    - OperationMetricsName: DropIndex
       OperationName: RunCommand
       OperationCommand:
         dropIndexes: *coll
         index: random_int
-  # Build an index on a string field.
-  - Repeat: 1
+  # Build an index on a heavily modified collection.
+  - Repeat: *numRepetitions
     Database: *db
     Operations:
-    - OperationMetricsName: CreateIndexString
+    - OperationMetricsName: CreateIndexSameCollWrites
       OperationName: RunCommand
       OperationCommand:
-        createIndexes: *coll
+        createIndexes: *otherColl
         indexes:
         - key:
-            randomString: 1
-          name: random_string
-    - OperationMetricsName: DropIndexString
+            randomInt: 1
+          name: random_int
+    - OperationMetricsName: DropIndexSameCollWrites
       OperationName: RunCommand
       OperationCommand:
-        dropIndexes: *coll
-        index: random_string
+        dropIndexes: *otherColl
+        index: random_int
 
-- Name: BackgroundWrites
-  Type: InsertRemove
-  Threads: 256
+- Name: UpdateOtherColl
+  Type: CrudActor
+  Database: *db
+  Threads: &numThreads 256
   Phases:
-  - *Nop
-  - *Nop
-  - *Nop
-  # Execute while building an index on an integer field.
-  - Blocking: None
-    Database: *db
-    Collection: &otherColl Collection1  # Work on a different collection to avoid overloading the index target.
-  # Execute while building an index on a string field.
-  - Blocking: None
-    Database: *db
-    Collection: *otherColl
+    OnlyActiveInPhases:
+      Active: [3, 4]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Blocking: None
+        Collection: *otherColl
+        Operations:
+        - OperationName: updateOne
+          OperationCommand:
+            Filter: &filter
+              numField: *numField
+            Update:
+              $inc: {counter: 1}
+
+- Name: RemoveOtherColl
+  Type: CrudActor
+  Database: *db
+  Threads: &halfThreads 128
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3, 4]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Blocking: None
+        Collection: *otherColl
+        Operations:
+        - OperationName: deleteOne
+          OperationCommand:
+            Filter: *filter
+
+- Name: InsertOtherCollSmall
+  Type: CrudActor
+  Database: *db
+  Threads: *halfThreads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3, 4]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Blocking: None
+        Collection: *otherColl
+        Operations:
+        - OperationName: insertOne
+          OperationCommand:
+            Document: *SmallDoc
 
 - Name: LoggingActor
   Type: LoggingActor
@@ -143,7 +217,7 @@ Actors:
   Phases:
     OnlyActiveInPhases:
       Active: [3, 4]
-      NopInPhasesUpTo: 4
+      NopInPhasesUpTo: *NumPhases
       PhaseConfig:
         LogEvery: 10 minutes
         Blocking: None
@@ -152,8 +226,8 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - replica
-      - replica-all-feature-flags
+      - single-replica
+      - single-replica-all-feature-flags
     branch_name:
       $neq:
       - v4.2


### PR DESCRIPTION
This PR rewrites the BackgroundIndexConstruction workload to reflect a more realistic scenario.

It lowers the dataset size so that we can repeat index creation to reduce noise and overall runs with better timings.

It is a clean cut from the previous workload, only the Setup actor has been kept with the same name.