### PR TITLE
EVG-20193: Warm up pool connection before returning

### DIFF
--- a/src/canaries/src/tasks.cpp
+++ b/src/canaries/src/tasks.cpp
@@ -20,6 +20,6 @@ Singleton::Singleton(std::string mongoUri)
             PingTask:
               URI: )" + mongoUri, ""
       },
-      client{_poolManager.client("PingTask", 1, ns.root())},
+      client{_poolManager.create_warmed_up_client("PingTask", 1, ns.root())},
       pingCmd{make_document(kvp("ping", 1))} {};
 }  // namespace genny::canaries::ping_task

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -528,7 +528,7 @@ public:
     }
 
     /**
-     * @return a pool from the "default" MongoDB connection-pool.
+     * @return a pool connection from the "default" MongoDB connection-pool.
      * @throws InvalidConfigurationException if no connections available.
      */
     template <class... Args>

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -285,7 +285,7 @@ public:
      * @throws
      *   InvalidConfigurationException if no connections available.
      */
-    mongocxx::pool::entry client(const std::string& name = "Default", size_t instance = 0);
+    mongocxx::pool::entry get_warmed_up_client(const std::string& name = "Default", size_t instance = 0);
 
     /**
      * Get states that can be shared across actors using the same WorkloadContext.
@@ -533,7 +533,7 @@ public:
      */
     template <class... Args>
     mongocxx::pool::entry client(Args&&... args) {
-        return this->_workload->client(std::forward<Args>(args)...);
+        return this->_workload->get_warmed_up_client(std::forward<Args>(args)...);
     }
 
     /**

--- a/src/gennylib/include/gennylib/v1/PoolManager.hpp
+++ b/src/gennylib/include/gennylib/v1/PoolManager.hpp
@@ -114,7 +114,7 @@ public:
 
     /**
      *  Connection/query-string parameters can be added via `Clients` configuration
-     *  passed in when calling `client()`.
+     *  passed in when calling `create_warmed_up_client()`.
      *  See PoolFactory for how this can be configured.
      *
      * @param callback
@@ -143,7 +143,7 @@ public:
      *   the WorkloadContext used to look up the configurations
      * @return a connection from the pool or throw if none available
      */
-    mongocxx::pool::entry client(const std::string& name, size_t instance, const Node& context);
+    mongocxx::pool::entry create_warmed_up_client(const std::string& name, size_t instance, const Node& context);
 
     // Only used for testing
     /** @private */
@@ -168,7 +168,7 @@ private:
     /** manages global key vaults & creates encryption contexts per pool */
     std::unique_ptr<EncryptionManager> _encryptionManager;
 
-    /** Helper method for client() */
+    /** Helper method for `create_warmed_up_client()` */
     mongocxx::pool::entry _client(const std::string& name, size_t instance, const Node& context);
 };
 

--- a/src/gennylib/include/gennylib/v1/PoolManager.hpp
+++ b/src/gennylib/include/gennylib/v1/PoolManager.hpp
@@ -169,7 +169,7 @@ private:
     std::unique_ptr<EncryptionManager> _encryptionManager;
 
     /** Helper method for `create_warmed_up_client()` */
-    mongocxx::pool::entry _client(const std::string& name, size_t instance, const Node& context);
+    mongocxx::pool::entry _create_client(const std::string& name, size_t instance, const Node& context);
 };
 
 }  // namespace genny::v1

--- a/src/gennylib/include/gennylib/v1/PoolManager.hpp
+++ b/src/gennylib/include/gennylib/v1/PoolManager.hpp
@@ -167,6 +167,9 @@ private:
 
     /** manages global key vaults & creates encryption contexts per pool */
     std::unique_ptr<EncryptionManager> _encryptionManager;
+
+    /** Helper method for client() */
+    mongocxx::pool::entry _client(const std::string& name, size_t instance, const Node& context);
 };
 
 }  // namespace genny::v1

--- a/src/gennylib/src/PoolManager.cpp
+++ b/src/gennylib/src/PoolManager.cpp
@@ -54,9 +54,9 @@ auto createPool(const std::string& name,
 }  // namespace genny::v1
 
 
