### PR TITLE
PERF-4225 add a workload to test resharding performance with indexes

### DIFF
--- a/src/workloads/sharding/ReshardCollectionWithIndexes.yml
+++ b/src/workloads/sharding/ReshardCollectionWithIndexes.yml
@@ -182,6 +182,17 @@ Actors:
     Operations: *WriteOperations
     GlobalRate: *WriteRate
 
+- Name: LoggingActor
+  Type: LoggingActor
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1, 2]
+      NopInPhasesUpTo: 4
+      PhaseConfig:
+        LogEvery: 15 minutes
+        Blocking: None
+
 AutoRun:
 - When:
     mongodb_setup:

--- a/src/workloads/sharding/ReshardCollectionWithIndexes.yml
+++ b/src/workloads/sharding/ReshardCollectionWithIndexes.yml
@@ -15,8 +15,8 @@ Description: |
 
   The workload consists of 3 phases:
     1. Turning off balancer and make the sharded collection exists on only 1 shard.
-    4. Running read and write operations on the collection while it is being resharded to 2 shards.
-    5. Running read and write operations on the collection while it is being resharded to 3 shards.
+    2. Running read and write operations on the collection while it is being resharded to 2 shards.
+    3. Running read and write operations on the collection while it is being resharded to 3 shards.
 
   All documents are generated through genny' data loader where the integer and length of short 
   string fields are randomly generated. The fields are designed like to form different combinations 
@@ -196,7 +196,7 @@ Actors:
   Phases:
     OnlyActiveInPhases:
       Active: [1, 2]
-      NopInPhasesUpTo: 4
+      NopInPhasesUpTo: 2
       PhaseConfig:
         LogEvery: 15 minutes
         Blocking: None

--- a/src/workloads/sharding/ReshardCollectionWithIndexes.yml
+++ b/src/workloads/sharding/ReshardCollectionWithIndexes.yml
@@ -181,3 +181,12 @@ Actors:
     Collection: *Collection
     Operations: *WriteOperations
     GlobalRate: *WriteRate
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - resharding-3shard.2023-08
+    branch_name:
+      $gte:
+      - v7.1

