### PR TITLE
PERF-4152: Add new genny workloads for sharded $lookup where the local and f…

### DIFF
--- a/src/workloads/query/LookupColocatedData.yml
+++ b/src/workloads/query/LookupColocatedData.yml
@@ -1,0 +1,367 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test exercises the behavior of $lookup when the local and foreign collection data is
+  co-located. In the queries below, for each local document on each shard, the $lookup subpipeline
+  is targeted to the same shard.
+  The workload consists of the following steps:
+    A. Creating empty collections, some unsharded and some sharded.
+    B. Populating collections with data.
+    C. Fsync.
+    D. Running $lookups. This includes pipelines using let/pipeline syntax, pipelines with
+       local/foreign field syntax, pipelines with different batch sizes, and pipelines run against
+       sharded and unsharded colls.
+GlobalDefaults:
+  UnshardedLocal: &UnshardedLocal UnshardedLocal
+  ShardedLocal: &ShardedLocal ShardedLocal
+  ShardedLocalAllOnOneShard: &ShardedLocalAllOnOneShard ShardedLocalAllOnOneShard
+  NumLocalDocs: &NumLocalDocs 15000
+  LocalShardKey: &LocalShardKey localField
+  BatchSize1k: &BatchSize1k 1000
+  BatchSize5k: &BatchSize5k 5000
+  BatchSize15k: &BatchSize15k 15000 
+  Database: &Database test
+  NumPhases: &NumPhases 23
+
+ActorTemplates:
+# Template for populating the sharded and unsharded collections. 
+- TemplateName: LoadDocuments
+  Config:
+    Name: LoadUnshardedInitialData
+    Type: CrudActor
+    Database: *Database
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Repeat: *NumLocalDocs
+          Threads: 1
+          Collection: {^Parameter: {Name: "Coll", Default: "localColl"}}
+          Operations:
+          - OperationName: insertOne
+            OperationCommand:
+              Document:
+                *LocalShardKey: {^RandomString: {length: 10}}
+                str: {^RandomString: {length: 100}}
+                smallInt: {^RandomInt: {min: 1, max: 10}}
+                mediumInt: {^RandomInt: {min: 1, max: 100}}
+
+# Template for running a $lookup using local/foreign field syntax. Note that the local and foreign
+# collections are the same. This is how we can easily enforce that the local and foreign data
+# will always be co-located.
+- TemplateName: SelfLookupLocalFieldForeignField
+  Config:
+    Name: RunLookup
+    Type: RunCommand
+    Database: *Database
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Repeat: 10
+          Database: *Database
+          Operations:
+          - OperationMetricsName: {^Parameter: {Name: "MetricsName", Default: "Lookup"}}
+            OperationName: RunCommand
+            OperationCommand:
+              aggregate: {^Parameter: {Name: "Coll", Default: "localColl"}}
+              pipeline:
+                [
+                  {$lookup: {
+                    from: {^Parameter: {Name: "Coll", Default: "localColl"}},
+                    localField: "localField",
+                    foreignField: "localField",
+                    as: "joined"
+                  }},
+                ]
+              cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 101}}}
+
+# Template for running a $lookup using let/pipeline (aka "expressive") syntax. For the reason
+# mentioned above, the local and foreign collections are the same.
+- TemplateName: SelfLookupLetPipeline
+  Config:
+    Name: RunLookup
+    Type: RunCommand
+    Database: *Database
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Repeat: 10
+          Database: *Database
+          Operations:
+          - OperationMetricsName: {^Parameter: {Name: "MetricsName", Default: "Lookup"}}
+            OperationName: RunCommand
+            OperationCommand:
+              aggregate: {^Parameter: {Name: "Coll", Default: "localColl"}}
+              pipeline:
+                [
+                  {$lookup: {
+                    from: {^Parameter: {Name: "Coll", Default: "localColl"}},
+                    let: {local_field: "localField"},
+                    pipeline: [
+                      {$match: 
+                        {
+                          $expr: {$eq: ['$localField','$$local_field']}
+                        }
+                      }
+                    ],
+                    as: "joined"
+                  }},
+                ]
+              cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 101}}}
+
+Actors:
+- Name: CreateShardedCollections
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: admin
+        Operations:
+        - OperationMetricsName: EnableSharding
+          OperationName: AdminCommand
+          OperationCommand:
+            enableSharding: *Database
+        # This collection will have data distributed across 6 chunks.
+        - OperationMetricsName: ShardLocalCollection
+          OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: test.ShardedLocal
+            key: {*LocalShardKey: hashed}
+            numInitialChunks: 6
+        # Here we use 1 chunk. This ensures that all the data for this coll is on one shard.
+        - OperationMetricsName: ShardLocalCollectionAllOnOneShard
+          OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: test.ShardedLocalAllOnOneShard
+            key: {*LocalShardKey: hashed}
+            numInitialChunks: 1
+        # Disable the balancer so that it can't skew results while the $lookups are running.
+        - OperationMetricsName: DisableBalancer
+          OperationName: AdminCommand
+          OperationCommand:
+            balancerStop: 1
+
+# On the sharded collections, an index wil automatically be created to support the shard key. Here
+# we create an equivalent index on the unsharded collection.
+- Name: CreateIndex
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            createIndexes: *UnshardedLocal
+            indexes:
+            - key: {*LocalShardKey: 1}
+              name: localShardKey_1
+
+- ActorFromTemplate:
+    TemplateName: LoadDocuments
+    TemplateParameters:
+      OnlyActiveInPhase: 2
+      Coll: *UnshardedLocal
+
+- ActorFromTemplate:
+    TemplateName: LoadDocuments
+    TemplateParameters:
+      OnlyActiveInPhase: 3
+      Coll: *ShardedLocal
+
+- ActorFromTemplate:
+    TemplateName: LoadDocuments
+    TemplateParameters:
+      OnlyActiveInPhase: 4
+      Coll: *ShardedLocalAllOnOneShard
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+
+#
+# Unsharded
+#
+- ActorFromTemplate:
+    TemplateName: SelfLookupLocalFieldForeignField
+    TemplateParameters:
+      OnlyActiveInPhase: 6
+      MetricsName: UnshardedLocalFieldForeignField1k
+      Coll: *UnshardedLocal
+      BatchSize: *BatchSize1k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLocalFieldForeignField
+    TemplateParameters:
+      OnlyActiveInPhase: 7
+      MetricsName: UnshardedLocalFieldForeignField5k
+      Coll: *UnshardedLocal
+      BatchSize: *BatchSize5k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLocalFieldForeignField
+    TemplateParameters:
+      OnlyActiveInPhase: 8
+      MetricsName: UnshardedLocalFieldForeignField15k
+      Coll: *UnshardedLocal
+      BatchSize: *BatchSize15k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLetPipeline
+    TemplateParameters:
+      OnlyActiveInPhase: 9
+      MetricsName: UnshardedLetPipeline1k
+      Coll: *UnshardedLocal
+      BatchSize: *BatchSize1k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLetPipeline
+    TemplateParameters:
+      OnlyActiveInPhase: 10
+      MetricsName: UnshardedLetPipeline5k
+      Coll: *UnshardedLocal
+      BatchSize: *BatchSize5k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLetPipeline
+    TemplateParameters:
+      OnlyActiveInPhase: 11
+      MetricsName: UnshardedLetPipeline15k
+      Coll: *UnshardedLocal
+      BatchSize: *BatchSize15k
+
+#
+# Sharded, distributed
+#
+- ActorFromTemplate:
+    TemplateName: SelfLookupLocalFieldForeignField
+    TemplateParameters:
+      OnlyActiveInPhase: 12
+      MetricsName: ShardedLocalFieldForeignField1k
+      Coll: *ShardedLocal
+      BatchSize: *BatchSize1k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLocalFieldForeignField
+    TemplateParameters:
+      OnlyActiveInPhase: 13
+      MetricsName: ShardedLocalFieldForeignField5k
+      Coll: *ShardedLocal
+      BatchSize: *BatchSize5k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLocalFieldForeignField
+    TemplateParameters:
+      OnlyActiveInPhase: 14
+      MetricsName: ShardedLocalFieldForeignField15k
+      Coll: *ShardedLocal
+      BatchSize: *BatchSize15k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLetPipeline
+    TemplateParameters:
+      OnlyActiveInPhase: 15
+      MetricsName: ShardedLetPipeline1k
+      Coll: *ShardedLocal
+      BatchSize: *BatchSize1k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLetPipeline
+    TemplateParameters:
+      OnlyActiveInPhase: 16
+      MetricsName: ShardedLetPipeline5k
+      Coll: *ShardedLocal
+      BatchSize: *BatchSize5k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLetPipeline
+    TemplateParameters:
+      OnlyActiveInPhase: 17
+      MetricsName: ShardedLetPipeline15k
+      Coll: *ShardedLocal
+      BatchSize: *BatchSize15k
+
+#
+# Sharded, all on same shard
+#
+- ActorFromTemplate:
+    TemplateName: SelfLookupLocalFieldForeignField
+    TemplateParameters:
+      OnlyActiveInPhase: 18
+      MetricsName: ShardedAllOnOneShardLocalFieldForeignField1k
+      Coll: *ShardedLocalAllOnOneShard
+      BatchSize: *BatchSize1k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLocalFieldForeignField
+    TemplateParameters:
+      OnlyActiveInPhase: 19
+      MetricsName: ShardedAllOnOneShardLocalFieldForeignField5k
+      Coll: *ShardedLocalAllOnOneShard
+      BatchSize: *BatchSize5k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLocalFieldForeignField
+    TemplateParameters:
+      OnlyActiveInPhase: 20
+      MetricsName: ShardedAllOnOneShardLocalFieldForeignField15k
+      Coll: *ShardedLocalAllOnOneShard
+      BatchSize: *BatchSize15k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLetPipeline
+    TemplateParameters:
+      OnlyActiveInPhase: 21
+      MetricsName: ShardedAllOnOneShardLetPipeline1k
+      Coll: *ShardedLocalAllOnOneShard
+      BatchSize: *BatchSize1k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLetPipeline
+    TemplateParameters:
+      OnlyActiveInPhase: 22
+      MetricsName: ShardedAllOnOneShardLetPipeline5k
+      Coll: *ShardedLocalAllOnOneShard
+      BatchSize: *BatchSize5k
+
+- ActorFromTemplate:
+    TemplateName: SelfLookupLetPipeline
+    TemplateParameters:
+      OnlyActiveInPhase: 23
+      MetricsName: ShardedAllOnOneShardLetPipeline15k
+      Coll: *ShardedLocalAllOnOneShard
+      BatchSize: *BatchSize15k
+
+AutoRun:
+- When:
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0
+    mongodb_setup:
+      $eq:
+      - shard-lite
+      - shard-lite-all-feature-flags

