### PR TITLE
PERF-3778 Increase socket timeout of ContentionTTLDeletions

### DIFF
--- a/src/workloads/scale/ContentionTTLDeletions.yml
+++ b/src/workloads/scale/ContentionTTLDeletions.yml
@@ -14,7 +14,8 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 10000
+      maxPoolSize: 2000
+      socketTimeoutMS: 1_200_000  # = 20 minutes
 
 SmallDoc: &SmallDoc
   a: {^FastRandomString: {length: 123}}


### PR DESCRIPTION
In some instances the workload can fail due to a socket timeout. This happens if the server is overloaded. As this workload purposefully overloads the server, we should increase the timeout.