--- a/src/workloads/sharding/ReshardCollectionWithIndexes.yml
+++ b/src/workloads/sharding/ReshardCollectionWithIndexes.yml
@@ -1,0 +1,175 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/sharding"
+Description: |
+  This test expects the target cluster is created using ebs snapshot with 1 billion 1KB records 
+  and has 3 shards, named shard-00, shard-01, shard-02. The collection has 10 indexes including 
+  _id index, single-key index and compound index. ReshardCollection should use same-key resharding 
+  and use shardDistribution parameter to reshard into 2 shards then 3 shards. There will be random 
+  CRUD operations during resharding but should run at a very low rate.
+
+  The workload consists of 3 phases:
+    1. Turning off balancer and make the sharded collection exists on only 1 shard.
+    4. Running read and write operations on the collection while it is being resharded to 2 shards.
+    5. Running read and write operations on the collection while it is being resharded to 3 shards.
+    
+
+  The inserted documents have the following form:
+
+      {
+        _id: 10,
+        shardKey: 20,
+        counter: 0,
+        num1: 1,
+        num2: 2,
+        str1: 'abc',
+        str2: 'xyz',
+        padding: 'random string of bytes ...'
+      }
+
+  The indexes are:
+      [
+        {_id: 1},
+        {shardKey: 1},
+        {counter: 1},
+        {num1: 1},
+        {num2: 1},
+        {str1: 1},
+        {str2: 1},
+        {shardKey: 1, counter:1},
+        {str1: 1, num1: 1},
+        {num2:1, str2: 1}
+      ]
+
+GlobalDefaults:
+  Nop: &Nop {Nop: true}
+
+  Database: &Database test
+  # Collection0 is the default collection populated by the MonotonicSingleLoader.
+  Collection: &Collection Collection0
+  Namespace: &Namespace test.Collection0
+
+  DocumentCount: &DocumentCount 1_000_000_000  # for an approximate total of 1TB
+  NumChunks: &NumChunks 1                # start with only 1 shard
+  Timeout: &Timeout 360_000_000 # = 100 hours
+
+  ShardKeyValueMin: &ShardKeyValueMin 1
+  # We use 100x the number of chunks so that the $sample aggregation to choose the new split points
+  # has a wide range of distinct values to choose from. It could be even larger.
+  ShardKeyValueMax: &ShardKeyValueMax 1_000_000
+  ShardName0: &Shard0 shard-00
+  ShardName1: &Shard1 shard-01
+  ShardName2: &Shard2 shard-02
+
+  ReadRate: &ReadRate 100 per 1 second
+  WriteRate: &WriteRate 10 per 10 seconds  # Keep the writes slow to pass critical section.
+
+  ReadOperations: &ReadOperations
+  - OperationName: findOne
+    OperationCommand:
+      Filter: {_id: {^RandomInt: {min: 1, max: *DocumentCount}}}
+
+  WriteOperations: &WriteOperations
+  - OperationName: updateOne
+    OperationCommand:
+      Filter: {_id: {^RandomInt: {min: 1, max: *DocumentCount}}}
+      Update: {$inc: {counter: 1}}
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 202
+      socketTimeoutMS: *Timeout  # = 100 hours
+  # The reshardCollection command is expected to take a long to complete so we give the actor
+  # running it a much higher socket timeout.
+  ReshardCollection:
+    QueryOptions:
+      maxPoolSize: 1
+      socketTimeoutMS: *Timeout  # = 100 hours
+
+Actors:
+- Name: CreateShardedCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationMetricsName: StopBalancer
+      OperationName: AdminCommand
+      OperationCommand:
+        balancerStop: 1
+        maxTimeMS: *Timeout
+    - OperationMetricsName: EnableSharding
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: *Database
+    - OperationMetricsName: ShardCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: *Namespace
+        key: {shardKey: hashed}
+  - *Nop
+  - *Nop
+
+- Name: ReshardCollection
+  Type: AdminCommand
+  Threads: 1
+  ClientName: ReshardCollection
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationMetricsName: ReshardCollectionToTwoShards
+      OperationName: AdminCommand
+      OperationCommand:
+        reshardCollection: *Namespace
+        key: {shardKey: 1}
+        shardDistribution: [{shard: *Shard0}, {shard: *Shard1}]
+        forceRedistribution: true
+        numInitialChunks: 20000
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationMetricsName: ReshardCollectionToThreeShards
+      OperationName: AdminCommand
+      OperationCommand:
+        reshardCollection: *Namespace
+        key: {shardKey: 1}
+        shardDistribution: [{shard: *Shard0}, {shard: *Shard1}, {shard: *Shard2}]
+        forceRedistribution: true
+        numInitialChunks: 20000
+
+- Name: ReadCollectionBeingResharded
+  Type: CrudActor
+  Threads: 95
+  Database: *Database
+  Phases:
+  - *Nop
+  - MetricsName: ReadDuringReshardingToTwoShards
+    Blocking: None
+    Collection: *Collection
+    Operations: *ReadOperations
+    GlobalRate: *ReadRate
+  - MetricsName: ReadDuringReshardingToThreeShards
+    Blocking: None
+    Collection: *Collection
+    Operations: *ReadOperations
+    GlobalRate: *ReadRate
+
+- Name: WriteCollectionBeingResharded
+  Type: CrudActor
+  Threads: 5
+  Database: *Database
+  Phases:
+  - *Nop
+  - MetricsName: WriteDuringReshardingToTwoShards
+    Blocking: None
+    Collection: *Collection
+    Operations: *WriteOperations
+    GlobalRate: *WriteRate
+  - MetricsName: WriteDuringReshardingToThreeShards
+    Blocking: None
+    Collection: *Collection
+    Operations: *WriteOperations
+    GlobalRate: *WriteRate

--- a/src/workloads/sharding/ReshardCollectionWithIndexes.yml
+++ b/src/workloads/sharding/ReshardCollectionWithIndexes.yml
@@ -187,6 +187,3 @@ AutoRun:
     mongodb_setup:
       $eq:
       - resharding-3shard.2023-08
-    branch_name:
-      $gte:
-      - v7.1

--- a/src/workloads/sharding/ReshardCollectionWithIndexes.yml
+++ b/src/workloads/sharding/ReshardCollectionWithIndexes.yml
@@ -3,7 +3,8 @@ Owner: "@mongodb/sharding"
 Description: |
   This test measures the time for a sharded cluster to reshard a collection from one shard to two 
   shards then to three shards. It was added August 2023 as part of PM-2322, to demonstrate planned 
