### PR TITLE
PERF-3141 Change TPC-H queries to leverage new ^Date syntax

### DIFF
--- a/src/phases/tpch/denormalized/Q1.yml
+++ b/src/phases/tpch/denormalized/Q1.yml
@@ -15,7 +15,7 @@ TPCHDenormalizedQuery1Aggregation: &TPCHDenormalizedQuery1Aggregation
       {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
       {$unwind: "$lineitem"},
       {$replaceWith: "$lineitem"},
-      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {^date: "1998-12-01"}, unit: "day", amount: *query1Delta}}]}}},
+      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {^Date: "1998-12-01"}, unit: "day", amount: *query1Delta}}]}}},
       {$group: {_id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"}, sum_qty: {$sum: "$l_quantity"}, sum_base_price: {$sum: "$l_extendedprice"}, sum_disc_price: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}, sum_charge: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}, {$add: [1, "$l_tax"]}]}}, avg_qty: {$avg: "$l_quantity"}, avg_price: {$avg: "$l_extendedprice"}, avg_disc: {$avg: "$l_discount"}, count_order: {$count: {}}}},
       {$project: {_id: 0, l_returnflag: "$_id.l_returnflag", l_linestatus: "$_id.l_linestatus", sum_qty: 1, sum_base_price: 1, sum_disc_price: 1, sum_charge: 1, avg_qty: 1, avg_price: 1, avg_disc: 1, count_order: 1}},
       {$sort: {l_returnflag: 1, l_linestatus: 1}}

--- a/src/phases/tpch/denormalized/Q1.yml
+++ b/src/phases/tpch/denormalized/Q1.yml
@@ -15,7 +15,7 @@ TPCHDenormalizedQuery1Aggregation: &TPCHDenormalizedQuery1Aggregation
       {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
       {$unwind: "$lineitem"},
       {$replaceWith: "$lineitem"},
-      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
+      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {^date: "1998-12-01"}, unit: "day", amount: *query1Delta}}]}}},
       {$group: {_id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"}, sum_qty: {$sum: "$l_quantity"}, sum_base_price: {$sum: "$l_extendedprice"}, sum_disc_price: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}]}}, sum_charge: {$sum: {$multiply: ["$l_extendedprice", {$subtract: [1, "$l_discount"]}, {$add: [1, "$l_tax"]}]}}, avg_qty: {$avg: "$l_quantity"}, avg_price: {$avg: "$l_extendedprice"}, avg_disc: {$avg: "$l_discount"}, count_order: {$count: {}}}},
       {$project: {_id: 0, l_returnflag: "$_id.l_returnflag", l_linestatus: "$_id.l_linestatus", sum_qty: 1, sum_base_price: 1, sum_disc_price: 1, sum_charge: 1, avg_qty: 1, avg_price: 1, avg_disc: 1, count_order: 1}},
       {$sort: {l_returnflag: 1, l_linestatus: 1}}

--- a/src/phases/tpch/denormalized/Q10.yml
+++ b/src/phases/tpch/denormalized/Q10.yml
@@ -13,8 +13,8 @@ TPCHDenormalizedQuery10Aggregation: &TPCHDenormalizedQuery10Aggregation
     [
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
-        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^date: *query10Date}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {^date: *query10Date}, unit: "month", amount: 3}}]}}]}},
       {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
       {$unwind: "$lineitem"},
       {$match: {"lineitem.l_returnflag": "R"}},

--- a/src/phases/tpch/denormalized/Q10.yml
+++ b/src/phases/tpch/denormalized/Q10.yml
@@ -13,8 +13,8 @@ TPCHDenormalizedQuery10Aggregation: &TPCHDenormalizedQuery10Aggregation
     [
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$gte: ["$orders.o_orderdate", {^date: *query10Date}]}},
-        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {^date: *query10Date}, unit: "month", amount: 3}}]}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^Date: *query10Date}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {^Date: *query10Date}, unit: "month", amount: 3}}]}}]}},
       {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
       {$unwind: "$lineitem"},
       {$match: {"lineitem.l_returnflag": "R"}},

--- a/src/phases/tpch/denormalized/Q12.yml
+++ b/src/phases/tpch/denormalized/Q12.yml
@@ -21,8 +21,8 @@ TPCHDenormalizedQuery12Aggregation: &TPCHDenormalizedQuery12Aggregation
         {$or: [{"lineitem.l_shipmode": *query12ShipMode1}, {"lineitem.l_shipmode": *query12ShipMode2}]},
         {$expr: {$lt: ["$lineitem.l_commitdate", "$lineitem.l_receiptdate"]}},
         {$expr: {$lt: ["$lineitem.l_shipdate", "$lineitem.l_commitdate"]}},
-        {$expr: {$gte: ["$lineitem.l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
-        {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
+        {$expr: {$gte: ["$lineitem.l_receiptdate", {^date: *query12Date}]}},
+        {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {^date: *query12Date}, unit: "year", amount: 1}}]}}]}},
       {$group: {_id: "$lineitem.l_shipmode", high_line_count: {$sum: {$cond: {if: {$or: [{$eq: ["$orders.o_orderpriority", "1-URGENT"]}, {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}, low_line_count: {$sum: {$cond: {if: {$and: [{$ne: ["$orders.o_orderpriority", "1-URGENT"]}, {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}}},
       {$project: {_id: 0, l_shipmode: "$_id", high_line_count: 1, low_line_count: 1}},
       {$sort: {l_shipmode: 1}}

--- a/src/phases/tpch/denormalized/Q12.yml
+++ b/src/phases/tpch/denormalized/Q12.yml
@@ -21,8 +21,8 @@ TPCHDenormalizedQuery12Aggregation: &TPCHDenormalizedQuery12Aggregation
         {$or: [{"lineitem.l_shipmode": *query12ShipMode1}, {"lineitem.l_shipmode": *query12ShipMode2}]},
         {$expr: {$lt: ["$lineitem.l_commitdate", "$lineitem.l_receiptdate"]}},
         {$expr: {$lt: ["$lineitem.l_shipdate", "$lineitem.l_commitdate"]}},
-        {$expr: {$gte: ["$lineitem.l_receiptdate", {^date: *query12Date}]}},
-        {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {^date: *query12Date}, unit: "year", amount: 1}}]}}]}},
+        {$expr: {$gte: ["$lineitem.l_receiptdate", {^Date: *query12Date}]}},
+        {$expr: {$lt: ["$lineitem.l_receiptdate", {$dateAdd: {startDate: {^Date: *query12Date}, unit: "year", amount: 1}}]}}]}},
       {$group: {_id: "$lineitem.l_shipmode", high_line_count: {$sum: {$cond: {if: {$or: [{$eq: ["$orders.o_orderpriority", "1-URGENT"]}, {$eq: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}, low_line_count: {$sum: {$cond: {if: {$and: [{$ne: ["$orders.o_orderpriority", "1-URGENT"]}, {$ne: ["$orders.o_orderpriority", "2-HIGH"]}]}, then: 1, else: 0}}}}},
       {$project: {_id: 0, l_shipmode: "$_id", high_line_count: 1, low_line_count: 1}},
       {$sort: {l_shipmode: 1}}

--- a/src/phases/tpch/denormalized/Q14.yml
+++ b/src/phases/tpch/denormalized/Q14.yml
@@ -15,8 +15,8 @@ TPCHDenormalizedQuery14Aggregation: &TPCHDenormalizedQuery14Aggregation
       {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
       {$unwind: "$lineitem"},
       {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
-        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
+        {$expr: {$gte: ["$lineitem.l_shipdate", {^date: *query14Date}]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {^date: *query14Date}, unit: "month", amount: 1}}]}}]}},
       {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part"}},
       {$unwind: "$part"},
       {$group: {_id: {}, promo_price_total: {$sum: {$cond: {if: {$cond: {if: {$regexMatch: {input: "$part.p_type", regex: "^PROMO.*$", options: "si"}}, then: 1, else: 0}}, then: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}, else: 0}}}, price_total: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}}, {$project: {_id: 0, promo_revenue: {$multiply: [100.0, {$divide: ["$promo_price_total", "$price_total"]}]}}}

--- a/src/phases/tpch/denormalized/Q14.yml
+++ b/src/phases/tpch/denormalized/Q14.yml
@@ -15,8 +15,8 @@ TPCHDenormalizedQuery14Aggregation: &TPCHDenormalizedQuery14Aggregation
       {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
       {$unwind: "$lineitem"},
       {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {^date: *query14Date}]}},
