### PR TITLE
PERF-4338: Disable genny tasks on M30 Atlas

### DIFF
--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -103,3 +103,7 @@ AutoRun:
       - replica-all-feature-flags
       - single-replica
       - standalone
+    atlas_setup:
+      $neq:
+      - M30-repl
+

--- a/src/workloads/execution/CreateIndex.yml
+++ b/src/workloads/execution/CreateIndex.yml
@@ -70,6 +70,9 @@ AutoRun:
       - replica
       - single-replica
       - standalone
+    atlas_setup:
+      $neq:
+      - M30-repl
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/networking/ServiceArchitectureWorkloads.yml
+++ b/src/workloads/networking/ServiceArchitectureWorkloads.yml
@@ -82,3 +82,6 @@ AutoRun:
       - replica
       - replica-noflowcontrol
       - replica-all-feature-flags
+    atlas_setup:
+      $neq:
+      - M30-repl

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -196,6 +196,9 @@ AutoRun:
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats
+    atlas_setup:
+      $neq:
+      - M30-repl
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/MatchFilters.yml
+++ b/src/workloads/query/MatchFilters.yml
@@ -338,6 +338,9 @@ AutoRun:
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats
+    atlas_setup:
+      $neq:
+      - M30-repl
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/PipelineUpdate.yml
+++ b/src/workloads/query/PipelineUpdate.yml
@@ -274,3 +274,6 @@ AutoRun:
     branch_name:
       $neq:
       - v4.0
+    atlas_setup:
+      $neq:
+      - M30-repl

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -268,6 +268,9 @@ AutoRun:
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats
+    atlas_setup:
+      $neq:
+      - M30-repl
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -145,3 +145,4 @@ AutoRun:
       $neq:
       - M10-repl
       - M20-repl
+      - M30-repl

--- a/src/workloads/scale/InsertBigDocs.yml
+++ b/src/workloads/scale/InsertBigDocs.yml
@@ -30,3 +30,7 @@ AutoRun:
       - replica
       - replica-all-feature-flags
       - single-replica
+    atlas_setup:
+      $neq:
+      - M30-repl
+

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -35,3 +35,7 @@ AutoRun:
       - shard-heuristic-bonsai
       - replica-1dayhistory-15gbwtcache
       - replica-all-feature-flags
+    atlas_setup:
+      $neq:
+      - M30-repl
+

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -105,3 +105,4 @@ AutoRun:
       $neq:
       - M10-repl
       - M20-repl
+      - M30-repl

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -83,3 +83,6 @@ AutoRun:
       - replica-all-feature-flags
       - single-replica
       - standalone
+    atlas_setup:
+      $neq:
+      - M30-repl

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -314,3 +314,6 @@ AutoRun:
       - single-replica-sampling-bonsai
       - single-replica-sbe
       - standalone
+    atlas_setup:
+      $neq:
+      - M30-repl

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -238,5 +238,8 @@ AutoRun:
       $eq:
       - atlas
       - replica
-      - replica-disable-execution-control 
+      - replica-disable-execution-control
       - atlas-like-replica.2022-10
+    atlas_setup:
+      $neq:
+      - M30-repl

--- a/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
@@ -274,3 +274,6 @@ AutoRun:
       - replica
       - replica-disable-execution-control
       - atlas-like-replica.2022-10
+    atlas_setup:
+      $neq:
+      - M30-repl


### PR DESCRIPTION
On SERVER-69824 we are going to enable M30 on sys perf, but we need to disable the genny workloads so it only runs industry_benchmarks, tpcc, and linkbench2. This ticket is to disable those workloads.