-  resharding performance improvements. 
+  resharding performance improvements. Note that the goal of this test is to show the performance 
+  gain on this setup rather than the performance difference on different kinds of data type.
   
   The test expects the target cluster is created using ebs snapshot with 1 billion 1KB records and 
   has 3 shards, named shard-00, shard-01, shard-02. The collection has 10 indexes including 
@@ -16,8 +17,12 @@ Description: |
     1. Turning off balancer and make the sharded collection exists on only 1 shard.
     4. Running read and write operations on the collection while it is being resharded to 2 shards.
     5. Running read and write operations on the collection while it is being resharded to 3 shards.
-    
 
+  All documents are generated through genny' data loader where the integer and length of short 
+  string fields are randomly generated. The fields are designed like to form different combinations 
+  of indexes. The goal of having 10 indexes is to test resharding performance with indexes and the 
+  number 10 comes from design, which is arbitrary from testing perspective.
+    
   The inserted documents have the following form:
 
       {
@@ -70,6 +75,9 @@ GlobalDefaults:
   ShardName1: &Shard1 shard-01
   ShardName2: &Shard2 shard-02
 
+  # The CRUD operations here are to test that resharding won't fail with CRUD operations. We keep 
+  # the rate small so it won't significantly affect the resharding performance. That says, these
+  # CRUD operations should keep minimal and should not slow down resharding.
   ReadRate: &ReadRate 100 per 1 second
   WriteRate: &WriteRate 10 per 10 seconds  # Keep the writes slow to pass critical section.
 

--- a/src/workloads/sharding/ReshardCollectionWithIndexes.yml
+++ b/src/workloads/sharding/ReshardCollectionWithIndexes.yml
@@ -1,8 +1,12 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/sharding"
 Description: |
-  This test expects the target cluster is created using ebs snapshot with 1 billion 1KB records 
-  and has 3 shards, named shard-00, shard-01, shard-02. The collection has 10 indexes including 
+  This test measures the time for a sharded cluster to reshard a collection from one shard to two 
+  shards then to three shards. It was added August 2023 as part of PM-2322, to demonstrate planned 
+  resharding performance improvements. 
+  
+  The test expects the target cluster is created using ebs snapshot with 1 billion 1KB records and 
+  has 3 shards, named shard-00, shard-01, shard-02. The collection has 10 indexes including 
   _id index, single-key index and compound index. The whole dataset is on 1 shard at the beginning.
   ReshardCollection should use same-key resharding and use shardDistribution parameter to reshard 
   into 2 shards then 3 shards. There will be random CRUD operations during resharding but should 
@@ -41,6 +45,12 @@ Description: |
         {num2:1, str2: 1}
       ]
 
+Keywords:
+- resharding
+- indexes
+- replication
+- collection copy
+
 GlobalDefaults:
   Nop: &Nop {Nop: true}
 
@@ -51,12 +61,11 @@ GlobalDefaults:
 
   DocumentCount: &DocumentCount 1_000_000_000  # for an approximate total of 1TB
   NumChunks: &NumChunks 1                # start with only 1 shard
+  NumChunksAfterResharding: &NumChunksAfterResharding 20000
+  # Each reshardCollection takes around 15h in past runs so 20h is a reasonable threshold to treat
+  # the reshardCollection as timed out.
   Timeout: &Timeout 72_000_000 # = 20 hours
 
-  ShardKeyValueMin: &ShardKeyValueMin 1
-  # We use 100x the number of chunks so that the $sample aggregation to choose the new split points
-  # has a wide range of distinct values to choose from. It could be even larger.
-  ShardKeyValueMax: &ShardKeyValueMax 1_000_000
   ShardName0: &Shard0 shard-00
   ShardName1: &Shard1 shard-01
   ShardName2: &Shard2 shard-02
@@ -126,7 +135,7 @@ Actors:
         key: {shardKey: 1}
         shardDistribution: [{shard: *Shard0}, {shard: *Shard1}]
         forceRedistribution: true
-        numInitialChunks: 20000
+        numInitialChunks: *NumChunksAfterResharding
   - Repeat: 1
     Database: admin
     Operations:
@@ -137,7 +146,7 @@ Actors:
         key: {shardKey: 1}
         shardDistribution: [{shard: *Shard0}, {shard: *Shard1}, {shard: *Shard2}]
         forceRedistribution: true
-        numInitialChunks: 20000
+        numInitialChunks: *NumChunksAfterResharding
 
 - Name: ReadCollectionBeingResharded
   Type: CrudActor

