### PR TITLE
EVG-19838 Set cpu arch based on linux_distro name

### DIFF
--- a/src/lamplib/src/genny/tasks/run_tests.py
+++ b/src/lamplib/src/genny/tasks/run_tests.py
@@ -23,6 +23,7 @@ CANNED_ARTIFACTS = {
     "ubuntu2004": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-linux-x86_64-ubuntu2004-6.0.0.tgz",
     "rhel70": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-linux-x86_64-rhel70-6.0.0.tgz",
     "rhel8": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-linux-x86_64-rhel80-6.0.0.tgz",
+    "ubuntu2204_arm64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-6.0.4.tgz",
 }
 
 # We rely on catch2 to report test failures, but it doesn't always do so.

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -100,7 +100,8 @@ def _compute_toolchain_info(
     ignore_toolchain_version: bool,
 ) -> ToolchainInfo:
     triplet_arch = "x64"
-    if linux_distro == "amazon2_arm64":
+    if len(linux_distro) > 6 and linux_distro[-6:] == "_arm64":
+        # assumes all arm64 linux distros have this suffix, e.g. 'ubuntu2204_arm64'
         triplet_arch = "arm64"
     if os_family == "Darwin":
         triplet_arch = "arm64" if platform.processor() == "arm" else "x64"


### PR DESCRIPTION
****Jira Ticket:**** EVG-19838

****Whats Changed:****

Currently, for Linux distros, genny sets `triplet_arch` to `arm64` for `amazon2_arm64` only. The code change is: if the distro name ends with `_arm64` (for instance: `ubuntu2204_arm64`) sets `triplet_arch` to `arm64`; otherwise, leave it as `x64`.

In addition to the above, I also added the download link for `ubuntu2204_arm64` into `CANNED_ARTIFACTS`.

****Patch testing results:****

With the following temporary changes

```diff
$ git df
diff --git a/src/lamplib/src/genny/toolchain.py b/src/lamplib/src/genny/toolchain.py
index 16a2b276..a25d00e6 100644
--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -239,7 +239,7 @@ class ToolchainDownloader(Downloader):
             else:
                 prefix = "macos_1100"
         else:
-            prefix = self._linux_distro
+            prefix = self._linux_distro+'_large'
         return (
             "https://s3.amazonaws.com/mciuploads/genny-toolchain/"
             "genny_toolchain_{}_{}/gennytoolchain.tgz".format(
diff --git a/src/resmokeconfig/genny_single_node_replset.yml b/src/resmokeconfig/genny_single_node_replset.yml
index 0db050be..72a09143 100644
--- a/src/resmokeconfig/genny_single_node_replset.yml
+++ b/src/resmokeconfig/genny_single_node_replset.yml
@@ -7,7 +7,7 @@ test_kind: gennylib_test

 executor:
   config:
-    program_executable: ../../src/genny/build/src/cast_core/cast_core_test
+    program_executable: ../../build/src/cast_core/cast_core_test
     verbatim_arguments:
     - "--reporter"
     - "junit"

```

I manually ran the following commands on a ubuntu2204-workstation-arm64 host

```text
./run-genny -v install --linux-distro ubuntu2204_arm64
./run-genny cmake-test
./run-genny resmoke-test --suites ../../src/resmokeconfig/genny_single_node_replset.yml
```

The first two commands finish without issue, the third one reports an error. As the focus of this ticket is to detecting arm64 build variants, we can ignore this smoke test issue.

```text
[resmoke] 06:57:23.819Z Summary of ../../src/resmokeconfig/genny_single_node_replset.yml suite: 3 test(s) ran in 75.52 seconds (2 succeeded, 0 were skipped, 1 failed, 0 errored)
```