### PR TITLE
PERF-3092 Adapt WouldChangeOwningShardBatchWrite workload to data size aware balancing

### DIFF
--- a/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+++ b/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
@@ -5,8 +5,7 @@ Description: |
   the shard key to trigger WouldChangeOwningShard errors.
 
   The workload consists of 3 phases:
-    1. Shard an empty collection (using ranged sharding) into two chunks and wait for the balancer
-    to distribute each chunk to its own shard.
+    1. Shard an empty collection (using ranged sharding) spreading 2 chunks across 2 shards.
     2. Populate the sharded collection with data.
     3. Update the shard key value to trigger WouldChangeOwningShard errors.
 
@@ -19,8 +18,6 @@ GlobalDefaults:
   Namespace: &Namespace test.Collection0
 
   DocumentCount: &DocumentCount 10000  # Number of documents to insert and modify.
-  BalancerWait: &BalancerWait "20 seconds"  # Wait out the 20 second delay between balancing rounds
-  # with a little extra leeway for balancing to finish.
 
 Actors:
 - Name: CreateShardedCollection
@@ -34,20 +31,18 @@ Actors:
       OperationName: AdminCommand
       OperationCommand:
         enableSharding: *Database
+        primaryShard: "rs0"
     - OperationMetricsName: ShardCollection
       OperationName: AdminCommand
       OperationCommand:
         shardCollection: *Namespace
         key: {x: 1}
-    - OperationMetricsName: SplitChunks
+    - OperationMetricsName: MoveRange
       OperationName: AdminCommand
       OperationCommand:
-        split: *Namespace
-        middle: {x: 5}
-    - OperationMetricsName: BalancerStart
-      OperationName: AdminCommand
-      OperationCommand:
-        balancerStart: 1
+        moveRange: *Namespace
+        min: {x: 5}
+        toShard: "rs1"
   - *Nop
   - *Nop
 
@@ -57,7 +52,6 @@ Actors:
   Phases:
   - *Nop
   - Repeat: 1
-    SleepBefore: *BalancerWait
     BatchSize: 1000
     DocumentCount: *DocumentCount
     Database: *Database


### PR DESCRIPTION
:evergreen_tree: https://spruce.mongodb.com/version/64400f713627e0a930a96126/

Manually triggered a `moveRange` (atomic split+move) to distribute chunks in the way the test was originally expecting them.