### PR TITLE
PERF-3967: Ensure tests that run against Atlas, also run against Atlas-like

### DIFF
--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -98,7 +98,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-all-feature-flags
       - single-replica

--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -98,6 +98,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - replica-all-feature-flags
       - single-replica

--- a/src/workloads/execution/CreateIndex.yml
+++ b/src/workloads/execution/CreateIndex.yml
@@ -66,7 +66,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - single-replica
       - standalone

--- a/src/workloads/execution/CreateIndex.yml
+++ b/src/workloads/execution/CreateIndex.yml
@@ -66,6 +66,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - single-replica
       - standalone

--- a/src/workloads/issues/ConnectionsBuildupNoSharding.yml
+++ b/src/workloads/issues/ConnectionsBuildupNoSharding.yml
@@ -60,7 +60,7 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-all-feature-flags
       - single-replica

--- a/src/workloads/networking/ServiceArchitectureWorkloads.yml
+++ b/src/workloads/networking/ServiceArchitectureWorkloads.yml
@@ -78,6 +78,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - replica-noflowcontrol
       - replica-all-feature-flags

--- a/src/workloads/networking/ServiceArchitectureWorkloads.yml
+++ b/src/workloads/networking/ServiceArchitectureWorkloads.yml
@@ -78,7 +78,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-noflowcontrol
       - replica-all-feature-flags

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -187,7 +187,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - single-replica
       - standalone

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -187,6 +187,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - single-replica
       - standalone

--- a/src/workloads/query/PipelineUpdate.yml
+++ b/src/workloads/query/PipelineUpdate.yml
@@ -267,6 +267,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica.2022-10
       - replica
       - replica-all-feature-flags
       - standalone

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -258,7 +258,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-all-feature-flags
       - shard-lite

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -258,6 +258,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - replica-all-feature-flags
       - shard-lite

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -128,6 +128,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - replica-1dayhistory-15gbwtcache
       - replica-all-feature-flags

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -128,7 +128,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-1dayhistory-15gbwtcache
       - replica-all-feature-flags

--- a/src/workloads/scale/InsertBigDocs.yml
+++ b/src/workloads/scale/InsertBigDocs.yml
@@ -26,6 +26,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - replica-all-feature-flags
       - single-replica

--- a/src/workloads/scale/InsertBigDocs.yml
+++ b/src/workloads/scale/InsertBigDocs.yml
@@ -26,7 +26,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-all-feature-flags
       - single-replica

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -27,6 +27,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - single-replica
       - standalone

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -27,7 +27,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - single-replica
       - standalone

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -88,6 +88,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - replica-all-feature-flags
       - shard

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -88,7 +88,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-all-feature-flags
       - shard

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -118,7 +118,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
     branch_name:
       $neq:

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -118,6 +118,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
     branch_name:
       $neq:

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -76,6 +76,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - replica-noflowcontrol
       - replica-1dayhistory-15gbwtcache

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -76,7 +76,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-noflowcontrol
       - replica-1dayhistory-15gbwtcache

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -302,6 +302,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica
       - replica
       - replica-1dayhistory-15gbwtcache
       - replica-all-feature-flags

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -302,7 +302,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-1dayhistory-15gbwtcache
       - replica-all-feature-flags

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -222,4 +222,4 @@ AutoRun:
       $eq:
       - atlas
       - replica
-      - atlas-like-replica
+      - atlas-like-replica.2022-10

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -222,3 +222,4 @@ AutoRun:
       $eq:
       - atlas
       - replica
+      - atlas-like-replica

--- a/src/workloads/transactions/LLTMixed.yml
+++ b/src/workloads/transactions/LLTMixed.yml
@@ -606,7 +606,7 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-all-feature-flags
       - single-replica

--- a/src/workloads/transactions/LLTMixedSmall.yml
+++ b/src/workloads/transactions/LLTMixedSmall.yml
@@ -31,7 +31,7 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - atlas-like-replica
+      - atlas-like-replica.2022-10
       - replica
       - replica-all-feature-flags
       - single-replica

--- a/src/workloads/transactions/templates/LLTInsertLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTInsertLowLtc.tmpl
@@ -277,7 +277,7 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - atlas-like-replica
+          - atlas-like-replica.2022-10
           - replica
           - replica-all-feature-flags
           - single-replica

--- a/src/workloads/transactions/templates/LLTMixedLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTMixedLowLtc.tmpl
@@ -565,7 +565,7 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - atlas-like-replica
+          - atlas-like-replica.2022-10
           - replica
           - replica-all-feature-flags
           - single-replica

--- a/src/workloads/transactions/templates/LLTQueryLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTQueryLowLtc.tmpl
@@ -296,7 +296,7 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - atlas-like-replica
+          - atlas-like-replica.2022-10
           - replica
           - replica-all-feature-flags
           - single-replica

--- a/src/workloads/transactions/templates/LLTRemoveLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTRemoveLowLtc.tmpl
@@ -292,7 +292,7 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - atlas-like-replica
+          - atlas-like-replica.2022-10
           - replica
           - replica-all-feature-flags
           - single-replica

--- a/src/workloads/transactions/templates/LLTUpdateLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTUpdateLowLtc.tmpl
@@ -314,7 +314,7 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - atlas-like-replica
+          - atlas-like-replica.2022-10
           - replica
           - replica-all-feature-flags
           - single-replica


### PR DESCRIPTION
Change AutoRun so the same tests that run on "atlas" also run on "atlas-like-replica.2022-10". Also changed those scheduled on the old "atlas-like-replica" that is not scheduled anymore so they now run on "atlas-like-replica.2022-10"