### PR TITLE
PERF-4011 Fix MultiPlanning.yml workload for 6.3

### DIFF
--- a/src/workloads/execution/MultiPlanning.yml
+++ b/src/workloads/execution/MultiPlanning.yml
@@ -17,7 +17,7 @@ Actors:
     Operations:
     - OperationName: RunCommand
       OperationCommand:
-        createIndexes: *Collection
+        createIndexes: &Collection Collection0
         indexes:
         - key:
             a: 1


### PR DESCRIPTION
**Jira Ticket:** PERF-4011

**Whats Changed:**  
Do not drop non-existing collection at the start of the workload

**Patch testing results:**  
https://spruce.mongodb.com/version/64351dfc0ae6063f93fba736