### PR TITLE
PERF-4000 record swallowed errors

### DIFF
--- a/src/workloads/issues/ConnectionPoolStress.yml
+++ b/src/workloads/issues/ConnectionPoolStress.yml
@@ -2,9 +2,17 @@ SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
   This workload was created to reproduce issues discovered during sharded stress testing. The workload can cause
-  low performance, spikes in latency and excessive connection creation (on mongos processes). The metrics to look at
-  for this workload are the latencies and more specifically the Latency90thPercentile to Latency99thPercentile metrics.
+  low performance, spikes in latency and excessive connection creation (on mongos processes).
 
+  The main metrics to monitor are:
+    * ErrorsTotal / ErrorRate: The total number of errors and rate of errors encountered by the workload. Networking
+      errors are not unexpected in general and they should be recoverable. This work load strives to provide a test to
+      allow us to measure the scale of networking errors in a stressful test and prove if the networking becomes more
+      stable (with lower total errors and a lower error rate).
+    * The Operation latency (more specifically the Latency90thPercentile to Latency99thPercentile metrics)
+    * The Operation Throughput
+    * "ss connections active": the number of connections.
+  
   The workload performs the following steps:
     - Phase 0
       - Upsert a Single Document in the collection
@@ -72,6 +80,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *GlobalConnectionDuration
+        RecordFailure: true
         Collection: *Collection
         Operations:
         - OperationName: find

--- a/src/workloads/scale/Mixed10KThreads.yml
+++ b/src/workloads/scale/Mixed10KThreads.yml
@@ -5,6 +5,15 @@ Description: |
   clients to simulate an extreme case of overload in the server. Both reads and writes happen
   at the same time in balanced fashion.
 
+  The metrics to monitor are:
+    * ErrorsTotal / ErrorRate: The total number of errors and rate of errors encountered by the workload. Networking
+      errors are not unexpected in general and they should be recoverable. This work load strives to provide a test to
+      allow us to measure the scale of networking errors in a stressful test and prove if the networking becomes more
+      stable (with lower total errors and a lower error rate).
+    * The Operation latency (more specifically the Latency90thPercentile to Latency99thPercentile metrics)
+    * The Operation Throughput
+    * "ss connections active": the number of connections.
+
 Keywords:
 - scale
 - insertMany
@@ -36,6 +45,7 @@ ActorTemplates:
         NopInPhasesUpTo: *NumPhases
         PhaseConfig:
           Duration: 3 minutes
+          RecordFailure: true
           CollectionCount: *NumColls
           Operations:
           - OperationName: insertOne
@@ -55,6 +65,7 @@ ActorTemplates:
         NopInPhasesUpTo: *NumPhases
         PhaseConfig:
           Duration: 3 minutes
+          RecordFailure: true
           CollectionCount: *NumColls
           Operations:
           - OperationName: find


### PR DESCRIPTION
**Jira Ticket:** PERF-4000 (BF-25451 / BF-25038)

**Whats Changed:**  
_kSwallowAndRecord_ mode was not actually counting errors. Updated the code to addErrors(1) to record the errors so that they can be surfaced in **ErrorsTotal** and **ErrorRate** metrics.

Transient networking error are not necessarily fatal, they can be recoverable. Counting these errors and reporting them rather than raising Exceptions will allow us to monitor and improve stressful networking workloads.

So far,  _ConnectionPoolStress.yml_ and _./src/workloads/scale/Mixed10KThreads.yml_ derived workloads can be changed  (these are highly stressful tests) to count errors rather than cause System Failures (BF-25451 / BF-25038).

**Patch testing results:**  
[New Behaviour](https://spruce.mongodb.com/version/64302e279ccd4eb02d53537a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC): should have ErrorsCount and Total.
[Old / Bad Behaviour](https://spruce.mongodb.com/version/64302e193627e07ca0030cf3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC): unpredictable system failures.

