### PR TITLE
PERF-4131 Use the correct options name for write concern

### DIFF
--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -67,7 +67,7 @@ Actors:
       OperationCommand:
         Filter: {}
         Update: {$inc: {i: 1}}
-        Options:
+        OperationOptions:
           WriteConcern:
             Level: 1
 


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** PERF-4131

**Whats Changed:**  
Changed "Options" to "OperationOptions" when setting write concern

**Patch testing results:**  
[If applicable, link a patch test showing code changes running successfully
](https://spruce.mongodb.com/task/sys_perf_linux_3_node_replSet.2022_11_many_update_patch_2c11ff69a7c7c475d2c356fc184a2ccffccdfc15_6467bd0c9ccd4eb3dff7c058_23_05_19_18_27_14/tests?execution=0&sortBy=STATUS&sortDir=ASC)

But there is a catch:  I still get the YAML Usage warning message.  Which is also there for /Filter at the same level.  I am not sure if this is a problem with the Usage warning or the workload is still broken.  It looks right based on the CrudActor code.

Also it appears other workloads may have the same issue, including query/update_large_documents

**Workload Submission form:**  
N/A

**Related PRs:**   
N/A
