### PR TITLE
PERF-4116 Fix MultiShardTransactions workload to actually use transactions

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -1047,6 +1047,7 @@ private:
  *    Operations:
  *    - OperationName: withTransaction
  *      OperationCommand:
+ *        OnSession: true
  *        OperationsInTransaction:
  *          - OperationName: insertOne
  *            OperationCommand:

--- a/src/workloads/sharding/MultiShardTransactions.yml
+++ b/src/workloads/sharding/MultiShardTransactions.yml
@@ -86,11 +86,10 @@ Actors:
     - MetricsName: ShardedCollectionUpdate
       Duration: 1 minute
       Collection: Collection0
-      ThrowOnFailure: false  # Transactions are allowed to fail.
-      RecordFailure: true  # We still want to record the metrics even if the transaction is rolled back.
       Operations:
       - OperationName: withTransaction
         OperationCommand:
+          OnSession: true
           OperationsInTransaction:
           - OperationName: updateOne
             OperationCommand:
@@ -134,12 +133,11 @@ Actors:
               Update: {$inc: {counter: 1}}
     - MetricsName: ShardedAndNonShardedCollectionsUpdate
       Duration: 1 minute
-      ThrowOnFailure: false  # Transactions are allowed to fail.
-      RecordFailure: true  # We still want to record the metrics even if the transaction is rolled back.
       Collection: Collection0
       Operations:
       - OperationName: withTransaction
         OperationCommand:
+          OnSession: true
           OperationsInTransaction:
           - OperationName: updateOne
             Collection: Collection0
@@ -193,12 +191,11 @@ Actors:
               Update: {$inc: {counter: 1}}
     - MetricsName: DifferentDatabasesNonShardedCollectionsUpdate
       Duration: 1 minute
-      ThrowOnFailure: false  # Transactions are allowed to fail.
-      RecordFailure: true  # We still want to record the metrics even if the transaction is rolled back.
       Collection: Collection1
       Operations:
       - OperationName: withTransaction
         OperationCommand:
+          OnSession: true
           OperationsInTransaction:
           - OperationName: updateOne
             Database: *Database0
@@ -252,12 +249,11 @@ Actors:
               Update: {$inc: {counter: 1}}
     - MetricsName: DifferentDatabasesShardedCollectionsUpdate
       Duration: 1 minute
-      ThrowOnFailure: false  # Transactions are allowed to fail.
-      RecordFailure: true  # We still want to record the metrics even if the transaction is rolled back.
       Collection: Collection0
       Operations:
       - OperationName: withTransaction
         OperationCommand:
+          OnSession: true
           OperationsInTransaction:
           - OperationName: updateOne
             Database: *Database0

--- a/src/workloads/sharding/MultiShardTransactions.yml
+++ b/src/workloads/sharding/MultiShardTransactions.yml
@@ -86,6 +86,8 @@ Actors:
     - MetricsName: ShardedCollectionUpdate
       Duration: 1 minute
       Collection: Collection0
+      ThrowOnFailure: false  # Transactions are allowed to fail.
+      RecordFailure: true  # We still want to record the metrics even if the transaction is rolled back.
       Operations:
       - OperationName: withTransaction
         OperationCommand:
@@ -134,6 +136,8 @@ Actors:
     - MetricsName: ShardedAndNonShardedCollectionsUpdate
       Duration: 1 minute
       Collection: Collection0
+      ThrowOnFailure: false  # Transactions are allowed to fail.
+      RecordFailure: true  # We still want to record the metrics even if the transaction is rolled back.
       Operations:
       - OperationName: withTransaction
         OperationCommand:
@@ -192,6 +196,8 @@ Actors:
     - MetricsName: DifferentDatabasesNonShardedCollectionsUpdate
       Duration: 1 minute
       Collection: Collection1
+      ThrowOnFailure: false  # Transactions are allowed to fail.
+      RecordFailure: true  # We still want to record the metrics even if the transaction is rolled back.
       Operations:
       - OperationName: withTransaction
         OperationCommand:
@@ -250,6 +256,8 @@ Actors:
     - MetricsName: DifferentDatabasesShardedCollectionsUpdate
       Duration: 1 minute
       Collection: Collection0
+      ThrowOnFailure: false  # Transactions are allowed to fail.
+      RecordFailure: true  # We still want to record the metrics even if the transaction is rolled back.
       Operations:
       - OperationName: withTransaction
         OperationCommand:


### PR DESCRIPTION
**Jira Ticket:** PERF-4116

**Whats Changed:**  
Because of missing OnSession parameter, transaction was not actually used.

**Patch testing results:**  
https://spruce.mongodb.com/version/6479b821a4cf471a400d5338/tasks

**Related PRs:**   
PR that introduced the workload https://github.com/mongodb/genny/pull/892