### PR TITLE
PERF-4076 Create performance benchmark for server startup and shutdown

### DIFF
--- a/src/phases/replication/startup/StartupPhasesTemplate.yml
+++ b/src/phases/replication/startup/StartupPhasesTemplate.yml
@@ -1,0 +1,237 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: |
+  Common definitions to support the workloads in replication/startup.
+
+DefaultNumPhases: &default_max_phase 13
+
+Document: &Doc
+  t: {^RandomInt: {min: 0, max: 10}}
+  w: {^RandomInt: {distribution: geometric, p: 0.1}}
+  x: 0
+  y: {^RandomInt: {min: 0, max: 1000}}
+  z: {^RandomInt: {min: 0, max: 2147483647}}  # This is for max int for low probability of conflicts
+  int0: &int {^RandomInt: {distribution: binomial, t: 200, p: 0.5}}
+  int1: *int
+  int2: *int
+  int3: *int
+  int4: *int
+  int5: *int
+  int6: *int
+  int7: *int
+  int8: *int
+  int9: *int
+  intArray:
+  - 1000
+  - 2000
+  - 3000
+  - 4000
+  - 5000
+  - 6000
+  - 7000
+  - 8000
+  - 9000
+  string0: &string {^RandomString: {length: {^RandomInt: {min: 5, max: 15}}}}
+  string1: *string
+  string2: *string
+  string3: *string
+  string4: *string
+  string5: *string
+  string6: *string
+  string7: *string
+  string8: *string
+  string9: *string
+  stringShort: {^RandomString: {length: 1}}
+  stringLong: {^RandomString: {length: 100}}
+  padding: {^FastRandomString: {length: {^Parameter: {Name: "approxDocumentSize", Default: 100}}}}
+
+IndexesForLoader: &IndexesForLoader  # 10 indexes
+- keys: {t: 1, w: 1}
+- keys: {y: 1}
+- keys: {t: 1, stringShort: 1}
+- keys: {string0: 1}
+- keys: {stringLong: 1}
+- keys: {stringShort: 1, y: 1}
+- keys: {int0: 1, int1: 1, int2: 1}
+- keys: {int3: 1}
+- keys: {int4: 1}
+- keys: {int5: 1, int6: 1}
+
+IndexesForCreateCmd: &IndexesForCreateCmd  # 10 indexes
+- key: {t: 1, w: 1}
+  name: "index_t_w"
+- key: {y: 1}
+  name: "index_y"
+- key: {t: 1, stringShort: 1}
+  name: "index_t_stringShort"
+- key: {string0: 1}
+  name: "index_string0"
+- key: {stringLong: 1}
+  name: "index_stringLong"
+- key: {stringShort: 1, y: 1}
+  name: "index_stringShort_y"
+- key: {int0: 1, int1: 1, int2: 1}
+  name: "index_int0_int1_int2"
+- key: {int3: 1}
+  name: "index_int3"
+- key: {int4: 1}
+  name: "index_int4"
+- key: {int5: 1, int6: 1}
+  name: "index_int5_int6"
+
+InsertDataTemplate:
+  Name: InsertData
+  Type: Loader
+  Threads: 100
+  Phases:
+    OnlyActiveInPhases:
+      Active: {^Parameter: {Name: "active", Default: [0]}}
+      NopInPhasesUpTo: {^Parameter: {Name: "nopInPhasesUpTo", Default: *default_max_phase}}
+      PhaseConfig:
+        Threads: 100
+        Repeat: 1
+        Database: {^Parameter: {Name: "database", Default: test}}
+        CollectionCount: {^Parameter: {Name: "collectionCount", Default: 1}}
+        DocumentCount: {^Parameter: {Name: "documentCount", Default: 1e6}}
+        BatchSize: {^Parameter: {Name: "batchSize", Default: 10000}}
+        Document: *Doc
+        Indexes: {^Parameter: {Name: "indexes", Default: *IndexesForLoader}}
+
+CrudOperationsTemplate:
+  Name: CrudOperations
+  Type: CrudActor
+  # Each thread will randomly choose a collection within the provided collectionCount.
+  Threads: {^Parameter: {Name: "numOfCollectionsTargeted", Default: 1}}
+  Database: {^Parameter: {Name: "database", Default: test}}
+  Phases:
+    OnlyActiveInPhases:
+      Active: {^Parameter: {Name: "active", Default: [0]}}
+      NopInPhasesUpTo: {^Parameter: {Name: "nopInPhasesUpTo", Default: *default_max_phase}}
+      PhaseConfig:
+        Repeat: {^Parameter: {Name: "numOfCrudOpsPerCollection", Default: 1}}
+        GlobalRate: 100 per 31 milliseconds
+        CollectionCount: {^Parameter: {Name: "collectionCount", Default: 1}}
+        Operations:
+        - OperationName: updateMany
+          OperationCommand:
+            Filter: {y: {^RandomInt: {distribution: poisson, mean: 100}}}
+            Update: {$inc: {x: 1}}
+
+ReadOperationsTemplate:
+  Name: ReadOperations
+  Type: CrudActor
+  # Each thread will randomly choose a collection within the provided collectionCount.
+  Threads: {^Parameter: {Name: "numOfCollectionsTargeted", Default: 1}}
+  Database: {^Parameter: {Name: "database", Default: test}}
+  Phases:
+    OnlyActiveInPhases:
+      Active: {^Parameter: {Name: "active", Default: [0]}}
+      NopInPhasesUpTo: {^Parameter: {Name: "nopInPhasesUpTo", Default: *default_max_phase}}
+      PhaseConfig:
+        Repeat: {^Parameter: {Name: "numOfReadOpsPerCollection", Default: 1}}
+        GlobalRate: 100 per 31 milliseconds
+        CollectionCount: {^Parameter: {Name: "collectionCount", Default: 1}}
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {y: {^RandomInt: {distribution: poisson, mean: 100}}}
+            Options:
+              Limit: 100
+
+CreateIndexesTemplate:
+  Name: IndexCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: {^Parameter: {Name: "active", Default: [0]}}
+      NopInPhasesUpTo: {^Parameter: {Name: "nopInPhasesUpTo", Default: *default_max_phase}}
+      PhaseConfig:
+        Duration: 2 seconds
+        Database: {^Parameter: {Name: "database", Default: test}}
+        # Stepdown will cause the command to return with error.
+        ThrowOnFailure: false
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            dropIndexes: {^Parameter: {Name: "collection", Default: Collection0}}
+            # This will drop all non-essential indexes (_id and any shard key index remain)
+            index: '*'
+        - OperationName: RunCommand
+          OperationCommand:
+            createIndexes: {^Parameter: {Name: "collection", Default: Collection0}}
+            indexes: {^Parameter: {Name: "indexes", Default: *IndexesForCreateCmd}}
+
+StepdownStepupCommandTemplate:
+  Name: StepdownStepupCommand
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: {^Parameter: {Name: "active", Default: [0]}}
+      NopInPhasesUpTo: {^Parameter: {Name: "nopInPhasesUpTo", Default: *default_max_phase}}
+      PhaseConfig:
+        Repeat: 1
+        SleepBefore: 10 seconds
+        ThrowOnFailure: false
+        Operations:
+        - OperationMetricsName: "Stepdown"
+          OperationName: AdminCommand
+          OperationCommand:
+            replSetStepDown: 60
+          OperationAwaitStepdown: true
+        - OperationMetricsName: "StepUp"
+          OperationName: AdminCommand
+          OperationCommand:
+            replSetStepUp: 1
+
+StopCheckpointTemplate:
+  Name: StopCheckpoint
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: {^Parameter: {Name: "active", Default: [0]}}
+      NopInPhasesUpTo: {^Parameter: {Name: "nopInPhasesUpTo", Default: *default_max_phase}}
+      PhaseConfig:
+        Repeat: 1
+        Database: admin
+        Operations:
+        - OperationName: AdminCommand
+          OperationCommand:
+            configureFailPoint: "disableSnapshotting"
+            mode: "alwaysOn"
+
+HangIndexBuildTemplate:
+  Name: StopIndexBuild
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: {^Parameter: {Name: "active", Default: [0]}}
+      NopInPhasesUpTo: {^Parameter: {Name: "nopInPhasesUpTo", Default: *default_max_phase}}
+      PhaseConfig:
+        Repeat: 1
+        Database: admin
+        Operations:
+        - OperationName: AdminCommand
+          OperationCommand:
+            configureFailPoint: "hangAfterInitializingIndexBuild"
+            mode: "alwaysOn"
+
+SetDefaultWCToLocalTemplate:
+  Name: SetDefaultWCToLocal
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: {^Parameter: {Name: "active", Default: [0]}}
+      NopInPhasesUpTo: {^Parameter: {Name: "nopInPhasesUpTo", Default: *default_max_phase}}
+      PhaseConfig:
+        Repeat: 1
+        Database: admin
+        Operations:
+        - OperationName: AdminCommand
+          OperationCommand:
+            setDefaultRWConcern: 1
+            defaultWriteConcern: {"w": 1}

