### PR TITLE
PERF-3827 Run missing SBE/classic engine variant tasks on correspondi…

### DIFF
--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -33,6 +33,7 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
+      - standalone
       - standalone-classic-query-engine
       - standalone-dsi-integration-test
       - standalone-sbe

--- a/src/workloads/query/ConstantFoldArithmetic.yml
+++ b/src/workloads/query/ConstantFoldArithmetic.yml
@@ -111,5 +111,6 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
+      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
@@ -100,5 +100,6 @@ AutoRun:
       - replica
       - shard-lite
       - shard-lite-all-feature-flags
+      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/LookupWithOnlyUnshardedColls.yml
@@ -109,5 +109,6 @@ AutoRun:
       - replica
       - shard-lite
       - shard-lite-all-feature-flags
+      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/LargeIndexedIns.yml
+++ b/src/workloads/scale/LargeIndexedIns.yml
@@ -64,5 +64,6 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
+      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/MajorityReads10KThreads.yml
+++ b/src/workloads/scale/MajorityReads10KThreads.yml
@@ -22,5 +22,6 @@ AutoRun:
       $eq:
       - replica
       - replica-all-feature-flags
+      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe


### PR DESCRIPTION
…ng regular variants

Evergreen: https://spruce.mongodb.com/version/63fe8049c9ec44160c5a4138/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

My plan for testing here was to verify that the above patch build ran all[ of the following tasks in the regular (non SBE nor classic) variants](https://github.com/10gen/PerformanceReports/blob/85dfdcaa0c31d8be8d46117b08422eafb4365f0c/scripts/perf_reports_sbe_perf.yml#L56-L125). Indeed, this led me to discover that we were running neither the tpcc nor the crud_workloads in the Linux standalone variant. I am going to open another PR shortly against the mongo repo to fix this, and will kick off another patch build at some point. 

PTAL!