### PR TITLE
PERF-4132 Change TimeSeriesSortCompound.yml to use bounded sort via hint

### DIFF
--- a/src/workloads/query/TimeSeriesSortCompound.yml
+++ b/src/workloads/query/TimeSeriesSortCompound.yml
@@ -88,8 +88,7 @@ Actors:
           {$skip: 1e10},
         ]
         cursor: {}
-        allowDiskUse: true
-
+        hint: {m: 1, t: 1}
   - *Nop
 
 AutoRun:


### PR DESCRIPTION
This was supposed to use a bounded sort, not a blocking sort. See ticket description for more info

In the [design doc](https://docs.google.com/document/d/1d1artozDJUU1WmwHfcViV2BPIaDjns-xcylvPDuHiiI/edit#bookmark=id.edo8gitvzpap) you can see the third row of the example queries shows this query needs a hint to trigger a bounded sort.

[patch](https://spruce.mongodb.com/version/645d317f0ae606ff137a0cc2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)