--- a/src/phases/replication/startup/StartupPhasesTemplate.yml
+++ b/src/phases/replication/startup/StartupPhasesTemplate.yml
@@ -5,6 +5,8 @@ Description: |
 
 DefaultNumPhases: &default_max_phase 13
 
+# The default document that will be inserted during 'InsertDataTemplate' will have its size
+# determined by the 'padding' field.
 Document: &Doc
   t: {^RandomInt: {min: 0, max: 10}}
   w: {^RandomInt: {distribution: geometric, p: 0.1}}
@@ -45,6 +47,7 @@ Document: &Doc
   stringLong: {^RandomString: {length: 100}}
   padding: {^FastRandomString: {length: {^Parameter: {Name: "approxDocumentSize", Default: 100}}}}
 
+# The default indexes that will be used in the 'InsertDataTemplate'.
 IndexesForLoader: &IndexesForLoader  # 10 indexes
 - keys: {t: 1, w: 1}
 - keys: {y: 1}
@@ -57,6 +60,7 @@ IndexesForLoader: &IndexesForLoader  # 10 indexes
 - keys: {int4: 1}
 - keys: {int5: 1, int6: 1}
 
+# The default indexes that will be used in the 'CreateIndexesTemplate'.
 IndexesForCreateCmd: &IndexesForCreateCmd  # 10 indexes
 - key: {t: 1, w: 1}
   name: "index_t_w"
@@ -79,6 +83,7 @@ IndexesForCreateCmd: &IndexesForCreateCmd  # 10 indexes
 - key: {int5: 1, int6: 1}
   name: "index_int5_int6"
 
+# Template that uses the 'Loader' actor to create and populate collections for startup workloads.
 InsertDataTemplate:
   Name: InsertData
   Type: Loader
@@ -97,6 +102,7 @@ InsertDataTemplate:
         Document: *Doc
         Indexes: {^Parameter: {Name: "indexes", Default: *IndexesForLoader}}
 
+# Template that uses the 'CrudActor' to issue 'update' operations to random collections.
 CrudOperationsTemplate:
   Name: CrudOperations
   Type: CrudActor
@@ -117,6 +123,7 @@ CrudOperationsTemplate:
             Filter: {y: {^RandomInt: {distribution: poisson, mean: 100}}}
             Update: {$inc: {x: 1}}
 
+# Template that uses the 'CrudActor' to issue 'find' operations to random collections.
 ReadOperationsTemplate:
   Name: ReadOperations
   Type: CrudActor
@@ -138,6 +145,7 @@ ReadOperationsTemplate:
             Options:
               Limit: 100
 
+# Template that uses the 'RunCommand' to create indexes for a specific collection.
 CreateIndexesTemplate:
   Name: IndexCollection
   Type: RunCommand
@@ -162,6 +170,8 @@ CreateIndexesTemplate:
             createIndexes: {^Parameter: {Name: "collection", Default: Collection0}}
             indexes: {^Parameter: {Name: "indexes", Default: *IndexesForCreateCmd}}
 
+# Template that waits 10 seconds then uses the 'AdminCommand' to initiate a primary stepdown and
+# then subsequently step it up again.
 StepdownStepupCommandTemplate:
   Name: StepdownStepupCommand
   Type: AdminCommand
@@ -185,6 +195,8 @@ StepdownStepupCommandTemplate:
           OperationCommand:
             replSetStepUp: 1
 