-mongocxx::pool::entry genny::v1::PoolManager::client(const std::string& name,
-                                                     size_t instance,
-                                                     const Node& context) {
+mongocxx::pool::entry genny::v1::PoolManager::create_warmed_up_client(const std::string& name,
+                                                                   size_t instance,
+                                                                   const Node& context) {
     auto pool_entry = this->_client(name, instance, context);
     pool_entry->list_databases();  // warm up the connection before returning it
     return pool_entry;
@@ -75,7 +75,7 @@ mongocxx::pool::entry genny::v1::PoolManager::_client(const std::string& name,
     }
 
     // ...but no need to keep the lock open past this.
-    // Two threads trying access client("foo",0) at the same
+    // Two threads trying access _client("foo",0) at the same
     // time will subsequently block on the unique_lock.
     getLock.unlock();
 

--- a/src/gennylib/src/PoolManager.cpp
+++ b/src/gennylib/src/PoolManager.cpp
@@ -57,13 +57,13 @@ auto createPool(const std::string& name,
 mongocxx::pool::entry genny::v1::PoolManager::create_warmed_up_client(const std::string& name,
                                                                    size_t instance,
                                                                    const Node& context) {
-    auto pool_entry = this->_client(name, instance, context);
+    auto pool_entry = this->_create_client(name, instance, context);
     pool_entry->list_databases();  // warm up the connection before returning it
     return pool_entry;
 }
 
 
-mongocxx::pool::entry genny::v1::PoolManager::_client(const std::string& name,
+mongocxx::pool::entry genny::v1::PoolManager::_create_client(const std::string& name,
                                                       size_t instance,
                                                       const Node& context) {
     // Only one thread can access pools.operator[] at a time...

--- a/src/gennylib/src/PoolManager.cpp
+++ b/src/gennylib/src/PoolManager.cpp
@@ -57,7 +57,7 @@ auto createPool(const std::string& name,
 mongocxx::pool::entry genny::v1::PoolManager::client(const std::string& name,
                                                      size_t instance,
                                                      const Node& context) {
-    mongocxx::pool::entry pool_entry = this->_client(name, instance, context);
+    auto pool_entry = this->_client(name, instance, context);
     pool_entry->list_databases();  // warm up the connection before returning it
     return pool_entry;
 }

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -124,7 +124,7 @@ ActorVector WorkloadContext::_constructActors(const Cast& cast,
     return actors;
 }
 
-mongocxx::pool::entry WorkloadContext::client(const std::string& name, size_t instance) {
+mongocxx::pool::entry WorkloadContext::get_warmed_up_client(const std::string& name, size_t instance) {
     return _poolManager.create_warmed_up_client(name, instance, this->_node);
 }
 

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -125,7 +125,7 @@ ActorVector WorkloadContext::_constructActors(const Cast& cast,
 }
 
 mongocxx::pool::entry WorkloadContext::client(const std::string& name, size_t instance) {
-    return _poolManager.client(name, instance, this->_node);
+    return _poolManager.create_warmed_up_client(name, instance, this->_node);
 }
 
 GlobalRateLimiter* WorkloadContext::getRateLimiter(const std::string& name, const RateSpec& spec) {

--- a/src/gennylib/test/PoolFactory_test.cpp
+++ b/src/gennylib/test/PoolFactory_test.cpp
@@ -348,15 +348,15 @@ TEST_CASE("PoolFactory behavior") {
         genny::NodeSource ns{"Clients: {Default: {URI: 'mongodb:://localhost:27017'}, Foo: {URI: 'mongodb:://localhost:27017'}, Bar: {URI: 'mongodb:://localhost:27018'}}", ""};
         auto& config = ns.root();
 
-        auto foo0 = manager.client("Foo", 0, config);
-        auto foo0again = manager.client("Foo", 0, config);
-        auto foo10 = manager.client("Foo", 10, config);
-        auto bar0 = manager.client("Bar", 0, config);
+        auto foo0 = manager.create_warmed_up_client("Foo", 0, config);
+        auto foo0again = manager.create_warmed_up_client("Foo", 0, config);
+        auto foo10 = manager.create_warmed_up_client("Foo", 10, config);
+        auto bar0 = manager.create_warmed_up_client("Bar", 0, config);
 
         // Note to future maintainers:
         //
         // This assertion doesn't actually verify that we aren't calling
-        // `createPool()` again when running `manager.client("Foo", 0, config)` a
+        // `createPool()` again when running `manager.create_warmed_up_client("Foo", 0, config)` a
         // second time.
         //
         // A different style of trying to write this test is to register a

--- a/src/testlib/include/testlib/ActorHelper.hpp
+++ b/src/testlib/include/testlib/ActorHelper.hpp
@@ -72,7 +72,7 @@ public:
     }
 
     auto client() {
-        return workload()->client("Default");
+        return workload()->get_warmed_up_client("Default");
     }
 
     WorkloadContext* workload() {


### PR DESCRIPTION
**Jira Ticket:** EVG-20193

**Whats Changed:**  
Warm up the pool connection before returning this connection to Actor. 

This code is only called [during setup](https://github.com/mongodb/genny/pull/960/files#diff-1c7f2006fe8a4fc6fdac7e96796e826197884da4111f3d850ac4127c31541d34R134-R135) in Actor constructors, and Actor constructors are only called by the `WorkloadContext` to create all Actors, before any of Actor is run. Therefore, this change should not negatively impact metric measurement. However, it is expected that this change might cause changepoints where throughput is improved (as the connection has been warmed up), but this change would stabilize metrics in the long run, because Actors no longer spend time waiting for the pool connection to warm up the first time they use the connection. Indeed, Perf Analyzer results below seem to indicate that this change would stabilize metrics.

**Patch testing results:**  
- [sys-perf on ARM](https://spruce.mongodb.com/version/64c9d84f3e8e86704a2163a3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (PERF-4166, connection_pool_stress)
[Perf Analyzer](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=a5a4b88d-e90d-4bba-a789-2c3bffbc68bc)
- [sys-perf on Intel](https://spruce.mongodb.com/version/64caff4532f417d5c6eac635/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (BF-28785, mixed_workloads_genny_stress, device_monitoring)
[Perf Analyzer](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=973a48df-1581-4ada-93da-8c9e94817ae5)
- [sys-perf on Intel](https://spruce.mongodb.com/version/64caff4532f417d5c6eac635/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (PERF-4166, majority_reads10_k_threads, majority_writes10_k_threads)
[Perf Analyzer](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=8a14fc25-5fa5-4649-95e2-f0d898742091)