### PR TITLE
Fix for BF-28934

### DIFF
--- a/src/workloads/scale/CreateDropView.yml
+++ b/src/workloads/scale/CreateDropView.yml
@@ -62,6 +62,18 @@ Actors:
         drop: myView
   - Nop: true
 
+# Guard Against timeout for no output.
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1, 2, 3]
+      NopInPhasesUpTo: 3
+      PhaseConfig:
+        LogEvery: 10 seconds
+        Blocking: None
+
 AutoRun:
 - When:
     mongodb_setup:


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** BF-28934

**Whats Changed:**  
added the logging actor into the create_drop_view workload that prevents tasks from failing if they are silent for too long

**Patch testing results:**  
[If applicable, link a patch test showing code changes running successfully](https://spruce.mongodb.com/version/648080603e8e8694bce2a40a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

