### PR TITLE
EVG-17874: Generate all tasks

### DIFF
--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -8,7 +8,7 @@ omegaconf==2.1.1
 pyyaml<=5.3.1
 requests==2.31.0
 yamllint==1.15.0
-shrub.py==1.1.0
+shrub.py==3.0.7
 black==22.10.0
 setuptools==65.7.0
 pytest==7.2.0

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -585,13 +585,15 @@ def auto_tasks(ctx: click.Context, tasks: str):
     required=True,
     help="An evergreen project file",
 )
+@click.option("--no-activate", default=False, is_flag=True, help="Ensure that generated tasks don't activate")
 @click.pass_context
-def auto_tasks_all(ctx: click.Context, project_file: str):
+def auto_tasks_all(ctx: click.Context, project_file: str, no_activate: bool):
     from genny.tasks import auto_tasks_all
 
     auto_tasks_all.main(
         project_file=project_file,
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
+        no_activate=no_activate,
     )
 
 

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -583,7 +583,7 @@ def auto_tasks(ctx: click.Context, tasks: str):
 @click.option(
     "--project-file",
     required=True,
-    help="An evergreen project file",
+    help="An evergreen project file, such as system_perf.yml",
 )
 @click.option("--no-activate", default=False, is_flag=True, help="Ensure that generated tasks don't activate")
 @click.pass_context

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -568,7 +568,29 @@ def auto_tasks(ctx: click.Context, tasks: str):
 
     auto_tasks.main(
         mode_name=tasks,
-        genny_repo_root=ctx.obj["GENNY_REPO_ROOT"],
+        workspace_root=ctx.obj["WORKSPACE_ROOT"],
+    )
+
+@cli.command(
+    name="auto-tasks-all",
+    help=(
+        "Determine which Genny workloads should be schedulable for a given evergreen yaml config. "
+        "Parses the config to find every build configuration."
+        "This is used by evergreen and allows new genny workloads to be created "
+        "without having to modify any repos outside of genny itself."
+    ),
+)
+@click.option(
+    "--project-file",
+    required=True,
+    help="An evergreen project file",
+)
+@click.pass_context
+def auto_tasks_all(ctx: click.Context, project_file: str):
+    from genny.tasks import auto_tasks_all
+
+    auto_tasks_all.main(
+        project_file=project_file,
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
     )
 

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -138,6 +138,12 @@ class CurrentBuildInfo:
         actual = self.conts[key]
         return any(actual == acceptable_value for acceptable_value in acceptable_values)
 
+    def __eq__(self, other):
+        return self.conts == other.conts
+
+    def __repr__(self):
+        return f"CurrentBuildInfo: {self.conts}"
+
 
 class GeneratedTask(NamedTuple):
     name: str
@@ -535,8 +541,8 @@ class ConfigWriter:
 
 
     @staticmethod
-    def configure_variant_tasks(config: Configuration, tasks: List[GeneratedTask], variant: str) -> None:
-        config.variant(variant).tasks([TaskSpec(task.name) for task in tasks])
+    def configure_variant_tasks(config: Configuration, tasks: List[GeneratedTask], variant: str, activate: bool = None) -> None:
+        config.variant(variant).tasks([TaskSpec(task.name).activate(activate) for task in tasks])
 
     @staticmethod
     def configure_all_tasks_modern(config: Configuration, tasks: List[GeneratedTask]) -> None:

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -575,6 +575,5 @@ def main(mode_name: str, workspace_root: str) -> None:
     tasks = repo.tasks(op=op, build=build)
 
     output_file = os.path.join(workspace_root, "build", "TaskJSON", "Tasks.json")
-    writer = ConfigWriter(op, build)
     config = ConfigWriter.create_config(op, build, tasks)