--- a/src/workloads/query/LookupColocatedData.yml
+++ b/src/workloads/query/LookupColocatedData.yml
@@ -363,5 +363,6 @@ AutoRun:
       - v5.0
     mongodb_setup:
       $eq:
+      - shard
       - shard-lite
       - shard-lite-all-feature-flags

--- a/src/workloads/query/LookupColocatedData.yml
+++ b/src/workloads/query/LookupColocatedData.yml
@@ -9,7 +9,7 @@ Description: |
     B. Populating collections with data.
     C. Fsync.
     D. Running $lookups. This includes pipelines using let/pipeline syntax, pipelines with
-       local/foreign field syntax, pipelines with different batch sizes, and pipelines run against
+       local/foreign field syntax, pipelines with different $limits, and pipelines run against
        sharded and unsharded colls.
 GlobalDefaults:
   UnshardedLocal: &UnshardedLocal UnshardedLocal
@@ -17,9 +17,9 @@ GlobalDefaults:
   ShardedLocalAllOnOneShard: &ShardedLocalAllOnOneShard ShardedLocalAllOnOneShard
   NumLocalDocs: &NumLocalDocs 15000
   LocalShardKey: &LocalShardKey localField
-  BatchSize1k: &BatchSize1k 1000
-  BatchSize5k: &BatchSize5k 5000
-  BatchSize15k: &BatchSize15k 15000 
+  Limit1k: &Limit1k 1000
+  Limit5k: &Limit5k 5000
+  Limit15k: &Limit15k 15000
   Database: &Database test
   NumPhases: &NumPhases 23
 
