### PR TITLE
EVG-19923: Update Genny dependencies flagged by Dependabot

### DIFF
--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -1,16 +1,16 @@
-wheel==0.36.2
+wheel==0.40.0
 pymongo>=3.9
 click==8.1.2
 click-option-group==0.5.5
 colorama==0.4.3
 structlog==20.1.0
 omegaconf==2.1.1
-PyYAML==5.1
-requests==2.21.0
+pyyaml>=5.4
+requests==2.31.0
 yamllint==1.15.0
 shrub.py==1.1.0
 black==22.10.0
-setuptools==65.5.0
+setuptools==65.7.0
 pytest==7.2.0
 progressbar==2.5
 

--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -1,5 +1,5 @@
 wheel==0.40.0
-pymongo>=3.9
+pymongo==4.3.3
 click==8.1.2
 click-option-group==0.5.5
 colorama==0.4.3

--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -5,7 +5,7 @@ click-option-group==0.5.5
 colorama==0.4.3
 structlog==20.1.0
 omegaconf==2.1.1
-pyyaml>=5.4
+pyyaml==5.4
 requests==2.31.0
 yamllint==1.15.0
 shrub.py==1.1.0


### PR DESCRIPTION
**Jira Ticket:** [EVG-19923](https://jira.mongodb.org/browse/EVG-19923)

**Whats Changed:**  
Update Genny dependencies flagged by Dependabot [here](https://github.com/mongodb/genny/security/dependabot).

**Patch testing results:**
- [sys-perf](https://spruce.mongodb.com/version/649942a70ae606c012941377/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

**Related PRs:**   
https://github.com/10gen/dsi/pull/1318