### PR TITLE
PERF-4119 Prevent ContentionTTLDeletions.yml from running on branches pre-7.0

### DIFF
--- a/src/workloads/scale/ContentionTTLDeletions.yml
+++ b/src/workloads/scale/ContentionTTLDeletions.yml
@@ -200,10 +200,7 @@ AutoRun:
       - single-replica
       - single-replica-all-feature-flags
     branch_name:
-      $neq:
-      - v4.2
-      - v4.4
-      - v5.0
+      $gte: v7.0
     infrastructure_provisioning:
       $neq:
       - graviton-single-lite.2022-11  # Instance runs out of memory and crashes


### PR DESCRIPTION
Since execution control and respective server parameters don't exist prior to 7.0, we should prevent this workload from running on older branches.
