### PR TITLE
EVG-20067: Add genny-canaries timing code for arm64 and variants other than Mac & x86-64

### DIFF
--- a/src/canaries/src/Loops.cpp
+++ b/src/canaries/src/Loops.cpp
@@ -37,8 +37,9 @@ namespace genny::canaries {
 /**
  * Use `rdtsc` as a low overhead, high resolution clock.
  *
- * Adapted from Google Benchmark
- * https://github.com/google/benchmark/blob/439d6b1c2a6da5cb6adc4c4dfc555af235722396/src/cycleclock.h#L61
+ * Adapted from Google Benchmark:
+ * x86_64/amd64: https://github.com/google/benchmark/blob/8f7b8dd9a3211e6043e742a383ccb35eb810829f/src/cycleclock.h#L82-L85
+ * arm64: https://github.com/google/benchmark/blob/8f7b8dd9a3211e6043e742a383ccb35eb810829f/src/cycleclock.h#L142-L149
  */
 inline Nanosecond now() {
 #if defined(__APPLE__)
@@ -47,6 +48,12 @@ inline Nanosecond now() {
     uint64_t low, high;
     __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
     return (high << 32) | low;
+#elif defined(__aarch64__)
+    int64_t virtual_timer_value;
+    asm volatile("mrs %0, cntvct_el0" : "=r"(virtual_timer_value));
+    return virtual_timer_value;
+#else
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 #endif
 }
 


### PR DESCRIPTION
**Jira Ticket:** EVG-20067

**Whats Changed:**  
The root cause of this ticket is that genny-canaries was missing timing code for arm64 and variants other than Mac & x86-64. This PR is to add timing code for arm64 and variants other than Mac & x86-64.

It is expected that this PR will trigger change points because it would fix the genny-canaries time series for ARM variants.

The new arm64 timing code, like the existing Mac & x86-64 timing code, adapted [Apache-2.0 licensed code](https://github.com/google/benchmark/blob/main/LICENSE) from [google/benchmark](https://github.com/google/benchmark/blob/8f7b8dd9a3211e6043e742a383ccb35eb810829f/src/cycleclock.h#L142-L149), which utilizes assembly code or platform-specific code. Specifically, google/benchmark's [arm64 timing code](https://github.com/google/benchmark/blob/8f7b8dd9a3211e6043e742a383ccb35eb810829f/src/cycleclock.h#L142-L149) reads from the [`CNTVCT_EL0` register](https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/CNTVCT-EL0--Counter-timer-Virtual-Count-register?lang=en) using the [`MRS` instruction](https://developer.arm.com/documentation/ddi0602/2023-06/Base-Instructions/MRS--Move-System-Register-to-general-purpose-register-?lang=en) ([the Linux kernel uses this same code](https://lore.kernel.org/lkml/20200914115311.2201-3-leo.yan@linaro.org/)). The [x86-64 timing code](https://github.com/google/benchmark/blob/8f7b8dd9a3211e6043e742a383ccb35eb810829f/src/cycleclock.h#L82-L85) uses the [`RDTSC` instruction](https://www.felixcloutier.com/x86/rdtsc) ([more details on this code](https://stackoverflow.com/a/13772771)). The [Mac timing code](https://github.com/google/benchmark/blob/8f7b8dd9a3211e6043e742a383ccb35eb810829f/src/cycleclock.h#L63-L73) uses the Mac-specific [`mach_absolute_time`](https://developer.apple.com/documentation/driverkit/3438076-mach_absolute_time).

The default timing code for other variants uses `std::chrono`, which is not optimized but has good cross-platform support and is not sensitive to hardware and assembly quirks. Genny metric measurement actually uses `std::chrono` as well.

**Note:** The existing code outputs the time measurements as nanoseconds, which is incorrect because `RDTSC` and `mach_absolute_time` (and `CNTVCT_EL0`) returns clock cycles, not nanoseconds. But I'm not sure if it's worth fixing, so I decided to leave it as-is for now.

**Patch testing results:**  
- [sys-perf](https://spruce.mongodb.com/version/64c88070c9ec44f1ce32ede1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (ARM only)
- [sys-perf-atlas](https://spruce.mongodb.com/version/64c8544757e85a60d06291a7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (ARM & Intel)