### PR TITLE
Miscellaneous fixes in Genny

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -514,7 +514,7 @@ Examples with these and other Actors can be found in [./src/workloads/docs](../s
 
 AutoRun is a utility to allow workload authors to determine scheduling of their workloads without having to commit to a separate repo. The utility is specifically designed for users who are using DSI through Evergreen. To use AutoRun, make sure your project has integrated DSI with Evergreen as explained [here](https://github.com/10gen/dsi/wiki/DSI-In-Evergreen).
 
-AutoRun searches in `./src/*/src/workloads` and assumes that all repos, including Genny itself, are checked out in `./src`.
+AutoRun searches in `[workspace]/src/*/src/workloads` and assumes that all workload repos, including Genny itself, are checked out in `[workspace]/src`.
 
 After performing the above integration, your Evergreen project should have a `schedule_variant_auto_tasks` task on each variant, which can be used to schedule all Genny workloads that are configured to run on this variant. There will also be the `schedule_patch_auto_tasks` task which will schedule any new or modified Genny workloads. If you want to run an unmodified workload, make a small edit (such as inserting whitespace) to force it to be picked up by that latter task.
 

--- a/docs/using.md
+++ b/docs/using.md
@@ -454,7 +454,7 @@ Try using `python test_results_summary.py --help` for more options.
     ./run-genny workload -u [connection_uri] src/workloads/[workload_dir/workload_name.yml]
     ```
 
-4.  (Optional) If you are using DSI, you can run your workload through it by copying or symlinking your Genny directory into your DSI workdir. See [Running DSI Locally](./run-dsi onboarding  # introductory DSI command; see link above for details) for details:
+4.  (Optional) If you are using DSI, you can run your workload through it by copying or symlinking your Genny directory into your DSI workdir. See [Running DSI Locally](go/running-dsi-locally) for details:
     
 	```bash
 	./run-dsi onboarding  # introductory DSI command; see link above for details

--- a/src/cast_python/src/mongosync_actor.py
+++ b/src/cast_python/src/mongosync_actor.py
@@ -92,13 +92,16 @@ def start(workload_yaml):
 def poll_for_cea(workload_yaml):
     poll(workload_yaml, lambda x: x != "change event application", "info")
 
+
 @cli.command(
     "poll_for_commit_point",
     help=("Wait till all the instances canCommit = true and lagTimeSeconds < 120"),
 )
 @click.argument("workload_yaml", nargs=1)
 def poll_for_commit_point(workload_yaml):
-    poll(workload_yaml, lambda x: bool(x) == False, "canCommit") or poll(workload_yaml, lambda x: int(x) > 120, "lagTimeSeconds")
+    poll(workload_yaml, lambda x: bool(x) == False, "canCommit") or poll(
+        workload_yaml, lambda x: int(x) > 120, "lagTimeSeconds"
+    )
 
 
 @cli.command(
@@ -144,7 +147,6 @@ def commit(workload_yaml):
 @click.argument("workload_yaml", nargs=1)
 def commit(workload_yaml):
     change_state(workload_yaml, "/api/v1/resume", {})
-
 
 
 if __name__ == "__main__":

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -343,7 +343,7 @@ def benchmark_test(ctx: click.Context) -> None:
 @click.pass_context
 def workload(
     ctx: click.Context,
-    workload_yaml: str,
+    workload_yaml: tuple[str],
     mongo_uri: str,
     verbosity: str,
     override: str,

--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -47,7 +47,7 @@ def _get_poplar_args(genny_repo_root: str, workspace_root: str):
 
 
 def _get_export_args(
-    genny_repo_root: str, workspace_root: str, input_path: str, output_path: str = None
+    genny_repo_root: str, workspace_root: str, input_path: str, output_path: Optional[str] = None
 ):
     """
     Returns the argument list used to export ftdc files to csv.
@@ -67,7 +67,7 @@ def _get_export_args(
 
 
 def _get_translate_args(
-    genny_repo_root: str, workspace_root: str, input_path: str, output_path: str = None
+    genny_repo_root: str, workspace_root: str, input_path: str, output_path: Optional[str] = None
 ):
     """
     Returns the argument list used to export genny workload files to ftdc.
@@ -109,7 +109,7 @@ def _create_metrics():
     os.makedirs(_METRICS_PATH, exist_ok=True)
 
 
-def export(workspace_root: str, genny_repo_root: str, input_path: str, output_path: str = None):
+def export(workspace_root: str, genny_repo_root: str, input_path: str, output_path: Optional[str] = None):
     args = _get_export_args(
         workspace_root=workspace_root,
         genny_repo_root=genny_repo_root,
@@ -119,7 +119,7 @@ def export(workspace_root: str, genny_repo_root: str, input_path: str, output_pa
     subprocess.run(args, check=True)
 
 
-def translate(workspace_root: str, genny_repo_root: str, input_path: str, output_path: str = None):
+def translate(workspace_root: str, genny_repo_root: str, input_path: str, output_path: Optional[str] = None):
     args = _get_translate_args(
         workspace_root=workspace_root,
         genny_repo_root=genny_repo_root,

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -15,10 +15,13 @@ def _sanitizer_flags(sanitizer: str, genny_repo_root: str):
         return []
 
     if sanitizer == "asan":
-        cmake_cxx_flags = " ".join([
-            "-DCMAKE_CXX_FLAGS=-pthread -fsanitize=address -O1 -fno-omit-frame-pointer -g",
-            "-mllvm -asan-use-private-alias=1", # suppress false odr-violation, clang only
-            f"-fsanitize-blacklist={genny_repo_root}/asan.ignorelist"]) # ignore existing ASAN issues.
+        cmake_cxx_flags = " ".join(
+            [
+                "-DCMAKE_CXX_FLAGS=-pthread -fsanitize=address -O1 -fno-omit-frame-pointer -g",
+                "-mllvm -asan-use-private-alias=1",  # suppress false odr-violation, clang only
+                f"-fsanitize-blacklist={genny_repo_root}/asan.ignorelist",
+            ]
+        )  # ignore existing ASAN issues.
         return [cmake_cxx_flags, "-DCMAKE_CXX_COMPILER=clang++"]
     elif sanitizer == "tsan":
         return ["-DCMAKE_CXX_FLAGS=-pthread -fsanitize=thread -g -O1"]

--- a/src/lamplib/src/genny/tasks/preprocess.py
+++ b/src/lamplib/src/genny/tasks/preprocess.py
@@ -11,6 +11,7 @@ from omegaconf import OmegaConf
 import yaml
 import structlog
 import numexpr
+from typing import Union
 
 SLOG = structlog.get_logger(__name__)
 # Cannot be in the default config because yaml merges overwrite lists instead of appending.
@@ -187,16 +188,17 @@ class _WorkloadParser(object):
 
     def parse(
         self,
-        yaml_input,
-        default_uri,
-        source=YamlSource.File,
-        path="",
-        parse_mode=_ParseMode.Normal,
+        yaml_input: str,
+        default_uri: str,
+        source: YamlSource = YamlSource.File,
+        path: Union[Path, str] = "",
+        parse_mode: _ParseMode =_ParseMode.Normal,
     ):
         """Parse the yaml input, assumed to be a file by default."""
 
         if path == "":
             raise ParseException("Must specify path of original yaml for parser.")
+        path = Path(path)
 
         self._default_uri = default_uri
         with self._context.enter():

--- a/src/lamplib/src/genny/tasks/preprocess.py
+++ b/src/lamplib/src/genny/tasks/preprocess.py
@@ -198,7 +198,7 @@ class _WorkloadParser(object):
 
         if path == "":
             raise ParseException("Must specify path of original yaml for parser.")
-        path = Path(path)
+        path = Path(path)  # Path("") is equivalent to Path("./")
 
         self._default_uri = default_uri
         with self._context.enter():

--- a/src/lamplib/src/genny/tasks/preprocess.py
+++ b/src/lamplib/src/genny/tasks/preprocess.py
@@ -458,7 +458,7 @@ class _WorkloadParser(object):
             if len(load_config) != keysSeen:
                 msg = (
                     "Invalid keys for 'LoadConfig'. Please set 'Path' and if any, 'Parameters' in the YAML "
-                    f"file: {path} with the following content: {external}"
+                    f"file: {path} with the following content: {load_config}"
                 )
                 raise ParseException(msg)
 


### PR DESCRIPTION
**Whats Changed:** 
This is to batch some miscellaneous fixes into one PR:
- Reformatting by linter after running `./run-genny lint-python --fix`. The modified files are `src/cast_python/src/mongosync_actor.py` and `src/lamplib/src/genny/tasks/compile.py`.
- Fix type error where `parent` is not a member of `str` (it's a member of `Path`) & add type annotations in `src/lamplib/src/genny/tasks/preprocess.py`
- Fix [incomplete refactoring in PR #515](https://github.com/mongodb/genny/pull/515/files#diff-c9ee5569fee04a5bd776c8b46b7c03abe31617d0116cd4ed7cd4983f2c4ef72aL316-L319) in `src/lamplib/src/genny/tasks/preprocess.py`