### PR TITLE
Make the example URLs for toolchain build ID more newbie-friendly

### DIFF
--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -183,14 +183,16 @@ def toolchain_info(
 
 
 class ToolchainDownloader(Downloader):
-    # These build IDs are from the genny-toolchain Evergreen task.
+    # These build IDs are from the genny-toolchain Evergreen task (which pulls from 10gen/vcpkg repo)
     # Old UI: https://evergreen.mongodb.com/waterfall/genny-toolchain
     # New UI: https://spruce.mongodb.com/commits/genny-toolchain
     #
-    # Find a compile task (for any build variant) and modify the URL. 
-    # For example:
+    # Find a compile task (for any build variant) and get TOOLCHAIN_BUILD_ID from URL
+    # https://spruce.mongodb.com/task/genny_toolchain_<$build-variant>_t_compile_<$TOOLCHAIN_BUILD_ID>
+    # Example for merged PR build on archlinux variant:
     # https://spruce.mongodb.com/task/genny_toolchain_archlinux_t_compile_82eb7c32ad09726f3ef0ddc8d7f24a18b03d9644_21_11_23_16_37_21
     # =>                                                                  82eb7c32ad09726f3ef0ddc8d7f24a18b03d9644_21_11_23_16_37_21
+    # Example for patch build on macos_1100_arm64 variant:
     # https://spruce.mongodb.com/task/genny_toolchain_macos_1100_arm64_t_compile_patch_87457e6fec1d98f270c84d915f83bec53554ecee_6451d23fc9ec4441c9ce233d_23_05_03_03_17_20
     # =>                                                                         patch_87457e6fec1d98f270c84d915f83bec53554ecee_6451d23fc9ec4441c9ce233d_23_05_03_03_17_20
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -187,7 +187,8 @@ class ToolchainDownloader(Downloader):
     # Old UI: https://evergreen.mongodb.com/waterfall/genny-toolchain
     # New UI: https://spruce.mongodb.com/commits/genny-toolchain
     #
-    # Find a compile task (for any build variant) and modify the URL:
+    # Find a compile task (for any build variant) and modify the URL. 
+    # For example:
     # https://spruce.mongodb.com/task/genny_toolchain_archlinux_t_compile_82eb7c32ad09726f3ef0ddc8d7f24a18b03d9644_21_11_23_16_37_21
     # =>                                                                  82eb7c32ad09726f3ef0ddc8d7f24a18b03d9644_21_11_23_16_37_21
     # https://spruce.mongodb.com/task/genny_toolchain_macos_1100_arm64_t_compile_patch_87457e6fec1d98f270c84d915f83bec53554ecee_6451d23fc9ec4441c9ce233d_23_05_03_03_17_20

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -184,13 +184,17 @@ def toolchain_info(
 
 class ToolchainDownloader(Downloader):
     # These build IDs are from the genny-toolchain Evergreen task.
-    # https://evergreen.mongodb.com/waterfall/genny-toolchain
+    # Old UI: https://evergreen.mongodb.com/waterfall/genny-toolchain
+    # New UI: https://spruce.mongodb.com/commits/genny-toolchain
+    #
     # Find a compile task (for any build variant) and modify the URL:
-    # genny_toolchain_archlinux_t_compile_82eb7c32ad09726f3ef0ddc8d7f24a18b03d9644_21_11_23_16_37_21
-    # =>                                  82eb7c32ad09726f3ef0ddc8d7f24a18b03d9644_21_11_23_16_37_21
+    # https://spruce.mongodb.com/task/genny_toolchain_archlinux_t_compile_82eb7c32ad09726f3ef0ddc8d7f24a18b03d9644_21_11_23_16_37_21
+    # =>                                                                  82eb7c32ad09726f3ef0ddc8d7f24a18b03d9644_21_11_23_16_37_21
+    # https://spruce.mongodb.com/task/genny_toolchain_macos_1100_arm64_t_compile_patch_87457e6fec1d98f270c84d915f83bec53554ecee_6451d23fc9ec4441c9ce233d_23_05_03_03_17_20
+    # =>                                                                         patch_87457e6fec1d98f270c84d915f83bec53554ecee_6451d23fc9ec4441c9ce233d_23_05_03_03_17_20
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
     #
-
+    
     TOOLCHAIN_BUILD_ID = "ae2e01a2da9996a364cf01ecafd90c1f4d893829_23_02_06_21_45_41"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 


### PR DESCRIPTION
When I was looking at this file to test my changes to [10gen/vcpkg/evergreen.yml](https://github.com/10gen/vcpkg/blob/master/evergreen.yml), I got confused for a while about how to get the toolchain build ID from the genny-toolchain Evergreen task because 
1) I'm using the new UI while the current example URL is for the old UI and 
2) My change is a patch so the build ID has "patch_" in front of it.

This change is to address these confusions.