-        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {^date: *query14Date}, unit: "month", amount: 1}}]}}]}},
+        {$expr: {$gte: ["$lineitem.l_shipdate", {^Date: *query14Date}]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {^Date: *query14Date}, unit: "month", amount: 1}}]}}]}},
       {$lookup: {from: "part", localField: "lineitem.l_partkey", foreignField: "p_partkey", as: "part"}},
       {$unwind: "$part"},
       {$group: {_id: {}, promo_price_total: {$sum: {$cond: {if: {$cond: {if: {$regexMatch: {input: "$part.p_type", regex: "^PROMO.*$", options: "si"}}, then: 1, else: 0}}, then: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}, else: 0}}}, price_total: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}}, {$project: {_id: 0, promo_revenue: {$multiply: [100.0, {$divide: ["$promo_price_total", "$price_total"]}]}}}

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -24,11 +24,11 @@ TPCHDenormalizedQuery15CreateView: &TPCHDenormalizedQuery15CreateView
           {$replaceWith: "$lineitem"},
           {$match: {
             $and: [
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
+              {$expr: {$gte: ["$l_shipdate", {^date: *query15Date}]}},
               {$expr: {
                 $lt: [
                   "$l_shipdate",
-                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}
+                  {$dateAdd: {startDate: {^date: *query15Date}, unit: "month", amount: 3}}
                 ]}}]}},
           {$group: {
             _id: "$l_suppkey",

--- a/src/phases/tpch/denormalized/Q15.yml
+++ b/src/phases/tpch/denormalized/Q15.yml
@@ -24,11 +24,11 @@ TPCHDenormalizedQuery15CreateView: &TPCHDenormalizedQuery15CreateView
           {$replaceWith: "$lineitem"},
           {$match: {
             $and: [
-              {$expr: {$gte: ["$l_shipdate", {^date: *query15Date}]}},
+              {$expr: {$gte: ["$l_shipdate", {^Date: *query15Date}]}},
               {$expr: {
                 $lt: [
                   "$l_shipdate",
-                  {$dateAdd: {startDate: {^date: *query15Date}, unit: "month", amount: 3}}
+                  {$dateAdd: {startDate: {^Date: *query15Date}, unit: "month", amount: 3}}
                 ]}}]}},
           {$group: {
             _id: "$l_suppkey",

--- a/src/phases/tpch/denormalized/Q20.yml
+++ b/src/phases/tpch/denormalized/Q20.yml
@@ -19,8 +19,8 @@ TPCHDenormalizedQuery20Aggregation: &TPCHDenormalizedQuery20Aggregation
       {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
       {$unwind: "$lineitem"},
       {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {^date: *query20Dat}]}},
-        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {^date: *query20Date}, unit: "year", amount: 1}}]}}]}},
+        {$expr: {$gte: ["$lineitem.l_shipdate", {^Date: *query20Dat}]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {^Date: *query20Date}, unit: "year", amount: 1}}]}}]}},
       {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
         {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},
       {$unwind: "$partsupp"},

--- a/src/phases/tpch/denormalized/Q20.yml
+++ b/src/phases/tpch/denormalized/Q20.yml
@@ -19,8 +19,8 @@ TPCHDenormalizedQuery20Aggregation: &TPCHDenormalizedQuery20Aggregation
       {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
       {$unwind: "$lineitem"},
       {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
-        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
+        {$expr: {$gte: ["$lineitem.l_shipdate", {^date: *query20Dat}]}},
+        {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {^date: *query20Date}, unit: "year", amount: 1}}]}}]}},
       {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
         {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},
       {$unwind: "$partsupp"},

--- a/src/phases/tpch/denormalized/Q20.yml
+++ b/src/phases/tpch/denormalized/Q20.yml
@@ -19,7 +19,7 @@ TPCHDenormalizedQuery20Aggregation: &TPCHDenormalizedQuery20Aggregation
       {$addFields: {quantity: {$multiply: ["$quantity", 0.5]}}},
       {$unwind: "$lineitem"},
       {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {^Date: *query20Dat}]}},
