### PR TITLE
PERF-4463: Include more sharded variants on query stats workloads

### DIFF
--- a/src/workloads/execution/ClusteredCollection.yml
+++ b/src/workloads/execution/ClusteredCollection.yml
@@ -28,8 +28,11 @@ AutoRun:
       - replica-query-stats
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10
-      - shard-lite-all-feature-flags
       - shard
       - shard-query-stats
+      - shard-limited-query-stats
+      - shard-lite-all-feature-flags
+      - shard-lite-query-stats
+      - shard-lite-limited-query-stats
     branch_name:
       $gte:  v5.3

--- a/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+++ b/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
@@ -28,8 +28,11 @@ AutoRun:
       - replica-query-stats
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10
-      - shard-lite-all-feature-flags
       - shard
       - shard-query-stats
+      - shard-limited-query-stats
+      - shard-lite-all-feature-flags
+      - shard-lite-query-stats
+      - shard-lite-limited-query-stats
     branch_name:
       $gte: v5.3

--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -119,7 +119,10 @@ AutoRun:
       - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
+      - shard-limited-query-stats
       - shard-lite
+      - shard-lite-query-stats
+      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -115,7 +115,10 @@ AutoRun:
       - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
+      - shard-limited-query-stats
       - shard-lite
+      - shard-lite-query-stats
+      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -112,7 +112,10 @@ AutoRun:
       - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
+      - shard-limited-query-stats
       - shard-lite
+      - shard-lite-query-stats
+      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -111,7 +111,10 @@ AutoRun:
       - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
+      - shard-limited-query-stats
       - shard-lite
+      - shard-lite-query-stats
+      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica


### PR DESCRIPTION
**Whats Changed:**  
We recently added variants for `shard-limited-query-stats`, `shard-lite-query-stats`, and `shard-lite-limited-query-stats`. This patch includes those variants to be run on workloads relevant to query stats.

**Patch testing results:**  
[Evergreen link](https://spruce.mongodb.com/version/64c2901a32f4179811ce7a32/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
