### PR TITLE
PERF-4514 Add sort by expression test case

### DIFF
--- a/src/workloads/query/SortByExpression.yml
+++ b/src/workloads/query/SortByExpression.yml
@@ -1,0 +1,91 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: >
+  This test exercises the scenario of sort by an expression with an $addFields preceding the $sort,
+  followed by a $project removing that field. This workload is designed to avoid repeated materialization
+  after every projection in SBE.
+
+Actors:
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: &db test
+    Threads: 1
+    CollectionCount: 1
+    # Choose a sufficiently small document count to keep from spilling to disk.
+    DocumentCount: 10000
+    BatchSize: &batchSize 10000
+    Document:
+      int: {^RandomInt: {min: 1, max: 100}}
+      str: {^RandomString: {length: 5, alphabet: "0123456789ABCDEFGabcdefg"}}
+  - &Nop {Nop: true}
+  - *Nop
+  - *Nop
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: admin
+  Phases:
+  - *Nop
+  - Repeat: 1
+  - *Nop
+  - *Nop
+
+- Name: SortByExpression
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 10
+    Database: *db
+    Operations:
+    - OperationMetricsName: SortByExpression
+      OperationName: RunCommand
+      OperationCommand:
+        aggregate: Collection0
+        pipeline:
+          [{$addFields: {lowerStr: {$toLower: "$str"}}}, {$sort: {lowerStr: 1}}, {$project: {lowerStr: 0}}]
+        cursor: {batchSize: *batchSize}
+  - *Nop
+
+- Name: SortByExpressionTwice
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    - *Nop
+    - *Nop
+    - *Nop
+    - Repeat: 10
+      Database: *db
+      Operations:
+        - OperationMetricsName: SortByExpressionTwice
+          OperationName: RunCommand
+          OperationCommand:
+            aggregate: Collection0
+            pipeline:
+              [
+                {$addFields: {lowerStr: {$toLower: "$str"}}}, {$sort: {lowerStr: 1}}, {$project: {lowerStr: 0}},
+                {$addFields: {upperStr: {$toUpper: "$str"}}}, {$sort: {upperStr: 1}}, {$project: {upperStr: 0}},
+              ]
+            cursor: {batchSize: *batchSize}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-sbe
+      - replica
+      - replica-all-feature-flags
+      - shard-lite
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4


### PR DESCRIPTION
This test exercises the scenario of sort by an expression with an $addFields preceding the $sort, followed by a $project removing that field. This workload is designed to avoid repeated materialization after every projection in SBE.