### PR TITLE
EVG-18380 - Add instructions for running resmoke-test locally

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -93,6 +93,9 @@ These commands assume that `git status` last output line is
 `nothing to commit, working tree clean`, and that the current working directory is
 `genny/` i.e. the root of the repo.
 
+Note: If you make any changes after having run `./run-genny install -d {your distro}`,
+please run that command again to compile your changes.
+
 #### MacOS:
 1. `mkdir -p data/db && sed -i '' '/mongos,/s!mongos,!mongos, "--dbpathPrefix", "data/db",!' src/lamplib/src/genny/tasks/run_tests.py`
 2. `sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/{YML file you want to use}`

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -100,7 +100,11 @@ These commands assume that `git status` last output line is
    # Example:
    sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
    ```
-3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor && sed -i '' '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp`
+3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor`. Fix the bug in the generated code, which is left as an exercise to ensure the reader understand the code. 
+	<details>
+     <summary>But if you're short on time, click here for the cheat code</summary>
+     <pre><code>sed -i '' '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp</code></pre>
+	</details>
 4. `./run-genny install -d not-linux`
 5. `./run-genny cmake-test` (Ignore the failed tests related to date & time, they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
 6. `./run-genny resmoke-test --suites {full path to YML file}`
@@ -117,7 +121,11 @@ These commands assume that `git status` last output line is
    # Example:
    sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
    ```
-3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor && sed -i '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp `
+3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor`. Fix the bug in the generated code, which is left as an exercise to ensure the reader understand the code. 
+	<details>
+     <summary>But if you're short on time, click here for the cheat code</summary>
+     <pre><code>sed -i '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp</code></pre>
+	</details>
 4. `./run-genny install -d {your distro}`
 5. `./run-genny cmake-test`
 6. `./run-genny resmoke-test --suites {full path to YML file}`

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -110,15 +110,16 @@ please run that command again to compile your changes.
      <pre><code>perl -i -pe 's!count == 101!count == 100!' ./src/cast_core/test/SelfTestActor_test.cpp</code></pre>
 	</details>
 5. The default Actor name used by `genny_create_new_actor.yml` is `SelfTestActor`. If you use another Actor name, please replace `SelfTestActor` in `genny_create_new_actor.yml` with that name: `perl -i -pe 's!SelfTestActor!{your Actor name}!' src/resmokeconfig/genny_create_new_actor.yml`
-6. `./run-genny install -d {your distro}`
-7. `./run-genny cmake-test` (MacOS: Ignore the failed tests related to date & time,
+6. `./run-genny clean`
+7. `./run-genny install -d {your distro}`
+8. `./run-genny cmake-test` (MacOS: Ignore the failed tests related to date & time,
    they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
-8. `./run-genny resmoke-test --suites {full path to YML file}`
+9. `./run-genny resmoke-test --suites {full path to YML file}`
    ```sh
    # Example:
    ./run-genny resmoke-test --suites /Users/foo.bar/genny/src/resmokeconfig/genny_sharded.yml
    ```
-9.  Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
+10. Cleanup: `git restore src/resmokeconfig/{YML file} src/lamplib/src/genny/tasks/run_tests.py && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
 
 ## Patch-Testing and Evergreen
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -108,14 +108,17 @@ please run that command again to compile your changes.
      <summary>But if you're short on time, click here for the cheat code</summary>
      <pre><code>sed -i '' '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/SelfTestActor_test.cpp</code></pre>
 	</details>
