### PR TITLE
PERF-4478 Generator for an array of distinct values

### DIFF
--- a/src/value_generators/include/value_generators/DocumentGenerator.hpp
+++ b/src/value_generators/include/value_generators/DocumentGenerator.hpp
@@ -52,6 +52,14 @@ public:
     using InvalidValueGeneratorSyntax::InvalidValueGeneratorSyntax;
 };
 
+/**
+ * Throw this to indicate that the generator exceeded runtime bounds while waiting for convergence.
+ */
+class ValueGeneratorConvergenceTimeout : public InvalidValueGeneratorSyntax {
+public:
+    using InvalidValueGeneratorSyntax::InvalidValueGeneratorSyntax;
+};
+
 struct GeneratorArgs {
     DefaultRandom& rng;
     ActorId actorId;

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -1812,6 +1812,10 @@ const auto [allParsers, arrayParsers, dateParsers, doubleParsers, intParsers, st
          [](const Node& node, GeneratorArgs generatorArgs) {
              return std::make_unique<ObjectIdGenerator>(node, generatorArgs);
          }},
+        {"^Verbatim",
+         [](const Node& node, GeneratorArgs generatorArgs) {
+             return valueGenerator<true, UniqueAppendable>(node, generatorArgs, allParsers);
+         }},
         {"^TwoDWalk",
          [](const Node& node, GeneratorArgs generatorArgs) {
              return std::make_unique<TwoDWalkGenerator>(node, generatorArgs);

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -1942,27 +1942,27 @@ UniqueGenerator<bsoncxx::array::value> literalArrayGenerator(const Node& node,
 UniqueGenerator<bsoncxx::array::value> distinctArrayGenerator(const Node& node,
                                                               GeneratorArgs generatorArgs) {
     try {
-        if (extractKnownParser(node, generatorArgs, intParsers)) {
+        if (extractKnownParser(node["of"], generatorArgs, intParsers)) {
             // known parser type
             return std::make_unique<DistinctArrayGenerator<int64_t>>(node, generatorArgs);
         }
     } catch (const InvalidConversionException& e) {
     }
     try {
-        if (extractKnownParser(node, generatorArgs, doubleParsers)) {
+        if (extractKnownParser(node["of"], generatorArgs, doubleParsers)) {
             // known parser type
             return std::make_unique<DistinctArrayGenerator<double>>(node, generatorArgs);
         }
     } catch (const InvalidConversionException& e) {
     }
     try {
-        if (extractKnownParser(node, generatorArgs, stringParsers)) {
+        if (extractKnownParser(node["of"], generatorArgs, stringParsers)) {
             // known parser type
             return std::make_unique<DistinctArrayGenerator<std::string>>(node, generatorArgs);
         }
     } catch (const InvalidConversionException& e) {
     }
-    BOOST_THROW_EXCEPTION(InvalidValueGeneratorSyntax("Unsupported values for distinct array"));
+    BOOST_THROW_EXCEPTION(InvalidValueGeneratorSyntax("Unsupported \"of\" for distinct array"));
 }
 
 /**

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -17,15 +17,14 @@
 #include <value_generators/FrequencyMap.hpp>
 
 #include <cmath>
-#include <deque>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <limits>
 #include <map>
-#include <set>
 #include <sstream>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/date_time.hpp>

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -1419,6 +1419,8 @@ public:
             // Choose initial bucket size of 2N to minimize hash collisions and resizes.
             std::unordered_set<bsoncxx::array::value, SetHasher, SetKeyEq> distinctValues(2 * times);
             int8_t consecutiveRepeats = 0;
+            const int8_t consecutiveRepeatsThreshold = 100;
+
             while (distinctValues.size() < times) {
                 bsoncxx::builder::basic::array sbuilder{};
                 _valueGen->append(sbuilder);
@@ -1437,8 +1439,7 @@ public:
 #undef BSONCXX_ENUM
                     }
                     consecutiveRepeats = 0;
-                } else if (++consecutiveRepeats > 100) {
-                    // Rate of failure: 100% of the past N pulls.
+                } else if (++consecutiveRepeats > consecutiveRepeatsThreshold) {
                     std::stringstream msg;
                     msg << "Repeatedly failed to find a new distinct value "
                         << consecutiveRepeats << " times. Terminating distinct array value "

--- a/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
+++ b/src/value_generators/test/DocGenYamlTestCaseRunner.cpp
@@ -84,7 +84,7 @@ public:
                     docGen();
                     FAIL("Expected exception " << this->_expectedExceptionMessage.as<std::string>()
                                                << " but none occurred");
-                } catch (const std::exception& x) {
+                } catch (const std::exception&) {
                     REQUIRE("InvalidValueGeneratorSyntax" ==
                             this->_expectedExceptionMessage.as<std::string>());
                 }

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -192,30 +192,28 @@ Tests:
   - Name: Array Generator creates an array with a repeated element
     GivenTemplate:
       a:
-        {^Array: {of: {^RandomInt: {min: 1, max: 4}}, number: 2}}
+        {^Array: {of: {^Repeat: {fromGenerator: {^Inc: {start: 1, max: 2}}, count: 2}}, number: 2}}
     ThenReturns:
       - {a: [{ "$numberLong": "1" }, { "$numberLong": "1" }]}
 
-  - Name: Distinct Array Generator creates an array with no repeated ints
+  - Name: Array Generator creates an array with no repeated ints when distinct flag is set
     GivenTemplate:
       a:
-        {^DistinctArray: {of: {^RandomInt: {min: 1, max: 4}}, number: 2}}
+        {^Array: {of: {^Repeat: {fromGenerator: {^Inc: {start: 1, max: 2}}, count: 2}}, number: 2, distinct: true}}
     ThenReturns:
       - {a: [{ "$numberLong": "1" }, { "$numberLong": "2" }]}
 
-  - Name: Distinct Array Generator creates an array with no repeated strings
+  - Name: Array Generator creates an array with no repeated strings when distinct flag is set
     GivenTemplate:
       a:
-        {^DistinctArray: {
-          of: {^Choose: {from: ["Mongo", "Mongo", "Mongo", "DB"], deterministic: true}},
-          number: 2}}
+        {^Array: {of: {^Repeat: {fromGenerator: {^FastRandomString: {length: 5}}, count: 2}}, number: 2, distinct: true}}
     ThenReturns:
-      - {a: ["Mongo", "DB"]}
+      - {a: ["mLkBO", "qgpGD"]}
 
-  - Name: Distinct Array Generator fails after too many iterations
+  - Name: Array Generator fails if it no longer makes progress when distinct flag is set
     GivenTemplate:
       a:
-        {^DistinctArray: {of: {^RandomInt: {min: 1, max: 4}}, number: 5}}
+        {^Array: {of: {^Repeat: {fromGenerator: {^Inc: {start: 1, max: 10}}, count: 5}}, number: 100}, distinct: true}
     ThenThrows: InvalidValueGeneratorSyntax
 
   - Name: Object Generator

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -189,6 +189,33 @@ Tests:
             "data" : "aaaaaaaaaaoEtN" }}
         ]}
 
+  - Name: Array Generator creates an array with a repeated element
+    GivenTemplate:
+      a:
+        {^Array: {of: {^RandomInt: {min: 1, max: 4}}, number: 2}}
+    ThenReturns:
+      - {a: [{ "$numberLong": "1" }, { "$numberLong": "1" }]}
+
+  - Name: Distinct Array Generator creates an array with no repeated ints
+    GivenTemplate:
+      a:
+        {^DistinctArray: {of: {^RandomInt: {min: 1, max: 4}}, number: 2}}
+    ThenReturns:
+      - {a: [{ "$numberLong": "1" }, { "$numberLong": "2" }]}
+
+  - Name: Distinct Array Generator creates an array with no repeated strings
+    GivenTemplate:
+      a:
+        {^DistinctArray: {of: {^Choose: {from: ["Mongo", "Mongo", "Mongo", "DB"]}}, number: 2}}
+    ThenReturns:
+      - {a: ["Mongo", "DB"]}
+
+  - Name: Distinct Array Generator fails after too many iterations
+    GivenTemplate:
+      a:
+        {^DistinctArray: {of: {^RandomInt: {min: 1, max: 4}}, number: 5}}
+    ThenThrows: InvalidValueGeneratorSyntax
+
   - Name: Object Generator
     GivenTemplate:
       a:

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -213,7 +213,7 @@ Tests:
   - Name: Array Generator fails if it no longer makes progress when distinct flag is set
     GivenTemplate:
       a:
-        {^Array: {of: {^Repeat: {fromGenerator: {^Inc: {start: 1, max: 10}}, count: 5}}, number: 100}, distinct: true}
+        {^Array: {of: {^Repeat: {fromGenerator: {^Inc: {start: 1, max: 10}}, count: 5}}, number: 100, distinct: true}}
     ThenThrows: InvalidValueGeneratorSyntax
 
   - Name: Object Generator

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -206,7 +206,9 @@ Tests:
   - Name: Distinct Array Generator creates an array with no repeated strings
     GivenTemplate:
       a:
-        {^DistinctArray: {of: {^Choose: {from: ["Mongo", "Mongo", "Mongo", "DB"]}}, number: 2}}
+        {^DistinctArray: {
+          of: {^Choose: {from: ["Mongo", "Mongo", "Mongo", "DB"], deterministic: true}},
+          number: 2}}
     ThenReturns:
       - {a: ["Mongo", "DB"]}
 

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -213,7 +213,7 @@ Tests:
   - Name: Array Generator fails if it no longer makes progress when distinct flag is set
     GivenTemplate:
       a:
-        {^Array: {of: {^Repeat: {fromGenerator: {^Inc: {start: 1, max: 10}}, count: 5}}, number: 100, distinct: true}}
+        {^Array: {of: {^Repeat: {fromGenerator: {^RandomInt: {min: 0, max: 10}}, count: 5}}, number: 100, distinct: true}}
     ThenThrows: InvalidValueGeneratorSyntax
 
   - Name: Object Generator

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -199,21 +199,30 @@ Tests:
   - Name: Array Generator creates an array with no repeated ints when distinct flag is set
     GivenTemplate:
       a:
-        {^Array: {of: {^Repeat: {fromGenerator: {^Inc: {start: 1, max: 2}}, count: 2}}, number: 2, distinct: true}}
+        {^Array: {
+            of: {^Repeat: {fromGenerator: {^Inc: {start: 1, max: 2}}, count: 2}},
+            number: 2,
+            distinct: true}}
     ThenReturns:
       - {a: [{ "$numberLong": "1" }, { "$numberLong": "2" }]}
 
   - Name: Array Generator creates an array with no repeated strings when distinct flag is set
     GivenTemplate:
       a:
-        {^Array: {of: {^Repeat: {fromGenerator: {^FastRandomString: {length: 5}}, count: 2}}, number: 2, distinct: true}}
+        {^Array: {
+            of: {^Repeat: {fromGenerator: {^FastRandomString: {length: 5}}, count: 2}},
+            number: 2,
+            distinct: true}}
     ThenReturns:
       - {a: ["mLkBO", "qgpGD"]}
 
   - Name: Array Generator fails if it no longer makes progress when distinct flag is set
     GivenTemplate:
       a:
-        {^Array: {of: {^Repeat: {fromGenerator: {^RandomInt: {min: 0, max: 10}}, count: 5}}, number: 100, distinct: true}}
+        {^Array: {
+            of: {^Repeat: {fromGenerator: {^RandomInt: {min: 0, max: 10}}, count: 5}},
+            number: 100,
+            distinct: true}}
     ThenThrows: InvalidValueGeneratorSyntax
 
   - Name: Object Generator

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -251,25 +251,21 @@ Actors:
             # The following example returns - repeatingSeq: [1, 2, 3, 1, 2]
             repeatingSeq: {^Array: {of: {^Choose: {from: [1, 2, 3], deterministic: true}}, number: 5}}
 
-            # You can also filter items out, similar to a set. For example, you can generate
-            # N distinct random integers.
-            distinctSeq10Ints: {^DistinctArray: {
-              of: {^RandomInt: {min: 0, max: 100000}}, number: 10}}
+            # You can also filter items out, similar to a set, by setting `distinct` = true.
+            # For example, you can generate N distinct random integers.
+            distinctSeq10Ints: {^Array: {of: {^Repeat: {count: 10, fromGenerator: {
+              ^Inc: {start: 0, end: 1000}}, number: 10, distinct: true}}}}
 
             # Just be careful, the generator will give up if the failure rate gets too high, such as
             # with this next generator.
-            distinctSeqFailure: {^DistinctArray: {
-              of: {^RandomInt: {min: 0, max: 1000}}, number: 1000}}
+            distinctSeqFailure: {^Array: {of: {^Repeat: {count: 10000, fromGenerator: {
+              ^Inc: {start: 0, end: 1000}}, number: 10, distinct: true}}}}
 
             # A good rule of thumb is that you should be selecting less than 50% of your range.
             # You're not limited to integers, though! You can also filter doubles, strings, even
             # certain documents and arrays.
-            distinctSeq10Strings: {^DistinctArray: {
-              of: {^Choose: {from: ["M", "o", "n", "g", "o", "D", "B"], deterministic: true}},
-              number: 5}}
-
-            # However, not all generators are supported, and DistinctArray doesn't support
-            # heterogeneous types, so the generator must output the same type of elements each time.
+            distinctSeq10Strings: {^Array: {of: {^Repeat: {count: 10, fromGenerator: {
+                ^FastRandomString: {length: 10}}, number: 10, distinct: true}}}}
 
             # Concatenate constant arrays and generated arrays together.
             combinedArrays: {^Concat: {arrays: [[1, 1], [2, 3, 5]]}}

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -252,9 +252,9 @@ Actors:
             repeatingSeq: {^Array: {of: {^Choose: {from: [1, 2, 3], deterministic: true}}, number: 5}}
 
             # You can also filter items out, similar to a set, by setting `distinct` = true.
-            # For example, you can generate N distinct random integers.
-            distinctSeq10Ints: {^Array: {of: {^Repeat: {count: 10, fromGenerator: {
-              ^Inc: {start: 0, end: 1000}}}}, number: 10, distinct: true}}
+            # For example, you can generate 10 distinct random integers. Without `distinct` = true,
+            # the generated array might have duplicate values.
+            distinctSeq10Ints: {^Array: {of: ^Inc: {start: 0, end: 1000}, number: 10, distinct: true}}
 
             # Just be careful, the generator will give up if the failure rate gets too high, such as
             # with this next generator.
@@ -264,8 +264,7 @@ Actors:
             # A good rule of thumb is that you should be selecting less than 50% of your range.
             # You're not limited to integers, though! You can also filter doubles, strings, even
             # documents and arrays.
-            distinctSeq10Strings: {^Array: {of: {^Repeat: {count: 10, fromGenerator: {
-                ^FastRandomString: {length: 10}}}}, number: 10, distinct: true}}
+            distinctSeq10Strings: {^Array: {of: ^FastRandomString: {length: 10}, number: 10, distinct: true}}
 
             # Concatenate constant arrays and generated arrays together.
             combinedArrays: {^Concat: {arrays: [[1, 1], [2, 3, 5]]}}

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -251,6 +251,26 @@ Actors:
             # The following example returns - repeatingSeq: [1, 2, 3, 1, 2]
             repeatingSeq: {^Array: {of: {^Choose: {from: [1, 2, 3], deterministic: true}}, number: 5}}
 
+            # You can also filter items out, similar to a set. For example, you can generate
+            # N distinct random integers.
+            distinctSeq10Ints: {^DistinctArray: {
+              of: {^RandomInt: {min: 0, max: 100000}}, number: 10}}
+
+            # Just be careful, the generator will give up if the failure rate gets too high, such as
+            # with this next generator.
+            distinctSeqFailure: {^DistinctArray: {
+              of: {^RandomInt: {min: 0, max: 1000}}, number: 1000}}
+
+            # A good rule of thumb is that you should be selecting less than 50% of your range.
+            # You're not limited to integers, though! You can also filter doubles, strings, even
+            # certain documents and arrays.
+            distinctSeq10Strings: {^DistinctArray: {
+              of: {^Choose: {from: ["M", "o", "n", "g", "o", "D", "B"], deterministic: true}},
+              number: 5}}
+
+            # However, not all generators are supported, and DistinctArray doesn't support
+            # heterogeneous types, so the generator must output the same type of elements each time.
+
             # Concatenate constant arrays and generated arrays together.
             combinedArrays: {^Concat: {arrays: [[1, 1], [2, 3, 5]]}}
             combinedArraysWithGenerator: {^Concat: {arrays: [{^Array: {of: 1, number: 2}}, [2, 3, 5]]}}

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -254,18 +254,18 @@ Actors:
             # You can also filter items out, similar to a set, by setting `distinct` = true.
             # For example, you can generate N distinct random integers.
             distinctSeq10Ints: {^Array: {of: {^Repeat: {count: 10, fromGenerator: {
-              ^Inc: {start: 0, end: 1000}}, number: 10, distinct: true}}}}
+              ^Inc: {start: 0, end: 1000}}}}, number: 10, distinct: true}}
 
             # Just be careful, the generator will give up if the failure rate gets too high, such as
             # with this next generator.
             distinctSeqFailure: {^Array: {of: {^Repeat: {count: 10000, fromGenerator: {
-              ^Inc: {start: 0, end: 1000}}, number: 10, distinct: true}}}}
+              ^Inc: {start: 0, end: 1000}}}}, number: 10, distinct: true}}
 
             # A good rule of thumb is that you should be selecting less than 50% of your range.
             # You're not limited to integers, though! You can also filter doubles, strings, even
             # documents and arrays.
             distinctSeq10Strings: {^Array: {of: {^Repeat: {count: 10, fromGenerator: {
-                ^FastRandomString: {length: 10}}, number: 10, distinct: true}}}}
+                ^FastRandomString: {length: 10}}}}, number: 10, distinct: true}}
 
             # Concatenate constant arrays and generated arrays together.
             combinedArrays: {^Concat: {arrays: [[1, 1], [2, 3, 5]]}}

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -263,7 +263,7 @@ Actors:
 
             # A good rule of thumb is that you should be selecting less than 50% of your range.
             # You're not limited to integers, though! You can also filter doubles, strings, even
-            # certain documents and arrays.
+            # documents and arrays.
             distinctSeq10Strings: {^Array: {of: {^Repeat: {count: 10, fromGenerator: {
                 ^FastRandomString: {length: 10}}, number: 10, distinct: true}}}}
 

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -254,7 +254,8 @@ Actors:
             # You can also filter items out, similar to a set, by setting `distinct` = true.
             # For example, you can generate 10 distinct random integers. Without `distinct` = true,
             # the generated array might have duplicate values.
-            distinctSeq10Ints: {^Array: {of: ^Inc: {start: 0, end: 1000}, number: 10, distinct: true}}
+            distinctSeq10Ints: {^Array: {
+                of: {^Inc: {start: 0, end: 1000}}, number: 10, distinct: true}}
 
             # Just be careful, the generator will give up if the failure rate gets too high, such as
             # with this next generator.
@@ -264,7 +265,8 @@ Actors:
             # A good rule of thumb is that you should be selecting less than 50% of your range.
             # You're not limited to integers, though! You can also filter doubles, strings, even
             # documents and arrays.
-            distinctSeq10Strings: {^Array: {of: ^FastRandomString: {length: 10}, number: 10, distinct: true}}
+            distinctSeq10Strings: {^Array: {
+                of: {^FastRandomString: {length: 10}}, number: 10, distinct: true}}
 
             # Concatenate constant arrays and generated arrays together.
             combinedArrays: {^Concat: {arrays: [[1, 1], [2, 3, 5]]}}


### PR DESCRIPTION
**Jira Ticket:** PERF-4478

**Whats Changed:**  
Add the `DistinctArray` generator, which is essentially a set, but as an array with no duplicate values. Unlike `Array`, `DistinctArray` operates solely on homogeneous array values.

Also implements a refactor for the parsers maps to deduplicate maps and hedge against the risk of accidentally leaving a parser off of `allParsers`.

**Patch testing results:**  
If applicable, link a patch test showing code changes running successfully (TBD)