### PR TITLE
EVG-18404 - Implement a new workload-level field: `IgnoredMetrics`

### DIFF
--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -519,6 +519,8 @@ public:
     /**
      * Convenience method for creating a metrics::Operation that's unique for this actor and thread.
      *
+     * If "MetricsIgnored" is specified for this actor, "__IGNORED__." will be prepended to metric name.
+     *
      * @param operationName the name of the operation being run.
      * @param id the id of this Actor.
      * @param internal whether this operation is Genny-internal.

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -597,8 +597,10 @@ public:
     /**
      * Convenience method for creating a metrics::Operation that's unique for this phase and thread.
      *
-     * If "MetricsName" is specified for a phase, it is used.
-     * Otherwise "[defaultMetricsName].[phaseNumber]" is used.
+     * If "MetricsIgnored" is specified for a phase, "__IGNORED__." will be prepended to metric name.
+     *
+     * If "MetricsName" is specified for a phase, it is used for metric name;
+     * otherwise, "[defaultMetricsName].[phaseNumber]" is used.
      *
      * @param defaultMetricName the default name of the metric if "MetricsName" is not specified
      *                          for a phase in the workload YAML.
@@ -607,6 +609,9 @@ public:
      */
     auto operation(const std::string& defaultMetricsName, ActorId id, bool internal = false) const {
         std::ostringstream stm;
+        if (this->_node["MetricsIgnored"].maybe<bool>()) {
+            stm << "__METRICS_IGNORED__.";
+        }
         if (auto metricsName = this->_node["MetricsName"].maybe<std::string>()) {
             stm << *metricsName;
         } else {

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -524,8 +524,13 @@ public:
      * @param internal whether this operation is Genny-internal.
      */
     auto operation(const std::string& operationName, ActorId id, bool internal = false) const {
+        std::ostringstream stm;
+        if (this->_node["MetricsIgnored"].maybe<bool>()) {
+            stm << "__METRICS_IGNORED__.";
+        }
+        stm << operationName;
         return this->_workload->_registry.operation(
-            this->_node["Name"].to<std::string>(), operationName, id, std::nullopt, internal);
+            this->_node["Name"].to<std::string>(), stm.str(), id, std::nullopt, internal);
     }
 
 private:

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -519,20 +519,13 @@ public:
     /**
      * Convenience method for creating a metrics::Operation that's unique for this actor and thread.
      *
-     * If "MetricsIgnored" is specified for this actor, "__IGNORED__." will be prepended to metric name.
-     *
      * @param operationName the name of the operation being run.
      * @param id the id of this Actor.
      * @param internal whether this operation is Genny-internal.
      */
     auto operation(const std::string& operationName, ActorId id, bool internal = false) const {
-        std::ostringstream stm;
-        if (this->_node["MetricsIgnored"].maybe<bool>()) {
-            stm << "__METRICS_IGNORED__.";
-        }
-        stm << operationName;
         return this->_workload->_registry.operation(
-            this->_node["Name"].to<std::string>(), stm.str(), id, std::nullopt, internal);
+            this->_node["Name"].to<std::string>(), operationName, id, std::nullopt, internal);
     }
 
 private:
@@ -604,10 +597,8 @@ public:
     /**
      * Convenience method for creating a metrics::Operation that's unique for this phase and thread.
      *
-     * If "MetricsIgnored" is specified for a phase, "__IGNORED__." will be prepended to metric name.
-     *
-     * If "MetricsName" is specified for a phase, it is used for metric name;
-     * otherwise, "[defaultMetricsName].[phaseNumber]" is used.
+     * If "MetricsName" is specified for a phase, it is used.
+     * Otherwise "[defaultMetricsName].[phaseNumber]" is used.
      *
      * @param defaultMetricName the default name of the metric if "MetricsName" is not specified
      *                          for a phase in the workload YAML.
@@ -616,9 +607,6 @@ public:
      */
     auto operation(const std::string& defaultMetricsName, ActorId id, bool internal = false) const {
         std::ostringstream stm;
-        if (this->_node["MetricsIgnored"].maybe<bool>()) {
-            stm << "__METRICS_IGNORED__.";
-        }
         if (auto metricsName = this->_node["MetricsName"].maybe<std::string>()) {
             stm << *metricsName;
         } else {

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -78,6 +78,13 @@ WorkloadContext::WorkloadContext(const Node& node,
 
     _registry = genny::metrics::Registry(std::move(format), std::move(metricsPath));
 
+    auto& ignoredMetrics = (*this)["IgnoredMetrics"];
+    if (ignoredMetrics && ignoredMetrics.isSequence()) {
+        for (const auto& [k, metric] : (*this)["IgnoredMetrics"]) {
+            _registry.ignore(metric.to<std::string>());
+        }
+    }
+
     _seedGenerator.seed((*this)["RandomSeed"].maybe<long>().value_or(RNG_SEED_BASE));
 
     // Make a bunch of actor contexts


### PR DESCRIPTION
**Jira Ticket:** EVG-18404

**Whats Changed:**
Adding a workload-level field: `IgnoredMetrics`, which is the list of metric names to mark as ignored (by adding `__METRICS_IGNORED__` to the end of ignored metrics' names). This is (I think) the only reliable way to detect metrics that should be ignored, no matter what an Actor's metric naming logic is.

Example usage for [CrudActor.yml](https://github.com/mongodb/genny/blob/9c61ea42035c0ad3eb38d5080f019672bbc2efad/src/workloads/docs/CrudActor.yml):
```yaml
SchemaVersion: 2018-07-01
...
IgnoredMetrics:
- CrudActor.Crud
- CrudActor.drop
- CrudActor.InsertAndUpdate
- CrudActor.Phase3.2
- CrudActor.insertMany
- CrudActor.Phase3.OtherInsertAndUpdate

Actors:
...
```

**Patch testing results:** (still running)  
- [sys-perf](https://spruce.mongodb.com/version/6489e0cba4cf4752a1bb1302/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
- [sys-perf-atlas](https://spruce.mongodb.com/version/6489de660305b9215ad0abd7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)