+# Template that uses the 'AdminCommand' to enable 'disableSnapshotting' failpoint which stops mongod
+# from taking more checkpoints.
 StopCheckpointTemplate:
   Name: StopCheckpoint
   Type: AdminCommand
@@ -202,6 +214,8 @@ StopCheckpointTemplate:
             configureFailPoint: "disableSnapshotting"
             mode: "alwaysOn"
 
+# Template that uses the 'AdminCommand' to enable 'hangAfterInitializingIndexBuild' failpoint which
+# hangs any index build.
 HangIndexBuildTemplate:
   Name: StopIndexBuild
   Type: AdminCommand
@@ -219,6 +233,7 @@ HangIndexBuildTemplate:
             configureFailPoint: "hangAfterInitializingIndexBuild"
             mode: "alwaysOn"
 
+# Template that uses the 'AdminCommand' to set default write concern to local.
 SetDefaultWCToLocalTemplate:
   Name: SetDefaultWCToLocal
   Type: AdminCommand

--- a/src/workloads/replication/startup/1_0_5GB.yml
+++ b/src/workloads/replication/startup/1_0_5GB.yml
@@ -2,6 +2,29 @@ SchemaVersion: 2018-07-01
 Owner: mongodb/server-replication"
 Description: >
   Loads the data for the light phase.
+  To know more about the test phases please refer to 'src/workloads/replication/startup/README.md'.
+
+  Expected behavior:
+  --------------
+  We expect after restarting mongod after running this workload to not having any ops to be applied
+  during startup recovery:
+
+  Sample logs:
+  +-------------------------------------------------------------------------------------------+
+  | {                                                                                         |
+  |     s: "I",                                                                               |
+  |     c: "REPL",                                                                            |
+  |     id: 21549,                                                                            |
+  |     ctx: "initandlisten",                                                                 |
+  |     msg: "No oplog entries to apply for recovery. Start point is at the top of the oplog" |
+  |   }                                                                                       |
+  +-------------------------------------------------------------------------------------------+
+
+Keywords:
+- startup
+- collections
+- indexes
+- defaultWC
 
 Clients:
   Default:
@@ -25,8 +48,11 @@ Actors:
       approxDocumentSize: 10000  # 10kB.
       documentCount: 100000  # for an approximate total of ~1GB.
 
-# The default WC is majority and 'disableSnapshotting' failpoint will prevent satisfying any
-# majority writes.
+# By default, the write concern (WC) is set to 'majority,' and enabling 'disableSnapshotting'
+# failpoint, leading to the blocking of majority writes.
+# As many upcoming workloads in 'replication/startup,' activate the 'disableSnapshotting' failpoint,
+# it is prudent to modify the default WC to 'local.' This adjustment will ensure the success of
+# write operations in those scenarios.
 - SetDefaultWCToLocal:
   LoadConfig:
     Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"

--- a/src/workloads/replication/startup/1_0_5GB.yml
+++ b/src/workloads/replication/startup/1_0_5GB.yml
@@ -1,0 +1,36 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: >
+  Loads the data for the light phase.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+
+NumPhases: &max_phase 1
+Database: &database "startup_5GB"
+CollectionCount: &collectionCount 5
+
+Actors:
+- LoadInitialData:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: InsertDataTemplate
+    Parameters:
+      active: [0]
+      nopInPhasesUpTo: *max_phase
+      database: *database
+      collectionCount: 5
+      approxDocumentSize: 10000  # 10kB.
+      documentCount: 100000  # for an approximate total of ~1GB.
+
+# The default WC is majority and 'disableSnapshotting' failpoint will prevent satisfying any
+# majority writes.
+- SetDefaultWCToLocal:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: SetDefaultWCToLocalTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase

--- a/src/workloads/replication/startup/1_0_5GB.yml
+++ b/src/workloads/replication/startup/1_0_5GB.yml
@@ -29,11 +29,12 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 2500
+      maxPoolSize: 300
 
-NumPhases: &max_phase 1
-Database: &database "startup_5GB"
-CollectionCount: &collectionCount 5
+GlobalDefaults:
+  - NumPhases: &max_phase 1
+  - Database: &database "startup_5GB"
+  - CollectionCount: &collectionCount 5
 
 Actors:
 - LoadInitialData:

--- a/src/workloads/replication/startup/1_1_5GB_crud.yml
+++ b/src/workloads/replication/startup/1_1_5GB_crud.yml
@@ -41,12 +41,13 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 2500
+      maxPoolSize: 300
 
-NumPhases: &max_phase 1
-# Should match values in 'src/workloads/replication/startup/1_0_5GB.yml'
-Database: &database "startup_5GB"
-CollectionCount: &collectionCount 5
+GlobalDefaults:
+  - NumPhases: &max_phase 1
+  # Should match values in 'src/workloads/replication/startup/1_0_5GB.yml'
+  - Database: &database "startup_5GB"
+  - CollectionCount: &collectionCount 5
 
 Actors:
 - StopCheckpointing:

--- a/src/workloads/replication/startup/1_1_5GB_crud.yml
+++ b/src/workloads/replication/startup/1_1_5GB_crud.yml
@@ -2,6 +2,41 @@ SchemaVersion: 2018-07-01
 Owner: mongodb/server-replication"
 Description: >
   Adds CRUD operations to be replayed during startup recovery for the light phase.
+  To know more about the test phases please refer to 'src/workloads/replication/startup/README.md'.
+
+  Expected behavior:
+  --------------
+  We expect after restarting mongod after running this workload to have alot of CRUD ops to be
+  applied during startup recovery:
+
+  Sample logs:
+  +--------------------------------------------------------+
+  |  {                                                     |
+  |       s: "I",                                          |
+  |       c: "REPL",                                       |
+  |       id: 21536,                                       |
+  |       ctx: "initandlisten",                            |
+  |       msg: "Completed oplog application for recovery", |
+  |       attr: {                                          |
+  |           numOpsApplied: 50207,                        |
+  |           numBatches: 142,                             |
+  |           applyThroughOpTime: {                        |
+  |               ts: {                                    |
+  |                   $timestamp: {                        |
+  |                       t: 1690277528,                   |
+  |                       i: 1                             |
+  |                   }                                    |
+  |               },                                       |
+  |               t: 6                                     |
+  |           }                                            |
+  |       }                                                |
+  |   }                                                    |
+  +--------------------------------------------------------+
+
+Keywords:
+- startup
+- stopCheckpointing
+- updates
 
 Clients:
   Default:

