### PR TITLE
PERF-4118 Use split+move rather than moveRange in WouldChangeOwningShardBatchWrite

### DIFF
--- a/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+++ b/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
@@ -37,12 +37,17 @@ Actors:
       OperationCommand:
         shardCollection: *Namespace
         key: {x: 1}
-    - OperationMetricsName: MoveRange
+    - OperationMetricsName: Split
       OperationName: AdminCommand
       OperationCommand:
-        moveRange: *Namespace
-        min: {x: 5}
-        toShard: "rs1"
+        split: *Namespace
+        middle: {x: 5}
+    - OperationMetricsName: MoveChunk
+      OperationName: AdminCommand
+      OperationCommand:
+        moveChunk: *Namespace
+        find: {x: 6}
+        to: "rs1"
   - *Nop
   - *Nop
 


### PR DESCRIPTION
:evergreen_tree: https://spruce.mongodb.com/version/645512fa9ccd4e6dd265581b (ongoing)
