### PR TITLE
PERF-4436: Update $queryStats to Exhaust Cursor in QueryStats.yml Genny Workload

### DIFF
--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -46,6 +46,9 @@ ActorTemplates:
               pipeline: [
                 {
                   $queryStats: {^Parameter: {Name: "queryStatsParameters", Default: {}}}
+                },
+                {
+                  $count: "numDocuments"
                 }
               ]
               cursor: {}

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -42,11 +42,11 @@ ActorTemplates:
             OperationName: AdminCommand
             OperationCommand:
               aggregate: 1
-              # TODO SERVER-77179: Update $queryStats parameters.
               pipeline: [
                 {
                   $queryStats: {^Parameter: {Name: "queryStatsParameters", Default: {}}}
                 },
+                # The purpose of $count is to ensure we've exhausted the cursor/ data stream and looked at each partition.
                 {
                   $count: "numDocuments"
                 }


### PR DESCRIPTION
Through https://jira.mongodb.org/browse/BF-29351 we realized that when calling $queryStats here https://github.com/mongodb/genny/blob/master/src/workloads/query/QueryStats.yml#L48 we are not getting all the entries, so there seemed to be a performance improvement since one partition is now smaller so quicker to read out. This fixes the workload to iterate through all the query stats entries.

https://spruce.mongodb.com/version/64b99103d6d80a0f834be0e0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Compared this new version to the patch from the BF and now results are more similar to before: 
https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=286b4dc3-8814-448a-aac3-97abfab4b13e&percent_filter=0%7C%7C100&z_filter=0%7C%7C10

<img width="1134" alt="Screenshot 2023-07-21 at 10 49 54 AM" src="https://github.com/mongodb/genny/assets/85578126/d268eee5-6adc-4be7-b253-8a86fa372096">