@@ -43,7 +43,8 @@ ActorTemplates:
           - OperationName: insertOne
             OperationCommand:
               Document:
-                *LocalShardKey: {^RandomString: {length: 10}}
+                # Set a large enough max so there are probably no duplicate keys.
+                *LocalShardKey: {^RandomInt: {min: 1, max: 20000}}
                 str: {^RandomString: {length: 100}}
                 smallInt: {^RandomInt: {min: 1, max: 10}}
                 mediumInt: {^RandomInt: {min: 1, max: 100}}
@@ -54,8 +55,8 @@ ActorTemplates:
 - TemplateName: SelfLookupLocalFieldForeignField
   Config:
     Name: RunLookup
-    Type: RunCommand
-    Database: *Database
+    Type: CrudActor
+    Threads: 1
     Phases:
       OnlyActiveInPhases:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
@@ -63,12 +64,12 @@ ActorTemplates:
         PhaseConfig:
           Repeat: 10
           Database: *Database
+          Collection: {^Parameter: {Name: "Coll", Default: "localColl"}}
           Operations:
           - OperationMetricsName: {^Parameter: {Name: "MetricsName", Default: "Lookup"}}
-            OperationName: RunCommand
+            OperationName: aggregate
             OperationCommand:
-              aggregate: {^Parameter: {Name: "Coll", Default: "localColl"}}
-              pipeline:
+              Pipeline:
                 [
                   {$lookup: {
                     from: {^Parameter: {Name: "Coll", Default: "localColl"}},
@@ -76,16 +77,19 @@ ActorTemplates:
                     foreignField: "localField",
                     as: "joined"
                   }},
+                  {$limit:  {^Parameter: {Name: "Limit", Default: 101}}}
                 ]
