### PR TITLE
EVG-19133: Pre-warm connection for Loader.cpp.

### DIFF
--- a/src/cast_core/src/Loader.cpp
+++ b/src/cast_core/src/Loader.cpp
@@ -126,6 +126,11 @@ struct Loader::PhaseConfig {
 
 void genny::actor::Loader::run() {
     for (auto&& config : _loop) {
+        if (!config.isNop()) {
+            // Warm up the connection to the database
+            auto ping = builder::stream::document{} << "ping" << 1 << builder::stream::finalize;
+            config->database.run_command(ping.view());
+        }
         for (auto&& _ : config) {
             for (uint i = config->collectionOffset;
                  i < config->collectionOffset + config->numCollections;


### PR DESCRIPTION
Since connections on clients in libmongoc are opened lazily, currently the connection time is being counted when we measure time to load initial data. This caused BF-27679 when we updated our infrastructure to have a valid certificate chain, likely due to OpenSSL doing more work to process opening a TLS connection. The recommended fix was to make sure our connections are warm and open before we measure database operation, since that steady state is what we care most about for user operations.

This change pings the database at the beginning of each phase to make sure that we already have an active connection before we time anything. This should bring timings down and reduce noise.