### PR TITLE
PERF-4191 Fix Data/Index to match query shapes

### DIFF
--- a/src/workloads/contrib/analysis/test_result_summary.py
+++ b/src/workloads/contrib/analysis/test_result_summary.py
@@ -129,11 +129,16 @@ def summarize_diffed_data(args, actor_name, metrics_of_interest):
             return np.format_float_positional(
                 number, precision=4, unique=False, fractional=False, trim='k')
 
+        try:
+            mode = rnd(statistics.mode(diffed_readings))
+        except statistics.StatisticsError:
+            mode = "N/A - multiple modes found. Try upgrading to python 3.8 which will return the first"
+
         results[metric_name] = {
             "count": len(diffed_readings),
             "average": rnd(statistics.mean(diffed_readings)),
             "median": rnd(statistics.median_grouped(diffed_readings)),
-            "mode": rnd(statistics.mode(diffed_readings)),
+            "mode": mode,
             "stddev": rnd(statistics.stdev(diffed_readings)) if len(diffed_readings) > 1 else None,
             "[min, max]": [rnd(sorted_res[0]), rnd(sorted_res[-1])],
             "sorted_raw_data": sorted_res

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -26,7 +26,7 @@ ActorTemplates:
   Config:
     Name: {^Parameter: {Name: "Name", Default: "QueryStatsAggregation"}}
     Type: AdminCommand
-    Threads: 32
+    Threads: 2
     Phases:
       OnlyActiveInPhases:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -26,6 +26,8 @@ ActorTemplates:
   Config:
     Name: {^Parameter: {Name: "Name", Default: "QueryStatsAggregation"}}
     Type: AdminCommand
+    # TODO SERVER-76597 Consider a higher value here. Until then, using a high value could cause OOM
+    # issues.
     Threads: 2
     Phases:
       OnlyActiveInPhases:

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -100,12 +100,11 @@ Actors:
         DocumentCount: *DocumentCount
         BatchSize: 1000
         Document:
-          a: &integer {^RandomInt: {min: -100, max: 100}}
-          b: *integer
+          a1: &integer {^RandomInt: {min: -100, max: 100}}
+          a2: *integer
           string: &string {^RandomString: {length: 5}}
         Indexes:
-          - keys: {a: 1, b: 1}
-          - keys: {string: 1}
+          - keys: {a1: 1, a2: 1}
 
 - Name: Quiesce
   Type: QuiesceActor


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** PERF-4191 

**Whats Changed:**  
I ran a profiled patch build and found this strange result:
![perf-test_phase-0006_flamegraph_connections_merged](https://github.com/mongodb/genny/assets/2263256/034dfbf1-ed17-4014-9f94-02b8dab77a38)

We are spending almost all our time doing the queries! Then I noticed that our index spec didn't evolve to match our queries as we changed the way we generate our queries.

**Patch testing results:**  
Launched one here: https://spruce.mongodb.com/version/646cd0ec9ccd4e2267dbc7d2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
