### PR TITLE
PERF-3726 external phase coordinator.

### DIFF
--- a/src/gennylib/include/gennylib/Orchestrator.hpp
+++ b/src/gennylib/include/gennylib/Orchestrator.hpp
@@ -29,7 +29,7 @@ using SteadyClock = std::chrono::steady_clock;
 
 class Orchestrator;
 
-using OrchestratorCB = std::function<void(const Orchestrator*)>;
+using OrchestratorCB = std::function<void(const Orchestrator*, const PhaseNumber)>;
 
 /**
  * Responsible for the synchronization of actors
@@ -98,6 +98,7 @@ public:
     void abort();
 
     void addPrePhaseStartHook(const OrchestratorCB& f);
+    void addPostPhaseStopHook(const OrchestratorCB& f);
 
     /**
      * @return whether the workload should continue running. This is true as long as
@@ -136,6 +137,7 @@ private:
     State state = State::PhaseEnded;
 
     std::vector<OrchestratorCB> _prePhaseHooks;
+    std::vector<OrchestratorCB> _postPhaseHooks;
 };
 
 }  // namespace genny

--- a/src/gennylib/include/gennylib/Orchestrator.hpp
+++ b/src/gennylib/include/gennylib/Orchestrator.hpp
@@ -136,8 +136,12 @@ private:
 
     State state = State::PhaseEnded;
 
-    std::vector<OrchestratorCB> _prePhaseHooks;
-    std::vector<OrchestratorCB> _postPhaseHooks;
+    // These hooks fire just before the current phase starts. The phase number in the invocation is the
+    // phase that is about to start, so 0, 1, 2 ... etc.
+    std::vector<OrchestratorCB> _prePhaseStartHooks;
+    // These hooks fire just after the current phase stops. The phase number in the invocation is the
+    // phase that just completed, so 0, 1, 2 ... etc.
+    std::vector<OrchestratorCB> _postPhaseStopHooks;
 };
 
 }  // namespace genny

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -129,7 +129,7 @@ public:
     void operator=(ExternalPhaseCoordinator&&) = delete;
 
     ~ExternalPhaseCoordinator(){
-        if (m_socket > 0) {
+        if (m_socket >= 0) {
             close(m_socket);
         };
     }

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -153,9 +153,9 @@ public:
 private:
     void _onPhase(std::string message);
 
-    std::string m_host;
-    int m_port;
-    int m_socket;
+    const std::string m_host;
+    const int m_port;
+    const int m_socket;
 };
 
 /**

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <map>
 #include <memory>
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -91,6 +92,46 @@ protected:
 }  // namespace v1
 
 class WorkloadContext;
+
+class ExternalPhaseCoordinator;
+using namespace std::literals::chrono_literals;
+
+class ExternalPhaseCoordinator {
+public:
+    /**
+     */
+    ExternalPhaseCoordinator(std::string out_pipe = "", std::string in_pipe = "");
+
+    // no copy or move
+    ExternalPhaseCoordinator(ExternalPhaseCoordinator&) = delete;
+    void operator=(ExternalPhaseCoordinator&) = delete;
+    ExternalPhaseCoordinator(ExternalPhaseCoordinator&&) = delete;
+    void operator=(ExternalPhaseCoordinator&&) = delete;
+
+    /**
+     * Handle onPhaseStart.
+     *
+     * @param phase
+     *   the phase number about to start.
+     */
+    void onPhaseStart(PhaseNumber phase);
+
+    /**
+     * Handle onPhaseStop.
+     *
+     * @param phase
+     *   the phase number about to stop.
+     */
+    void onPhaseStop(PhaseNumber phase);
+
+private:
+    void _onPhase(std::string message, PhaseNumber phase);
+
+    mutable std::string m_out_pipe;
+    mutable std::string m_in_pipe;
+    mutable std::fstream m_ofs;
+    mutable bool m_fifo;
+};
 
 /**
  * Represents the top-level/"global" configuration and context for configuring actors.
@@ -306,6 +347,7 @@ private:
     std::mutex _limiterLock;
 
     std::string _workloadPath;
+    ExternalPhaseCoordinator _coordinator;
 };
 
 // For some reason need to decl this; see impl below

--- a/src/gennylib/src/Orchestrator.cpp
+++ b/src/gennylib/src/Orchestrator.cpp
@@ -84,7 +84,7 @@ PhaseNumber Orchestrator::awaitPhaseStart(bool block, int addTokens) {
     const auto currentPhase = this->_current;
     if (_currentTokens >= _requireTokens) {
         for (auto&& cb : _prePhaseHooks) {
-            cb(this);
+            cb(this, currentPhase);
         }
         BOOST_LOG_TRIVIAL(info) << "Beginning phase " << currentPhase;
         _phaseChange.notify_all();
@@ -136,8 +136,12 @@ bool Orchestrator::awaitPhaseEnd(bool block, int removeTokens) {
     // compare with >= rather than ==.
 
     if (_currentTokens <= 0) {
+        const auto currentPhase = _current;
         ++_current;
-        BOOST_LOG_TRIVIAL(info) << "Ended phase " << (this->_current - 1);
+        BOOST_LOG_TRIVIAL(info) << "Ended phase " << currentPhase;
+        for (auto&& cb : _postPhaseHooks) {
+            cb(this, currentPhase);
+        }
         _phaseChange.notify_all();
         state = State::PhaseEnded;
     } else {
@@ -154,6 +158,11 @@ bool Orchestrator::awaitPhaseEnd(bool block, int removeTokens) {
 void Orchestrator::addPrePhaseStartHook(const OrchestratorCB& f) {
     writer lock{_mutex};
     _prePhaseHooks.push_back(f);
+}
+
+void Orchestrator::addPostPhaseStopHook(const OrchestratorCB& f) {
+    writer lock{_mutex};
+    _postPhaseHooks.push_back(f);
 }
 
 void Orchestrator::abort() {

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -47,7 +47,7 @@ WorkloadContext::WorkloadContext(const Node& node,
       _rateLimiters{10},
       _poolManager{apmCallback, dryRun},
       _workloadPath{node.key()} ,
-      _coordinator{"./pipe.to", "./pipe.from"} {
+      _coordinator{"./build/Genny.out", "./build/Genny.in"} {
     std::set<std::string> validSchemaVersions{"2018-07-01"};
 
     // This is good enough for now. Later can add a WorkloadContextValidator concept
@@ -227,7 +227,7 @@ bool is_fifo(const char *path) {
 
 ExternalPhaseCoordinator::ExternalPhaseCoordinator(std::string out_pipe,std::string in_pipe) : m_out_pipe(out_pipe), m_in_pipe(in_pipe){
     m_fifo = is_fifo(out_pipe.c_str());
-    BOOST_LOG_TRIVIAL(debug) << "ExternalPhaseCoordinator('" << out_pipe << "', '" << in_pipe << "') --> " << m_fifo;
+    BOOST_LOG_TRIVIAL(info) << "ExternalPhaseCoordinator('" << out_pipe << "', '" << in_pipe << "') --> " << m_fifo;
     if (m_fifo) {
         m_ofs.open(out_pipe.c_str());
     }

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -235,7 +235,7 @@ ExternalPhaseCoordinator::ExternalPhaseCoordinator(std::string out_pipe,std::str
 void ExternalPhaseCoordinator::_onPhase(std::string message, PhaseNumber phase){
     BOOST_LOG_TRIVIAL(debug) << "ExternalPhaseCoordinator::onPhase('" << message << "'," << phase << "') start";
     if (m_fifo) {
-        m_ofs << "{ \"message\": \"" << message << "\",\"phase\":" <<  phase << "}" << std::endl << std::flush;
+        m_ofs << "{ \"message\": \"" << message << "\",\"phase\":" <<  phase << ",\"request\":" <<  1 << "}" << std::endl << std::flush;
 
         // The file open will block until there is a writer.
         BOOST_LOG_TRIVIAL(debug) << "ExternalPhaseCoordinator::_onPhase('"  << message << "'," << phase << ") waiting ";

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -47,7 +47,7 @@ WorkloadContext::WorkloadContext(const Node& node,
       _rateLimiters{10},
       _poolManager{apmCallback, dryRun},
       _workloadPath{node.key()} ,
-      _coordinator{"./build/Genny.out", "./build/Genny.in"} {
+      _coordinator{"./build/fifos/workload_client.0/Genny.out","./build/fifos/workload_client.0/Genny.in"} {
     std::set<std::string> validSchemaVersions{"2018-07-01"};
 
     // This is good enough for now. Later can add a WorkloadContextValidator concept

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -215,6 +215,8 @@ bool PhaseContext::isNop() const {
     return nop.maybe<bool>().value_or(false);
 }
 
+// Connect to the specified IP Address (use INADDR_ANY if the IP is blank) and port. If the connect
+// succeeds then the socket is returned, otherwise return -1.
 int connect(std::string ipaddress, int port) {
     struct sockaddr_in addr = {0};
     addr.sin_addr.s_addr = INADDR_ANY;
@@ -240,7 +242,7 @@ ExternalPhaseCoordinator::ExternalPhaseCoordinator(std::string host, int port) :
 }
 void ExternalPhaseCoordinator::_onPhase(std::string event){
     BOOST_LOG_TRIVIAL(debug) << "ExternalPhaseCoordinator::onPhase('" << event << "') start";
-    if(m_socket > 0) {
+    if(m_socket >= 0) {
         write(m_socket, event.c_str(), event.length());
         char buf[1024];
         bzero(buf, sizeof(buf));

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -216,7 +216,7 @@ bool PhaseContext::isNop() const {
 }
 
 // Connect to the specified IP Address (use INADDR_ANY if the IP is blank) and port. If the connect
-// succeeds then the socket is returned, otherwise return -1.
+// call succeeds then the socket is returned, otherwise return -1.
 int connect(std::string ipaddress, int port) {
     struct sockaddr_in addr = {0};
     addr.sin_addr.s_addr = INADDR_ANY;
@@ -235,6 +235,8 @@ int connect(std::string ipaddress, int port) {
     return sd;
 }
 
+// Note: this constructor calls connect to ensure that the socket connection is acquired before the
+// instance is available to use.
 ExternalPhaseCoordinator::ExternalPhaseCoordinator(std::string host, int port) :
       m_host(host), m_port(port), m_socket(connect(host, port)){
     BOOST_LOG_TRIVIAL(info) << "ExternalPhaseCoordinator::ExternalPhaseCoordinator('"
@@ -249,7 +251,7 @@ void ExternalPhaseCoordinator::_onPhase(std::string event){
         int rval = read(m_socket, buf, 1024);
         std::string response(buf);
         boost::trim(response);
-        BOOST_LOG_TRIVIAL(info) << "ExternalPhaseCoordinator::onPhase' read '"
+        BOOST_LOG_TRIVIAL(debug) << "ExternalPhaseCoordinator::onPhase' read '"
                                  << response << "' " << rval ;
     }
     BOOST_LOG_TRIVIAL(debug) << "ExternalPhaseCoordinator::onPhase('" << event << "') end";


### PR DESCRIPTION
**What:**
The genny portion of the phase event handling. When run with './run-genny' directly, the named pipes are not created so genny does not emit any events. When run under DSI, the named pipes are available so genny writes phase to the out named pipe and waits for an ack from dsi before continuing.

The code addes start and end phase events. These could be trimmed to just a single event type.

The phase number was added as a parameter to the callback because there is already a write lock taken out, so it is not possible to read the phase number through the accessor. Adding the number to the start and stop seems reasonable to me.

**Patches:** 
[updated sys perf patch](https://spruce.mongodb.com/version/64049adb5623436fe78fec71/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
~~[sys perf](https://spruce.mongodb.com/version/6402097e0ae6061e081c36be/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).~~

**Other PRs:**
[DSI](https://github.com/10gen/dsi/pull/1227)