+        {$expr: {$gte: ["$lineitem.l_shipdate", {^Date: *query20Date}]}},
         {$expr: {$lt: ["$lineitem.l_shipdate", {$dateAdd: {startDate: {^Date: *query20Date}, unit: "year", amount: 1}}]}}]}},
       {$lookup: {from: "partsupp", as: "partsupp", localField: "lineitem.l_partkey", foreignField: "ps_partkey", let: {l_suppkey: "$lineitem.l_suppkey", quantity: "$quantity"}, pipeline: [
         {$match: {$and: [{$expr: {$eq: ["$$l_suppkey", "$ps_suppkey"]}}, {$expr: {$gt: ["$ps_availqty", "$$quantity"]}}]}}]}},

--- a/src/phases/tpch/denormalized/Q3.yml
+++ b/src/phases/tpch/denormalized/Q3.yml
@@ -15,9 +15,9 @@ TPCHDenormalizedQuery3Aggregation: &TPCHDenormalizedQuery3Aggregation
     [
       {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
       {$unwind: "$orders"},
-      {$match: {$expr: {$lt: ["$orders.o_orderdate", {^date: *query3Date}]}}},
+      {$match: {$expr: {$lt: ["$orders.o_orderdate", {^Date: *query3Date}]}}},
       {$unwind: "$orders.lineitem"},
-      {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {^date: *query3Date}]}}},
+      {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {^Date: *query3Date}]}}},
       {$group: {
         _id: {l_orderkey: "$orders.lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"},
         revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},

--- a/src/phases/tpch/denormalized/Q3.yml
+++ b/src/phases/tpch/denormalized/Q3.yml
@@ -15,9 +15,9 @@ TPCHDenormalizedQuery3Aggregation: &TPCHDenormalizedQuery3Aggregation
     [
       {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
       {$unwind: "$orders"},
-      {$match: {$expr: {$lt: ["$orders.o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
+      {$match: {$expr: {$lt: ["$orders.o_orderdate", {^date: *query3Date}]}}},
       {$unwind: "$orders.lineitem"},
-      {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}},
+      {$match: {$expr: {$gt: ["$orders.lineitem.l_shipdate", {^date: *query3Date}]}}},
       {$group: {
         _id: {l_orderkey: "$orders.lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"},
         revenue: {$sum: {$multiply: ["$orders.lineitem.l_extendedprice", {$subtract: [1, "$orders.lineitem.l_discount"]}]}}}},

--- a/src/phases/tpch/denormalized/Q4.yml
+++ b/src/phases/tpch/denormalized/Q4.yml
@@ -13,8 +13,8 @@ TPCHDenormalizedQuery4Aggregation: &TPCHDenormalizedQuery4Aggregation
     [
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$gte: ["$orders.o_orderdate", {^date: *query4Date}]}},
-        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {^date: *query4Date}, unit: "month", amount: 3}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^Date: *query4Date}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {^Date: *query4Date}, unit: "month", amount: 3}}]}},
         {$expr: {$gt: [{$size: {$filter: {input: "$orders.lineitem", cond: {$lt: ["$$this.l_commitdate", "$$this.l_receiptdate"]}}}}, 0]}}]}},
       {$group: {_id: "$orders.o_orderpriority", order_count: {$count: {}}}},
       {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},

--- a/src/phases/tpch/denormalized/Q4.yml
+++ b/src/phases/tpch/denormalized/Q4.yml
@@ -13,8 +13,8 @@ TPCHDenormalizedQuery4Aggregation: &TPCHDenormalizedQuery4Aggregation
     [
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
-        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^date: *query4Date}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {^date: *query4Date}, unit: "month", amount: 3}}]}},
         {$expr: {$gt: [{$size: {$filter: {input: "$orders.lineitem", cond: {$lt: ["$$this.l_commitdate", "$$this.l_receiptdate"]}}}}, 0]}}]}},
       {$group: {_id: "$orders.o_orderpriority", order_count: {$count: {}}}},
       {$project: {_id: 0, o_orderpriority: "$_id", order_count: 1}},

