### PR TITLE
PERF-4044: Noop unused dropCollection phases from ParallelInsert

### DIFF
--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -122,43 +122,43 @@ Actors:
         drop: myCollection
         writeConcern: {w: majority}
   - *Nop
-  - *DropCollection
+  - *Nop
   - *Nop
   - *DropCollection
   - *Nop
-  - *DropCollection
+  - *Nop
   - *Nop
   - *DropCollection
   - *Nop
-  - *DropCollection
+  - *Nop
   - *Nop
   - *DropCollection
   - *Nop
-  - *DropCollection
+  - *Nop
   - *Nop
   - *DropCollection
   - *Nop
-  - *DropCollection
+  - *Nop
   - *Nop
   - *DropCollection
   - *Nop
-  - *DropCollection
+  - *Nop
   - *Nop
   - *DropCollection
   - *Nop
-  - *DropCollection
+  - *Nop
   - *Nop
   - *DropCollection
   - *Nop
-  - *DropCollection
+  - *Nop
   - *Nop
   - *DropCollection
   - *Nop
-  - *DropCollection
+  - *Nop
   - *Nop
   - *DropCollection
   - *Nop
-  - *DropCollection
+  - *Nop
 
 AutoRun:
 - When:


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [PERF-4044](https://jira.mongodb.org/browse/PERF-4044)

**Whats Changed:**  
Noop unused dropCollection phases from ParallelInsert

**Patch testing results:**  
6.0: https://spruce.mongodb.com/version/643e0bcc1e2d17c174086ebd/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=parallel

master: https://spruce.mongodb.com/version/643e0cf37742aed559c852f4/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=parallel