### PR TITLE
PERF-3966 Use throughputProbingMaxConcurrency to set max concurrency at runtime

### DIFF
--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -97,8 +97,7 @@ Actors:
         - OperationName: AdminCommand
           OperationCommand:
             setParameter: 1
-            storageEngineConcurrencyAdjustmentAlgorithm: ""
-            storageEngineConcurrentWriteTransactions: 32
+            throughputProbingMaxConcurrency: 32
         - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
           OperationName: RunCommand
           OperationCommand:

--- a/src/workloads/scale/ContentionTTLDeletions.yml
+++ b/src/workloads/scale/ContentionTTLDeletions.yml
@@ -91,8 +91,7 @@ Actors:
           OperationCommand:
             setParameter: 1
             # Reduce tickets to force contention.
-            storageEngineConcurrencyAdjustmentAlgorithm: ""
-            storageEngineConcurrentWriteTransactions: 32
+            throughputProbingMaxConcurrency: 32
         SleepAfter: 60 seconds  # Wait 60 seconds for the new configurations to establish.
 
 - Name: UpdateOtherColl


### PR DESCRIPTION
[evergreen patch](https://spruce.mongodb.com/version/642329d80305b9e03adf108e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)