### PR TITLE
EVG-19833 Update TOOLCHAIN_BUILD_ID to avail ubuntu2204 toolchains and add mongod ubuntu2204 download link

### DIFF
--- a/src/lamplib/src/genny/tasks/run_tests.py
+++ b/src/lamplib/src/genny/tasks/run_tests.py
@@ -24,6 +24,7 @@ CANNED_ARTIFACTS = {
     "rhel70": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-linux-x86_64-rhel70-6.0.0.tgz",
     "rhel8": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-linux-x86_64-rhel80-6.0.0.tgz",
     "ubuntu2204_arm64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-6.0.4.tgz",
+    "ubuntu2204": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.4.tgz",
 }
 
 # We rely on catch2 to report test failures, but it doesn't always do so.

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -199,7 +199,7 @@ class ToolchainDownloader(Downloader):
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
     #
 
-    TOOLCHAIN_BUILD_ID = "77d7b8df6042f53ef392097cde191b2bfef252cc_23_05_05_02_21_38"
+    TOOLCHAIN_BUILD_ID = "96f57a1f981eadf6a630d449142d7d4ee64e2647_23_05_17_00_46_17"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 
     def __init__(


### PR DESCRIPTION
****Jira Ticket:**** EVG-19833

****Whats Changed:****

Update TOOLCHAIN\_BUILD\_ID to one that builds the toolchain for ubuntu2204 amd64 and arm64.

****Patch testing results:****

The following genny cmake-test and resmoke-test succeeded on ubuntu2204 x86\_64:

```text
sudo mkdir -p /data/db
sudo chown ${whoami}:${whoami} /data/db
./run-genny clean
./run-genny create-new-actor HelloWorldActor
sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' ./src/resmokeconfig/genny_single_node_replset.yml
sed -i '/REQUIRE(count == 101)/s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp
./run-genny install -d ubuntu2204
./run-genny cmake-test
./run-genny resmoke-test --suites ../../src/resmokeconfig/genny_single_node_replset.yml
```