--- a/src/phases/tpch/denormalized/Q5.yml
+++ b/src/phases/tpch/denormalized/Q5.yml
@@ -15,8 +15,8 @@ TPCHDenormalizedQuery5Aggregation: &TPCHDenormalizedQuery5Aggregation
       {$match: {"nation.region.r_name": *query5Region}},
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$gte: ["$orders.o_orderdate", {^date: *query5Date}]}},
-        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {^date: *query5Date}, unit: "year", amount: 1}}]}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^Date: *query5Date}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {^Date: *query5Date}, unit: "year", amount: 1}}]}}]}},
       {$unwind: "$orders.lineitem"},
       {$lookup: {from: "supplier", as: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", let: {c_nationkey: "$nation.n_nationkey"}, pipeline: [
         {$match: {$expr: {$eq: ["$nation.n_nationkey", "$$c_nationkey"]}}}]}},

--- a/src/phases/tpch/denormalized/Q5.yml
+++ b/src/phases/tpch/denormalized/Q5.yml
@@ -15,8 +15,8 @@ TPCHDenormalizedQuery5Aggregation: &TPCHDenormalizedQuery5Aggregation
       {$match: {"nation.region.r_name": *query5Region}},
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
-        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^date: *query5Date}]}},
+        {$expr: {$lt: ["$orders.o_orderdate", {$dateAdd: {startDate: {^date: *query5Date}, unit: "year", amount: 1}}]}}]}},
       {$unwind: "$orders.lineitem"},
       {$lookup: {from: "supplier", as: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", let: {c_nationkey: "$nation.n_nationkey"}, pipeline: [
         {$match: {$expr: {$eq: ["$nation.n_nationkey", "$$c_nationkey"]}}}]}},

--- a/src/phases/tpch/denormalized/Q6.yml
+++ b/src/phases/tpch/denormalized/Q6.yml
@@ -19,8 +19,8 @@ TPCHDenormalizedQuery6Aggregation: &TPCHDenormalizedQuery6Aggregation
       {$unwind: "$lineitem"},
       {$replaceWith: "$lineitem"},
       {$match: {$and: [
-        {$expr: {$gte: ["$l_shipdate", {^date: *query6Date}]}},
-        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {^date: *query6Date}, unit: "year", amount: 1}}]}},
+        {$expr: {$gte: ["$l_shipdate", {^Date: *query6Date}]}},
+        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {^Date: *query6Date}, unit: "year", amount: 1}}]}},
         {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
         {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
         {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},

--- a/src/phases/tpch/denormalized/Q6.yml
+++ b/src/phases/tpch/denormalized/Q6.yml
@@ -19,8 +19,8 @@ TPCHDenormalizedQuery6Aggregation: &TPCHDenormalizedQuery6Aggregation
       {$unwind: "$lineitem"},
       {$replaceWith: "$lineitem"},
       {$match: {$and: [
-        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
-        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+        {$expr: {$gte: ["$l_shipdate", {^date: *query6Date}]}},
+        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {^date: *query6Date}, unit: "year", amount: 1}}]}},
         {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
         {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
         {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},

--- a/src/phases/tpch/denormalized/Q7.yml
+++ b/src/phases/tpch/denormalized/Q7.yml
@@ -16,8 +16,8 @@ TPCHDenormalizedQuery7Aggregation: &TPCHDenormalizedQuery7Aggregation
       {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
       {$unwind: "$lineitem"},
       {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {^date: "1995-01-01"}]}},
-        {$expr: {$lte: ["$lineitem.l_shipdate", {^date: "1996-12-31"}]}}]}},
+        {$expr: {$gte: ["$lineitem.l_shipdate", {^Date: "1995-01-01"}]}},
+        {$expr: {$lte: ["$lineitem.l_shipdate", {^Date: "1996-12-31"}]}}]}},
       {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
       {$unwind: "$supplier"},
       {$match: {$or: [

--- a/src/phases/tpch/denormalized/Q7.yml
+++ b/src/phases/tpch/denormalized/Q7.yml
@@ -16,8 +16,8 @@ TPCHDenormalizedQuery7Aggregation: &TPCHDenormalizedQuery7Aggregation
       {$addFields: {lineitem: "$orders.lineitem", "orders.lineitem": "$$REMOVE"}},
       {$unwind: "$lineitem"},
       {$match: {$and: [
-        {$expr: {$gte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
-        {$expr: {$lte: ["$lineitem.l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}},
+        {$expr: {$gte: ["$lineitem.l_shipdate", {^date: "1995-01-01"}]}},
+        {$expr: {$lte: ["$lineitem.l_shipdate", {^date: "1996-12-31"}]}}]}},
       {$lookup: {from: "supplier", localField: "lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
       {$unwind: "$supplier"},
       {$match: {$or: [

--- a/src/phases/tpch/denormalized/Q8.yml
+++ b/src/phases/tpch/denormalized/Q8.yml
@@ -17,8 +17,8 @@ TPCHDenormalizedQuery8Aggregation: &TPCHDenormalizedQuery8Aggregation
       {$match: {"nation.region.r_name": {$eq: *query8Region}}},
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+        {$expr: {$lte: ["$orders.o_orderdate", {^date: "1996-12-31"}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^date: "1995-01-01"}]}}]}},
       {$unwind: "$orders.lineitem"},
       {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
       {$unwind: "$supplier"},

--- a/src/phases/tpch/denormalized/Q8.yml
+++ b/src/phases/tpch/denormalized/Q8.yml
@@ -17,8 +17,8 @@ TPCHDenormalizedQuery8Aggregation: &TPCHDenormalizedQuery8Aggregation
       {$match: {"nation.region.r_name": {$eq: *query8Region}}},
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$lte: ["$orders.o_orderdate", {^date: "1996-12-31"}]}},
-        {$expr: {$gte: ["$orders.o_orderdate", {^date: "1995-01-01"}]}}]}},
+        {$expr: {$lte: ["$orders.o_orderdate", {^Date: "1996-12-31"}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^Date: "1995-01-01"}]}}]}},
       {$unwind: "$orders.lineitem"},
       {$lookup: {from: "supplier", localField: "orders.lineitem.l_suppkey", foreignField: "s_suppkey", as: "supplier"}},
       {$unwind: "$supplier"},

--- a/src/phases/tpch/normalized/Q1.yml
+++ b/src/phases/tpch/normalized/Q1.yml
@@ -11,7 +11,7 @@ TPCHNormalizedQuery1Aggregation: &TPCHNormalizedQuery1Aggregation
   aggregate: lineitem
   pipeline:
     [
-      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: "1998-12-01"}}, unit: "day", amount: *query1Delta}}]}}},
+      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {^date: "1998-12-01"}, unit: "day", amount: *query1Delta}}]}}},
       {$group: {
         _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
         sum_qty: {$sum: "$l_quantity"},

--- a/src/phases/tpch/normalized/Q1.yml
+++ b/src/phases/tpch/normalized/Q1.yml
@@ -11,7 +11,7 @@ TPCHNormalizedQuery1Aggregation: &TPCHNormalizedQuery1Aggregation
   aggregate: lineitem
   pipeline:
     [
-      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {^date: "1998-12-01"}, unit: "day", amount: *query1Delta}}]}}},
+      {$match: {$expr: {$lte: ["$l_shipdate", {$dateAdd: {startDate: {^Date: "1998-12-01"}, unit: "day", amount: *query1Delta}}]}}},
       {$group: {
         _id: {l_returnflag: "$l_returnflag", l_linestatus: "$l_linestatus"},
         sum_qty: {$sum: "$l_quantity"},

--- a/src/phases/tpch/normalized/Q10.yml
+++ b/src/phases/tpch/normalized/Q10.yml
@@ -12,8 +12,8 @@ TPCHNormalizedQuery10Aggregation: &TPCHNormalizedQuery10Aggregation
   pipeline:
     [
       {$match: {$and: [
-        {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query10Date}}]}},
-        {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query10Date}}, unit: "month", amount: 3}}]}}]}},
+        {$expr: {$gte: ["$o_orderdate", {^date: *query10Date}]}},
+        {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {^date: *query10Date}, unit: "month", amount: 3}}]}}]}},
       {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
         {$match: {l_returnflag: "R"}}]}},
       {$unwind: "$lineitem"},

