### PR TITLE
EVG-19909 Run cmake-test on macOS but skip flaky tests

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -377,7 +377,7 @@ functions:
       - -v
       - cmake-test
       - --regex-exclude
-      - "(sleepNonBlocking|Non-Blocking end|Actual Actor Example)"
+      - "(sleepNonBlocking|Non-Blocking end|Actual Actor Example Timing)"
 
   ##
   # Runs benchmarks via ctest.

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -116,7 +116,7 @@ buildvariants:
   run_on:
   - macos-1100
   tasks:
-  - name: tg_compile
+  - name: tg_compile_and_test_with_server_on_macos
 
 - name: macos-1100-arm64
   display_name: macOS Bug Sur arm64
@@ -124,7 +124,7 @@ buildvariants:
   run_on:
   - macos-1100-arm64
   tasks:
-  - name: tg_compile
+  - name: tg_compile_and_test_with_server_on_macos
 
 # - name: centos6-perf
 #   display_name: CentOS 6 for Performance
@@ -167,6 +167,10 @@ tasks:
 - name: t_cmake_test
   commands:
   - func: f_cmake_test
+
+- name: t_cmake_test_ignore_flaky
+  commands:
+  - func: f_cmake_test_ignore_flaky
 
 - name: t_benchmark_test
   commands:
@@ -269,6 +273,17 @@ task_groups:
   - t_integration_test_sharded
   - t_test_create_new_actor_script  # Must run this task last.
 
+- <<: *a_compile_and_test
+  name: tg_compile_and_test_with_server_on_macos
+  tasks:
+  - t_compile
+  - t_python_test
+  - t_cmake_test_ignore_flaky
+  - t_integration_test_single_node_replset
+  - t_integration_test_three_node_replset
+  - t_integration_test_sharded
+  - t_test_create_new_actor_script  # Must run this task last.
+
 - name: tg_compile
   max_hosts: 1
   tasks:
@@ -348,6 +363,21 @@ functions:
       args:
       - -v
       - cmake-test
+
+  ##
+  # Runs tests via ctest, ignoring flaky tests (see EVG-19909).
+  # Requires f_compile to have been run first.
+  # Feel free to update regex_clude per the latest test results
+  ##
+  f_cmake_test_ignore_flaky:
+  - command: subprocess.exec
+    params:
+      binary: ./src/genny/run-genny
+      args:
+      - -v
+      - cmake-test
+      - --regex-exclude
+      - "(sleepNonBlocking|Non-Blocking end|Actual Actor Example)"
 
   ##
   # Runs benchmarks via ctest.

--- a/src/gennylib/test/PhaseLoop_test.cpp
+++ b/src/gennylib/test/PhaseLoop_test.cpp
@@ -310,34 +310,35 @@ struct CounterProducer : public ActorProducer {
     std::unordered_map<int, int> counters;
 };
 
