### PR TITLE
EVG-19821 Add ability to override Database and Collection for single operations in CrudActor

### DIFF
--- a/src/cast_core/include/cast_core/actors/CrudActor.hpp
+++ b/src/cast_core/include/cast_core/actors/CrudActor.hpp
@@ -39,8 +39,6 @@ namespace genny::actor {
  * Actors:
  * - Name: BulkWriteInTransaction
  *   Type: CrudActor
- *   Database:
- *   Type: CrudActor
  *   Database: testdb
  *   Phases:
  *   - Repeat: 1

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -114,12 +114,6 @@ public:
     CollectionHandle(mongocxx::client* client, std::string database, std::string collection)
         : _client(client), _database(std::move(database)), _collection(std::move(collection)) {}
 
-    CollectionHandle(CollectionHandle&) = default;
-    CollectionHandle& operator=(CollectionHandle&) = default;
-
-    CollectionHandle(CollectionHandle&&) = default;
-    CollectionHandle& operator=(CollectionHandle&&) = default;
-
     mongocxx::collection collection() {
         return (*_client)[_database][_collection];
     }

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -468,11 +468,11 @@ C baseCallback = [](const Node& opNode,
 
 template <class P, class C, class O>
 C collectionHandleCallback = [](const Node& opNode,
-                    bool onSession,
-                    CollectionHandle collection,
-                    metrics::Operation operation,
-                    PhaseContext& context,
-                    ActorId id) -> std::unique_ptr<P> {
+                                bool onSession,
+                                CollectionHandle collection,
+                                metrics::Operation operation,
+                                PhaseContext& context,
+                                ActorId id) -> std::unique_ptr<P> {
     return std::make_unique<O>(opNode, onSession, collection, operation, context, id);
 };
 
@@ -1235,7 +1235,8 @@ std::unordered_map<std::string, OpCallback&> getOpConstructors() {
         {"insertMany", baseCallback<BaseOperation, OpCallback, InsertManyOperation>},
         {"startTransaction", baseCallback<BaseOperation, OpCallback, StartTransactionOperation>},
         {"commitTransaction", baseCallback<BaseOperation, OpCallback, CommitTransactionOperation>},
-        {"withTransaction", collectionHandleCallback<BaseOperation, OpCallback, WithTransactionOperation>},
+        {"withTransaction",
+         collectionHandleCallback<BaseOperation, OpCallback, WithTransactionOperation>},
         {"setReadConcern", baseCallback<BaseOperation, OpCallback, SetReadConcernOperation>},
         {"drop", baseCallback<BaseOperation, OpCallback, DropOperation>},
         {"insertOne", baseCallback<BaseOperation, OpCallback, InsertOneOperation>},

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -865,7 +865,7 @@ Tests:
             Filter: { a: 1 }
             Options:
               AwaitData: true
-    Error: | 
+    Error: |
       .*Cannot set 'awaitData' to true without also setting 'tailable' to true.*
 
   - Description: Test that an error is thrown when an invalid projection is specified in 'findOne'.
@@ -1018,3 +1018,45 @@ Tests:
             AwaitData: true
     Error: |
       .*Cannot set 'awaitData' to true without also setting 'tailable' to true.*
+
+  - Description: Test that overriding database and collection in operation description works.
+    Operations:
+      - OperationName: insertOne
+        OperationCommand:
+          Document: { a: 1 }
+        Collection: test2
+      - OperationName: insertOne
+        OperationCommand:
+          Document: { a: 1 }
+        Database: testdb2
+        Collection: testOtherDb
+    ExpectedCollectionsExist:
+      test: false
+      test2: true
+      testOtherDb: false
+
+  - Description: Test that overriding database and collection inside WithTransaction works.
+    Operations:
+      - OperationName: withTransaction
+        Collection: test1
+        OperationCommand:
+          OperationsInTransaction:
+          - OperationName: insertOne
+            OperationCommand:
+              Document: { a: 1 }
+            Collection: test2
+          - OperationName: insertOne
+            OperationCommand:
+              Document: { a: 1 }
+            Collection: test3
+          - OperationName: insertOne
+            OperationCommand:
+              Document: { a: 1 }
+            Database: testdb2
+            Collection: testOtherDb
+    ExpectedCollectionsExist:
+      test: false
+      test1: false
+      test2: true
+      test3: true
+      testOtherDb: false

--- a/src/workloads/docs/CrudActorTransaction.yml
+++ b/src/workloads/docs/CrudActorTransaction.yml
@@ -46,6 +46,40 @@ Actors:
             # because OnSession is also present on withTransaction
             OnSession: true
   - Repeat: 1
-    Collection: test
-    Operation:
-      OperationName: drop
+    Collection: test1
+    Operations:
+    - OperationName: withTransaction
+      OperationCommand:
+        OnSession: true
+        ThrowOnFailure: false
+        RecordFailure: true
+        Options:
+          MaxCommitTime: 500 milliseconds
+        OperationsInTransaction:
+          - OperationName: insertOne
+            Collection: test2
+            OperationCommand:
+              Document: {overrideCollection: 1}
+          - OperationName: insertOne
+            Database: testdb2
+            OperationCommand:
+              Document: {overrideDatabase: 1}
+          - OperationName: insertOne
+            Database: testdb2
+            Collection: test2
+            OperationCommand:
+              Document: {overrideDatabase: 1, overrideCollection: 1}
+          - OperationName: insertOne
+            OperationCommand:
+              Document: {}
+    #- Repeat: 1
+    #Collection: test
+    #Operations:
+      #- OperationName: drop
+        #Collection: test2
+      #- OperationName: drop
+        #Database: testdb2
+      #- OperationName: drop
+        #Database: testdb2
+        #Collection: test2
+      #- OperationName: drop

--- a/src/workloads/docs/CrudActorTransaction.yml
+++ b/src/workloads/docs/CrudActorTransaction.yml
@@ -46,40 +46,6 @@ Actors:
             # because OnSession is also present on withTransaction
             OnSession: true
   - Repeat: 1
-    Collection: test1
-    Operations:
-    - OperationName: withTransaction
-      OperationCommand:
-        OnSession: true
-        ThrowOnFailure: false
-        RecordFailure: true
-        Options:
-          MaxCommitTime: 500 milliseconds
-        OperationsInTransaction:
-          - OperationName: insertOne
-            Collection: test2
-            OperationCommand:
-              Document: {overrideCollection: 1}
-          - OperationName: insertOne
-            Database: testdb2
-            OperationCommand:
-              Document: {overrideDatabase: 1}
-          - OperationName: insertOne
-            Database: testdb2
-            Collection: test2
-            OperationCommand:
-              Document: {overrideDatabase: 1, overrideCollection: 1}
-          - OperationName: insertOne
-            OperationCommand:
-              Document: {}
-    #- Repeat: 1
-    #Collection: test
-    #Operations:
-      #- OperationName: drop
-        #Collection: test2
-      #- OperationName: drop
-        #Database: testdb2
-      #- OperationName: drop
-        #Database: testdb2
-        #Collection: test2
-      #- OperationName: drop
+    Collection: test
+    Operation:
+      OperationName: drop


### PR DESCRIPTION
**Jira Ticket:** EVG-19821

**Whats Changed:**  
Added support for Database and Collection fields per Operation in CrudActor, including inside WithTransaction operation.

**Patch testing results:**  
There are no workloads that use this (yet), but I've added tests to CrudActorYamlTests:
https://spruce.mongodb.com/version/645d00982a60ed3b68c8ef40/tasks
Also added a sys-perf run: https://spruce.mongodb.com/version/645d015ac9ec441ab5225599

