### PR TITLE
PERF-4242 Add perf workload for the coinbase/binance query

### DIFF
--- a/src/workloads/query/TimeSeriesCoinbaseBinanceQuery.yml
+++ b/src/workloads/query/TimeSeriesCoinbaseBinanceQuery.yml
@@ -1,0 +1,180 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test exercises the behavior of the Coinbase/Binance query. The query has $addFields as the
+  first stage, followed by a dependent $match, multiple group stages dependent on computed fields,
+  and a sort stage at the end of the pipeline.
+
+Keywords:
+- timeseries
+- aggregate
+- sbe
+
+GlobalDefaults:
+  Database: &Database test
+  Collection: &Collection Collection0
+  DocumentCount: &DocumentCount 1e6
+  NumGroups: &NumGroups 100
+  Repeat: &Repeat 10
+  Threads: &Threads 1
+  BatchSize: &BatchSize 30000
+  MaxPhases: &MaxPhases 5
+
+Actors:
+# Clear any pre-existing collection state.
+- Name: ClearCollection
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: *Threads
+        Collection: *Collection
+        Operations:
+        - OperationName: drop
+
+- Name: CreateTimeSeriesCollection
+  Type: RunCommand
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Operation:
+          OperationMetricsName: CreateTimeSeriesCollection
+          OperationName: RunCommand
+          OperationCommand:
+            {create: *Collection, timeseries: {timeField: "time", metaField: "symbol", granularity: "seconds"}}
+
+- Name: DropAllIndexesUponCreation
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Operation:
+          OperationMetricsName: DropAllIndexesUponCreation
+          OperationName: RunCommand
+          OperationCommand:
+            dropIndexes: *Collection
+            index: "*"
+
+- Name: InsertData
+  Type: Loader
+  Threads: 4
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        MultipleThreadsPerCollection: true
+        CollectionCount: 1
+        Collection: *Collection
+        DocumentCount: *DocumentCount
+        BatchSize: *BatchSize
+        Document:
+          time: {^IncDate: {start: {^Now: {}}, step: 1000}}
+          symbol: {^Cycle: {ofLength: *NumGroups, fromGenerator: {^RandomString: {length: 6}}}}
+          price: {^RandomDouble: {min: 100.0, max: 1000.0}}
+
+# Phase 4: Ensure all data is synced to disk.
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [4]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+
+# Phase 5: Run Query
+- Name: CoinbaseBinanceQuery
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Database: *Database
+        Collection: *Collection
+        Operations:
+        - OperationMetricsName: {^Parameter: {Name: "operationMetricsName", Default: OperationMetric}}
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [{$addFields:
+                          {"hourDiff": {$dateDiff: {"startDate": "$time", "endDate": "$$NOW", "unit": "hour"}}}},
+                          {$match: {"hourDiff": {$lte: 24}}},
+                          {$group:
+                            {"_id" :
+                              { "symbol" : "$symbol" ,
+                                "time": { "$dateTrunc" : {"date": "$time", "unit": "minute", "binSize" : 60}}
+                              },
+                              "open" : {"$first" : "$price"},
+                              "close" : {"$last" : "$price"}}
+                          },
+                          {
+                              $addFields : {
+                                  "diffPercentage" : {$round : [{$multiply : [100, { $divide : [{$subtract : ["$close", "$open"]}, "$open"] }]}, 2]}
+                              }
+                          },
+                          {
+                            $group: {
+                                  "_id" : "$_id.time",
+                                  "topN": {
+                                      $topN: {
+                                          "output": ["$_id.symbol", "$diffPercentage", "$close"],
+                                          "sortBy" : { "diffPercentage" : -1 },
+                                          "n": 3
+                                      }
+                                  },
+                                  "bottomN": {
+                                      $bottomN: {
+                                          "output": ["$_id.symbol", "$diffPercentage", "$close"],
+                                          "sortBy" : { "diffPercentage" : 1 },
+                                          "n": 3
+                                      }
+                                  },
+                              }
+                          },
+                          {
+                              $sort : {
+                                  "_id" : -1
+                              }
+                          }]
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-sbe
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0
+      - v5.1
+      - v5.2
+      - v5.3

--- a/src/workloads/query/TimeSeriesCoinbaseBinanceQuery.yml
+++ b/src/workloads/query/TimeSeriesCoinbaseBinanceQuery.yml
@@ -117,7 +117,7 @@ Actors:
         Database: *Database
         Collection: *Collection
         Operations:
-        - OperationMetricsName: {^Parameter: {Name: "operationMetricsName", Default: OperationMetric}}
+        - OperationMetricsName: CoinbaseBinanceQuery
           OperationName: aggregate
           OperationCommand:
             Pipeline: [{$addFields:


### PR DESCRIPTION
**Jira Ticket:** PERF-4242

**Whats Changed:**  
This change adds a workload mimicking the coinable/ finance query.

**Patch testing results:**  
https://spruce.mongodb.com/version/648888071e2d17582427b50e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

**Workload Submission form:**  
If applicable, only required if there is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)