### PR TITLE
Batch miscellaneous fixes for Genny

### DIFF
--- a/src/lamplib/src/genny/tasks/genny_runner.py
+++ b/src/lamplib/src/genny/tasks/genny_runner.py
@@ -1,8 +1,7 @@
-from typing import List
+import shlex
+import time
 
 import structlog
-import tempfile
-import shutil
 import os
 
 from genny.cmd_runner import run_command
@@ -63,9 +62,6 @@ def main_genny_runner(
         cmd.append(processed_workload)
 
         if hang:
-            import time
-            import shlex
-
             SLOG.info(
                 "Debug mode. Poplar is running. "
                 "Start genny_core (./build/src/driver/genny_core or ./dist/bin/genny_core) "


### PR DESCRIPTION
**Whats Changed:**  
This is to batch some miscellaneous fixes into one PR:
- [context.hpp](https://github.com/mongodb/genny/pull/925/files#diff-91bfd6be8c6be7eea49589d45d788b78164899e2a666e0dc8780b4228da9d40a): 
    + Use explicit `this` pointer (instead of implicit class member attributes) throughout for consistency and readability.
    + Rename `PhaseContext`'s private member attribute `ActorContext* _actor` to `ActorContext* _actorContext` to prevent confusion (as `ActorContext` and `Actor` are completely different: One `ActorContext` could map to multiple `Actor`'s). 
    + Code formatting done by linter.

**Related PRs:**
I accidentally discarded the above changes to context.hpp in https://github.com/mongodb/genny/pull/925