### PR TITLE
PERF-3657 Add sinusoidal read/write workload for execution control

### DIFF
--- a/src/lamplib/src/genny/tasks/dry_run.py
+++ b/src/lamplib/src/genny/tasks/dry_run.py
@@ -36,6 +36,7 @@ def dry_run_workload(
         "MajorityReads10KThreads.yml",
         "MajorityWrites10KThreads.yml",
         "ConnectionPoolStress.yml",
+        "SinusoidalReadWrites.yml",
     ]:
         SLOG.info("TIG-1435 skipping dry run on macOS", file=yaml_file_path)
         return

--- a/src/workloads/execution/SinusoidalReadWrites.yml
+++ b/src/workloads/execution/SinusoidalReadWrites.yml
@@ -42,7 +42,7 @@ ActorTemplates:
         NopInPhasesUpTo: *NumPhases
         PhaseConfig:
           Duration: 3 minutes
-          SleepAfter: 1.5 minutes
+          SleepAfter: 90 seconds
           Repeat: 3
           CollectionCount: *NumColls
           Operations:
@@ -62,7 +62,7 @@ ActorTemplates:
         Active: {^Parameter: {Name: "ActivePhases", Default: [1]}}
         NopInPhasesUpTo: *NumPhases
         PhaseConfig:
-          SleepBefore: 1.5 minutes
+          SleepBefore: 90 seconds
           Duration: 3 minutes
           Repeat: 3
           CollectionCount: *NumColls
@@ -120,7 +120,3 @@ AutoRun:
       - v5.1
       - v5.2
       - v5.3
-      - v6.0
-      - v6.1
-      - v6.2
-      - v6.3

--- a/src/workloads/execution/SinusoidalReadWrites.yml
+++ b/src/workloads/execution/SinusoidalReadWrites.yml
@@ -28,7 +28,7 @@ Document: &doc
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 1000
+      maxPoolSize: 1001
 
 ActorTemplates:
 - TemplateName: WritesActorWithSleepTemplate

--- a/src/workloads/execution/SinusoidalReadWrites.yml
+++ b/src/workloads/execution/SinusoidalReadWrites.yml
@@ -4,7 +4,7 @@ Description: |
   This workload attempts to create a sinusoidal distribution of reads/writes to test
   the behavior of execution control when the load on the system changes over time.
 
-  We do this with two actors, one for writes and one for reads and spawn 5000 client
+  We do this with two actors, one for writes and one for reads and spawn 500 client
   threads. Though the actors run concurrently, we use the sleep functionality
   to effectively stop work on one actor while the other reaches its peak. We then
   alternate for a couple repetitions.
@@ -28,7 +28,7 @@ Document: &doc
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 5100
+      maxPoolSize: 55
 
 ActorTemplates:
 - TemplateName: WritesActorWithSleepTemplate
@@ -36,7 +36,7 @@ ActorTemplates:
     Name: {^Parameter: {Name: "Name", Default: WritesActorWithSleep}}
     Type: CrudActor
     Database: *dbname
-    Threads: {^Parameter: {Name: "Threads", Default: 1000}}
+    Threads: {^Parameter: {Name: "Threads", Default: 100}}
     Phases:
       OnlyActiveInPhases:
         Active: {^Parameter: {Name: "ActivePhases", Default: [1]}}
@@ -57,7 +57,7 @@ ActorTemplates:
     Name: {^Parameter: {Name: "Name", Default: ReadsActorWithSleep}}
     Type: CrudActor
     Database: *dbname
-    Threads: {^Parameter: {Name: "Threads", Default: 1000}}
+    Threads: {^Parameter: {Name: "Threads", Default: 100}}
     Phases:
       OnlyActiveInPhases:
         Active: {^Parameter: {Name: "ActivePhases", Default: [1]}}
@@ -97,14 +97,14 @@ Actors:
     TemplateName: WritesActorWithSleepTemplate
     TemplateParameters:
       Name: {^Parameter: {Name: "WritingName", Default: WritingActor_50_50}}