-              cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 101}}}
+              Options:
+                BatchSize: {^Parameter: {Name: "Limit", Default: 101}}
+                AllowDiskUse: true
 
 # Template for running a $lookup using let/pipeline (aka "expressive") syntax. For the reason
 # mentioned above, the local and foreign collections are the same.
 - TemplateName: SelfLookupLetPipeline
   Config:
     Name: RunLookup
-    Type: RunCommand
-    Database: *Database
+    Type: CrudActor
+    Threads: 1
     Phases:
       OnlyActiveInPhases:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
@@ -93,12 +97,12 @@ ActorTemplates:
         PhaseConfig:
           Repeat: 10
           Database: *Database
+          Collection: {^Parameter: {Name: "Coll", Default: "localColl"}}
           Operations:
           - OperationMetricsName: {^Parameter: {Name: "MetricsName", Default: "Lookup"}}
-            OperationName: RunCommand
+            OperationName: aggregate
             OperationCommand:
-              aggregate: {^Parameter: {Name: "Coll", Default: "localColl"}}
-              pipeline:
+              Pipeline:
                 [
                   {$lookup: {
                     from: {^Parameter: {Name: "Coll", Default: "localColl"}},
@@ -112,8 +116,11 @@ ActorTemplates:
                     ],
                     as: "joined"
                   }},
+                  {$limit:  {^Parameter: {Name: "Limit", Default: 101}}}
                 ]
-              cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 101}}}
+              Options:
+                BatchSize: {^Parameter: {Name: "Limit", Default: 101}}
+                AllowDiskUse: true
 
 Actors:
 - Name: CreateShardedCollections
@@ -209,7 +216,7 @@ Actors:
       OnlyActiveInPhase: 6
       MetricsName: UnshardedLocalFieldForeignField1k
       Coll: *UnshardedLocal
-      BatchSize: *BatchSize1k
+      Limit: *Limit1k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLocalFieldForeignField
@@ -217,7 +224,7 @@ Actors:
       OnlyActiveInPhase: 7
       MetricsName: UnshardedLocalFieldForeignField5k
       Coll: *UnshardedLocal
-      BatchSize: *BatchSize5k
+      Limit: *Limit5k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLocalFieldForeignField
@@ -225,7 +232,7 @@ Actors:
       OnlyActiveInPhase: 8
       MetricsName: UnshardedLocalFieldForeignField15k
       Coll: *UnshardedLocal
