### PR TITLE
EVG-20471 - Downgrade PyYAML to fixed version compatible with Cython 3.0

### DIFF
--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -5,7 +5,7 @@ click-option-group==0.5.5
 colorama==0.4.3
 structlog==20.1.0
 omegaconf==2.1.1
-pyyaml==5.4
+pyyaml<=5.3.1
 requests==2.31.0
 yamllint==1.15.0
 shrub.py==1.1.0

--- a/src/lamplib/src/genny/tasks/run_tests.py
+++ b/src/lamplib/src/genny/tasks/run_tests.py
@@ -1,12 +1,13 @@
-import structlog
 import os
-import sys
+import re
 import shutil
 import subprocess
-import re
-from typing import Callable, TypeVar, Tuple, Optional
+import sys
+from typing import Callable, Optional, Tuple, TypeVar
 
-from genny import curator, cmd_runner, toolchain
+import structlog
+
+from genny import cmd_runner, curator, toolchain
 
 SLOG = structlog.get_logger(__name__)
 
@@ -307,6 +308,36 @@ def _setup_resmoke(
         venv.create(env_dir=resmoke_venv, with_pip=True, symlinks=True)
         reqs_file = os.path.join(mongo_repo_path, "etc", "pip", "evgtest-requirements.txt")
 
+        # Cython >=3 is not compatable with PyYaml <=6.0.1 && >5.3.1. Because we
+        # don't control this requirements.txt, we'll pre-install a pyyaml AND a
+        # Cython that works, and hope that one of them survive. We do the work
+        # here to make sure that old MongoDB versions are compatible with New
+        # Genny.
+        #
+        # If this requirements file is ever upgraded to account for this, the
+        # dependencies manually installed in this line should automatically
+        # upgraded. This line is to make sure that a working set of
+        # dependencies is _already_ installed so that pip wont bother upgrading
+        # them.
+        #
+        # See: https://jira.mongodb.org/browse/EVG-20471
+        # See: https://github.com/yaml/pyyaml/issues/601
+        cmd = [
+            resmoke_python,
+            "-mpip",
+            "install",
+            "Cython<3.0",
+            "PyYAML<=5.3.1",
+            "--no-build-isolation",
+        ]
+        cmd_runner.run_command(
+            cmd=cmd,
+            cwd=workspace_root,
+            capture=False,
+            check=True,
+        )
+
+        # Now install the dependencies in the requirements file like normal
         cmd = [resmoke_python, "-mpip", "install", "-r", reqs_file]
         cmd_runner.run_command(
             cmd=cmd,


### PR DESCRIPTION
**Jira Ticket:** [EVG-20471](https://jira.mongodb.org/browse/EVG-20471)

This PR fixes an issue with Genny where the explicitly defined version of PyYAML is incompatible with the implicitly installed Cython 3.0 dependency. They are [not](https://github.com/yaml/pyyaml/issues/601) compatible. PyYAML is being downgraded to 5.3.1 instead of being upgraded to 6.0.1 because I ran into some transitive dependency issues still requiring PyYAML ~5.

Because Genny, during its own testing, pulls in an additional `requirements.txt` from Mongo, defined [here](https://github.com/mongodb/mongo/blob/master/etc/pip/components/core.req#L4) I have additionally added a pre-install step, hopefully causing `pip`'s resolver to not try and upgrade PyYAML or Cython.

**Patch testing results:**  
The [sys-perf patch](https://spruce.mongodb.com/version/64b623e12a60ed88ef4e1e74/tasks) with the changes from this PR and the related DSI one.

In addition to the passing self-tests on this PR, there is a replication of the issue and a test that demonstrates it passing.
- `master` (as of this PR) currently failing on re-run: https://spruce.mongodb.com/task/genny_amazon2_arm64_t_compile_3245493ece1df04649d564f3944727dda4e072b3_23_07_13_01_54_38/logs?execution=1
- This PR: https://spruce.mongodb.com/task/genny_amazon2_arm64_t_compile_patch_3245493ece1df04649d564f3944727dda4e072b3_64b5ef1a0305b95a1481006c_23_07_18_01_47_07/logs?execution=0

**Related PRs:**   
This PR is related to a similar one in [DSI](https://github.com/10gen/dsi/pull/1346)