### PR TITLE
EVG-20421: Add "Options" to insertMany in CrudActor

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -938,6 +938,9 @@ struct InsertManyOperation : public BaseOperation {
         for (auto&& [k, document] : documents) {
             _docExprs.push_back(document.to<DocumentGenerator>(context, id));
         }
+        if (opNode["Options"]) {
+            _options = opNode["Options"].to<mongocxx::options::insert>();
+        }
     }
 
     void run(mongocxx::client_session& session) override {

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -381,11 +381,23 @@ Tests:
             - { a: 1 }
             - { a: 1 }
             - { b: 1 }
+          Options:
+            Ordered: true
+            WriteConcern:
+              Level: 1
+              Timeout: 1000 milliseconds
+              Journal: true
     OutcomeCounts:
       - Filter: {a: 1}
         Count: 2
       - Filter: {b: 1}
         Count: 1
+    ExpectAllEvents:
+      writeConcern:
+        w: 1
+        wtimeout: 1000
+        j: true
+        ordered: true
 
   - Description: Insert a document into a collection.
     Operations:

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -11,7 +11,7 @@
 # - OutcomeCounts: is a shortcut these tests take to avoid having to
 #   specify every single document in the collection.
 #
-# - Error: indicates a string of what type of error (syntax error
+# - Error: indicates a string of what type of error (syntax error)
 #   encountered during setup or a runtime error
 #
 # - name: (omitted) we always assume everything happens on the same db and collection
@@ -238,7 +238,7 @@ Tests:
         wtimeout: 2500
         j: true
 
-  - Description: Write concern 0 with timeout and journalling false.
+  - Description: Write concern 0 with timeout and journaling false.
     Operations:
       - OperationName: bulkWrite
         OperationCommand:

--- a/src/cast_core/test/CrudActorYamlTests.yml
+++ b/src/cast_core/test/CrudActorYamlTests.yml
@@ -373,7 +373,7 @@ Tests:
       - Filter: {a: 1}
         Count: 0
 
-  - Description: The correct documents are inserted.
+  - Description: The correct documents are inserted, with correct insert options.
     Operations:
       - OperationName: insertMany
         OperationCommand:
@@ -382,22 +382,25 @@ Tests:
             - { a: 1 }
             - { b: 1 }
           Options:
-            Ordered: true
+            BypassDocumentValidation: true
+            Ordered: false
             WriteConcern:
               Level: 1
               Timeout: 1000 milliseconds
-              Journal: true
+              Journal: false
     OutcomeCounts:
       - Filter: {a: 1}
         Count: 2
       - Filter: {b: 1}
         Count: 1
     ExpectAllEvents:
+      bypassDocumentValidation: true
+      ordered: false
       writeConcern:
         w: 1
         wtimeout: 1000
-        j: true
-        ordered: true
+        j: false
+        ordered: false
 
   - Description: Insert a document into a collection.
     Operations:


### PR DESCRIPTION
**Jira Ticket:** EVG-20421

**Whats Changed:**  
Add the "Options" keyword to CrudActor's "insertMany" operation. This would enable "insertMany" to support setting [insert options](https://www.mongodb.com/docs/manual/reference/command/insert/#syntax) via MongoDB C++ Driver's [`mongocxx::options::insert`](http://mongocxx.org/api/mongocxx-v3/classmongocxx_1_1options_1_1insert.html). These options include "WriteConcern", "Ordered", and "BypassDocumentValidation".

**Patch testing results:**
- sys-perf's [background_ttl_deletions](https://spruce.mongodb.com/task/sys_perf_linux_standalone_all_feature_flags.2022_11_background_ttl_deletions_patch_ccf65577c26aaa1ba825a587aaf5834c37eaf9bd_64b7817d1e2d17b64ec17388_23_07_19_06_24_48/logs?execution=0) (which uses insertMany). There is [no performance change](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=5434bccf-3da5-4390-a07b-40ea45b2d3c1&percent_filter=0%7C%7C100&z_filter=0%7C%7C10).