### PR TITLE
PERF-4137 Run telemetry workload on standalone also

### DIFF
--- a/src/workloads/query/TelemetryQueryShapes.yml
+++ b/src/workloads/query/TelemetryQueryShapes.yml
@@ -136,3 +136,4 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone-telemetry
+      - standalone


### PR DESCRIPTION
I think it's good to keep the all feature flags coverage also, but the rest of our comparisons are to the normal "no feature flags" baselines, so this will standardize things more.

**Patch testing results:**  
https://spruce.mongodb.com/version/645cfb2dc9ec441ab522454b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

**Related PRs:**   
https://github.com/10gen/PerformanceReports/pull/91