### PR TITLE
PERF-3945 safely extract data from the aggregation cursor

### DIFF
--- a/src/cast_core/src/CommitLatency.cpp
+++ b/src/cast_core/src/CommitLatency.cpp
@@ -82,6 +82,17 @@ struct CommitLatency::PhaseConfig {
     }
 };
 
+::int64_t get_total(bsoncxx::document::view &doc) {
+    auto total = doc["total"];
+    if (total && total.type() == bsoncxx::type::k_int32){
+        return total.get_int32();
+    }
+    if (total && total.type() == bsoncxx::type::k_int64){
+        return total.get_int64();
+    }
+    return -1L;
+}
+
 void CommitLatency::run() {
     using namespace bsoncxx::builder::stream;
 
@@ -162,7 +173,8 @@ void CommitLatency::run() {
             // exact value of the metric is therefore uninteresting, it's only significant
             // whether it is zero or non-zero.
             for (auto doc : cursor) {
-                if (doc["total"].get_int64() != 200) {
+                auto total = get_total(doc);
+                if (total != 200) {
                     ctx.addErrors(1);
                 }
             }


### PR DESCRIPTION
JIRA Ticket: [PERF-3945](https://jira.mongodb.org/browse/PERF-3945)

**Whats changed:**
The ```doc["total"].get_int64()``` raises  ```std::exception``` for some cases which in reality are errors that we wish to track. This change checks for a total field and then extracts the total by bson type.
 
**Patch Test:**
Legacy 4.4 no flow control [patch](https://spruce.mongodb.com/version/641b1ff032f4172716860d97/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). This variant has been decommissioned but I'd still like to see if the issue is gone.
Sys Perf [patch](https://spruce.mongodb.com/version/641b275fd6d80adffa250714/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) 