### PR TITLE
PERF-3788 Use multi-threading to speed up Loader in ExpressiveQueries workload

### DIFF
--- a/src/workloads/docs/CollectionScanner.yml
+++ b/src/workloads/docs/CollectionScanner.yml
@@ -13,7 +13,7 @@ Actors:
     Database: cold
     CollectionCount: 6
     Threads: 1
-    DocumentCount: 2e5
+    DocumentCount: 200000
     BatchSize: 100000
     Document:
       a: {^RandomString: { length: 100 }}
@@ -21,7 +21,7 @@ Actors:
     Database: hot
     CollectionCount: 6
     Threads: 1
-    DocumentCount: 2e5
+    DocumentCount: 200000
     BatchSize: 100000
     Document:
       a: {^RandomString: { length: 100 }}

--- a/src/workloads/docs/CollectionScanner.yml
+++ b/src/workloads/docs/CollectionScanner.yml
@@ -13,7 +13,7 @@ Actors:
     Database: cold
     CollectionCount: 6
     Threads: 1
-    DocumentCount: 200000
+    DocumentCount: 2e5
     BatchSize: 100000
     Document:
       a: {^RandomString: { length: 100 }}
@@ -21,7 +21,7 @@ Actors:
     Database: hot
     CollectionCount: 6
     Threads: 1
-    DocumentCount: 200000
+    DocumentCount: 2e5
     BatchSize: 100000
     Document:
       a: {^RandomString: { length: 100 }}

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -168,7 +168,8 @@ Actors:
       OperationName: find
       OperationCommand:
         Filter: *filter
-        Projection: &projection {_id: 0, firstname: 1, lastname: 1, dob: 1}
+        Options:
+          Projection: &projection {_id: 0, firstname: 1, lastname: 1, dob: 1}
   - *Nop
   - *Nop
   - Repeat: 1000  # This query is very fast, so we need to run it more times than others.
@@ -180,7 +181,8 @@ Actors:
       OperationName: find
       OperationCommand:
         Filter: *filter
-        Projection: *projection
+        Options:
+          Projection: *projection
 
 AutoRun:
 - When:

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -19,15 +19,13 @@ Actors:
 
 - Name: InsertData
   Type: Loader
-  # Loader doesn't support multiple threads for a single collection.
-  # TODO: TIG-2938 Use multiple threads to speedup insertion.
-  Threads: 1
+  Threads: 4
   Phases:
   - Repeat: 1
     Database: &DB test
-    Threads: 1
+    MultipleThreadsPerCollection: true
     CollectionCount: 1  # Collection name will be Collection0, this is not configurable.
-    DocumentCount: 1e6
+    DocumentCount: 1000000
     BatchSize: 1000
     Document:
       region: {^RandomInt: {min: 0, max: 1999}}

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -25,7 +25,7 @@ Actors:
     Database: &DB test
     MultipleThreadsPerCollection: true
     CollectionCount: 1  # Collection name will be Collection0, this is not configurable.
-    DocumentCount: 1000000
+    DocumentCount: 1e6
     BatchSize: 1000
     Document:
       region: {^RandomInt: {min: 0, max: 1999}}


### PR DESCRIPTION
There is a TODO to use multithreading to load documents faster in ExpressiveQueries workload. This now can be fixed using MultipleThreadsPerCollection option.

