### PR TITLE
PERF-4516 Implement Genny preprocessor key FormatString

### DIFF
--- a/src/lamplib/src/genny/tasks/preprocess.py
+++ b/src/lamplib/src/genny/tasks/preprocess.py
@@ -241,7 +241,7 @@ class _WorkloadParser(object):
             out = self._replace_numexpr(value)
         elif key == "^FlattenOnce":
             out = self._replace_flattenonce(value)
-        elif key == "^FormatString":
+        elif key == "^PreprocessorFormatString":
             out = self._replace_formatstr(value)
         elif key == "ActorTemplates":
             self._parse_templates(value)
@@ -346,7 +346,7 @@ class _WorkloadParser(object):
             raise ParseException(msg)
 
     def _replace_formatstr(self, input):
-        OP_KEY = "^FormatString"
+        OP_KEY = "^PreprocessorFormatString"
         FORMAT_KEY = "format"
         ARGS_KEY = "withArgs"
 
@@ -371,8 +371,7 @@ class _WorkloadParser(object):
                 f"Node source: {input}\n"
                 f"Faulting key: {e}\n"
             )
-            print(msg, file=sys.stderr)
-            return {OP_KEY: self._recursive_parse(input)}
+            raise ParseException(msg)
         except Exception as e:
             msg = (
                 f"Warning: not preprocessing '{OP_KEY}' because:\n"
@@ -380,8 +379,7 @@ class _WorkloadParser(object):
                 f"Node source: {input}\n"
                 f"Exception: {e}\n"
             )
-            print(msg, file=sys.stderr)
-            return {OP_KEY: self._recursive_parse(input)}
+            raise ParseException(msg)
 
     def _parse_templates(self, templates):
         for template_node in templates:

