### PR TITLE
PERF-3480 Enable GroupSpillToDisk.yml on variants where the queries use SBE

### DIFF
--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -129,14 +129,16 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      # TODO PERF-3480: Enable this workload against 'standalone', 'standalone-all-feature-flags'
-      # and 'standalone-sbe' once the SBE performance improves. These queries will use SBE unless
-      # classic is forced, but they run for too long at the moment due to the performance problem
-      # reported in SERVER-70395.
+      - standalone
+      - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-sbe
     branch_name:
       $neq:
       - v4.0
       - v4.2
       - v4.4
       - v5.0
+      - v6.0
+      - v6.1
+      - v6.2


### PR DESCRIPTION
This must be merged _after_ https://github.com/10gen/mongo/pull/9906. I kicked off a sys-perf patch build incorporating the changes from both repositories here: https://spruce.mongodb.com/version/63cee21da4cf4751fbe848a0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC.

I also ran the workload locally through Genny. Below I've included excerpts of the result summaries generated by running `python src/workloads/contrib/analysis/test_result_summary.py -d <workload output directory>`. First, the results when run against a server started with `./mongod --setParameter internalQueryFrameworkControl="forceClassicEngine"`:

```
GroupAddToSetAccumulatorWithLargeSets.aggregate summary:
	timers.dur (measured in nanoseconds, displayed in milliseconds):
		count     : 1
		average   : 5580.5

GroupPushAccumulatorConstructingLargeArrays.aggregate summary:
	timers.dur (measured in nanoseconds, displayed in milliseconds):
		count     : 1
		average   : 4268.0

GroupSumAccumulatorSpillDueToManyGroups.aggregate summary:
	timers.dur (measured in nanoseconds, displayed in milliseconds):
		count     : 1
		average   : 15824.5
```

Second, the equivalent results but against a server started with `./mongod --setParameter featureFlagSbeFull=true`:

```
GroupAddToSetAccumulatorWithLargeSets.aggregate summary:
	timers.dur (measured in nanoseconds, displayed in milliseconds):
		count     : 1
		average   : 6801.4

GroupPushAccumulatorConstructingLargeArrays.aggregate summary:
	timers.dur (measured in nanoseconds, displayed in milliseconds):
		count     : 1
		average   : 4374.9

GroupSumAccumulatorSpillDueToManyGroups.aggregate summary:
	timers.dur (measured in nanoseconds, displayed in milliseconds):
		count     : 1
		average   : 15719.2
```

The results actually look pretty good! We seem to be getting roughly comparably performance, although SBE might be a touch slower for the first two benchmarks. It will be interesting to see if the official results on Evergreen show the same thing.

As one final note, these new benchmarks will need to be added to our dashboard and tagged. So expect a few more future patch sets under this ticket.