--- a/src/phases/tpch/normalized/Q10.yml
+++ b/src/phases/tpch/normalized/Q10.yml
@@ -12,8 +12,8 @@ TPCHNormalizedQuery10Aggregation: &TPCHNormalizedQuery10Aggregation
   pipeline:
     [
       {$match: {$and: [
-        {$expr: {$gte: ["$o_orderdate", {^date: *query10Date}]}},
-        {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {^date: *query10Date}, unit: "month", amount: 3}}]}}]}},
+        {$expr: {$gte: ["$o_orderdate", {^Date: *query10Date}]}},
+        {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {^Date: *query10Date}, unit: "month", amount: 3}}]}}]}},
       {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
         {$match: {l_returnflag: "R"}}]}},
       {$unwind: "$lineitem"},

--- a/src/phases/tpch/normalized/Q12.yml
+++ b/src/phases/tpch/normalized/Q12.yml
@@ -19,10 +19,10 @@ TPCHNormalizedQuery12Aggregation: &TPCHNormalizedQuery12Aggregation
           {$or: [{l_shipmode: *query12ShipMode1}, {l_shipmode: *query12ShipMode2}]},
           {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
           {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
-          {$expr: {$gte: ["$l_receiptdate", {$dateFromString: {dateString: *query12Date}}]}},
+          {$expr: {$gte: ["$l_receiptdate", {^date: *query12Date}]}},
           {$expr: {$lt: [
             "$l_receiptdate",
-            {$dateAdd: {startDate: {$dateFromString: {dateString: *query12Date}}, unit: "year", amount: 1}}]}}]}},
+            {$dateAdd: {startDate: {^date: *query12Date}, unit: "year", amount: 1}}]}}]}},
       {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
       {$unwind: "$orders"},
       {$group: {

--- a/src/phases/tpch/normalized/Q12.yml
+++ b/src/phases/tpch/normalized/Q12.yml
@@ -19,10 +19,10 @@ TPCHNormalizedQuery12Aggregation: &TPCHNormalizedQuery12Aggregation
           {$or: [{l_shipmode: *query12ShipMode1}, {l_shipmode: *query12ShipMode2}]},
           {$expr: {$lt: ["$l_commitdate", "$l_receiptdate"]}},
           {$expr: {$lt: ["$l_shipdate", "$l_commitdate"]}},
-          {$expr: {$gte: ["$l_receiptdate", {^date: *query12Date}]}},
+          {$expr: {$gte: ["$l_receiptdate", {^Date: *query12Date}]}},
           {$expr: {$lt: [
             "$l_receiptdate",
-            {$dateAdd: {startDate: {^date: *query12Date}, unit: "year", amount: 1}}]}}]}},
+            {$dateAdd: {startDate: {^Date: *query12Date}, unit: "year", amount: 1}}]}}]}},
       {$lookup: {from: "orders", localField: "l_orderkey", foreignField: "o_orderkey", as: "orders"}},
       {$unwind: "$orders"},
       {$group: {

--- a/src/phases/tpch/normalized/Q14.yml
+++ b/src/phases/tpch/normalized/Q14.yml
@@ -13,11 +13,11 @@ TPCHNormalizedQuery14Aggregation: &TPCHNormalizedQuery14Aggregation
     [
       {$match: {
         $and: [
-          {$expr: {$gte: ["$l_shipdate", {^date: *query14Date}]}},
+          {$expr: {$gte: ["$l_shipdate", {^Date: *query14Date}]}},
           {$expr: {
             $lt: [
               "$l_shipdate",
-              {$dateAdd: {startDate: {^date: *query14Date}, unit: "month", amount: 1}}]}}]}},
+              {$dateAdd: {startDate: {^Date: *query14Date}, unit: "month", amount: 1}}]}}]}},
       {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
       {$unwind: "$part"},
       {$group: {

--- a/src/phases/tpch/normalized/Q14.yml
+++ b/src/phases/tpch/normalized/Q14.yml
@@ -13,11 +13,11 @@ TPCHNormalizedQuery14Aggregation: &TPCHNormalizedQuery14Aggregation
     [
       {$match: {
         $and: [
-          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query14Date}}]}},
+          {$expr: {$gte: ["$l_shipdate", {^date: *query14Date}]}},
           {$expr: {
             $lt: [
               "$l_shipdate",
-              {$dateAdd: {startDate: {$dateFromString: {dateString: *query14Date}}, unit: "month", amount: 1}}]}}]}},
+              {$dateAdd: {startDate: {^date: *query14Date}, unit: "month", amount: 1}}]}}]}},
       {$lookup: {from: "part", localField: "l_partkey", foreignField: "p_partkey", as: "part"}},
       {$unwind: "$part"},
       {$group: {

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -20,11 +20,11 @@ TPCHNormalizedQuery15CreateView: &TPCHNormalizedQuery15CreateView
         [
           {$match: {
             $and: [
-              {$expr: {$gte: ["$l_shipdate", {^date: *query15Date}]}},
+              {$expr: {$gte: ["$l_shipdate", {^Date: *query15Date}]}},
               {$expr: {
                 $lt: [
                   "$l_shipdate",
-                  {$dateAdd: {startDate: {^date: *query15Date}, unit: "month", amount: 3}}
+                  {$dateAdd: {startDate: {^Date: *query15Date}, unit: "month", amount: 3}}
                 ]}}]}},
           {$group: {
             _id: "$l_suppkey",

--- a/src/phases/tpch/normalized/Q15.yml
+++ b/src/phases/tpch/normalized/Q15.yml
@@ -20,11 +20,11 @@ TPCHNormalizedQuery15CreateView: &TPCHNormalizedQuery15CreateView
         [
           {$match: {
             $and: [
-              {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query15Date}}]}},
+              {$expr: {$gte: ["$l_shipdate", {^date: *query15Date}]}},
               {$expr: {
                 $lt: [
                   "$l_shipdate",
-                  {$dateAdd: {startDate: {$dateFromString: {dateString: *query15Date}}, unit: "month", amount: 3}}
+                  {$dateAdd: {startDate: {^date: *query15Date}, unit: "month", amount: 3}}
                 ]}}]}},
           {$group: {
             _id: "$l_suppkey",

--- a/src/phases/tpch/normalized/Q20.yml
+++ b/src/phases/tpch/normalized/Q20.yml
@@ -25,8 +25,8 @@ TPCHNormalizedQuery20Aggregation: &TPCHNormalizedQuery20Aggregation
       {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
         {$match: {$and: [
           {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
-          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query20Date}}]}},
-          {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query20Date}}, unit: "year", amount: 1}}]}}]}},
+          {$expr: {$gte: ["$l_shipdate", {^date: *query20Date}]}},
+          {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {^date: *query20Date}, unit: "year", amount: 1}}]}}]}},
         {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
         {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
       {$unwind: "$lineitem"},

--- a/src/phases/tpch/normalized/Q20.yml
+++ b/src/phases/tpch/normalized/Q20.yml
@@ -25,8 +25,8 @@ TPCHNormalizedQuery20Aggregation: &TPCHNormalizedQuery20Aggregation
       {$lookup: {from: "lineitem", localField: "partsupp.ps_partkey", foreignField: "l_partkey", let: {s_suppkey: "$s_suppkey"}, as: "lineitem", pipeline: [
         {$match: {$and: [
           {$expr: {$eq: ["$$s_suppkey", "$l_suppkey"]}},
-          {$expr: {$gte: ["$l_shipdate", {^date: *query20Date}]}},
-          {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {^date: *query20Date}, unit: "year", amount: 1}}]}}]}},
+          {$expr: {$gte: ["$l_shipdate", {^Date: *query20Date}]}},
+          {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {^Date: *query20Date}, unit: "year", amount: 1}}]}}]}},
         {$group: {_id: {}, quantity: {$sum: "$l_quantity"}}},
         {$project: {_id: 0, quantity: {$multiply: ["$quantity", 0.5]}}}]}},
       {$unwind: "$lineitem"},

