### PR TITLE
[PERF-2932] - Commit latency updates to include ReadConcern "Available"

### DIFF
--- a/src/workloads/networking/CommitLatency.yml
+++ b/src/workloads/networking/CommitLatency.yml
@@ -76,9 +76,6 @@ Actors:
   - *DropCollection
   - *Load
   - *Nop
-  - *DropCollection
-  - *Load
-  - *Nop
 
 
 - Name: CommitLatency
@@ -269,18 +266,6 @@ Actors:
       Level: 1
     ReadConcern:
       Level: available
-    ReadPreference:
-      ReadMode: secondary
-  - *Nop
-  - *Nop
-  - MetricsName: CommitLatency_wmajority_linearizable_sec
-    Collection: *Collection
-    Repeat: 500
-    Threads: 1
-    WriteConcern:
-      Level: majority
-    ReadConcern:
-      Level: linearizable
     ReadPreference:
       ReadMode: secondary
   - *Nop

--- a/src/workloads/networking/CommitLatency.yml
+++ b/src/workloads/networking/CommitLatency.yml
@@ -73,9 +73,6 @@ Actors:
   - *DropCollection
   - *Load
   - *Nop
-  - *DropCollection
-  - *Load
-  - *Nop
 
 
 - Name: CommitLatency
@@ -268,19 +265,6 @@ Actors:
       Level: available
     ReadPreference:
       ReadMode: secondary
-  - *Nop
-  - *Nop
-  - MetricsName: CommitLatency_wmajority_majority_sec_trx
-    Collection: *Collection
-    Repeat: 500
-    Threads: 1
-    WriteConcern:
-      Level: majority
-    ReadConcern:
-      Level: snapshot
-    ReadPreference:
-      ReadMode: secondary
-    Transaction: true  # Implies Session
 
 AutoRun:
 - When:

--- a/src/workloads/networking/CommitLatency.yml
+++ b/src/workloads/networking/CommitLatency.yml
@@ -61,7 +61,24 @@ Actors:
   - *DropCollection
   - *Load
   - *Nop
-
+  - *DropCollection
+  - *Load
+  - *Nop
+  - *DropCollection
+  - *Load
+  - *Nop
+  - *DropCollection
+  - *Load
+  - *Nop
+  - *DropCollection
+  - *Load
+  - *Nop
+  - *DropCollection
+  - *Load
+  - *Nop
+  - *DropCollection
+  - *Load
+  - *Nop
 
 
 - Name: CommitLatency
@@ -204,6 +221,80 @@ Actors:
       Level: snapshot
     ReadPreference:
       ReadMode: primary
+    Transaction: true  # Implies Session
+  - *Nop
+  - *Nop
+  - MetricsName: CommitLatency_w0_available
+    Collection: *Collection
+    Repeat: 500
+    Threads: 1
+    WriteConcern:
+      Level: 0
+    ReadConcern:
+      Level: available
+    ReadPreference:
+      ReadMode: primary
+  - *Nop
+  - *Nop
+  - MetricsName: CommitLatency_w1_available
+    Collection: *Collection
+    Repeat: 500
+    Threads: 1
+    WriteConcern:
+      Level: 1
+    ReadConcern:
+      Level: available
+    ReadPreference:
+      ReadMode: primary
+  - *Nop
+  - *Nop
+  - MetricsName: CommitLatency_w1_jtrue_available
+    Collection: *Collection
+    Repeat: 500
+    Threads: 1
+    WriteConcern:
+      Level: 1
+      Journal: true
+    ReadConcern:
+      Level: available
+    ReadPreference:
+      ReadMode: primary
+  - *Nop
+  - *Nop
+  - MetricsName: CommitLatency_w1_available_sec
+    Collection: *Collection
+    Repeat: 500
+    Threads: 1
+    WriteConcern:
+      Level: 1
+    ReadConcern:
+      Level: available
+    ReadPreference:
+      ReadMode: secondary
+  - *Nop
+  - *Nop
+  - MetricsName: CommitLatency_wmajority_linearizable_sec
+    Collection: *Collection
+    Repeat: 500
+    Threads: 1
+    WriteConcern:
+      Level: majority
+    ReadConcern:
+      Level: linearizable
+    ReadPreference:
+      ReadMode: secondary
+  - *Nop
+  - *Nop
+  - MetricsName: CommitLatency_wmajority_majority_sec_trx
+    Collection: *Collection
+    Repeat: 500
+    Threads: 1
+    WriteConcern:
+      Level: majority
+    ReadConcern:
+      Level: snapshot
+    ReadPreference:
+      ReadMode: secondary
     Transaction: true  # Implies Session
 
 AutoRun:


### PR DESCRIPTION
**Jira Ticket:** [PERF-2932](https://jira.mongodb.org/browse/PERF-2932)

**Whats Changed:**  
We have added in 4 new phases to the commit latency workload to cover testing of the "available" ReadConcern option. We are testing this with W:1, W:0, journaling and readMode as primary and secondary.

**Patch testing results:**  
A successful patch can be found here:
https://spruce.mongodb.com/version/649b294ad1fe07b787b40405/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