-TEST_CASE("Actual Actor Example") {
 
-    class IncrementsMapValues : public Actor {
-    protected:
-        struct IncrPhaseConfig {
-            int _key;
-            IncrPhaseConfig(PhaseContext& ctx, int keyOffset)
-                : _key{ctx["Key"].to<int>() + keyOffset} {}
-        };
-
-        PhaseLoop<IncrPhaseConfig> _loop;
-        std::unordered_map<int, int>& _counters;
-
-    public:
-        IncrementsMapValues(ActorContext& actorContext, std::unordered_map<int, int>& counters)
-            : Actor(actorContext), _loop{actorContext, 1}, _counters{counters} {}
-        //                        ↑ is forwarded to the IncrementsMapValues ctor as the
-        //                        keyOffset param.
-
-        void run() override {
-            for (auto&& cfg : _loop) {
-                for (auto&& _ : cfg) {
-                    ++this->_counters[cfg->_key];
-                }
-            }
-        }
+class IncrementsMapValues : public Actor {
+protected:
+    struct IncrPhaseConfig {
+        int _key;
+        IncrPhaseConfig(PhaseContext& ctx, int keyOffset)
+            : _key{ctx["Key"].to<int>() + keyOffset} {}
     };
 
+    PhaseLoop<IncrPhaseConfig> _loop;
+    std::unordered_map<int, int>& _counters;
+
+public:
+    IncrementsMapValues(ActorContext& actorContext, std::unordered_map<int, int>& counters)
+        : Actor(actorContext), _loop{actorContext, 1}, _counters{counters} {}
+    //                        ↑ is forwarded to the IncrementsMapValues ctor as the
+    //                        keyOffset param.
+
+    void run() override {
+        for (auto&& cfg : _loop) {
+            for (auto&& _ : cfg) {
+                ++this->_counters[cfg->_key];
+            }
+        }
+    }
+};
+
+
+TEST_CASE("Actual Actor Example") {
     SECTION("Simple Actor") {
         // ////////
         // setup and run (bypass the driver)
@@ -435,33 +436,6 @@ TEST_CASE("Actual Actor Example") {
                     {94, 3}});
     }
 
-    SECTION("SleepBefore and SleepAfter") {
-        using namespace std::literals::chrono_literals;
-        NodeSource config(R"(
-            SchemaVersion: 2018-07-01
-            Actors:
-            - Type: Inc
-              Name: Inc
-              Phases:
-              - Repeat: 3
-                SleepBefore: 50 milliseconds
-                SleepAfter: 100 milliseconds
-                Key: 71
-        )",
-                          "");
-
-        auto imvProducer = std::make_shared<CounterProducer<IncrementsMapValues>>("Inc");
-        ActorHelper ah(config.root(), 1, {{"Inc", imvProducer}});
-
-        auto start = std::chrono::high_resolution_clock::now();
-        ah.run();
-
-        auto duration = std::chrono::high_resolution_clock::now() - start;
-
-        REQUIRE(duration > 450ms);
-        REQUIRE(duration < 550ms);
-    }
-
     SECTION("SleepBefore < 0") {
         using namespace std::literals::chrono_literals;
         NodeSource config(R"(
@@ -512,6 +486,58 @@ TEST_CASE("Actual Actor Example") {
                             Catch::Matchers::ContainsSubstring("GlobalRate must *not* be specified alongside"));
     }
 
+    SECTION("Missing explicit Blocking = None") {
+        using namespace std::literals::chrono_literals;
+        NodeSource config(R"(
+            SchemaVersion: 2018-07-01
+            Actors:
+            - Type: Inc
+              Name: Inc
+              Phases:
+              - Key: 72
+        )",
+                          "");
+
+        auto imvProducer = std::make_shared<CounterProducer<IncrementsMapValues>>("Inc");
+
+        REQUIRE_THROWS_WITH(([&]() {
+                                ActorHelper ah(config.root(), 1, {{"Inc", imvProducer}});
+                                ah.run();
+                            }()),
+                            Catch::Matchers::ContainsSubstring("Must specify 'Blocking: None'"));
+    }
+}
+
+TEST_CASE("Actual Actor Example Timing") {
+
+    SECTION("SleepBefore and SleepAfter") {
+        using namespace std::literals::chrono_literals;
+        NodeSource config(R"(
+            SchemaVersion: 2018-07-01
+            Actors:
+            - Type: Inc
+              Name: Inc
+              Phases:
+              - Repeat: 3
+                SleepBefore: 50 milliseconds
+                SleepAfter: 100 milliseconds
+                Key: 71
+        )",
+                          "");
+
+        auto imvProducer = std::make_shared<CounterProducer<IncrementsMapValues>>("Inc");
+        ActorHelper ah(config.root(), 1, {{"Inc", imvProducer}});
+
+        auto start = std::chrono::high_resolution_clock::now();
+        ah.run();
+
+        auto duration = std::chrono::high_resolution_clock::now() - start;
+
+        REQUIRE(duration > 450ms);
+        REQUIRE(duration < 550ms);
+    }
+
+
     SECTION("SleepBefore = 0") {
         using namespace std::literals::chrono_literals;
         NodeSource config(R"(
@@ -539,24 +565,4 @@ TEST_CASE("Actual Actor Example") {
         REQUIRE(duration < 350ms);
     }
 
-    SECTION("Missing explicit Blocking = None") {
-        using namespace std::literals::chrono_literals;
-        NodeSource config(R"(
-            SchemaVersion: 2018-07-01
-            Actors:
-            - Type: Inc
-              Name: Inc
-              Phases:
-              - Key: 72
-        )",
-                          "");
-
-        auto imvProducer = std::make_shared<CounterProducer<IncrementsMapValues>>("Inc");
-
-        REQUIRE_THROWS_WITH(([&]() {
-                                ActorHelper ah(config.root(), 1, {{"Inc", imvProducer}});
-                                ah.run();
-                            }()),
-                            Catch::Matchers::ContainsSubstring("Must specify 'Blocking: None'"));
-    }
 }

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -254,6 +254,13 @@ def clean(ctx: click.Context) -> None:
     help=("Regex to match against tests."),
 )
 @click.option(
+    "-E",
+    "--regex-exclude",
+    required=False,
+    default=None,
+    help=("Exclude tests names of which match this regex."),
+)
+@click.option(
     "-r",
     "--repeat-until-fail",
     required=False,
@@ -263,13 +270,14 @@ def clean(ctx: click.Context) -> None:
     ),
 )
 @click.pass_context
