### PR TITLE
PERF-4075 Enable more genny workloads on telemetry variants

### DIFF
--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -29,3 +29,4 @@ AutoRun:
       - standalone-classic-query-engine
       - standalone-dsi-integration-test
       - standalone-sbe
+      - standalone-telemetry

--- a/src/workloads/execution/MultiPlanning.yml
+++ b/src/workloads/execution/MultiPlanning.yml
@@ -126,4 +126,5 @@ AutoRun:
         - standalone-all-feature-flags
         - standalone-classic-query-engine
         - standalone-sbe
+        - standalone-telemetry
 

--- a/src/workloads/query/AggregateExpressions.yml
+++ b/src/workloads/query/AggregateExpressions.yml
@@ -952,6 +952,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/ArrayTraversal.yml
+++ b/src/workloads/query/ArrayTraversal.yml
@@ -269,6 +269,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -192,6 +192,7 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/ExternalSort.yml
+++ b/src/workloads/query/ExternalSort.yml
@@ -105,6 +105,7 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/FilterWithComplexLogicalExpression.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpression.yml
@@ -688,6 +688,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -133,6 +133,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/LookupNLJ.yml
+++ b/src/workloads/query/LookupNLJ.yml
@@ -338,6 +338,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/LookupSBEPushdown.yml
+++ b/src/workloads/query/LookupSBEPushdown.yml
@@ -438,6 +438,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/query/LookupSBEPushdownINLJMisc.yml
@@ -387,6 +387,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/MatchFilters.yml
+++ b/src/workloads/query/MatchFilters.yml
@@ -333,6 +333,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/RepeatedPathTraversal.yml
+++ b/src/workloads/query/RepeatedPathTraversal.yml
@@ -211,6 +211,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -264,6 +264,7 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/VariadicAggregateExpressions.yml
+++ b/src/workloads/query/VariadicAggregateExpressions.yml
@@ -603,6 +603,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -136,3 +136,4 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -96,3 +96,4 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-sbe
+      - standalone-telemetry


### PR DESCRIPTION
**Jira Ticket:** PERF-4075

**Whats Changed:**  
More genny tests running on telemetry build variants. For a start, I just looked for all the `standalone-sbe` and ran those. I think this will be good enough until we get to tackling the broader https://jira.mongodb.org/browse/SERVER-74399.

**Patch testing results:**  
https://spruce.mongodb.com/version/6442c733c9ec44d5e0c18373/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

**Workload Submission form:**  
N/A no new workloads

**Related PRs:**   
None for now. Related to https://jira.mongodb.org/browse/SERVER-76083. 