-      BatchSize: *BatchSize15k
+      Limit: *Limit15k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLetPipeline
@@ -233,7 +240,7 @@ Actors:
       OnlyActiveInPhase: 9
       MetricsName: UnshardedLetPipeline1k
       Coll: *UnshardedLocal
-      BatchSize: *BatchSize1k
+      Limit: *Limit1k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLetPipeline
@@ -241,7 +248,7 @@ Actors:
       OnlyActiveInPhase: 10
       MetricsName: UnshardedLetPipeline5k
       Coll: *UnshardedLocal
-      BatchSize: *BatchSize5k
+      Limit: *Limit5k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLetPipeline
@@ -249,7 +256,7 @@ Actors:
       OnlyActiveInPhase: 11
       MetricsName: UnshardedLetPipeline15k
       Coll: *UnshardedLocal
-      BatchSize: *BatchSize15k
+      Limit: *Limit15k
 
 #
 # Sharded, distributed
@@ -260,7 +267,7 @@ Actors:
       OnlyActiveInPhase: 12
       MetricsName: ShardedLocalFieldForeignField1k
       Coll: *ShardedLocal
-      BatchSize: *BatchSize1k
+      Limit: *Limit1k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLocalFieldForeignField
@@ -268,7 +275,7 @@ Actors:
       OnlyActiveInPhase: 13
       MetricsName: ShardedLocalFieldForeignField5k
       Coll: *ShardedLocal
-      BatchSize: *BatchSize5k
+      Limit: *Limit5k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLocalFieldForeignField
@@ -276,7 +283,7 @@ Actors:
       OnlyActiveInPhase: 14
       MetricsName: ShardedLocalFieldForeignField15k
       Coll: *ShardedLocal
-      BatchSize: *BatchSize15k
+      Limit: *Limit15k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLetPipeline
@@ -284,7 +291,7 @@ Actors:
       OnlyActiveInPhase: 15
       MetricsName: ShardedLetPipeline1k
       Coll: *ShardedLocal
-      BatchSize: *BatchSize1k
+      Limit: *Limit1k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLetPipeline
@@ -292,7 +299,7 @@ Actors:
       OnlyActiveInPhase: 16
       MetricsName: ShardedLetPipeline5k
       Coll: *ShardedLocal
-      BatchSize: *BatchSize5k
+      Limit: *Limit5k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLetPipeline
@@ -300,7 +307,7 @@ Actors:
       OnlyActiveInPhase: 17
       MetricsName: ShardedLetPipeline15k
       Coll: *ShardedLocal
-      BatchSize: *BatchSize15k
+      Limit: *Limit15k
 
 #
 # Sharded, all on same shard
@@ -311,7 +318,7 @@ Actors:
       OnlyActiveInPhase: 18
       MetricsName: ShardedAllOnOneShardLocalFieldForeignField1k
       Coll: *ShardedLocalAllOnOneShard
-      BatchSize: *BatchSize1k
+      Limit: *Limit1k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLocalFieldForeignField
@@ -319,7 +326,7 @@ Actors:
       OnlyActiveInPhase: 19
       MetricsName: ShardedAllOnOneShardLocalFieldForeignField5k
       Coll: *ShardedLocalAllOnOneShard
-      BatchSize: *BatchSize5k
+      Limit: *Limit5k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLocalFieldForeignField
@@ -327,7 +334,7 @@ Actors:
       OnlyActiveInPhase: 20
       MetricsName: ShardedAllOnOneShardLocalFieldForeignField15k
       Coll: *ShardedLocalAllOnOneShard
-      BatchSize: *BatchSize15k
+      Limit: *Limit15k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLetPipeline
@@ -335,7 +342,7 @@ Actors:
       OnlyActiveInPhase: 21
       MetricsName: ShardedAllOnOneShardLetPipeline1k
       Coll: *ShardedLocalAllOnOneShard
-      BatchSize: *BatchSize1k
+      Limit: *Limit1k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLetPipeline
@@ -343,7 +350,7 @@ Actors:
       OnlyActiveInPhase: 22
       MetricsName: ShardedAllOnOneShardLetPipeline5k
       Coll: *ShardedLocalAllOnOneShard