--- a/src/phases/tpch/normalized/Q3.yml
+++ b/src/phases/tpch/normalized/Q3.yml
@@ -15,11 +15,11 @@ TPCHNormalizedQuery3Aggregation: &TPCHNormalizedQuery3Aggregation
     [
       {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
       {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-        {$match: {$expr: {$lt: ["$o_orderdate", {$dateFromString: {dateString: *query3Date}}]}}},
+        {$match: {$expr: {$lt: ["$o_orderdate", {^date: *query3Date}]}}},
         {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
       {$unwind: "$orders"},
       {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-        {$match: {$expr: {$gt: ["$l_shipdate", {$dateFromString: {dateString: *query3Date}}]}}}]}},
+        {$match: {$expr: {$gt: ["$l_shipdate", {^date: *query3Date}]}}}]}},
       {$unwind: "$lineitem"},
       {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
       {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},

--- a/src/phases/tpch/normalized/Q3.yml
+++ b/src/phases/tpch/normalized/Q3.yml
@@ -15,11 +15,11 @@ TPCHNormalizedQuery3Aggregation: &TPCHNormalizedQuery3Aggregation
     [
       {$match: {$expr: {$eq: ["$c_mktsegment", *query3Segment]}}},
       {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", pipeline: [
-        {$match: {$expr: {$lt: ["$o_orderdate", {^date: *query3Date}]}}},
+        {$match: {$expr: {$lt: ["$o_orderdate", {^Date: *query3Date}]}}},
         {$project: {o_orderdate: 1, o_shippriority: 1, o_orderkey: 1}}]}},
       {$unwind: "$orders"},
       {$lookup: {from: "lineitem", localField: "orders.o_orderkey", foreignField: "l_orderkey", as: "lineitem", pipeline: [
-        {$match: {$expr: {$gt: ["$l_shipdate", {^date: *query3Date}]}}}]}},
+        {$match: {$expr: {$gt: ["$l_shipdate", {^Date: *query3Date}]}}}]}},
       {$unwind: "$lineitem"},
       {$group: {_id: { l_orderkey: "$lineitem.l_orderkey", o_orderdate: "$orders.o_orderdate", o_shippriority: "$orders.o_shippriority"}, revenue: {$sum: {$multiply: ["$lineitem.l_extendedprice", {$subtract: [1, "$lineitem.l_discount"]}]}}}},
       {$project: {_id: 0, l_orderkey: "$_id.l_orderkey", o_orderdate: "$_id.o_orderdate", o_shippriority: "$_id.o_shippriority", revenue: 1}},