--- a/src/workloads/replication/startup/1_1_5GB_crud.yml
+++ b/src/workloads/replication/startup/1_1_5GB_crud.yml
@@ -1,0 +1,35 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: >
+  Adds CRUD operations to be replayed during startup recovery for the light phase.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+
+NumPhases: &max_phase 1
+# Should match values in 'src/workloads/replication/startup/1_0_5GB.yml'
+Database: &database "startup_5GB"
+CollectionCount: &collectionCount 5
+
+Actors:
+- StopCheckpointing:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: StopCheckpointTemplate
+    Parameters:
+      active: [0]
+      nopInPhasesUpTo: *max_phase
+
+- CrudOperations:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: CrudOperationsTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase
+      database: *database
+      collectionCount: *collectionCount
+      numOfCollectionsTargeted: *collectionCount
+      numOfCrudOpsPerCollection: 10000   # ~50k operations in total.

--- a/src/workloads/replication/startup/1_2_5GB_ddl.yml
+++ b/src/workloads/replication/startup/1_2_5GB_ddl.yml
@@ -2,6 +2,54 @@ SchemaVersion: 2018-07-01
 Owner: mongodb/server-replication"
 Description: >
   Adds DDL operations to be replayed during startup recovery for the light phase.
+  To know more about the test phases please refer to 'src/workloads/replication/startup/README.md'.
+
+  Expected behavior:
+  --------------
+  We expect after restarting mongod after running this workload to have alot of DDL ops to be
+  applied during startup recovery:
+
+  Sample logs:
+  +------------------------------------------------------------------------------------+
+  |   1- Alot of "Dropping unknown ident".                                             |
+  |   2- Alot of createCollection ops:                                                 |
+  |   {                                                                                |
+  |       s: "I",                                                                      |
+  |       c: "REPL",                                                                   |
+  |       id: 7360109,                                                                 |
+  |       ctx: "initandlisten",                                                        |
+  |       msg: "Processing DDL command oplog entry in OplogBatcher",                   |
+  |       attr: {                                                                      |
+  |           oplogEntry: {                                                            |
+  |               oplogEntry: {                                                        |
+  |                   op: "c",                                                         |
+  |                   ns: "startup_5GB_ddl.$cmd",                                      |
+  |                   o: {                                                             |
+  |                       create: "Collection2",                                       |
+  |                       idIndex: {                                                   |
+  |                           v: 2,                                                    |
+  |                           key: {                                                   |
+  |                               _id: 1                                               |
+  |                           },                                                       |
+  |                           name: "_id_"                                             |
+  |                           ...                                                      |
+  |   }                                                                                |
+  |   3- Alot of IndexBuilds:                                                          |
+  |   {                                                                                |
+  |     s: "I",                                                                        |
+  |     c: "STORAGE",                                                                  |
+  |     id: 5039100,                                                                   |
+  |     ctx: "IndexBuildsCoordinatorMongod-2",                                         |
+  |     msg: "Index build: in replication recovery. Not waiting for last optime before |
+  |     interceptors to be majority committed",                                        |
+  |   }                                                                                |
+  +------------------------------------------------------------------------------------+
+
+Keywords:
+- startup
+- stopCheckpointing
+- collections
+- indexes
 
 Clients:
   Default:

--- a/src/workloads/replication/startup/1_2_5GB_ddl.yml
+++ b/src/workloads/replication/startup/1_2_5GB_ddl.yml
@@ -1,0 +1,34 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: >
+  Adds DDL operations to be replayed during startup recovery for the light phase.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+
+NumPhases: &max_phase 1
+Database: &database "startup_5GB_ddl"
+CollectionCount: &collectionCount 5
+
+Actors:
+- StopCheckpointing:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: StopCheckpointTemplate
+    Parameters:
+      active: [0]
+      nopInPhasesUpTo: *max_phase
+
+- DDLAndCrudOperations:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: InsertDataTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase
+      database: *database
+      collectionCount: *collectionCount
+      approxDocumentSize: 10000  # 10kB
+      documentCount: 100  # for an approximate total of ~1MB per collection, ~5MB total.

--- a/src/workloads/replication/startup/1_2_5GB_ddl.yml
+++ b/src/workloads/replication/startup/1_2_5GB_ddl.yml
@@ -54,11 +54,12 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 2500
+      maxPoolSize: 300
 
-NumPhases: &max_phase 1
-Database: &database "startup_5GB_ddl"
-CollectionCount: &collectionCount 5
+GlobalDefaults:
+  - NumPhases: &max_phase 1
+  - Database: &database "startup_5GB_ddl"
+  - CollectionCount: &collectionCount 5
 
 Actors:
 - StopCheckpointing:

--- a/src/workloads/replication/startup/1_3_5GB_index.yml
+++ b/src/workloads/replication/startup/1_3_5GB_index.yml
@@ -1,0 +1,42 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: >
+  Initiates an index build to be continued during startup recovery for the light load phase.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+
+NumPhases: &max_phase 1
+# Should match values in 'src/workloads/replication/startup/1_0_5GB.yml'
+Database: &database "startup_5GB"
+
+Actors:
+- HangIndexBuild:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: HangIndexBuildTemplate
+    Parameters:
+      active: [0]
+      nopInPhasesUpTo: *max_phase
+
+- CreateIndexes:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: CreateIndexesTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase
+      database: *database
+
+# During Phase 1, the execution of 'createIndexes' will be blocked due to enabling the failpoint in
+# Phase 0. Hence, stepping down the primary after 10 seconds within the same phase, allowing the
+# 'createIndexes' command to return with error without aborting the index build.
+- StepdownStepup:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: StepdownStepupCommandTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase

--- a/src/workloads/replication/startup/1_3_5GB_index.yml
+++ b/src/workloads/replication/startup/1_3_5GB_index.yml
@@ -2,6 +2,75 @@ SchemaVersion: 2018-07-01
 Owner: mongodb/server-replication"
 Description: >
   Initiates an index build to be continued during startup recovery for the light load phase.
+  To know more about the test phases please refer to 'src/workloads/replication/startup/README.md'.
+
+  Expected behavior:
+  --------------
+  We expect after restarting mongod after running this workload to not have any ops to be applied
+  during startup recovery but we should see continuation of the index builds.
+
+  Sample logs:
+  +-----------------------------------------------------------------+
+  |   1- Alot of "Dropping unknown ident".                          |
+  |   2- Continuation of the index build:                           |
+  |   {                                                             |
+  |     s: "I",                                                     |
+  |     c: "STORAGE",                                               |
+  |     id: 22253,                                                  |
+  |     ctx: "initandlisten",                                       |
+  |     msg: "Found index from unfinished build",                   |
+  |     attr: {                                                     |
+  |         namespace: "startup_5GB.Collection0",                   |
+  |         index: "index_int5_int6",                               |
+  |         buildUUID: {                                            |
+  |             uuid: {                                             |
+  |                 $uuid: "8d713ff8-88e8-4198-a15d-7d590acd9cb9"   |
+  |             }                                                   |
+  |         }                                                       |
+  |     }                                                           |
+  |   }                                                             |
+  |   {                                                             |
+  |       t: {                                                      |
+  |           $date: "2023-07-25T10:08:47.569+00:00"                |
+  |       },                                                        |
+  |       s: "I",                                                   |
+  |       c: "STORAGE",                                             |
+  |       id: 4841700,                                              |
+  |       ctx: "initandlisten",                                     |
+  |       msg: "Index build: resuming",                             |
+  |       attr: {                                                   |
+  |           buildUUID: {                                          |
+  |               uuid: {                                           |
+  |                   $uuid: "8d713ff8-88e8-4198-a15d-7d590acd9cb9" |
+  |               }                                                 |
+  |           },                                                    |
+  |           namespace: "startup_5GB.Collection0",                 |
+  |           ...                                                   |
+  |   }                                                             |
+  |   {                                                             |
+  |       s: "I",                                                   |
+  |       c: "INDEX",                                               |
+  |       id: 20346,                                                |
+  |       ctx: "initandlisten",                                     |
+  |       msg: "Index build: initialized",                          |
+  |       attr: {                                                   |
+  |           buildUUID: {                                          |
+  |               uuid: {                                           |
+  |                   $uuid: "8d713ff8-88e8-4198-a15d-7d590acd9cb9" |
+  |               }                                                 |
+  |           },                                                    |
+  |           namespace: "startup_5GB.Collection0",                 |
+  |       }                                                         |
+  |   }                                                             |
+  +-----------------------------------------------------------------+
+
+Keywords:
+- startup
+- hangIndexBuild
+- collections
+- indexes
+- stepdown
+- stepup
 
 Clients:
   Default:

--- a/src/workloads/replication/startup/1_3_5GB_index.yml
+++ b/src/workloads/replication/startup/1_3_5GB_index.yml
@@ -75,11 +75,12 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 2500
+      maxPoolSize: 300
 
-NumPhases: &max_phase 1
-# Should match values in 'src/workloads/replication/startup/1_0_5GB.yml'
-Database: &database "startup_5GB"
+GlobalDefaults:
+  - NumPhases: &max_phase 1
+  # Should match values in 'src/workloads/replication/startup/1_0_5GB.yml'
+  - Database: &database "startup_5GB"
 
 Actors:
 - HangIndexBuild:

--- a/src/workloads/replication/startup/2_0_50GB.yml
+++ b/src/workloads/replication/startup/2_0_50GB.yml
@@ -28,14 +28,15 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 2500
+      maxPoolSize: 300
       # Allow for longer duration since index builds may take a while.
       socketTimeoutMS: 3_600_000  # = 1 hour
       connectTimeoutMS: 3_600_000
 
-NumPhases: &max_phase 0
-Database: &database "startup_50GB"
-CollectionCount: &collectionCount 10000  # 10k collections with 11 indexes each (100k+ tables).
+GlobalDefaults:
+  - NumPhases: &max_phase 0
+  - Database: &database "startup_50GB"
+  - CollectionCount: &collectionCount 10000  # 10k collections with 11 indexes each (100k+ tables).
 
 Actors:
 - LoadInitialData:

--- a/src/workloads/replication/startup/2_0_50GB.yml
+++ b/src/workloads/replication/startup/2_0_50GB.yml
@@ -2,11 +2,36 @@ SchemaVersion: 2018-07-01
 Owner: mongodb/server-replication"
 Description: >
   Loads the data for the heavy phase.
+  To know more about the test phases please refer to 'src/workloads/replication/startup/README.md'.
+
+  Expected behavior:
+  --------------
+  We expect after restarting mongod after running this workload to not having any ops to be applied
+  during startup recovery:
+
+  Sample logs:
+  +-------------------------------------------------------------------------------------------+
+  | {                                                                                         |
+  |     s: "I",                                                                               |
+  |     c: "REPL",                                                                            |
+  |     id: 21549,                                                                            |
+  |     ctx: "initandlisten",                                                                 |
+  |     msg: "No oplog entries to apply for recovery. Start point is at the top of the oplog" |
+  |   }                                                                                       |
+  +-------------------------------------------------------------------------------------------+
+
+Keywords:
+- startup
+- collections
+- indexes
 
 Clients:
   Default:
     QueryOptions:
       maxPoolSize: 2500
+      # Allow for longer duration since index builds may take a while.
+      socketTimeoutMS: 3_600_000  # = 1 hour
+      connectTimeoutMS: 3_600_000
 
 NumPhases: &max_phase 0
 Database: &database "startup_50GB"

--- a/src/workloads/replication/startup/2_0_50GB.yml
+++ b/src/workloads/replication/startup/2_0_50GB.yml
@@ -1,0 +1,27 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: >
+  Loads the data for the heavy phase.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+
+NumPhases: &max_phase 0
+Database: &database "startup_50GB"
+CollectionCount: &collectionCount 10000  # 10k collections with 11 indexes each (100k+ tables).
+
+Actors:
+- LoadInitialData:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: InsertDataTemplate
+    Parameters:
+      active: [0]
+      nopInPhasesUpTo: *max_phase
+      database: *database
+      collectionCount: *collectionCount
+      approxDocumentSize: 1000  # 1kB
+      documentCount: 5000  # for an approximate total of ~5MB per collection, total ~50GB.
+

--- a/src/workloads/replication/startup/2_1_50GB_crud.yml
+++ b/src/workloads/replication/startup/2_1_50GB_crud.yml
@@ -2,6 +2,41 @@ SchemaVersion: 2018-07-01
 Owner: mongodb/server-replication"
 Description: >
   Adds CRUD operations to be replayed during startup recovery for the heavy phase.
+  To know more about the test phases please refer to 'src/workloads/replication/startup/README.md'.
+
+  Expected behavior:
+  --------------
+  We expect after restarting mongod after running this workload to have alot of CRUD ops to be
+  applied during startup recovery:
+
+  Sample logs:
+  +--------------------------------------------------------+
+  |  {                                                     |
+  |       s: "I",                                          |
+  |       c: "REPL",                                       |
+  |       id: 21536,                                       |
+  |       ctx: "initandlisten",                            |
+  |       msg: "Completed oplog application for recovery", |
+  |       attr: {                                          |
+  |           numOpsApplied: 50207282,                     |
+  |           numBatches: 10042,                           |
+  |           applyThroughOpTime: {                        |
+  |               ts: {                                    |
+  |                   $timestamp: {                        |
+  |                       t: 1690277528,                   |
+  |                       i: 1                             |
+  |                   }                                    |
+  |               },                                       |
+  |               t: 6                                     |
+  |           }                                            |
+  |       }                                                |
+  |   }                                                    |
+  +--------------------------------------------------------+
+
+Keywords:
+- startup
+- stopCheckpointing
+- updates
 
 Clients:
   Default:

--- a/src/workloads/replication/startup/2_1_50GB_crud.yml
+++ b/src/workloads/replication/startup/2_1_50GB_crud.yml
@@ -41,12 +41,13 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 2500
+      maxPoolSize: 300
 
-NumPhases: &max_phase 1
-# Should match values in 'src/workloads/replication/startup/2_0_50GB.yml'
-Database: &database "startup_50GB"
-CollectionCount: &collectionCount 10000
+GlobalDefaults:
+  - NumPhases: &max_phase 1
+  # Should match values in 'src/workloads/replication/startup/2_0_50GB.yml'
+  - Database: &database "startup_50GB"
+  - CollectionCount: &collectionCount 10000
 
 Actors:
 - StopCheckpointing:

--- a/src/workloads/replication/startup/2_1_50GB_crud.yml
+++ b/src/workloads/replication/startup/2_1_50GB_crud.yml
@@ -1,0 +1,38 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: >
+  Adds CRUD operations to be replayed during startup recovery for the heavy phase.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+
+NumPhases: &max_phase 1
+# Should match values in 'src/workloads/replication/startup/2_0_50GB.yml'
+Database: &database "startup_50GB"
+CollectionCount: &collectionCount 10000
+
+Actors:
+- StopCheckpointing:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: StopCheckpointTemplate
+    Parameters:
+      active: [0]
+      nopInPhasesUpTo: *max_phase
+
+- CrudOperations:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: CrudOperationsTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase
+      database: *database
+      collectionCount: *collectionCount
+      # 1% of the total collection count, keep it low as this also controls the number of threads as
+      # each collection will operate in its own thread.
+      numOfCollectionsTargeted: 100
+      numOfCrudOpsPerCollection: 100000  # ~10M operations in total.
+

--- a/src/workloads/replication/startup/2_2_50GB_ddl.yml
+++ b/src/workloads/replication/startup/2_2_50GB_ddl.yml
@@ -61,7 +61,7 @@ Clients:
 
 NumPhases: &max_phase 1
 Database: &database "startup_50GB_ddl"
-CollectionCount: &collectionCount 10000  # 10k collections with 11 indexes each (100k+ tables).
+CollectionCount: &collectionCount 1000  # 1k collections with 11 indexes each (10k+ tables).
 
 Actors:
 - StopCheckpointing:

--- a/src/workloads/replication/startup/2_2_50GB_ddl.yml
+++ b/src/workloads/replication/startup/2_2_50GB_ddl.yml
@@ -2,11 +2,62 @@ SchemaVersion: 2018-07-01
 Owner: mongodb/server-replication"
 Description: >
   Adds DDL operations to be replayed during startup recovery for the heavy phase.
+  To know more about the test phases please refer to 'src/workloads/replication/startup/README.md'.
+
+  Expected behavior:
+  --------------
+  We expect after restarting mongod after running this workload to have alot of DDL ops to be
+  applied during startup recovery:
+
+  Sample logs:
+  +------------------------------------------------------------------------------------+
+  |   1- Alot of "Dropping unknown ident".                                             |
+  |   2- Alot of createCollection ops:                                                 |
+  |   {                                                                                |
+  |       s: "I",                                                                      |
+  |       c: "REPL",                                                                   |
+  |       id: 7360109,                                                                 |
+  |       ctx: "initandlisten",                                                        |
+  |       msg: "Processing DDL command oplog entry in OplogBatcher",                   |
+  |       attr: {                                                                      |
+  |           oplogEntry: {                                                            |
+  |               oplogEntry: {                                                        |
+  |                   op: "c",                                                         |
+  |                   ns: "startup_50GB_ddl.$cmd",                                     |
+  |                   o: {                                                             |
+  |                       create: "Collection9500",                                    |
+  |                       idIndex: {                                                   |
+  |                           v: 2,                                                    |
+  |                           key: {                                                   |
+  |                               _id: 1                                               |
+  |                           },                                                       |
+  |                           name: "_id_"                                             |
+  |                           ...                                                      |
+  |   }                                                                                |
+  |   3- Alot of IndexBuilds:                                                          |
+  |   {                                                                                |
+  |     s: "I",                                                                        |
+  |     c: "STORAGE",                                                                  |
+  |     id: 5039100,                                                                   |
+  |     ctx: "IndexBuildsCoordinatorMongod-2",                                         |
+  |     msg: "Index build: in replication recovery. Not waiting for last optime before |
+  |     interceptors to be majority committed",                                        |
+  |   }                                                                                |
+  +------------------------------------------------------------------------------------+
+
+Keywords:
+- startup
+- stopCheckpointing
+- collections
+- indexes
 
 Clients:
   Default:
     QueryOptions:
       maxPoolSize: 2500
+      # Allow for longer duration since index builds may take a while.
+      socketTimeoutMS: 3_600_000  # = 1 hour
+      connectTimeoutMS: 3_600_000
 
 NumPhases: &max_phase 1
 Database: &database "startup_50GB_ddl"

--- a/src/workloads/replication/startup/2_2_50GB_ddl.yml
+++ b/src/workloads/replication/startup/2_2_50GB_ddl.yml
@@ -54,14 +54,15 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 2500
+      maxPoolSize: 300
       # Allow for longer duration since index builds may take a while.
       socketTimeoutMS: 3_600_000  # = 1 hour
       connectTimeoutMS: 3_600_000
 
-NumPhases: &max_phase 1
-Database: &database "startup_50GB_ddl"
-CollectionCount: &collectionCount 1000  # 1k collections with 11 indexes each (10k+ tables).
+GlobalDefaults:
+  - NumPhases: &max_phase 1
+  - Database: &database "startup_50GB_ddl"
+  - CollectionCount: &collectionCount 1000  # 1k collections with 11 indexes each (10k+ tables).
 
 Actors:
 - StopCheckpointing:

--- a/src/workloads/replication/startup/2_2_50GB_ddl.yml
+++ b/src/workloads/replication/startup/2_2_50GB_ddl.yml
@@ -1,0 +1,34 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: >
+  Adds DDL operations to be replayed during startup recovery for the heavy phase.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+
+NumPhases: &max_phase 1
+Database: &database "startup_50GB_ddl"
+CollectionCount: &collectionCount 10000  # 10k collections with 11 indexes each (100k+ tables).
+
+Actors:
+- StopCheckpointing:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: StopCheckpointTemplate
+    Parameters:
+      active: [0]
+      nopInPhasesUpTo: *max_phase
+
+- DDLAndCrudOperations:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: InsertDataTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase
+      database: *database
+      collectionCount: *collectionCount
+      approxDocumentSize: 1000  # 1kB
+      documentCount: 100  # for an approximate total of 100KB per collection, total ~1GB.

--- a/src/workloads/replication/startup/2_3_50GB_index.yml
+++ b/src/workloads/replication/startup/2_3_50GB_index.yml
@@ -75,11 +75,12 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 2500
+      maxPoolSize: 300
 
-NumPhases: &max_phase 1
-# Should match values in 'src/workloads/replication/startup/2_0_50GB.yml'
-Database: &database "startup_50GB"
+GlobalDefaults:
+  - NumPhases: &max_phase 1
+  # Should match values in 'src/workloads/replication/startup/2_0_50GB.yml'
+  - Database: &database "startup_50GB"
 
 Actors:
 - HangIndexBuild:

--- a/src/workloads/replication/startup/2_3_50GB_index.yml
+++ b/src/workloads/replication/startup/2_3_50GB_index.yml
@@ -2,6 +2,75 @@ SchemaVersion: 2018-07-01
 Owner: mongodb/server-replication"
 Description: >
   Initiates an index build to be continued during startup recovery for the heavy load phase.
+  To know more about the test phases please refer to 'src/workloads/replication/startup/README.md'.
+
+  Expected behavior:
+  --------------
+  We expect after restarting mongod after running this workload to not have any ops to be applied
+  during startup recovery but we should see continuation of the index builds during initialization.
+
+  Sample logs:
+  +-----------------------------------------------------------------+
+  |   1- Alot of "Dropping unknown ident".                          |
+  |   2- Continuation of the index build:                           |
+  |   {                                                             |
+  |     s: "I",                                                     |
+  |     c: "STORAGE",                                               |
+  |     id: 22253,                                                  |
+  |     ctx: "initandlisten",                                       |
+  |     msg: "Found index from unfinished build",                   |
+  |     attr: {                                                     |
+  |         namespace: "startup_50GB.Collection0",                  |
+  |         index: "index_int5_int6",                               |
+  |         buildUUID: {                                            |
+  |             uuid: {                                             |
+  |                 $uuid: "8d713ff8-88e8-4198-a15d-7d590acd9cb9"   |
+  |             }                                                   |
+  |         }                                                       |
+  |     }                                                           |
+  |   }                                                             |
+  |   {                                                             |
+  |       t: {                                                      |
+  |           $date: "2023-07-25T10:08:47.569+00:00"                |
+  |       },                                                        |
+  |       s: "I",                                                   |
+  |       c: "STORAGE",                                             |
+  |       id: 4841700,                                              |
+  |       ctx: "initandlisten",                                     |
+  |       msg: "Index build: resuming",                             |
+  |       attr: {                                                   |
+  |           buildUUID: {                                          |
+  |               uuid: {                                           |
+  |                   $uuid: "8d713ff8-88e8-4198-a15d-7d590acd9cb9" |
+  |               }                                                 |
+  |           },                                                    |
+  |           namespace: "startup_50GB.Collection0",                |
+  |           ...                                                   |
+  |   }                                                             |
+  |   {                                                             |
+  |       s: "I",                                                   |
+  |       c: "INDEX",                                               |
+  |       id: 20346,                                                |
+  |       ctx: "initandlisten",                                     |
+  |       msg: "Index build: initialized",                          |
+  |       attr: {                                                   |
+  |           buildUUID: {                                          |
+  |               uuid: {                                           |
+  |                   $uuid: "8d713ff8-88e8-4198-a15d-7d590acd9cb9" |
+  |               }                                                 |
+  |           },                                                    |
+  |           namespace: "startup_50GB.Collection0",                |
+  |       }                                                         |
+  |   }                                                             |
+  +-----------------------------------------------------------------+
+
+Keywords:
+- startup
+- hangIndexBuild
+- collections
+- indexes
+- stepdown
+- stepup
 
 Clients:
   Default:

--- a/src/workloads/replication/startup/2_3_50GB_index.yml
+++ b/src/workloads/replication/startup/2_3_50GB_index.yml
@@ -1,0 +1,42 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: >
+  Initiates an index build to be continued during startup recovery for the heavy load phase.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+
+NumPhases: &max_phase 1
+# Should match values in 'src/workloads/replication/startup/2_0_50GB.yml'
+Database: &database "startup_50GB"
+
+Actors:
+- HangIndexBuild:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: HangIndexBuildTemplate
+    Parameters:
+      active: [0]
+      nopInPhasesUpTo: *max_phase
+
+- CreateIndexes:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: CreateIndexesTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase
+      database: *database
+
+# During Phase 1, the execution of 'createIndexes' will be blocked due to enabling the failpoint in
+# Phase 0. Hence, stepping down the primary after 10 seconds within the same phase, allowing the
+# 'createIndexes' command to return with error without aborting the index build.
+- StepdownStepup:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: StepdownStepupCommandTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase

--- a/src/workloads/replication/startup/3_0_Reads.yml
+++ b/src/workloads/replication/startup/3_0_Reads.yml
@@ -11,15 +11,16 @@ Keywords:
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 2500
+      maxPoolSize: 300
 
-NumPhases: &max_phase 1
-# Should match values in 'src/workloads/replication/startup/1_0_5GB.yml'
-Database1: &database1 "startup_5GB"
-CollectionCount1: &collectionCount1 5
-# Should match values in 'src/workloads/replication/startup/2_0_50GB.yml'
-Database2: &database2 "startup_50GB"
-CollectionCount2: &collectionCount2 10000
+GlobalDefaults:
+  - NumPhases: &max_phase 1
+  # Should match values in 'src/workloads/replication/startup/1_0_5GB.yml'
+  - Database1: &database1 "startup_5GB"
+  - CollectionCount1: &collectionCount1 5
+  # Should match values in 'src/workloads/replication/startup/2_0_50GB.yml'
+  - Database2: &database2 "startup_50GB"
+  - CollectionCount2: &collectionCount2 10000
 
 Actors:
 - ReadOperationsDB1:

--- a/src/workloads/replication/startup/3_0_Reads.yml
+++ b/src/workloads/replication/startup/3_0_Reads.yml
@@ -1,0 +1,42 @@
+SchemaVersion: 2018-07-01
+Owner: mongodb/server-replication"
+Description: >
+ Issues dummy reads against both databases used in the light and the heavy phases.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2500
+
+NumPhases: &max_phase 1
+# Should match values in 'src/workloads/replication/startup/1_0_5GB.yml'
+Database1: &database1 "startup_5GB"
+CollectionCount1: &collectionCount1 5
+# Should match values in 'src/workloads/replication/startup/2_0_50GB.yml'
+Database2: &database2 "startup_50GB"
+CollectionCount2: &collectionCount2 10000
+
+Actors:
+- ReadOperationsDB1:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: ReadOperationsTemplate
+    Parameters:
+      active: [0]
+      nopInPhasesUpTo: *max_phase
+      database: *database1
+      collectionCount: *collectionCount1
+      numOfCollectionsTargeted: *collectionCount1
+      numOfReadOpsPerCollection: 1000
+
+- ReadOperationsDB2:
+  LoadConfig:
+    Path: "../../../phases/replication/startup/StartupPhasesTemplate.yml"
+    Key: ReadOperationsTemplate
+    Parameters:
+      active: [1]
+      nopInPhasesUpTo: *max_phase
+      database: *database2
+      collectionCount: *collectionCount2
+      numOfCollectionsTargeted: 50
+      numOfReadOpsPerCollection: 1000

--- a/src/workloads/replication/startup/3_0_Reads.yml
+++ b/src/workloads/replication/startup/3_0_Reads.yml
@@ -2,6 +2,11 @@ SchemaVersion: 2018-07-01
 Owner: mongodb/server-replication"
 Description: >
  Issues dummy reads against both databases used in the light and the heavy phases.
+  To know more about the test phases please refer to 'src/workloads/replication/startup/README.md'.
+
+Keywords:
+- startup
+- reads
 
 Clients:
   Default:

--- a/src/workloads/replication/startup/README.md
+++ b/src/workloads/replication/startup/README.md
@@ -1,0 +1,40 @@
+## BACKGROUND
+
+This directory contains some Genny workloads to test the performance of the mongod shutdown/startup process.
+
+## TEST DESCRIPTION
+
+The test is structured with several Genny workloads that are executed in order by a DSI custom test control that restarts the mongod between the workloads, allowing us to measure shutdown/startup performance.
+
+### The test has two phases:
+  
+  **1. Light load:**
+
+    - Workload names preceded with "1_".
+    - Collection count: 5.
+    - Document count: 100K.
+    - Approx document size: 10KB.
+    - Data size per collection: 1GB.
+    - Total data size: 5GB.
+    - Number of secondary indexes per collection: 10.
+    - Number of storage tables: 55+.
+
+  **2. Heavy load**:
+
+    - Workload names preceded with "2_".
+    - Collection count: 10K.
+    - Document count: 5K.
+    - Approx document size: 1KB.
+    - Data size per collection: 5MB.
+    - Total data size: 50GB.
+    - Number of secondary indexes per collection: 10.
+    - Number of storage tables: 100k+.
+    
+### Workloads for each phase:
+
+  1. Load the data.
+  2. Stop checkpointing and add update CRUD operations (which controls the number of oplogs that will be replayed in startup recovery).
+  3. Stop checkpointing and add DDL and CRUD operations.
+  4. Stop any IndexBuild from getting completed and start an IndexBuild that will continue after startup recovery.
+
+To ensure DSI restarts mongod after the last workload, a dummy read workload has been added as the final workload.


### PR DESCRIPTION
Jira Ticket: < [PERF-4076](https://jira.mongodb.org/browse/PERF-4076) >

Whats Changed:
Create performance benchmark for server startup and shutdown

Patch testing results:
[Patch1](https://spruce.mongodb.com/version/64c11835d1fe0740ac80cf02/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[Patch2](https://spruce.mongodb.com/version/64c1184161837db62cfb9a93/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[Patch3](https://spruce.mongodb.com/version/64c1185b2fbabe72a9517f34/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

Related PRs:
[Mongo](https://github.com/10gen/mongo/pull/14458)
[DSI](https://github.com/10gen/dsi/pull/1357)