### PR TITLE
PERF-3888 Add mixed workload with scans

### DIFF
--- a/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
@@ -1,0 +1,275 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  This workload is a more stressful version of MixedWorkloadsGenny.yml, which itself is a port of
+  the mixed_workloads in the workloads repo.
+  https://github.com/10gen/workloads/blob/master/workloads/mix.js. In particular, this workload
+  extends MixedWorkloadsGennyStress.yml by adding aggregations that perform index scans. It runs 5
+  sets of operations, each with dedicated actors/threads. The 5 operations are insertOne, findOne,
+  updateOne, deleteOne, and aggregate. Since each type of operation runs in a dedicated thread it
+  enables interesting behavior, such as reads getting faster because of a write regression, or reads
+  being starved by writes. The origin of the test was as a reproduction for BF-2385 in which reads
+  were starved out by writes.
+
+  This more stressful version of the test only runs one test phase, using 1024 threads per operation
+  for 45 minutes.
+
+# This workload does not support sharding yet.
+
+Keywords:
+- scale
+- insertOne
+- insert
+- findOne
+- find
+- updateOne
+- update
+- deleteOne
+- delete
+- aggregate
+
+dbname: &dbname mix
+DocumentCount: &NumDocs 1024
+CollectionCount: &NumColls 512
+PhaseDuration: &PhaseDuration 45 minutes
+StringLength: &StringLength 950
+Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
+Document: &doc
+  id: {^RandomInt: {min: 0, max: *NumDocs}}
+  a: {^RandomInt: {min: 0, max: *NumDocs}}
+  # Note that in the original workload the string c was perfectly compressable. We can put a
+  # constant there if needed.
+  c: &string {^FastRandomString: {length: *StringLength}}  # Adjust StringLength for 1000B docs
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+  Insert:
+    QueryOptions:
+      maxPoolSize: 2500
+  Query:
+    QueryOptions:
+      maxPoolSize: 2500
+  Remove:
+    QueryOptions:
+      maxPoolSize: 2500
+  Update:
+    QueryOptions:
+      maxPoolSize: 2500
+  Scan:
+    QueryOptions:
+      maxPoolSize: 2500
+
+ActorTemplates:
+- TemplateName: UpdateTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Update"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Update
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 2
+        PhaseConfig:
+          Duration: *PhaseDuration
+          RecordFailure: true
+          CollectionCount: *NumColls
+          NumDocs: *NumDocs
+          Operations:
+          - OperationName: updateOne
+            OperationCommand:
+              Filter: *filter
+              Update:
+                $inc: {a: 1}
+                $set: {c: *string}
+
+- TemplateName: RemoveTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Remove"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Remove
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 2
+        PhaseConfig:
+          Duration: *PhaseDuration
+          RecordFailure: true
+          CollectionCount: *NumColls
+          Operations:
+          - OperationName: deleteOne
+            OperationCommand:
+              Filter: *filter
+
+- TemplateName: InsertTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Insert"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Insert
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 2
+        PhaseConfig:
+          Duration: *PhaseDuration
+          RecordFailure: true
+          CollectionCount: *NumColls
+          Operations:
+          - OperationName: insertOne
+            OperationCommand:
+              Document: *doc
+
+- TemplateName: FindTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Find"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Query
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 2
+        PhaseConfig:
+          Duration: *PhaseDuration
+          RecordFailure: true
+          CollectionCount: *NumColls
+          Operations:
+          - OperationName: findOne
+            OperationCommand:
+              Filter: *filter
+
+- TemplateName: ScanTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "Scan"}}
+    Type: CrudActor
+    Database: *dbname
+    ClientName: Scan
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
+        NopInPhasesUpTo: 2
+        PhaseConfig:
+          Duration: *PhaseDuration
+          RecordFailure: true
+          CollectionCount: *NumColls
+          Operations:
+          - OperationName: aggregate
+            OperationCommand:
+              Pipeline: [{$project: {avg: {$avg: "$a"}}}]
+
+Actors:
+#
+## Reduce the log level to avoid creating log files
+## of serveral GB
+#
+- Name: LogLevel
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationName: RunCommand
+      OperationCommand: { profile: 0, slowms: 1000, sampleRate: 0.1 }
+  - &nop {Nop: true}
+  - *nop
+
+- Name: Setup
+  Type: Loader
+  Threads: 8
+  Phases:
+  - Repeat: 1
+    BatchSize: 100
+    Threads: 8
+    DocumentCount: *NumDocs
+    Database: *dbname
+    CollectionCount: *NumColls
+    Document: *doc
+    Indexes:
+    - keys: {id: 1}
+    - keys: {a: 1}
+  - Phase: 1..2
+    Nop: true
+
+- Name: QuiesceBetweenLevels
+  Type: QuiesceActor
+  Threads: 1
+  Database: *dbname
+  Phases:
+  - *nop
+  - Repeat: 1
+  - *nop
+
+# Update Actors
+- ActorFromTemplate:
+    TemplateName: UpdateTemplate
+    TemplateParameters:
+      Name: Update_1024
+      Threads: 1024
+      OnlyActiveInPhase: 2
+
+#
+## Remove Actors
+#
+- ActorFromTemplate:
+    TemplateName: RemoveTemplate
+    TemplateParameters:
+      Name: Remove_1024
+      Threads: 1024
+      OnlyActiveInPhase: 2
+
+## Insert Actors
+#
+- ActorFromTemplate:
+    TemplateName: InsertTemplate
+    TemplateParameters:
+      Name: Insert_1024
+      Threads: 1024
+      OnlyActiveInPhase: 2
+
+## Find Actors
+
+- ActorFromTemplate:
+    TemplateName: FindTemplate
+    TemplateParameters:
+      Name: Find_1024
+      Threads: 1024
+      OnlyActiveInPhase: 2
+
+# Scan Actors
+- ActorFromTemplate:
+    TemplateName: ScanTemplate
+    TemplateParameters:
+      Name: Scan_1024
+      Threads: 1024
+      OnlyActiveInPhase: 2
+
+# Guard Against timeout for no output.
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0, 2]
+      NopInPhasesUpTo: 2
+      PhaseConfig:
+        LogEvery: 10 seconds
+        Blocking: None
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - atlas
+      - replica
+      - replica-disable-execution-control
+      - atlas-like-replica.2022-10


### PR DESCRIPTION
**Jira Ticket:** [PERF-3888](https://jira.mongodb.org/browse/PERF-3888)

**Whats Changed:**  
This adds a new workload, `mixed_workloads_genny_stress_with_scans`, which is based on `mixed_workloads_genny_stress` but additionally runs aggregations that perform index scans.

**Patch testing results:**  
https://spruce.mongodb.com/version/646fc61d562343a21a94b8fd/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

**Workload Submission form:**  
https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform?edit2=2_ABaOnueQqEcTHhtN7JhahjFNJJPFYeFzFFB7Ym_erm3tsN2l7-VnM5j0z2lG_Pb61ppuIx4

**Related PRs:**   
N/A
