### PR TITLE
PERF-4060: move runCommand to phase0

### DIFF
--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -150,12 +150,12 @@ Actors:
   Type: RunCommand
   Threads: 1
   Phases:
-  - &nop {Nop: true}
   - Repeat: 1
     Database: admin
     Operations:
     - OperationName: RunCommand
       OperationCommand: { profile: 0, slowms: 1000, sampleRate: 0.1 }
+  - &nop {Nop: true}
   - *nop
 
 - Name: Setup


### PR DESCRIPTION
Moved the RunCommand actor to phase0 in order to eliminate the 50th latency regression.