### PR TITLE
PERF-3988: Reduce slow query logging on mixed_workloads_genny_stress

### DIFF
--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -237,4 +237,5 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
+      - atlas-like-replica.2022-10
       - replica

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -237,5 +237,4 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas
-      - atlas-like-replica.2022-10
       - replica

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -142,6 +142,10 @@ ActorTemplates:
               Filter: *filter
 
 Actors:
+#
+## Reduce the log level to avoid creating log files
+## of serveral GB
+#
 - Name: LogLevel
   Type: RunCommand
   Threads: 1

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -142,6 +142,18 @@ ActorTemplates:
               Filter: *filter
 
 Actors:
+- Name: LogLevel
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - &nop {Nop: true}
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: { profile: 0, slowms: 1000, sampleRate: 0.1 }
+  - *nop
+
 - Name: Setup
   Type: Loader
   Threads: 8
@@ -164,7 +176,7 @@ Actors:
   Threads: 1
   Database: *dbname
   Phases:
-  - &nop {Nop: true}
+  - *nop
   - Repeat: 1
   - *nop
 


### PR DESCRIPTION
As seen on PERF-3979, this workload is expected to cause slow queries. But on some systems, like M60-like the resulting log file could be up to 35GB in size, making evergreen to fail because of disk space issues or memory exhaustion. This change is to reduce the query logging on this particular workload.