### PR TITLE
Use IntergerSpec for DocumentCount across Loader actor

### DIFF
--- a/src/cast_core/src/Loader.cpp
+++ b/src/cast_core/src/Loader.cpp
@@ -91,12 +91,12 @@ struct Loader::PhaseConfig {
                 BOOST_THROW_EXCEPTION(InvalidConfigurationException(ss.str()));
             }
             uint numThreads = totalThreads / collectionCount;
-            numDocuments = context["DocumentCount"].to<int64_t>() / numThreads;
+            numDocuments = context["DocumentCount"].to<IntegerSpec>() / numThreads;
             if (thread / collectionCount == 0) {
                 // The first thread for each collection:
                 //   1. Picks up any extra documents left over by the division.
                 //   2. Is responsible for creating the indexes.
-                numDocuments += context["DocumentCount"].to<uint>() % numThreads;
+                numDocuments += context["DocumentCount"].to<IntegerSpec>() % numThreads;
                 createIndexes();
             }
         } else {

--- a/src/workloads/docs/CollectionScanner.yml
+++ b/src/workloads/docs/CollectionScanner.yml
@@ -21,8 +21,8 @@ Actors:
     Database: hot
     CollectionCount: 6
     Threads: 1
-    DocumentCount: 200000
-    BatchSize: 100000
+    DocumentCount: 2e5
+    BatchSize: 1e5
     Document:
       a: {^RandomString: { length: 100 }}
     FindOptions:


### PR DESCRIPTION
This allows us to use 1eN notation instead of 10...00 which is difficult to read of the number of zeros is high