### PR TITLE
PERF-4466 Implement support for binary data type Sensitive and use this for query stats HMAC key generation

### DIFF
--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -19,7 +19,7 @@ GlobalDefaults:
   MaxPhases: &MaxPhases 8
   nop: &Nop {Nop: true}
   dbname: &db test
-  binDataGen: &binDataGen {^BinData: {numBytes: 32}}
+  binDataGen: &binDataGen {^BinDataSensitive: {numBytes: 32}}
 
 ActorTemplates:
 - TemplateName: QueryStatsAggregation


### PR DESCRIPTION
**Jira Ticket:**
PERF-4466

**Whats Changed:**
Implement support for generating binary data type Sensitive (and generally speaking, any binary data subtype).

**Patch testing results:**  
If applicable, link a patch test showing code changes running successfully

**Related PRs:**   
https://github.com/mongodb/mongo-cxx-driver/pull/995
