### PR TITLE
PERF-3905 Add validate cmd workload with full option

### DIFF
--- a/src/phases/execution/ValidateCmd.yml
+++ b/src/phases/execution/ValidateCmd.yml
@@ -1,0 +1,62 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/server-execution"
+Description: |
+   This workload inserts ~1GB of documents, creates various indexes on the data, and then runs the
+   validate command. We created this workload to see the performance benefits of improvements
+   to the validate command, including background validation.
+
+GlobalDefaults:
+  FullValidation: &FullValidation {^Parameter: {Name: "FullValidation", Default: false}}
+
+Actors:
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: &db test
+    Threads: 1
+    CollectionCount: 1
+    DocumentCount: 1250000
+    BatchSize: 10000
+    Document:
+      x: &x {^RandomInt: {min: 0, max: 2147483647}}
+      y: &y {^RandomInt: {min: -1000, max: 1000}}
+      z: &z {^RandomInt: {distribution: geometric, p: 0.1}}
+      a: &a {^RandomString: {length: 128}}
+      b: &b {^RandomString: {length: 15}}
+      arr:
+      - *x
+      - *y
+      - *z
+      loc2d: &loc2d [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -180, max: 180}}]
+      loc2dSphere: &loc2dSphere [{^RandomInt: {min: -180, max: 180}}, {^RandomInt: {min: -90, max: 90}}]
+    Indexes:
+    - keys: {x: 1}
+    - keys: {x: -1}
+      options: {expireAfterSeconds: 1000000}
+    - keys: {x: 1, y: 1}
+    - keys: {x: 1, y: 1, b: 1}
+    - keys: {arr: 1, z: 1}
+    - keys: {arr: 1, b: 1}
+    - keys: {a: "text"}
+    - keys: {a: 1}
+      options: {sparse: true}
+    - keys: {a: "hashed"}
+    - keys: {loc2d: "2d"}
+    - keys: {loc2dSphere: "2dsphere"}
+  - &Nop {Nop: true}
+
+- Name: Validate
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 10  # Run validate() 10 times to reduce noise.
+    Database: *db
+    Operation:
+      OperationMetricsName: ValidateCmd
+      OperationName: RunCommand
+      OperationCommand:
+        validate: Collection0
+        full: *FullValidation

--- a/src/workloads/execution/ValidateCmdFull.yml
+++ b/src/workloads/execution/ValidateCmdFull.yml
@@ -13,7 +13,7 @@ Keywords:
 LoadConfig:
   Path: "../../phases/execution/ValidateCmd.yml"
   Parameters:
-    FullValidation: false
+    FullValidation: true
 
 AutoRun:
 - When:


### PR DESCRIPTION
**Jira Ticket:** [PERF-3905](https://jira.mongodb.org/browse/PERF-3905)

**Whats Changed:**  
Adds a variant of the ValidateCmd.yml workload using full validation.

**Patch testing results:**  
https://spruce.mongodb.com/version/643fc9b661837d294ec25a45/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

**Workload Submission form:**  
If applicable, only required if there is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)
