### PR TITLE
PERF-4050 Allow heuristic Bonsai variants to run auto Genny workloads

### DIFF
--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -28,6 +28,7 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-dsi-integration-test
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/execution/MultiPlanning.yml
+++ b/src/workloads/execution/MultiPlanning.yml
@@ -122,6 +122,7 @@ AutoRun:
         - standalone
         - standalone-all-feature-flags
         - standalone-classic-query-engine
+        - standalone-heuristic-bonsai
         - standalone-sampling-bonsai
         - standalone-sbe
         - standalone-query-stats

--- a/src/workloads/query/AggregateExpressions.yml
+++ b/src/workloads/query/AggregateExpressions.yml
@@ -976,6 +976,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/ArrayTraversal.yml
+++ b/src/workloads/query/ArrayTraversal.yml
@@ -268,6 +268,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/ConstantFoldArithmetic.yml
+++ b/src/workloads/query/ConstantFoldArithmetic.yml
@@ -113,5 +113,6 @@ AutoRun:
       - replica
       - single-replica
       - single-replica-classic-query-engine
+      - single-replica-heuristic-bonsai
       - single-replica-sampling-bonsai
       - single-replica-sbe

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -192,6 +192,7 @@ AutoRun:
       - single-replica
       - standalone
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/ExternalSort.yml
+++ b/src/workloads/query/ExternalSort.yml
@@ -104,6 +104,7 @@ AutoRun:
       $eq:
       - standalone
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/FilterWithComplexLogicalExpression.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpression.yml
@@ -687,6 +687,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
@@ -102,5 +102,6 @@ AutoRun:
       - shard-lite-all-feature-flags
       - single-replica
       - single-replica-classic-query-engine
+      - single-replica-heuristic-bonsai
       - single-replica-sampling-bonsai
       - single-replica-sbe

--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -132,6 +132,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/LookupNLJ.yml
+++ b/src/workloads/query/LookupNLJ.yml
@@ -337,6 +337,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/LookupSBEPushdown.yml
+++ b/src/workloads/query/LookupSBEPushdown.yml
@@ -437,6 +437,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/query/LookupSBEPushdownINLJMisc.yml
@@ -386,6 +386,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/LookupWithOnlyUnshardedColls.yml
@@ -111,5 +111,6 @@ AutoRun:
       - shard-lite-all-feature-flags
       - single-replica
       - single-replica-classic-query-engine
+      - single-replica-heuristic-bonsai
       - single-replica-sampling-bonsai
       - single-replica-sbe

--- a/src/workloads/query/MatchFilters.yml
+++ b/src/workloads/query/MatchFilters.yml
@@ -334,6 +334,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/PercentilesAgg.yml
+++ b/src/workloads/query/PercentilesAgg.yml
@@ -19,6 +19,7 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/PercentilesExpr.yml
+++ b/src/workloads/query/PercentilesExpr.yml
@@ -15,6 +15,7 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/PercentilesWindow.yml
+++ b/src/workloads/query/PercentilesWindow.yml
@@ -26,6 +26,7 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/PercentilesWindowSpillToDisk.yml
+++ b/src/workloads/query/PercentilesWindowSpillToDisk.yml
@@ -23,6 +23,7 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/RepeatedPathTraversal.yml
+++ b/src/workloads/query/RepeatedPathTraversal.yml
@@ -210,6 +210,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -264,6 +264,7 @@ AutoRun:
       - shard-lite
       - standalone
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/query/VariadicAggregateExpressions.yml
+++ b/src/workloads/query/VariadicAggregateExpressions.yml
@@ -602,6 +602,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -137,6 +137,7 @@ AutoRun:
       - single-replica
       - standalone
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/scale/LargeIndexedIns.yml
+++ b/src/workloads/scale/LargeIndexedIns.yml
@@ -66,8 +66,7 @@ AutoRun:
       - replica
       - single-replica
       - single-replica-classic-query-engine
-      # TODO PERF-4127: Uncomment this build variant after fixing the system failure.
+      # TODO after SERVER-77129: Uncomment the following build variants after fixing the issue with long $in lists.
       # - single-replica-sampling-bonsai
-      # TODO PERF-4050:
       # - single-replica-heuristic-bonsai
       - single-replica-sbe

--- a/src/workloads/scale/LargeIndexedIns.yml
+++ b/src/workloads/scale/LargeIndexedIns.yml
@@ -68,4 +68,6 @@ AutoRun:
       - single-replica-classic-query-engine
       # TODO PERF-4127: Uncomment this build variant after fixing the system failure.
       # - single-replica-sampling-bonsai
+      # TODO PERF-4050:
+      # - single-replica-heuristic-bonsai
       - single-replica-sbe

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -96,6 +96,7 @@ AutoRun:
       - single-replica-15gbwtcache
       - standalone
       - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats

--- a/src/workloads/scale/MajorityReads10KThreads.yml
+++ b/src/workloads/scale/MajorityReads10KThreads.yml
@@ -24,5 +24,6 @@ AutoRun:
       - replica-all-feature-flags
       - single-replica
       - single-replica-classic-query-engine
+      - single-replica-heuristic-bonsai
       - single-replica-sampling-bonsai
       - single-replica-sbe

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -310,6 +310,7 @@ AutoRun:
       - replica-noflowcontrol
       - single-replica
       - single-replica-classic-query-engine
+      - single-replica-heuristic-bonsai
       - single-replica-sampling-bonsai
       - single-replica-sbe
       - standalone

--- a/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
@@ -192,5 +192,7 @@ AutoRun:
       - replica-noflowcontrol
       - single-replica
       - single-replica-classic-query-engine
+      - single-replica-heuristic-bonsai
+      - single-replica-sampling-bonsai
       - single-replica-sbe
       - standalone

--- a/src/workloads/scale/ScanWithLongLived.yml
+++ b/src/workloads/scale/ScanWithLongLived.yml
@@ -104,5 +104,6 @@ AutoRun:
       - replica-noflowcontrol
       - single-replica
       - single-replica-classic-query-engine
+      - single-replica-heuristic-bonsai
       - single-replica-sampling-bonsai
       - single-replica-sbe

--- a/src/workloads/transactions/LLTMixed.yml
+++ b/src/workloads/transactions/LLTMixed.yml
@@ -611,6 +611,7 @@ AutoRun:
       - replica-all-feature-flags
       - single-replica
       - single-replica-classic-query-engine
+      - single-replica-heuristic-bonsai
       - single-replica-sampling-bonsai
       - single-replica-sbe
     branch_name:


### PR DESCRIPTION
**Jira Ticket:** PERF-4050

**Whats Changed:**  
Allow Genny workload to run with Bonsai Heuristic variant

**Patch testing results:**  
https://spruce.mongodb.com/version/646e04fbe3c331718d4d831a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

**Related PRs:**   
DSI: https://github.com/10gen/dsi/pull/1289

