### PR TITLE
PERF-3824: Remove w1 tests from ParallelInsert test

### DIFF
--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -24,16 +24,7 @@ Actors:
         documents: &Doc [{a: {^FastRandomString: {length: 1000}}}]
         writeConcern: {w: majority}
   - &Nop {Nop: true}
-  - &Insert_W1_JTrue
-    MetricsName: Insert_W1_JTrue
-    Duration: 30 seconds
-    Database: test
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        insert: myCollection
-        documents: *Doc
-        writeConcern: {w: 1, j: true}
+  - *Nop
   - *Nop
   - &Insert_WMajority_JFalse
     MetricsName: Insert_WMajority_JFalse
@@ -46,16 +37,7 @@ Actors:
         documents: *Doc
         writeConcern: {w: majority, j: false}
   - *Nop
-  - &Insert_W1
-    MetricsName: Insert_W1
-    Duration: 30 seconds
-    Database: test
-    Operations:
-    - OperationName: RunCommand
-      OperationCommand:
-        insert: myCollection
-        documents: *Doc
-        writeConcern: {w: 1}
+  - *Nop
   - *Nop
   - Phase: 8..39
     Nop: true
@@ -68,11 +50,11 @@ Actors:
     Nop: true
   - *Insert_WMajority
   - *Nop
-  - *Insert_W1_JTrue
+  - *Nop
   - *Nop
   - *Insert_WMajority_JFalse
   - *Nop
-  - *Insert_W1
+  - *Nop
   - *Nop
   - Phase: 16..39
     Nop: true
@@ -85,11 +67,11 @@ Actors:
     Nop: true
   - *Insert_WMajority
   - *Nop
-  - *Insert_W1_JTrue
+  - *Nop
   - *Nop
   - *Insert_WMajority_JFalse
   - *Nop
-  - *Insert_W1
+  - *Nop
   - *Nop
   - Phase: 24..39
     Nop: true
@@ -102,11 +84,11 @@ Actors:
     Nop: true
   - *Insert_WMajority
   - *Nop
-  - *Insert_W1_JTrue
+  - *Nop
   - *Nop
   - *Insert_WMajority_JFalse
   - *Nop
-  - *Insert_W1
+  - *Nop
   - *Nop
   - Phase: 32..39
     Nop: true
@@ -119,11 +101,11 @@ Actors:
     Nop: true
   - *Insert_WMajority
   - *Nop
-  - *Insert_W1_JTrue
+  - *Nop
   - *Nop
   - *Insert_WMajority_JFalse
   - *Nop
-  - *Insert_W1
+  - *Nop
   - *Nop
 
 - Name: CleanUp


### PR DESCRIPTION
Decided to `Nop` those w:1 phases instead of removing them due to [EVG-19039](https://jira.mongodb.org/browse/EVG-19039).

[Evergreen build](https://spruce.mongodb.com/task/sys_perf_linux_3_node_replSet_intel.2022_11_parallel_insert_replica_patch_205649df343783082c38ad1790b6b46e3edb7a07_63f7903032f41743079429ea_23_02_23_16_12_21/tests?execution=1&sortBy=STATUS&sortDir=ASC)