### PR TITLE
PERF-3543 - Add in PingCommand workload to replace ping canary

### DIFF
--- a/src/workloads/execution/PingCommand.yml
+++ b/src/workloads/execution/PingCommand.yml
@@ -35,6 +35,8 @@ ActorTemplates:
 Actors:
 - ActorFromTemplate:
     TemplateName: PingTemplate
+    TemplateParameters:
+      Name: OneThreadPingRateLimited
 
 - ActorFromTemplate:
     TemplateName: PingTemplate

--- a/src/workloads/execution/PingCommand.yml
+++ b/src/workloads/execution/PingCommand.yml
@@ -1,0 +1,64 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: >
+  This is a simple test that runs ping command on MongoDB to meassure the latency of command dispatch.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 500
+
+GlobalDefaults:
+  MaxPhases: &MaxPhases 2
+  dbname: &dbname admin
+
+ActorTemplates:
+- TemplateName: PingTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "TwoThreadPing"}}
+    Type: RunCommand
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: {^Parameter: {Name: "Active", Default: [0]}}
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Duration: {^Parameter: {Name: "Duration", Default: "60 seconds"}}
+          GlobalRate: {^Parameter: {Name: "Rate", Default: "100 per 1 second"}}
+          Database: *dbname
+          Operations:
+          - OperationName: RunCommand
+            OperationIsQuiet: true
+            OperationCommand:
+              ping: 1
+
+Actors:
+- ActorFromTemplate:
+    TemplateName: PingTemplate
+    TemplateParameters:
+      Name: OneThreadPingRateLimited
+
+- ActorFromTemplate:
+    TemplateName: PingTemplate
+    TemplateParameters:
+      Name: ThirtyTwoThreadsPingRateLimited
+      Threads: 32
+      Active: [2]
+
+- Name: QuiescePhase
+  Type: QuiesceActor
+  Threads: 1
+  Database: *dbname
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - single-replica
+      - standalone

--- a/src/workloads/execution/PingCommand.yml
+++ b/src/workloads/execution/PingCommand.yml
@@ -15,7 +15,7 @@ GlobalDefaults:
 ActorTemplates:
 - TemplateName: PingTemplate
   Config:
-    Name: {^Parameter: {Name: "Name", Default: "TwoThreadPing"}}
+    Name: {^Parameter: {Name: "Name", Default: "OneThreadPingRateLimited"}}
     Type: RunCommand
     Threads: {^Parameter: {Name: "Threads", Default: 1}}
     Phases:
@@ -35,8 +35,6 @@ ActorTemplates:
 Actors:
 - ActorFromTemplate:
     TemplateName: PingTemplate
-    TemplateParameters:
-      Name: OneThreadPingRateLimited
 
 - ActorFromTemplate:
     TemplateName: PingTemplate


### PR DESCRIPTION
JIRA Ticket: [PERF-3543](https://jira.mongodb.org/browse/PERF-3543)

Whats changed:
Adding in a new workload that will call the ping command between nodes. The workload runs the command using a rate limit across actors using 2, 4, 8, 16, 32 and 64 threads. Workload is set to auto run for all replica and sharded setups.

Patch Test:
This [patch](https://spruce.mongodb.com/version/63ffa8280305b93ff77552c7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) shows the workload running and reporting the metrics across the various actors. [This](https://spruce.mongodb.com/version/64137ea461837d2961450a33/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) patch shows the workload being picked up by the Genny autorun.