-def cmake_test(ctx: click.Context, regex: str, repeat_until_fail: int) -> None:
+def cmake_test(ctx: click.Context, regex: str, regex_exclude: str, repeat_until_fail: int) -> None:
     from genny.tasks import run_tests
 
     run_tests.cmake_test(
         genny_repo_root=ctx.obj["GENNY_REPO_ROOT"],
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
         regex=regex,
+        regex_exclude=regex_exclude,
         repeat_until_fail=repeat_until_fail,
     )
 

--- a/src/lamplib/src/genny/tasks/run_tests.py
+++ b/src/lamplib/src/genny/tasks/run_tests.py
@@ -89,7 +89,11 @@ def _run_command_with_sentinel_report(
 
 
 def cmake_test(
-    genny_repo_root: str, workspace_root: str, regex: str = None, repeat_until_fail: int = 1
+    genny_repo_root: str,
+    workspace_root: str,
+    regex=None,
+    regex_exclude=None,
+    repeat_until_fail: int = 1,
 ):
     info = toolchain.toolchain_info(genny_repo_root=genny_repo_root, workspace_root=workspace_root)
     workdir = os.path.join(genny_repo_root, "build")
@@ -111,6 +115,9 @@ def cmake_test(
 
     if regex is not None:
         ctest_cmd += ["--tests-regex", regex]
+
+    if regex_exclude is not None:
+        ctest_cmd += ["--exclude-regex", regex_exclude]
 
     def cmd_func() -> bool:
         output: cmd_runner.RunCommandOutput = cmd_runner.run_command(


### PR DESCRIPTION
**Jira Ticket:** [EVG-19909](https://jira.mongodb.org/browse/EVG-19909)  

**Whats Changed:**  

-   Split the test case "Actual Actor Example" to "Actual Actor Example" and  
    "Actual Actor Example Timing"
-   Modify 'run-genny cmake-test' to accept the option '&#x2013;regex-exclude'
-   Modify 'evergreen.yml' run cmake-test on macOS with '&#x2013;regex-exclude'

At the moment, the `f_cmake_test_ignore_flaky` function runs cmake-test with  
`--regex-exclude` to skip timing/random number related tests which are known to  
fail on macOS. In the future, should more such tests are discovered, please skip  
them similarly.  

**Patch testing results:**  
<https://spruce.mongodb.com/version/6492ab750ae6065cd41edb29/tasks>  
<https://spruce.mongodb.com/version/649a474457e85a45efc31d70/tasks>  
<https://spruce.mongodb.com/version/649a46c0d1fe074124687ff2/tasks>  
