### PR TITLE
PERF-4123 run match_filters in atlas and repl variants

### DIFF
--- a/src/workloads/query/MatchFilters.yml
+++ b/src/workloads/query/MatchFilters.yml
@@ -329,6 +329,8 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
+      - atlas
+      - replica
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine


### PR DESCRIPTION
Currently, `match_filters` only runs in standalones. We care about these tests and it should run in more variants that actually reflect a release configuration.