--- a/src/phases/tpch/normalized/Q4.yml
+++ b/src/phases/tpch/normalized/Q4.yml
@@ -13,8 +13,8 @@ TPCHNormalizedQuery4Aggregation: &TPCHNormalizedQuery4Aggregation
     [
       {$match: {
         $and: [
-          {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query4Date}}]}},
-          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query4Date}}, unit: "month", amount: 3}}]}}]}},
+          {$expr: {$gte: ["$o_orderdate", {^date: *query4Date}]}},
+          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {^date: *query4Date}, unit: "month", amount: 3}}]}}]}},
       {$lookup: {
         from: "lineitem",
         localField: "o_orderkey",

--- a/src/phases/tpch/normalized/Q4.yml
+++ b/src/phases/tpch/normalized/Q4.yml
@@ -13,8 +13,8 @@ TPCHNormalizedQuery4Aggregation: &TPCHNormalizedQuery4Aggregation
     [
       {$match: {
         $and: [
-          {$expr: {$gte: ["$o_orderdate", {^date: *query4Date}]}},
-          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {^date: *query4Date}, unit: "month", amount: 3}}]}}]}},
+          {$expr: {$gte: ["$o_orderdate", {^Date: *query4Date}]}},
+          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {^Date: *query4Date}, unit: "month", amount: 3}}]}}]}},
       {$lookup: {
         from: "lineitem",
         localField: "o_orderkey",

--- a/src/phases/tpch/normalized/Q5.yml
+++ b/src/phases/tpch/normalized/Q5.yml
@@ -14,8 +14,8 @@ TPCHNormalizedQuery5Aggregation: &TPCHNormalizedQuery5Aggregation
     [
       {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
         {$match: {$and: [
-          {$expr: {$gte: ["$o_orderdate", {$dateFromString: {dateString: *query5Date}}]}},
-          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query5Date}}, unit: "year", amount: 1}}]}}]}},
+          {$expr: {$gte: ["$o_orderdate", {^date: *query5Date}]}},
+          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {^date: *query5Date}, unit: "year", amount: 1}}]}}]}},
         {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
           {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
             {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},

--- a/src/phases/tpch/normalized/Q5.yml
+++ b/src/phases/tpch/normalized/Q5.yml
@@ -14,8 +14,8 @@ TPCHNormalizedQuery5Aggregation: &TPCHNormalizedQuery5Aggregation
     [
       {$lookup: {from: "orders", localField: "c_custkey", foreignField: "o_custkey", as: "orders", let: {c_nationkey: "$c_nationkey"}, pipeline: [
         {$match: {$and: [
-          {$expr: {$gte: ["$o_orderdate", {^date: *query5Date}]}},
-          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {^date: *query5Date}, unit: "year", amount: 1}}]}}]}},
+          {$expr: {$gte: ["$o_orderdate", {^Date: *query5Date}]}},
+          {$expr: {$lt: ["$o_orderdate", {$dateAdd: {startDate: {^Date: *query5Date}, unit: "year", amount: 1}}]}}]}},
         {$lookup: {from: "lineitem", localField: "o_orderkey", foreignField: "l_orderkey", as: "lineitem", let: {c_nationkey: "$$c_nationkey"}, pipeline: [
           {$lookup: {from: "supplier", localField: "l_suppkey", foreignField: "s_suppkey", as: "supplier", pipeline: [
             {$match: {$expr: {$eq: ["$s_nationkey", "$$c_nationkey"]}}},

--- a/src/phases/tpch/normalized/Q6.yml
+++ b/src/phases/tpch/normalized/Q6.yml
@@ -15,8 +15,8 @@ TPCHNormalizedQuery6Aggregation: &TPCHNormalizedQuery6Aggregation
   pipeline:
     [
       {$match: {$and: [
-        {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: *query6Date}}]}},
-        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {$dateFromString: {dateString: *query6Date}}, unit: "year", amount: 1}}]}},
+        {$expr: {$gte: ["$l_shipdate", {^date: *query6Date}]}},
+        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {^date: *query6Date}, unit: "year", amount: 1}}]}},
         {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
         {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
         {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},

--- a/src/phases/tpch/normalized/Q6.yml
+++ b/src/phases/tpch/normalized/Q6.yml
@@ -15,8 +15,8 @@ TPCHNormalizedQuery6Aggregation: &TPCHNormalizedQuery6Aggregation
   pipeline:
     [
       {$match: {$and: [
-        {$expr: {$gte: ["$l_shipdate", {^date: *query6Date}]}},
-        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {^date: *query6Date}, unit: "year", amount: 1}}]}},
+        {$expr: {$gte: ["$l_shipdate", {^Date: *query6Date}]}},
+        {$expr: {$lt: ["$l_shipdate", {$dateAdd: {startDate: {^Date: *query6Date}, unit: "year", amount: 1}}]}},
         {$expr: {$gte: ["$l_discount", {$subtract: [*query6Discount, 0.01]}]}},
         {$expr: {$lte: ["$l_discount", {$add: [*query6Discount, 0.011]}]}},
         {$expr: {$lt: ["$l_quantity", *query6Quantity]}}]}},