-4. `./run-genny install -d not-linux`
-5. `./run-genny cmake-test` (Ignore the failed tests related to date & time, they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
-6. `./run-genny resmoke-test --suites {full path to YML file}`
+4. The default Actor name used by genny_create_new_actor.yml is "SelfTestActor".
+	If you use another Actor name, please replace "SelfTestActor" in 
+	genny_create_new_actor.yml with that name.
+5. `./run-genny install -d not-linux`
+6. `./run-genny cmake-test` (Ignore the failed tests related to date & time, they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
+7. `./run-genny resmoke-test --suites {full path to YML file}`
    ```sh
    # Example:
    ./run-genny resmoke-test --suites /Users/foo.bar/genny/src/resmokeconfig/genny_sharded.yml
    ```
-7. Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
+8.  Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
 
 #### Linux:
 1. `mkdir -p data/db && sed -i '/mongos,/s!mongos,!mongos, "--dbpathPrefix", "data/db",!' src/lamplib/src/genny/tasks/run_tests.py`
@@ -129,14 +132,17 @@ please run that command again to compile your changes.
      <summary>But if you're short on time, click here for the cheat code</summary>
      <pre><code>sed -i '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/SelfTestActor_test.cpp</code></pre>
 	</details>
-4. `./run-genny install -d {your distro}`
-5. `./run-genny cmake-test`
-6. `./run-genny resmoke-test --suites {full path to YML file}`
+4. The default Actor name used by genny_create_new_actor.yml is "SelfTestActor".
+	If you use another Actor name, please replace "SelfTestActor" in 
+	genny_create_new_actor.yml with that name.
+5. `./run-genny install -d {your distro}`
+6. `./run-genny cmake-test`
+7. `./run-genny resmoke-test --suites {full path to YML file}`
    ```sh
    # Example:
    ./run-genny resmoke-test --suites /home/ubuntu/genny/src/resmokeconfig/genny_sharded.yml
    ```
-7. Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
+8. Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
 
 
 ## Patch-Testing and Evergreen

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -96,54 +96,29 @@ These commands assume that `git status` last output line is
 Note: If you make any changes after having run `./run-genny install -d {your distro}`,
 please run that command again to compile your changes.
 
-#### MacOS:
-1. `mkdir -p data/db && sed -i '' '/mongos,/s!mongos,!mongos, "--dbpathPrefix", "data/db",!' src/lamplib/src/genny/tasks/run_tests.py`
-2. `sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/{YML file you want to use}`
+1. `mkdir -p data/db`
+2. `perl -i -pe 's!mongos,!mongos, "--dbpathPrefix", "data/db",!' src/lamplib/src/genny/tasks/run_tests.py`
+3. `perl -i -pe 's!../../src/genny!../..!' src/resmokeconfig/{YML file you want to use}`
    ```sh
    # Example:
-   sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
+   perl -i -pe 's!../../src/genny!../..!' src/resmokeconfig/genny_sharded.yml
    ```
-3. If using genny_create_new_actor.yml: `./run-genny create-new-actor SelfTestActor`. Fix the bug in the generated code, which is left as an exercise to ensure the reader understand the code.
+4. If using `genny_create_new_actor.yml`: `./run-genny create-new-actor SelfTestActor`.
+   Fix the bug in the generated code, which is left as an exercise to ensure the reader understand the code.
 	<details>
      <summary>But if you're short on time, click here for the cheat code</summary>
-     <pre><code>sed -i '' '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/SelfTestActor_test.cpp</code></pre>
+     <pre><code>perl -i -pe 's!count == 101!count == 100!' ./src/cast_core/test/SelfTestActor_test.cpp</code></pre>
 	</details>
-4. The default Actor name used by genny_create_new_actor.yml is "SelfTestActor".
-	If you use another Actor name, please replace "SelfTestActor" in 
-	genny_create_new_actor.yml with that name.
-5. `./run-genny install -d not-linux`
-6. `./run-genny cmake-test` (Ignore the failed tests related to date & time, they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
-7. `./run-genny resmoke-test --suites {full path to YML file}`
+5. The default Actor name used by `genny_create_new_actor.yml` is `SelfTestActor`. If you use another Actor name, please replace `SelfTestActor` in `genny_create_new_actor.yml` with that name: `perl -i -pe 's!SelfTestActor!{your Actor name}!' src/resmokeconfig/genny_create_new_actor.yml`
+6. `./run-genny install -d {your distro}`
+7. `./run-genny cmake-test` (MacOS: Ignore the failed tests related to date & time,
+   they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
+8. `./run-genny resmoke-test --suites {full path to YML file}`
    ```sh
    # Example:
    ./run-genny resmoke-test --suites /Users/foo.bar/genny/src/resmokeconfig/genny_sharded.yml
    ```
-8.  Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
-
-#### Linux:
-1. `mkdir -p data/db && sed -i '/mongos,/s!mongos,!mongos, "--dbpathPrefix", "data/db",!' src/lamplib/src/genny/tasks/run_tests.py`
-2. `sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/{YML file you want to use}`
-   ```sh
-   # Example:
-   sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
-   ```
-3. If using genny_create_new_actor.yml: `./run-genny create-new-actor SelfTestActor`. Fix the bug in the generated code, which is left as an exercise to ensure the reader understand the code.
-	<details>
-     <summary>But if you're short on time, click here for the cheat code</summary>
-     <pre><code>sed -i '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/SelfTestActor_test.cpp</code></pre>
-	</details>
-4. The default Actor name used by genny_create_new_actor.yml is "SelfTestActor".
-	If you use another Actor name, please replace "SelfTestActor" in 
-	genny_create_new_actor.yml with that name.
-5. `./run-genny install -d {your distro}`
-6. `./run-genny cmake-test`
-7. `./run-genny resmoke-test --suites {full path to YML file}`
-   ```sh
-   # Example:
-   ./run-genny resmoke-test --suites /home/ubuntu/genny/src/resmokeconfig/genny_sharded.yml
-   ```
-8. Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
-
+9.  Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
 
 ## Patch-Testing and Evergreen
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -96,35 +96,35 @@ These commands assume that `git status` last output line is
 #### MacOS:
 1. `mkdir -p data/db && sed -i '' '/mongos,/s!mongos,!mongos, "--dbpathPrefix", "data/db",!' src/lamplib/src/genny/tasks/run_tests.py`
 2. `sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/{YML file you want to use}`
-```sh
-# Example:
-sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
-```
+   ```sh
+   # Example:
+   sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
+   ```
 3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor && sed -i '' '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp`
 4. `./run-genny install -d not-linux`
 5. `./run-genny cmake-test` (Ignore the failed tests related to date & time, they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
 6. `./run-genny resmoke-test --suites {full path to YML file}`
-```sh
-# Example:
-./run-genny resmoke-test --suites /Users/foo.bar/genny/src/resmokeconfig/genny_sharded.yml
-```
+   ```sh
+   # Example:
+   ./run-genny resmoke-test --suites /Users/foo.bar/genny/src/resmokeconfig/genny_sharded.yml
+   ```
 7. Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
 
 #### Linux:
 1. `mkdir -p data/db && sed -i '/mongos,/s!mongos,!mongos, "--dbpathPrefix", "data/db",!' src/lamplib/src/genny/tasks/run_tests.py`
 2. `sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/{YML file you want to use}`
-```sh
-# Example:
-sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
-```
+   ```sh
+   # Example:
+   sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
+   ```
 3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor && sed -i '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp `
 4. `./run-genny install -d {your distro}`
 5. `./run-genny cmake-test`
 6. `./run-genny resmoke-test --suites {full path to YML file}`
-```sh
-# Example:
-./run-genny resmoke-test --suites /home/ubuntu/genny/src/resmokeconfig/genny_sharded.yml
-```
+   ```sh
+   # Example:
+   ./run-genny resmoke-test --suites /home/ubuntu/genny/src/resmokeconfig/genny_sharded.yml
+   ```
 7. Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
 
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -114,10 +114,10 @@ please run that command again to compile your changes.
 7. `./run-genny install -d {your distro}`
 8. `./run-genny cmake-test` (MacOS: Ignore the failed tests related to date & time,
    they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
-9. `./run-genny resmoke-test --suites {full path to YML file}`
+9. `./run-genny resmoke-test --suites {YML file}`
    ```sh
    # Example:
-   ./run-genny resmoke-test --suites /Users/foo.bar/genny/src/resmokeconfig/genny_sharded.yml
+   ./run-genny resmoke-test --suites src/resmokeconfig/genny_sharded.yml
    ```
 10. Cleanup: `git restore src/resmokeconfig/{YML file} src/lamplib/src/genny/tasks/run_tests.py && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -77,11 +77,6 @@ The Actor tests use resmoke to set up a real MongoDB cluster and execute
 the test binary. The resmoke yaml config files that define the different
 cluster configurations are defined in `src/resmokeconfig`.
 
-```sh
-# Example:
-./run-genny resmoke-test --suites src/resmokeconfig/genny_sharded.yml
-```
-
 Each yaml configuration file will only run tests that are associated
 with their specific tags. (Eg. `genny_sharded.yml` will only run
 tests that have been tagged with the `[sharded]` tag.)
@@ -89,6 +84,48 @@ tests that have been tagged with the `[sharded]` tag.)
 When creating a new Actor, `./run-genny create-new-actor` will generate a new test case
 template to ensure the new Actor can run against different MongoDB topologies,
 please update the template as needed so it uses the newly-created Actor.
+
+Currently, the code to implement resmoke-test assumes that it will be run by
+Evergreen. Therefore, to run resmoke-test locally, some modifications must be made.
+The commands to make these modifications on MacOS and on Linux are detailed below.
+
+These commands assume that `git status` last output line is
+`nothing to commit, working tree clean`, and that the current working directory is
+`genny/` i.e. the root of the repo.
+
+#### MacOS:
+1. `mkdir -p data/db && sed -i '' '/mongos,/s/mongos,/mongos, "--dbpathPrefix", "data\/db"/' src/lamplib/src/genny/tasks/run_tests.py`
+2. `sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/{YML file you want to use}`
+```sh
+# Example:
+sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
+```
+3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor && sed -i '' '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp`
+4. `./run-genny install -d not-linux`
+5. `./run-genny cmake-test` (Ignore the failed tests related to date & time, they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
+6. `./run-genny resmoke-test --suites {full path to YML file}`
+```sh
+# Example:
+./run-genny resmoke-test --suites /Users/foo.bar/genny/src/resmokeconfig/genny_sharded.yml
+```
+7. Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
+
+#### Linux:
+1. `mkdir -p data/db && sed -i '/mongos,/s/mongos,/mongos, "--dbpathPrefix", "data\/db"/' src/lamplib/src/genny/tasks/run_tests.py`
+2. `sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/{YML file you want to use}`
+```sh
+# Example:
+sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
+```
+3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor && sed -i '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp `
+4. `./run-genny install -d {your distro}`
+5. `./run-genny cmake-test`
+6. `./run-genny resmoke-test --suites {full path to YML file}`
+```sh
+# Example:
+./run-genny resmoke-test --suites /home/ubuntu/genny/src/resmokeconfig/genny_sharded.yml
+```
+7. Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
 
 
 ## Patch-Testing and Evergreen

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -103,10 +103,10 @@ please run that command again to compile your changes.
    # Example:
    sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
    ```
-3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor`. Fix the bug in the generated code, which is left as an exercise to ensure the reader understand the code. 
+3. If using genny_create_new_actor.yml: `./run-genny create-new-actor SelfTestActor`. Fix the bug in the generated code, which is left as an exercise to ensure the reader understand the code.
 	<details>
      <summary>But if you're short on time, click here for the cheat code</summary>
-     <pre><code>sed -i '' '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp</code></pre>
+     <pre><code>sed -i '' '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/SelfTestActor_test.cpp</code></pre>
 	</details>
 4. `./run-genny install -d not-linux`
 5. `./run-genny cmake-test` (Ignore the failed tests related to date & time, they're known to be flaky on MacOS ([EVG-19776](https://jira.mongodb.org/browse/EVG-19776)))
@@ -124,10 +124,10 @@ please run that command again to compile your changes.
    # Example:
    sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/genny_sharded.yml
    ```
-3. If using genny_create_new_actor.yml: `./run-genny create-new-actor HelloWorldActor`. Fix the bug in the generated code, which is left as an exercise to ensure the reader understand the code. 
+3. If using genny_create_new_actor.yml: `./run-genny create-new-actor SelfTestActor`. Fix the bug in the generated code, which is left as an exercise to ensure the reader understand the code.
 	<details>
      <summary>But if you're short on time, click here for the cheat code</summary>
-     <pre><code>sed -i '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/HelloWorldActor_test.cpp</code></pre>
+     <pre><code>sed -i '/REQUIRE(count == 101./s/101/100/' ./src/cast_core/test/SelfTestActor_test.cpp</code></pre>
 	</details>
 4. `./run-genny install -d {your distro}`
 5. `./run-genny cmake-test`

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -79,12 +79,12 @@ cluster configurations are defined in `src/resmokeconfig`.
 
 ```sh
 # Example:
-./run-genny resmoke-test --suites src/resmokeconfig/genny_standalone.yml
+./run-genny resmoke-test --suites src/resmokeconfig/genny_sharded.yml
 ```
 
 Each yaml configuration file will only run tests that are associated
-with their specific tags. (Eg. `genny_standalone.yml` will only run
-tests that have been tagged with the `[standalone]` tag.)
+with their specific tags. (Eg. `genny_sharded.yml` will only run
+tests that have been tagged with the `[sharded]` tag.)
 
 When creating a new Actor, `./run-genny create-new-actor` will generate a new test case
 template to ensure the new Actor can run against different MongoDB topologies,

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -94,7 +94,7 @@ These commands assume that `git status` last output line is
 `genny/` i.e. the root of the repo.
 
 #### MacOS:
-1. `mkdir -p data/db && sed -i '' '/mongos,/s/mongos,/mongos, "--dbpathPrefix", "data\/db"/' src/lamplib/src/genny/tasks/run_tests.py`
+1. `mkdir -p data/db && sed -i '' '/mongos,/s!mongos,!mongos, "--dbpathPrefix", "data/db",!' src/lamplib/src/genny/tasks/run_tests.py`
 2. `sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/{YML file you want to use}`
 ```sh
 # Example:
@@ -111,7 +111,7 @@ sed -i '' '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test
 7. Cleanup: `git restore . && git clean -fd` (you can do `git clean -fdn` to preview what will be cleaned)
 
 #### Linux:
-1. `mkdir -p data/db && sed -i '/mongos,/s/mongos,/mongos, "--dbpathPrefix", "data\/db"/' src/lamplib/src/genny/tasks/run_tests.py`
+1. `mkdir -p data/db && sed -i '/mongos,/s!mongos,!mongos, "--dbpathPrefix", "data/db",!' src/lamplib/src/genny/tasks/run_tests.py`
 2. `sed -i '/program_executable/s!:.*$!: ../../build/src/cast_core/cast_core_test!' src/resmokeconfig/{YML file you want to use}`
 ```sh
 # Example:

--- a/src/lamplib/src/genny/tasks/run_tests.py
+++ b/src/lamplib/src/genny/tasks/run_tests.py
@@ -333,6 +333,7 @@ def resmoke_test(
         suites = os.path.join(genny_repo_root, "src", "resmokeconfig", "genny_create_new_actor.yml")
         checker_func = _check_create_new_actor_test_report(workspace_root=workspace_root)
     else:
+        suites = os.path.abspath(suites)
         checker_func = _nop_true
 
     resmoke_python, mongo_repo_path, bin_dir = _setup_resmoke(

--- a/src/lamplib/src/genny/tasks/run_tests.py
+++ b/src/lamplib/src/genny/tasks/run_tests.py
@@ -333,7 +333,6 @@ def resmoke_test(
         suites = os.path.join(genny_repo_root, "src", "resmokeconfig", "genny_create_new_actor.yml")
         checker_func = _check_create_new_actor_test_report(workspace_root=workspace_root)
     else:
-        suites = os.path.abspath(suites)
         checker_func = _nop_true
 
     resmoke_python, mongo_repo_path, bin_dir = _setup_resmoke(


### PR DESCRIPTION
Currently, the code to implement resmoke-test assumes that it will be run by Evergreen. Therefore, to run resmoke-test locally, some modifications must be made. This PR is to add the commands to make these modifications.

I've thought about creating a script to automatically run these commands, but the root cause of why we have to use these commands is fundamentally a bug in Genny ([EVG-18189](https://jira.mongodb.org/browse/EVG-18189)), so that script would just be papering over this bug.