### PR TITLE
PERF-4181 Enable relevant Genny workloads on the heuristic Bonsai 3-Shard variant

### DIFF
--- a/src/workloads/execution/CreateIndexSharded.yml
+++ b/src/workloads/execution/CreateIndexSharded.yml
@@ -111,6 +111,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - shard
+      - shard-heuristic-bonsai
       - shard-lite
     branch_name:
       $neq:

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -32,5 +32,6 @@ AutoRun:
       - single-replica
       - standalone
       - shard
+      - shard-heuristic-bonsai
       - replica-1dayhistory-15gbwtcache
       - replica-all-feature-flags

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -92,6 +92,7 @@ AutoRun:
       - replica
       - replica-all-feature-flags
       - shard
+      - shard-heuristic-bonsai
       - single-replica
       - single-replica-15gbwtcache
       - standalone

--- a/src/workloads/sharding/MultiShardTransactions.yml
+++ b/src/workloads/sharding/MultiShardTransactions.yml
@@ -315,6 +315,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - shard
+      - shard-heuristic-bonsai
       - shard-lite
       - shard-lite-all-feature-flags
     branch_name:

--- a/src/workloads/sharding/ReshardCollectionMixed.yml
+++ b/src/workloads/sharding/ReshardCollectionMixed.yml
@@ -186,6 +186,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - shard
+      - shard-heuristic-bonsai
       - shard-lite
       - shard-lite-all-feature-flags
     branch_name:

--- a/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+++ b/src/workloads/sharding/ReshardCollectionReadHeavy.yml
@@ -186,6 +186,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - shard
+      - shard-heuristic-bonsai
       - shard-lite
       - shard-lite-all-feature-flags
     branch_name:

--- a/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+++ b/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
@@ -88,6 +88,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - shard
+      - shard-heuristic-bonsai
       - shard-lite
       - shard-lite-all-feature-flags
     branch_name:


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** PERF-4181

**Whats Changed:**  
Added a AutoRun hook that runs workloads with Linux-3-Shard heuristic Bonsai build variant.

**Patch testing results:**  
https://spruce.mongodb.com/version/6470c5da9ccd4eb12fc1ecf8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

**Related PRs:**   
https://github.com/10gen/mongo/pull/13216
https://github.com/10gen/dsi/pull/1293

