### PR TITLE
EVG-19731 - Redact password in MongoDB URI logging

### DIFF
--- a/src/gennylib/src/PoolFactory.cpp
+++ b/src/gennylib/src/PoolFactory.cpp
@@ -239,7 +239,12 @@ mongocxx::options::pool PoolFactory::makeOptions() const {
 
 std::unique_ptr<mongocxx::pool> PoolFactory::makePool() const {
     auto uriStr = makeUri();
-    BOOST_LOG_TRIVIAL(info) << "Constructing pool with MongoURI '" << uriStr << "'";
+
+    std::string password{*_config->get(OptionType::kAccessOption, "Password")};
+    _config->set(OptionType::kAccessOption, "Password", "[REDACTED]");
+    auto redactedUriStr = makeUri();
+    BOOST_LOG_TRIVIAL(info) << "Constructing pool with MongoURI '" << redactedUriStr << "'";
+    _config->set(OptionType::kAccessOption, "Password", password);
 
     auto uri = mongocxx::uri{uriStr};
 

--- a/src/gennylib/src/PoolFactory.cpp
+++ b/src/gennylib/src/PoolFactory.cpp
@@ -241,10 +241,9 @@ std::unique_ptr<mongocxx::pool> PoolFactory::makePool() const {
     auto uriStr = makeUri();
 
     std::string password{*_config->get(OptionType::kAccessOption, "Password")};
-    _config->set(OptionType::kAccessOption, "Password", "[REDACTED]");
-    auto redactedUriStr = makeUri();
+
+    auto redactedUriStr = std::regex_replace(uriStr, std::regex(password), "[REDACTED]" );
     BOOST_LOG_TRIVIAL(info) << "Constructing pool with MongoURI '" << redactedUriStr << "'";
-    _config->set(OptionType::kAccessOption, "Password", password);
 
     auto uri = mongocxx::uri{uriStr};
 

--- a/src/gennylib/test/PoolFactory_test.cpp
+++ b/src/gennylib/test/PoolFactory_test.cpp
@@ -237,16 +237,6 @@ TEST_CASE("PoolFactory behavior") {
 
         auto pool = factory.makePool();
         REQUIRE(pool);
-
-        // We should be able to change the value of an option
-        auto expectedRedactedUri = [&]() {
-            return kProtocol + "boss:[REDACTED]@" + kHost + "/admin?appName=Genny&tls=true";
-        };
-        factory.setOption(OptionType::kAccessOption, "Password", "[REDACTED]");
-        auto redactedFactoryUri = factory.makeUri();
-        REQUIRE(redactedFactoryUri == expectedRedactedUri());
-        auto redactedPool = factory.makePool();
-        REQUIRE(redactedPool);
     }
 
     SECTION("Make a pool with client-side encryption enabled") {

--- a/src/gennylib/test/PoolFactory_test.cpp
+++ b/src/gennylib/test/PoolFactory_test.cpp
@@ -237,6 +237,16 @@ TEST_CASE("PoolFactory behavior") {
 
         auto pool = factory.makePool();
         REQUIRE(pool);
+
+        // We should be able to change the value of an option
+        auto expectedRedactedUri = [&]() {
+            return kProtocol + "boss:[REDACTED]@" + kHost + "/admin?appName=Genny&tls=true";
+        };
+        factory.setOption(OptionType::kAccessOption, "Password", "[REDACTED]");
+        auto redactedFactoryUri = factory.makeUri();
+        REQUIRE(redactedFactoryUri == expectedRedactedUri());
+        auto redactedPool = factory.makePool();
+        REQUIRE(redactedPool);
     }
 
     SECTION("Make a pool with client-side encryption enabled") {


### PR DESCRIPTION
**Jira Ticket:** EVG-19731

**Whats Changed:** Redact password in MongoDB URI logging.

Patch Run:
https://spruce.mongodb.com/task/sys_perf_atlas_M60_atlas_repl_big_update_patch_cd1cfc52029ccfba3214f22b8dcb5b09848df5f3_646f29c49ccd4e17993b29c9_23_05_25_09_29_05/logs?execution=1&sortBy=STATUS&sortDir=ASC

Redacted log line outputted by Genny:
https://parsley.mongodb.com/evergreen/sys_perf_atlas_M60_atlas_repl_big_update_patch_cd1cfc52029ccfba3214f22b8dcb5b09848df5f3_646f29c49ccd4e17993b29c9_23_05_25_09_29_05/1/task?bookmarks=0,2488,4678&shareLine=2488

**Related PRs:** https://github.com/10gen/dsi/pull/1286