--- a/src/phases/tpch/normalized/Q7.yml
+++ b/src/phases/tpch/normalized/Q7.yml
@@ -17,8 +17,8 @@ TPCHNormalizedQuery7Aggregation: &TPCHNormalizedQuery7Aggregation
       {$unwind: "$n1"},
       {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
         {$match: {$and: [
-          {$expr: {$gte: ["$l_shipdate", {$dateFromString: {dateString: "1995-01-01"}}]}},
-          {$expr: {$lte: ["$l_shipdate", {$dateFromString: {dateString: "1996-12-31"}}]}}]}}]}},
+          {$expr: {$gte: ["$l_shipdate", {^date:"1995-01-01"}]}},
+          {$expr: {$lte: ["$l_shipdate", {^date: "1996-12-31"}]}}]}}]}},
       {$unwind: "$lineitem"},
       {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
       {$unwind: "$orders"},

--- a/src/phases/tpch/normalized/Q7.yml
+++ b/src/phases/tpch/normalized/Q7.yml
@@ -17,8 +17,8 @@ TPCHNormalizedQuery7Aggregation: &TPCHNormalizedQuery7Aggregation
       {$unwind: "$n1"},
       {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
         {$match: {$and: [
-          {$expr: {$gte: ["$l_shipdate", {^date:"1995-01-01"}]}},
-          {$expr: {$lte: ["$l_shipdate", {^date: "1996-12-31"}]}}]}}]}},
+          {$expr: {$gte: ["$l_shipdate", {^Date:"1995-01-01"}]}},
+          {$expr: {$lte: ["$l_shipdate", {^Date: "1996-12-31"}]}}]}}]}},
       {$unwind: "$lineitem"},
       {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
       {$unwind: "$orders"},

--- a/src/phases/tpch/normalized/Q7.yml
+++ b/src/phases/tpch/normalized/Q7.yml
@@ -17,7 +17,7 @@ TPCHNormalizedQuery7Aggregation: &TPCHNormalizedQuery7Aggregation
       {$unwind: "$n1"},
       {$lookup: {from: "lineitem", localField: "s_suppkey", foreignField: "l_suppkey", as: "lineitem", pipeline: [
         {$match: {$and: [
-          {$expr: {$gte: ["$l_shipdate", {^Date:"1995-01-01"}]}},
+          {$expr: {$gte: ["$l_shipdate", {^Date: "1995-01-01"}]}},
           {$expr: {$lte: ["$l_shipdate", {^Date: "1996-12-31"}]}}]}}]}},
       {$unwind: "$lineitem"},
       {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},

--- a/src/phases/tpch/normalized/Q8.yml
+++ b/src/phases/tpch/normalized/Q8.yml
@@ -24,8 +24,8 @@ TPCHNormalizedQuery8Aggregation: &TPCHNormalizedQuery8Aggregation
       {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$lte: ["$orders.o_orderdate", {^date: "1996-12-31"}]}},
-        {$expr: {$gte: ["$orders.o_orderdate", {^date: "1995-01-01"}]}}]}},
+        {$expr: {$lte: ["$orders.o_orderdate", {^Date: "1996-12-31"}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^Date: "1995-01-01"}]}}]}},
       {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
       {$unwind: "$customer"},
       {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n1"}},

--- a/src/phases/tpch/normalized/Q8.yml
+++ b/src/phases/tpch/normalized/Q8.yml
@@ -24,8 +24,8 @@ TPCHNormalizedQuery8Aggregation: &TPCHNormalizedQuery8Aggregation
       {$lookup: {from: "orders", localField: "lineitem.l_orderkey", foreignField: "o_orderkey", as: "orders"}},
       {$unwind: "$orders"},
       {$match: {$and: [
-        {$expr: {$lte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1996-12-31"}}]}},
-        {$expr: {$gte: ["$orders.o_orderdate", {$dateFromString: {dateString: "1995-01-01"}}]}}]}},
+        {$expr: {$lte: ["$orders.o_orderdate", {^date: "1996-12-31"}]}},
+        {$expr: {$gte: ["$orders.o_orderdate", {^date: "1995-01-01"}]}}]}},
       {$lookup: {from: "customer", localField: "orders.o_custkey", foreignField: "c_custkey", as: "customer"}},
       {$unwind: "$customer"},
       {$lookup: {from: "nation", localField: "customer.c_nationkey", foreignField: "n_nationkey", as: "n1"}},


### PR DESCRIPTION
Jira Ticket: PERF-3141

Whats Changed:
Modified TPC-H queries to use the new ^Date syntax to make the queries a bit simpler

Patch testing results:
https://spruce.mongodb.com/version/644225aa2a60ed5c48651f65/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Workload Submission form:

Related PRs: