### PR TITLE
Rename function for the "export" CLI command

### DIFF
--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -199,7 +199,7 @@ def evaluate(
     help=("Filepath where the output CSV will be written. Will write to stdout by default."),
 )
 @click.pass_context
-def evaluate(ctx: click.Context, ftdc_path: str, output):
+def export_ftdc_to_csv(ctx: click.Context, ftdc_path: str, output):
     from genny.curator import export
 
     export(


### PR DESCRIPTION
This is to avoid confusion with the "evaluate" CLI command's `evaluate()` function. The new name is chosen to avoid collision with `genny.curator`'s `export()` function.