-    ConfigWriter.write_config(build.execution, tasks, output_file)
+    ConfigWriter.write_config(build.execution, config, output_file)

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -38,8 +38,6 @@ class YamlReader:
         :return: deserialized yaml file
         """
         joined = os.path.join(workspace_root, path)
-        if not os.path.exists(joined):
-            raise Exception(f"File {joined} not found.")
         with open(joined) as handle:
             return yaml.safe_load(handle)
 

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -429,9 +429,9 @@ class Repo:
 
 
     def all_workloads(self) -> List[Workload]:
-        all_files = self.lister.all_workload_files()
-        modified = self.lister.modified_workload_files()
         if self._all_workloads is None:
+            all_files = self.lister.all_workload_files()
+            modified = self.lister.modified_workload_files()
             self._all_workloads = [
                 Workload(
                     workspace_root=self.workspace_root,

--- a/src/lamplib/src/genny/tasks/auto_tasks_all.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_all.py
@@ -1,0 +1,58 @@
+from typing import List
+import os
+import yaml
+import structlog
+from shrub.config import Configuration
+
+from genny.tasks.auto_tasks import (
+    CurrentBuildInfo,
+    WorkloadLister,
+    Repo,
+    ConfigWriter,
+    YamlReader,
+)
+
+SLOG = structlog.get_logger(__name__)
+
+def get_all_builds(global_expansions: dict[str, str], project_file_path: str) -> List[CurrentBuildInfo]:
+    """
+    Attempts to compute the expansions 
+    """
+    with open(project_file_path) as project_file:
+        project = yaml.safe_load(project_file)
+    variants = project["buildvariants"]
+    all_builds = []
+    for variant in variants:
+        if "expansions" in variant and "mongodb_setup" in variant["expansions"]:
+            build_info_dict = {}
+            build_info_dict.update(global_expansions)
+            build_info_dict.update(variant["expansions"])
+            build_info_dict["build_variant"] = variant["name"]
+            all_builds.append(CurrentBuildInfo(build_info_dict))
+    return all_builds
+
+
+def main(project_file: str, workspace_root: str) -> None:
+    reader = YamlReader()
+    global_expansions = reader.load(workspace_root, "expansions.yml")
+    execution = int(global_expansions["execution"])
+    builds = get_all_builds(global_expansions, project_file)
+    
+    lister = WorkloadLister(workspace_root=workspace_root)
+    repo = Repo(lister=lister, reader=reader, workspace_root=workspace_root)
+
+    all_tasks = repo.all_tasks()
+
+    config = Configuration()
+    ConfigWriter.configure_all_tasks_modern(config, all_tasks)
+    for build in builds:
+
+        build_tasks = repo.variant_tasks(build)
+        if len(build_tasks) > 0:
+            SLOG.info(f"Generating auto-tasks for variant: {build.variant}")
+            ConfigWriter.configure_variant_tasks(config, build_tasks, build.variant)
+        else:
+            SLOG.info(f"No auto-tasks for variant: {build.variant}")
+
+    output_file = os.path.join(workspace_root, "build", "TaskJSON", "Tasks.json")
+    ConfigWriter.write_config(execution, config, output_file)

--- a/src/lamplib/src/genny/tasks/auto_tasks_all.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_all.py
@@ -1,5 +1,6 @@
 from typing import List
 import os
+import sys
 import yaml
 import structlog
 from shrub.config import Configuration
@@ -48,7 +49,11 @@ def create_configuration(repo: Repo, builds: List[CurrentBuildInfo], no_activate
 
 def main(project_file: str, workspace_root: str, no_activate: bool) -> None:
     reader = YamlReader()
-    global_expansions = reader.load(workspace_root, "expansions.yml")
+    try:
+        global_expansions = reader.load(workspace_root, "expansions.yml")
+    except FileNotFoundError:
+        SLOG.error(f"Evergreen expansions file {os.path.join(workspace_root, 'expansions.yml')} does not exist. Ensure this file exists and that it is in the correct location.")
+        sys.exit(1)
     execution = int(global_expansions["execution"])
     builds = get_all_builds(global_expansions, project_file)
 

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -58,7 +58,6 @@ class BaseTestClass(unittest.TestCase):
         # Create "dumb" mocks.
         lister: WorkloadLister = MagicMock(name="lister", spec=WorkloadLister, instance=True)
         reader: YamlReader = MockReader(given_files)
-        genny_repo_root = os.path.join(self.workspace_root, "/src/genny")
         # Make them smarter.
         lister.all_workload_files.return_value = [
             v.base_name

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -78,9 +78,8 @@ class BaseTestClass(unittest.TestCase):
         op = OpName.from_flag(and_mode)
         repo = Repo(lister, reader, workspace_root=self.workspace_root)
         tasks = repo.tasks(op, build)
-        writer = ConfigWriter(op, build)
 
-        config = writer.write(tasks, None)
+        config = ConfigWriter.create_config(op, build, tasks)
         parsed = json.loads(config.to_json())
         try:
             self.assertDictEqual(then_writes, parsed)
@@ -920,8 +919,7 @@ def test_dry_run_all_tasks():
             tasks = repo.tasks(op=op, build=build)
             os.path.join(workspace_root, "build", "TaskJSON", "Tasks.json")
 
-            writer = ConfigWriter(op, build)
-            writer.write(tasks, None)
+            ConfigWriter.create_config(op, build, tasks)
     except Exception as e:
         SLOG.error(
             "'./run-genny auto-tasks --tasks all_tasks' is failing. "

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -157,6 +157,7 @@ class AutoTasksTests(BaseTestClass):
             ],
             and_mode="all_tasks",
             then_writes={
+                "exec_timeout_secs": 64800,
                 "tasks": [
                     {
                         "name": "empty_unmodified",
@@ -307,7 +308,6 @@ class AutoTasksTests(BaseTestClass):
                         "priority": 5,
                     },
                 ],
-                "timeout": 64800,
             },
             to_file="./build/TaskJSON/Tasks.json",
         )
@@ -907,18 +907,15 @@ def test_dry_run_all_tasks():
             f"This is set when you run through the 'run-genny' wrapper"
         )
     try:
-        with patch.object(CurrentBuildInfo, "expansions", return_value={}), patch.object(
-            YamlReader, "load", return_value={"execution": "0"}
-        ):
-            reader = YamlReader()
-            build = CurrentBuildInfo(reader=reader, workspace_root=workspace_root)
-            op = OpName.from_flag("all_tasks")
-            lister = WorkloadLister(workspace_root=workspace_root)
-            repo = Repo(lister=lister, reader=reader, workspace_root=workspace_root)
-            tasks = repo.tasks(op=op, build=build)
-            os.path.join(workspace_root, "build", "TaskJSON", "Tasks.json")
+        build = CurrentBuildInfo({"build_variant": "Test Variant", "execution": 1})
+        op = OpName.from_flag("all_tasks")
+        lister = WorkloadLister(workspace_root=workspace_root)
+        reader = YamlReader()
+        repo = Repo(lister=lister, reader=reader, workspace_root=workspace_root)
+        tasks = repo.tasks(op=op, build=build)
+        os.path.join(workspace_root, "build", "TaskJSON", "Tasks.json")
 
-            ConfigWriter.create_config(op, build, tasks)
+        ConfigWriter.create_config(op, build, tasks)
     except Exception as e:
         SLOG.error(
             "'./run-genny auto-tasks --tasks all_tasks' is failing. "

--- a/src/lamplib/src/tests/test_auto_tasks_all.py
+++ b/src/lamplib/src/tests/test_auto_tasks_all.py
@@ -1,0 +1,339 @@
+import json
+import shutil
+import unittest
+import os
+from typing import NamedTuple, List, Optional
+from unittest.mock import MagicMock, mock_open
+from unittest.mock import patch
+import structlog
+
+from genny.tasks.auto_tasks import (
+    CurrentBuildInfo,
+    OpName,
+    WorkloadLister,
+    Repo,
+    ConfigWriter,
+    YamlReader,
+)
+from genny.tasks.auto_tasks_all import create_configuration, get_all_builds
+import genny.tasks.auto_tasks_all
+from tests.test_auto_tasks import MockFile, MockReader
+
+SLOG = structlog.get_logger(__name__)
+
+
+class BaseTestClass(unittest.TestCase):
+    def setUp(self):
+        self.workspace_root = "."
+
+    def cleanUp(self):
+        shutil.rmtree(self.workspace_root)
+
+    def assert_result(
+        self,
+        given_project_file: MockFile,
+        and_expansion_file: MockFile,
+        and_workload_files: List[MockFile],
+        and_mode: str,
+        then_writes: dict,
+        to_file: str,
+    ):
+        # Create "dumb" mocks.
+        lister: WorkloadLister = MagicMock(name="lister", spec=WorkloadLister, instance=True)
+        reader: YamlReader = MockReader(given_files + [given_project_file, and_expansion_file])
+        # Make them smarter.
+        lister.all_workload_files.return_value = [v.base_name for v in and_workload_files]
+        lister.modified_workload_files.return_value = [
+            v.base_name for v in and_workload_files if v.modified
+        ]
+
+        # And send them off into the world.
+        expansions = reader.load(self.workspace_root, "expansions.yml")
+        build = CurrentBuildInfo(expansions)
+        op = OpName.from_flag(and_mode)
+        repo = Repo(lister, reader, workspace_root=self.workspace_root)
+        tasks = repo.tasks(op, build)
+
+        config = ConfigWriter.create_config(op, build, tasks)
+        parsed = json.loads(config.to_json())
+        try:
+            self.assertDictEqual(then_writes, parsed)
+        except AssertionError:
+            print(parsed)
+            raise
+
+
+TIMEOUT_COMMAND = {
+    "command": "timeout.update",
+    "params": {"exec_timeout_secs": 86400, "timeout_secs": 7200},
+}
+
+
+def expansions_mock(exp_vars) -> MockFile:
+    yaml_conts = {"build_variant": "some-build-variant", "execution": "0"}
+    yaml_conts.update(exp_vars)
+    return MockFile(
+        base_name="expansions.yml",
+        modified=False,
+        yaml_conts=yaml_conts,
+    )
+
+
+def make_auto_run(name: str, mongodb_setup: str):
+    return MockFile(
+        base_name=f"src/genny/src/workloads/src/{name}.yml",
+        modified=True,
+        yaml_conts={"AutoRun": [{"When": {"mongodb_setup": {"$eq": mongodb_setup}}}]},
+    )
+
+
+class AutoTasksTests(BaseTestClass):
+    def test_generate_all(self):
+        """
+        Tests generating all tasks for a given parsed list of variants in a config file.
+        Specifically, tasks a, b, c and c2 correspond to variants/mongodb_setups in the config file,
+        while task d does not. This should mean that we generate variants that run a, b, c, and c2
+        but no variant should run d.
+        """
+        EXPECTED = {
+            "tasks": [
+                {
+                    "name": "task_a",
+                    "commands": [
+                        TIMEOUT_COMMAND,
+                        {
+                            "func": "f_run_dsi_workload",
+                            "vars": {
+                                "test_control": "task_a",
+                                "auto_workload_path": "src/genny/src/workloads/src/TaskA.yml",
+                            },
+                        },
+                    ],
+                    "priority": 5,
+                },
+                {
+                    "name": "task_b",
+                    "commands": [
+                        TIMEOUT_COMMAND,
+                        {
+                            "func": "f_run_dsi_workload",
+                            "vars": {
+                                "test_control": "task_b",
+                                "auto_workload_path": "src/genny/src/workloads/src/TaskB.yml",
+                            },
+                        },
+                    ],
+                    "priority": 5,
+                },
+                {
+                    "name": "task_c",
+                    "commands": [
+                        TIMEOUT_COMMAND,
+                        {
+                            "func": "f_run_dsi_workload",
+                            "vars": {
+                                "test_control": "task_c",
+                                "auto_workload_path": "src/genny/src/workloads/src/TaskC.yml",
+                            },
+                        },
+                    ],
+                    "priority": 5,
+                },
+                {
+                    "name": "task_c2",
+                    "commands": [
+                        TIMEOUT_COMMAND,
+                        {
+                            "func": "f_run_dsi_workload",
+                            "vars": {
+                                "test_control": "task_c2",
+                                "auto_workload_path": "src/genny/src/workloads/src/TaskC2.yml",
+                            },
+                        },
+                    ],
+                    "priority": 5,
+                },
+                {
+                    # This task is generated  but not included in any variants.
+                    "name": "task_d",
+                    "commands": [
+                        TIMEOUT_COMMAND,
+                        {
+                            "func": "f_run_dsi_workload",
+                            "vars": {
+                                "test_control": "task_d",
+                                "auto_workload_path": "src/genny/src/workloads/src/TaskD.yml",
+                            },
+                        },
+                    ],
+                    "priority": 5,
+                },
+            ],
+            "buildvariants": [
+                {"name": "a", "tasks": [{"name": "task_a"}]},
+                {"name": "b", "tasks": [{"name": "task_b"}]},
+                {"name": "c", "tasks": [{"name": "task_c"}, {"name": "task_c2"}]},
+            ],
+            "exec_timeout_secs": 64800,
+        }
+
+        workload_files = [
+            make_auto_run("TaskA", "a_setup"),
+            make_auto_run("TaskB", "b_setup"),
+            make_auto_run("TaskC", "c_setup"),
+            make_auto_run("TaskC2", "c_setup"),
+            make_auto_run("TaskD", "d_setup"),
+        ]
+
+        reader: YamlReader = MockReader(workload_files)
+        lister: WorkloadLister = MagicMock(name="lister", spec=WorkloadLister, instance=True)
+
+        lister.all_workload_files.return_value = [v.base_name for v in workload_files]
+        lister.modified_workload_files.return_value = [
+            v.base_name for v in workload_files if v.modified
+        ]
+
+        build_infos = [
+            CurrentBuildInfo(
+                {
+                    "build_variant": "a",
+                    "mongodb_setup": "a_setup",
+                    "execution": "0",
+                }
+            ),
+            CurrentBuildInfo(
+                {
+                    "build_variant": "b",
+                    "mongodb_setup": "b_setup",
+                    "execution": "0",
+                }
+            ),
+            CurrentBuildInfo(
+                {
+                    "build_variant": "c",
+                    "mongodb_setup": "c_setup",
+                    "execution": "0",
+                }
+            ),
+        ]
+
+        expected = {}
+
+        repo = Repo(lister, reader, workspace_root=".")
+        config = create_configuration(repo, build_infos, False)
+
+        parsed = json.loads(config.to_json())
+        self.assertEqual(EXPECTED, parsed)
+
+    def test_parse_project_file(self):
+        """
+        Simple test for parsing a YAML project file from Evergreen. Checks that we can find both 
+        build variants and get the expansions from each of them.
+        """
+
+        YAML_INPUT = """
+tasks: 
+  - name: bestbuy_agg_merge_target_hashed
+    priority: 5
+    commands:
+      - func: f_run_dsi_workload
+        vars:
+        test_control: "bestbuy_agg_merge_target_hashed"
+buildvariants:
+  - name: task_generation
+    display_name: Task Generation
+    cron: "0 0 1 1 *"  # Every year starting 1/1 at 00:00
+    expansions:
+      platform: linux
+      project_dir: dsi
+    run_on:
+      - amazon2-build
+    tasks:
+      - name: schedule_global_auto_tasks
+  - name: linux-standalone.2022-11
+    display_name: Linux Standalone 2022-11
+    cron: "0 0 * * *"  # Everyday at 00:00
+    expansions:
+      mongodb_setup_release: 2022-11
+      mongodb_setup: standalone
+      infrastructure_provisioning_release: 2022-11
+      infrastructure_provisioning: single
+      workload_setup: 2022-11
+      platform: linux
+      project_dir: dsi
+      authentication: enabled
+      storageEngine: wiredTiger
+      compile_variant: "-arm64"
+    run_on:
+      - "rhel70-perf-single"
+    tasks:
+      - name: bestbuy_agg_merge_target_hashed
+
+  - name: linux-standalone-all-feature-flags.2022-11
+    display_name: Linux Standalone (all feature flags) 2022-11
+    cron: "0 0 * * 2,4,6"  # Tuesday, Thursday and Saturday at 00:00
+    expansions:
+      mongodb_setup_release: 2022-11
+      mongodb_setup: standalone-all-feature-flags
+      infrastructure_provisioning_release: 2022-11
+      infrastructure_provisioning: single
+      workload_setup: 2022-11
+      platform: linux
+      project_dir: dsi
+      authentication: enabled
+      storageEngine: wiredTiger
+      compile_variant: "-arm64"
+    run_on:
+      - "rhel70-perf-single"
+    tasks:
+      - name: schedule_patch_auto_tasks
+        """
+
+        m = mock_open(read_data=YAML_INPUT)
+        reader: YamlReader = YamlReader()
+
+        with patch.object(genny.tasks.auto_tasks_all, "open", m), patch(
+            "os.path.exists", lambda x: True
+        ):
+            all_builds = get_all_builds({"execution": 0, "build_variant": "Generate"}, "ignored")
+        self.assertEqual(
+            all_builds,
+            [
+                CurrentBuildInfo(
+                    {
+                        "execution": 0,
+                        "build_variant": "linux-standalone.2022-11",
+                        "mongodb_setup_release": "2022-11",
+                        "mongodb_setup": "standalone",
+                        "infrastructure_provisioning_release": "2022-11",
+                        "infrastructure_provisioning": "single",
+                        "workload_setup": "2022-11",
+                        "platform": "linux",
+                        "project_dir": "dsi",
+                        "authentication": "enabled",
+                        "storageEngine": "wiredTiger",
+                        "compile_variant": "-arm64",
+                    }
+                ),
+                CurrentBuildInfo(
+                    {
+                        "execution": 0,
+                        "build_variant": "linux-standalone-all-feature-flags.2022-11",
+                        "mongodb_setup_release": "2022-11",
+                        "mongodb_setup": "standalone-all-feature-flags",
+                        "infrastructure_provisioning_release": "2022-11",
+                        "infrastructure_provisioning": "single",
+                        "workload_setup": "2022-11",
+                        "platform": "linux",
+                        "project_dir": "dsi",
+                        "authentication": "enabled",
+                        "storageEngine": "wiredTiger",
+                        "compile_variant": "-arm64",
+                    }
+                ),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [EVG-17874](https://jira.mongodb.org/browse/EVG-17874)

**Whats Changed:**  
This is a draft PR for switching to having a single task generation task for all the variants in Genny. The advantage of this is that generated tasks will be scheduled only when other variant tasks are scheduled, but will also always be available to run on any waterfall build, allowing individual tasks to be run. 

This change also makes it possible to generate tasks in a patch build without running all of them, in case there is a specific generated task that needs to be run.

See https://github.com/mongodb/mongo/blob/EVG-17874-taskgen-test/etc/system_perf_taskgen_test.yml#L455 for how this would be used in a sysperf test. That file is a modified sys-perf that doesn't actually run DSI ever in order to test scheduling

See https://spruce.mongodb.com/commits/sys-perf-taskgen-test?view=FAILED to view how scheduling works. 