--- a/src/workloads/sharding/ReshardCollectionWithIndexes.yml
+++ b/src/workloads/sharding/ReshardCollectionWithIndexes.yml
@@ -200,9 +200,3 @@ Actors:
       PhaseConfig:
         LogEvery: 15 minutes
         Blocking: None
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - resharding-3shard.2023-08

--- a/src/workloads/sharding/ReshardCollectionWithIndexes.yml
+++ b/src/workloads/sharding/ReshardCollectionWithIndexes.yml
@@ -3,9 +3,10 @@ Owner: "@mongodb/sharding"
 Description: |
   This test expects the target cluster is created using ebs snapshot with 1 billion 1KB records 
   and has 3 shards, named shard-00, shard-01, shard-02. The collection has 10 indexes including 
-  _id index, single-key index and compound index. ReshardCollection should use same-key resharding 
-  and use shardDistribution parameter to reshard into 2 shards then 3 shards. There will be random 
-  CRUD operations during resharding but should run at a very low rate.
+  _id index, single-key index and compound index. The whole dataset is on 1 shard at the beginning.
+  ReshardCollection should use same-key resharding and use shardDistribution parameter to reshard 
+  into 2 shards then 3 shards. There will be random CRUD operations during resharding but should 
+  run at a very low rate.
 
   The workload consists of 3 phases:
     1. Turning off balancer and make the sharded collection exists on only 1 shard.
@@ -16,14 +17,14 @@ Description: |
   The inserted documents have the following form:
 
       {
-        _id: 10,
-        shardKey: 20,
-        counter: 0,
-        num1: 1,
-        num2: 2,
-        str1: 'abc',
-        str2: 'xyz',
-        padding: 'random string of bytes ...'
+        _id: integer(default _id index),
+        shardKey: integer(for the shard key),
+        counter: integer(used for counting updates),
+        num1: integer(random generated between [1, 1000000000]),
+        num2: integer(random generated between [1, 1000000000]),
+        str1: string(length <= 20),
+        str2: string(length <= 20),
+        padding: string(random string of bytes ...)
       }
 
   The indexes are:
@@ -50,7 +51,7 @@ GlobalDefaults:
 
   DocumentCount: &DocumentCount 1_000_000_000  # for an approximate total of 1TB
   NumChunks: &NumChunks 1                # start with only 1 shard
-  Timeout: &Timeout 360_000_000 # = 100 hours
+  Timeout: &Timeout 72_000_000 # = 20 hours
 
   ShardKeyValueMin: &ShardKeyValueMin 1
   # We use 100x the number of chunks so that the $sample aggregation to choose the new split points
@@ -78,13 +79,12 @@ Clients:
   Default:
     QueryOptions:
       maxPoolSize: 202
-      socketTimeoutMS: *Timeout  # = 100 hours
   # The reshardCollection command is expected to take a long to complete so we give the actor
   # running it a much higher socket timeout.
   ReshardCollection:
     QueryOptions:
       maxPoolSize: 1
-      socketTimeoutMS: *Timeout  # = 100 hours
+      socketTimeoutMS: *Timeout  # = 20 hours
 
 Actors:
 - Name: CreateShardedCollection
@@ -94,11 +94,10 @@ Actors:
   - Repeat: 1
     Database: admin
     Operations:
-    - OperationMetricsName: StopBalancer
+    - OperationMetricsName: DisableBalancer
       OperationName: AdminCommand
       OperationCommand:
         balancerStop: 1
-        maxTimeMS: *Timeout
     - OperationMetricsName: EnableSharding
       OperationName: AdminCommand
       OperationCommand:


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [PERF-4225](https://jira.mongodb.org/browse/PERF-4225)

**Whats Changed:**  
Add a workload for resharding with 10 indexes

**Patch testing results:**  
[Patch](https://spruce.mongodb.com/version/64cbcb7ca4cf47bf54dbdcc6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). The patch hasn't run successfully due to lack of available instance and long sys-perf queue.

**Workload Submission form:**  
[Form](https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform?edit2=2_ABaOnueG5Z-djqaIYwlIPrAzY5kbAC7mtqj-G6FpcajAukgf6ir-0hH56oObruNBoF3PxXI)

**Related PRs:**   
[dsi](https://github.com/10gen/dsi/pull/1369)
https://github.com/10gen/mongo/pull/14666
