### PR TITLE
EVG-18844: Properly handle "!!str" in DocumentGenerator.

### DIFF
--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -1607,7 +1607,7 @@ Out valueGenerator(const Node& node,
         return std::make_unique<ConstantAppender<bsoncxx::types::b_null>>();
     }
     if (node.isScalar()) {
-        if (node.tag() != "!") {
+        if (node.tag() != "tag:yaml.org,2002:str") {
             try {
                 return std::make_unique<ConstantAppender<int32_t>>(node.to<int32_t>());
             } catch (const InvalidConversionException& e) {

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -1395,3 +1395,11 @@ Tests:
         - foo : v2
         - foo : v3
         - foo : v3
+
+  - Name: StringCastTest
+    GivenTemplate:
+        foo:
+          - !!str "1.0"
+    ThenReturns:
+        - foo:
+          - "1.0"


### PR DESCRIPTION
We should check for an actual "!!str" value tag. Based on testing I don't think the value of the tag is ever "!".