### PR TITLE
EVG-17874: Update Genny with --no-activate flag.

### DIFF
--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -8,7 +8,7 @@ omegaconf==2.1.1
 PyYAML==5.1
 requests==2.21.0
 yamllint==1.15.0
-shrub.py==1.1.0
+shrub.py==3.0.5
 black==22.10.0
 setuptools==65.5.0
 pytest==7.2.0

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -554,13 +554,14 @@ def lint_yaml(ctx: click.Context):
     required=True,
     type=click.Choice(["all_tasks", "variant_tasks", "patch_tasks"]),
 )
+@click.option('--no-activate', is_flag=True, default=False, help="Generated tasks should not be immediately run by evergreen.")
 @click.pass_context
-def auto_tasks(ctx: click.Context, tasks: str):
+def auto_tasks(ctx: click.Context, tasks: str, no_activate: bool):
     from genny.tasks import auto_tasks
 
     auto_tasks.main(
         mode_name=tasks,
-        genny_repo_root=ctx.obj["GENNY_REPO_ROOT"],
+        no_activate=no_activate,
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
     )
 


### PR DESCRIPTION
This allows us to create task generation tasks that don't immediately execute all the generated variants.

It's a bit awkward to pass through a flag that is phrased in the negative (as opposed to using an "activate" flag and variable), but in this case we need to because an explicit activate flag would have different behavior than the default of not specifying the "activate" parameter. If the "activate" parameter is present on a task, then that task is always activated, but if it is not present then it defaults to if the version is activated or through batchtime.

Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** < Ticket Number >

**Whats Changed:**  
High level explanation of changes

**Patch testing results:**  
If applicable, link a patch test showing code changes running successfully

**Workload Submission form:**  
If applicable, only required if there is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)

**Related PRs:**   
If applicable, link related PRs

PLEASE READ AND REMOVE THE SECTION BELOW BEFORE SUBMITTING YOUR PR FOR REVIEW

1.  Once (1) you get approval from the STM or the Product Perf team for your change and (2) all your CI tests pass, you can initiate a merge by entering a comment on your PR with the text

    > evergreen merge

    This kicks your PR into the [evergreen commit queue][ecq]. Evergreen will automatically squash-merge your commit after checking that you have PR approval and that the CI tests all pass.

[ecq]: https://github.com/evergreen-ci/evergreen/wiki/Commit-Queue
