### PR TITLE
EVG-19909 Rename "Acutual Actor Example Timing" to "Actual Actor Example IgnoredOnMacOS"

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -377,7 +377,7 @@ functions:
       - -v
       - cmake-test
       - --regex-exclude
-      - "(sleepNonBlocking|Non-Blocking end|Actual Actor Example Timing)"
+      - "(sleepNonBlocking|Non-Blocking end|IgnoredOnMacOs)"
 
   ##
   # Runs benchmarks via ctest.

--- a/src/gennylib/test/PhaseLoop_test.cpp
+++ b/src/gennylib/test/PhaseLoop_test.cpp
@@ -508,7 +508,7 @@ TEST_CASE("Actual Actor Example") {
     }
 }
 
-TEST_CASE("Actual Actor Example Timing") {
+TEST_CASE("Actual Actor Example IgnoredOnMacOs") {
 
     SECTION("SleepBefore and SleepAfter") {
         using namespace std::literals::chrono_literals;


### PR DESCRIPTION
**Jira Ticket:** EVG-19909

**Whats Changed:**

Rename "Acutual Actor Example Timing" to "Actual Actor Example IgnoredOnMacOS"

**Patch testing results:** 

<https://spruce.mongodb.com/version/649ba6b70ae606acbdb6af22/tasks>