### PR TITLE
Add Evergreen build for Ubuntu 22.04

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -90,6 +90,16 @@ buildvariants:
   tasks:
   - name: tg_compile
 
+- name: ubuntu2204
+  display_name: Ubuntu 22.04
+  modules: [mongo]
+  expansions:
+    distro: ubuntu2204
+  run_on:
+  - ubuntu2204-large
+  tasks:
+  - name: tg_compile
+
 - name: ubuntu1804
   display_name: Ubuntu 18.04
   modules: [mongo]


### PR DESCRIPTION
Now that Genny supports Ubuntu 22.04, and that Ubuntu 22.04 is the recommended distro for Evergreen workstations, we should add the Evergreen build for this distro as well. Given how we don't run Genny patches that often, this should not bump infra cost much.