-      Threads: {^Parameter: {Name: "WritingThreads", Default: 2500}}
+      Threads: {^Parameter: {Name: "WritingThreads", Default: 500}}
       ActivePhases: [1]
 
 - ActorFromTemplate:
     TemplateName: ReadsActorWithSleepTemplate
     TemplateParameters:
       Name: {^Parameter: {Name: "ReadingName", Default: ReadsActor_50_50}}
-      Threads: {^Parameter: {Name: "ReadingThreads", Default: 2500}}
+      Threads: {^Parameter: {Name: "ReadingThreads", Default: 500}}
       ActivePhases: [1]
 
 AutoRun:

--- a/src/workloads/execution/SinusoidalReadWrites.yml
+++ b/src/workloads/execution/SinusoidalReadWrites.yml
@@ -1,0 +1,126 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/server-execution"
+Description: |
+  This workload attempts to create a sinusoidal distribution of reads/writes to test
+  the behavior of execution control when the load on the system changes over time.
+
+  We do this with two actors, one for writes and one for reads. Though the actors
+  run concurrently, we use the sleep functionality to effectively stop work on one
+  actor while the other reaches its peak. When then alternate for a couple repetitions.
+
+  In this workload, we try to ensure that reads and writes do not overlap much.
+Keywords:
+- sinusoidal
+- execution control
+- insertMany
+- find
+- CrudActor
+
+dbname: &dbname mixed_sinusoidal
+DocumentCount: &NumDocs 5000
+CollectionCount: &NumColls 1
+
+NumPhases: &NumPhases 2
+Document: &doc
+  a: {^RandomInt: {min: 0, max: *NumDocs}}
+  b: {^RandomString: {length: 16}}
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 5100
+
+ActorTemplates:
+- TemplateName: WritesActorWithSleepTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: WritesActorWithSleep}}
+    Type: CrudActor
+    Database: *dbname
+    Threads: {^Parameter: {Name: "Threads", Default: 1000}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: {^Parameter: {Name: "ActivePhases", Default: [1]}}
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Duration: 3 minutes
+          SleepAfter: 1.5 minutes
+          Repeat: 3
+          CollectionCount: *NumColls
+          Operations:
+          - OperationName: insertOne
+            OperationMetricsName: WriteDocs
+            OperationCommand:
+              Document: *doc
+            ThrowOnFailure: false
+- TemplateName: ReadsActorWithSleepTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: ReadsActorWithSleep}}
+    Type: CrudActor
+    Database: *dbname
+    Threads: {^Parameter: {Name: "Threads", Default: 1000}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: {^Parameter: {Name: "ActivePhases", Default: [1]}}
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          SleepBefore: 1.5 minutes
+          Duration: 3 minutes
+          Repeat: 3
+          CollectionCount: *NumColls
+          Operations:
+          - OperationName: find
+            OperationCommand:
+              Filter: { a: { ^RandomInt: { min: 0, max: *NumDocs } } }
+            OperationMetricsName: ReadDocs
+            ThrowOnFailure: false
+Actors:
+- Name: Setup
+  Type: Loader
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        # Have 5k documents ready at start
+        Repeat: 1
+        BatchSize: 100
+        Threads: 1
+        DocumentCount: *NumDocs
+        Database: *dbname
+        CollectionCount: *NumColls
+        Document: *doc
+        Indexes:
+        - keys: {a: 1}
+
+- ActorFromTemplate:
+    TemplateName: WritesActorWithSleepTemplate
+    TemplateParameters:
+      Name: {^Parameter: {Name: "WritingName", Default: WritingActor_50_50}}
+      Threads: {^Parameter: {Name: "WritingThreads", Default: 2500}}
+      ActivePhases: [1]
+
+- ActorFromTemplate:
+    TemplateName: ReadsActorWithSleepTemplate
+    TemplateParameters:
+      Name: {^Parameter: {Name: "ReadingName", Default: ReadsActor_50_50}}
+      Threads: {^Parameter: {Name: "ReadingThreads", Default: 2500}}
+      ActivePhases: [1]
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-all-feature-flags
+    branch_name:
+      $neq:
+      - v4.2
+      - v4.4
+      - v5.0
+      - v5.1
+      - v5.2
+      - v5.3
+      - v6.0
+      - v6.1
+      - v6.2
+      - v6.3

--- a/src/workloads/execution/SinusoidalReadWrites.yml
+++ b/src/workloads/execution/SinusoidalReadWrites.yml
@@ -4,9 +4,10 @@ Description: |
   This workload attempts to create a sinusoidal distribution of reads/writes to test
   the behavior of execution control when the load on the system changes over time.
 
-  We do this with two actors, one for writes and one for reads. Though the actors
-  run concurrently, we use the sleep functionality to effectively stop work on one
-  actor while the other reaches its peak. When then alternate for a couple repetitions.
+  We do this with two actors, one for writes and one for reads and spawn 5000 client
+  threads. Though the actors run concurrently, we use the sleep functionality
+  to effectively stop work on one actor while the other reaches its peak. We then
+  alternate for a couple repetitions.
 
   In this workload, we try to ensure that reads and writes do not overlap much.
 Keywords:

--- a/src/workloads/execution/SinusoidalReadWrites.yml
+++ b/src/workloads/execution/SinusoidalReadWrites.yml
@@ -18,7 +18,7 @@ Keywords:
 - CrudActor
 
 dbname: &dbname mixed_sinusoidal
-DocumentCount: &NumDocs 5000
+DocumentCount: &NumDocs 500
 CollectionCount: &NumColls 1
 
 NumPhases: &NumPhases 2
@@ -42,9 +42,9 @@ ActorTemplates:
         Active: {^Parameter: {Name: "ActivePhases", Default: [1]}}
         NopInPhasesUpTo: *NumPhases
         PhaseConfig:
-          Duration: 3 minutes
-          SleepAfter: 90 seconds
-          Repeat: 3
+          Duration: 1 minute
+          SleepAfter: 30 seconds
+          Repeat: 6
           CollectionCount: *NumColls
           Operations:
           - OperationName: insertOne
@@ -63,9 +63,9 @@ ActorTemplates:
         Active: {^Parameter: {Name: "ActivePhases", Default: [1]}}
         NopInPhasesUpTo: *NumPhases
         PhaseConfig:
-          SleepBefore: 90 seconds
-          Duration: 3 minutes
-          Repeat: 3
+          SleepBefore: 30 seconds
+          Duration: 1 minute
+          Repeat: 6
           CollectionCount: *NumColls
           Operations:
           - OperationName: find
@@ -82,7 +82,7 @@ Actors:
       Active: [0]
       NopInPhasesUpTo: *NumPhases
       PhaseConfig:
-        # Have 5k documents ready at start
+        # Have 500 documents ready at start
         Repeat: 1
         BatchSize: 100
         Threads: 1

--- a/src/workloads/execution/SinusoidalReadWrites.yml
+++ b/src/workloads/execution/SinusoidalReadWrites.yml
@@ -28,7 +28,7 @@ Document: &doc
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 550
+      maxPoolSize: 1000
 
 ActorTemplates:
 - TemplateName: WritesActorWithSleepTemplate

--- a/src/workloads/execution/SinusoidalReadWrites.yml
+++ b/src/workloads/execution/SinusoidalReadWrites.yml
@@ -28,7 +28,7 @@ Document: &doc
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 55
+      maxPoolSize: 550
 
 ActorTemplates:
 - TemplateName: WritesActorWithSleepTemplate

--- a/src/workloads/execution/SinusoidalReadWrites.yml
+++ b/src/workloads/execution/SinusoidalReadWrites.yml
@@ -113,11 +113,5 @@ AutoRun:
       $eq:
       - standalone
       - standalone-all-feature-flags
-    branch_name:
-      $neq:
-      - v4.2
-      - v4.4
-      - v5.0
-      - v5.1
-      - v5.2
-      - v5.3
+      - replica
+      - replica-all-feature-flags


### PR DESCRIPTION
The patch runs successfully on evergreen, but I'm still working on manually obtaining the intra-run data so we can see the distribution.

In the meantime, I wanted to put this patch up for review to see if we agree on the format.