--- a/src/lamplib/src/tests/test_preprocess.py
+++ b/src/lamplib/src/tests/test_preprocess.py
@@ -632,7 +632,7 @@ Test: {^NumExpr: {withExpression: "a - b", andValues: {a: *Param1, b: "25"}}}
     def test_formatstring_with_preprocessable_args(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Document:
-  ^FormatString:
+  ^PreprocessorFormatString:
     format: "%s %04d"
     withArgs:
     - Test
@@ -652,12 +652,12 @@ Document: Test 0012
     def test_formatstring_with_invalid_args(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Document:
-- ^FormatString:
+- ^PreprocessorFormatString:
     format: "%s %04d"
     withArgs:
     - Test
     - [0, 0, 1, 2]
-- ^FormatString:
+- ^PreprocessorFormatString:
     format: "%04d"
     withArgs:
     - ^Array:
@@ -665,90 +665,19 @@ Document:
         of: 1
 """
 
-        expected = """SchemaVersion: '2018-07-01'
-Document:
-- ^FormatString:
-    format: '%s %04d'
-    withArgs:
-    - Test
-    - - 0
-      - 0
-      - 1
-      - 2
-- ^FormatString:
-    format: '%04d'
-    withArgs:
-    - ^Array:
-        number: 4
-        of: 1
-"""
-
-        self._assertYaml(yaml_input, expected)
+        self._assertParseException(yaml_input)
 
     def test_formatstring_with_invalid_arg_type(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Document:
-  ^FormatString:
+  ^PreprocessorFormatString:
     format: "%s %04d"
     withArgs:
     - Test
     - "0012"
 """
 
-        expected = """SchemaVersion: '2018-07-01'
-Document:
-  ^FormatString:
-    format: '%s %04d'
-    withArgs:
-    - Test
-    - '0012'
-"""
-
-        self._assertYaml(yaml_input, expected)
-
-    def test_formatstring_with_mixed_success(self):
-        yaml_input = """SchemaVersion: 2018-07-01
-Document:
-- ^FormatString:
-    format: "%s %04d"
-    withArgs:
-    - Test
-    - ^NumExpr:
-        withExpression: "a * b"
-        andValues:
-          a: 3
-          b: 4
-- ^FormatString:
-    format: '%s %04d'
-    withArgs:
-    - Test
-    - [0, 0, 1, 2]
-- ^FormatString:
-    format: "%s %04d"
-    withArgs:
-    - Test
-    - "0012"
-"""
-
-        expected = """SchemaVersion: '2018-07-01'
-Document:
-- Test 0012
-- ^FormatString:
-    format: '%s %04d'
-    withArgs:
-    - Test
-    - - 0
-      - 0
-      - 1
-      - 2
-- ^FormatString:
-    format: '%s %04d'
-    withArgs:
-    - Test
-    - '0012'
-"""
-
-        self._assertYaml(yaml_input, expected)
+        self._assertParseException(yaml_input)
 
     def test_flatten_array_valid_type_arrays(self):
         yaml_input = """SchemaVersion: 2018-07-01

--- a/src/lamplib/src/tests/test_preprocess.py
+++ b/src/lamplib/src/tests/test_preprocess.py
@@ -629,6 +629,127 @@ Test: {^NumExpr: {withExpression: "a - b", andValues: {a: *Param1, b: "25"}}}
 """
         self._assertParseException(yaml_input)
 
+    def test_formatstring_with_preprocessable_args(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Document:
+  ^FormatString:
+    format: "%s %04d"
+    withArgs:
+    - Test
+    - ^NumExpr:
+        withExpression: "a * b"
+        andValues:
+          a: 3
+          b: 4
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Document: Test 0012
+"""
+
+        self._assertYaml(yaml_input, expected)
+
+    def test_formatstring_with_invalid_args(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Document:
+- ^FormatString:
+    format: "%s %04d"
+    withArgs:
+    - Test
+    - [0, 0, 1, 2]
+- ^FormatString:
+    format: "%04d"
+    withArgs:
+    - ^Array:
+        number: 4
+        of: 1
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Document:
+- ^FormatString:
+    format: '%s %04d'
+    withArgs:
+    - Test
+    - - 0
+      - 0
+      - 1
+      - 2
+- ^FormatString:
+    format: '%04d'
+    withArgs:
+    - ^Array:
+        number: 4
+        of: 1
+"""
+
+        self._assertYaml(yaml_input, expected)
+
+    def test_formatstring_with_invalid_arg_type(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Document:
+  ^FormatString:
+    format: "%s %04d"
+    withArgs:
+    - Test
+    - "0012"
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Document:
+  ^FormatString:
+    format: '%s %04d'
+    withArgs:
+    - Test
+    - '0012'
+"""
+
+        self._assertYaml(yaml_input, expected)
+
+    def test_formatstring_with_mixed_success(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Document:
+- ^FormatString:
+    format: "%s %04d"
+    withArgs:
+    - Test
+    - ^NumExpr:
+        withExpression: "a * b"
+        andValues:
+          a: 3
+          b: 4
+- ^FormatString:
+    format: '%s %04d'
+    withArgs:
+    - Test
+    - [0, 0, 1, 2]
+- ^FormatString:
+    format: "%s %04d"
+    withArgs:
+    - Test
+    - "0012"
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Document:
+- Test 0012
+- ^FormatString:
+    format: '%s %04d'
+    withArgs:
+    - Test
+    - - 0
+      - 0
+      - 1
+      - 2
+- ^FormatString:
+    format: '%s %04d'
+    withArgs:
+    - Test
+    - '0012'
+"""
+
+        self._assertYaml(yaml_input, expected)
+
     def test_flatten_array_valid_type_arrays(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Document:

--- a/src/workloads/docs/HelloWorld.yml
+++ b/src/workloads/docs/HelloWorld.yml
@@ -33,10 +33,10 @@ Actors:
       ^NumExpr:
         withExpression: "messages / threads"
         andValues: {messages: *TotalMessageCount, threads: *Threads}
-  # To concatenate strings, use the ^FormatString preprocessor directive. It works similarly to the
-  # ^FormatString generator.
+  # To concatenate strings, use the ^PreprocessorFormatString preprocessor directive. It works
+  # similarly to the ^FormatString generator.
   - Message:
-      ^FormatString:
+      ^PreprocessorFormatString:
         format: "%s Phase %d"
         withArgs: ["Hello", 4]
     Repeat: 1

--- a/src/workloads/docs/HelloWorld.yml
+++ b/src/workloads/docs/HelloWorld.yml
@@ -33,6 +33,12 @@ Actors:
       ^NumExpr:
         withExpression: "messages / threads"
         andValues: {messages: *TotalMessageCount, threads: *Threads}
+  # To concatenate strings, use the ^FormatString preprocessor directive. It works similarly to the
+  # ^FormatString generator.
+  - Message:
+      ^FormatString:
+        format: "%s Phase %d"
+        withArgs: ["Hello", 4]
 
 # As an alternate phase syntax, use the following for an actor that
 # runs a total of 3 phases, active in phases named 0 and 2 and Nop for the rest:

--- a/src/workloads/docs/HelloWorld.yml
+++ b/src/workloads/docs/HelloWorld.yml
@@ -39,6 +39,7 @@ Actors:
       ^FormatString:
         format: "%s Phase %d"
         withArgs: ["Hello", 4]
+    Repeat: 1
 
 # As an alternate phase syntax, use the following for an actor that
 # runs a total of 3 phases, active in phases named 0 and 2 and Nop for the rest:


### PR DESCRIPTION
**Jira Ticket:** PERF-4516

**Whats Changed:**  
Add `^FormatString` as a preprocessor key. It mimics the `^FormatString` value generator. If `^FormatString` fails at the preprocess step, it'll ignore the failure and let the value generator version of `^FormatString` handle it.

**Patch testing results:**  
If applicable, link a patch test showing code changes running successfully