-      BatchSize: *BatchSize5k
+      Limit: *Limit5k
 
 - ActorFromTemplate:
     TemplateName: SelfLookupLetPipeline
@@ -351,7 +358,7 @@ Actors:
       OnlyActiveInPhase: 23
       MetricsName: ShardedAllOnOneShardLetPipeline15k
       Coll: *ShardedLocalAllOnOneShard
-      BatchSize: *BatchSize15k
+      Limit: *Limit15k
 
 AutoRun:
 - When:


### PR DESCRIPTION
…oreign data are co-located

**Jira Ticket:** [PERF-4152](https://jira.mongodb.org/browse/PERF-4152)

**Whats Changed:**  
This new workload exercises the behavior of $lookup when the local and foreign collection data is co-located. In the queries, for each local document on each shard, the $lookup subpipeline is targeted to the same shard. The queries include pipelines with let/pipeline syntax, pipelines with local/foreign field syntax, pipelines with different $limits, and pipelines run against sharded and unsharded colls.

**Workload Submission form:**  
Submitted! Submission [here](https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform?edit2=2_ABaOnueF9oSrnorDeTQxFIjOEWZFXR73y7dNXcwjxf0PK8vkvg4N3Ix_631uJKF_WJcFLdI)


**Results and explanation**  
Results: [here](https://spruce.mongodb.com/task/sys_perf_linux_shard_lite.2022_11_lookup_colocated_data_patch_dc864de3212e83b2d2a7553b6d9a975c523305e6_646df918c9ec44795509dd32_23_05_24_11_49_21/trend-charts?execution=0&sortBy=STATUS&sortDir=ASC) (against master) and [here](https://spruce.mongodb.com/task/sys_perf_linux_shard_lite.2022_11_lookup_colocated_data_patch_dc864de3212e83b2d2a7553b6d9a975c523305e6_646dfa8561837d7089c11251_23_05_24_11_53_16/trend-charts?execution=0&sortBy=STATUS&sortDir=ASC) (against master with local read disabled). DSI modified in both cases to forceClassic 

New results with $limit [here](https://spruce.mongodb.com/task/sys_perf_linux_shard_lite.2022_11_lookup_colocated_data_patch_3aa51a4623b5869c6f57745ad1371aacf02c8d34_6483869c7742aef18d13c9e6_23_06_09_20_09_42/trend-charts?execution=0&sortBy=STATUS&sortDir=ASC).

Config: unsharded (coll unsharded), sharded (coll sharded across multiple chunks/shards), sharded one chunk (coll sharded with a single chunk which exists on one shard)

local/foreign field syntax, sorted from lowest to highest latency

| Config | Batch size | Avg latency (sec)  |
|---|--|---|
| Unsharded | 1k | .125 |
| Sharded | 1k | .470 |
| Sharded one chunk | 1k | .478 |
| Unsharded | 5k | .550 |
| Unsharded | 15k | 1.60 |
| Sharded |  5k | 2.26 |
| Sharded one chunk |  5k | 2.32 |
| Sharded |  15k |  3.60 |
| Sharded one chunk |  15k | 6.92 |

let/pipeline syntax

| Config | Batch size | Avg latency (sec)  |
|---|--|---|
| Unsharded | 1k | .135 |
| Sharded one chunk | 1k | .554 |
| Sharded | 1k | .563 |
| Unsharded | 5k | .594 |
| Unsharded | 15k | 1.75 |
| Sharded one chunk |  5k | 2.70 |
| Sharded |  5k | 2.71 |
| Sharded |  15k |  4.18 |
| Sharded one chunk |  15k | 8.02 |


Things to note: 
- As expected from help ticket, sharded $lookup is slower than unsharded $lookup 
-  As mentioned in the help ticket, $lookup is sometimes faster when all the data is on a single shard. Now that I'm using $limit in the queries instead of batch size, the evergreen results no longer show this (though I do see it locally). Not sure why :/
- When I manually remove the local read path, unsharded $lookup regresses nearly to the "Sharded one chunk" numbers.
