### PR TITLE
PERF-4517 Implement Genny preprocessor key FlattenArray

### DIFF
--- a/src/lamplib/src/genny/tasks/preprocess.py
+++ b/src/lamplib/src/genny/tasks/preprocess.py
@@ -239,8 +239,8 @@ class _WorkloadParser(object):
             out = self._replace_param(value)
         elif key == "^NumExpr":
             out = self._replace_numexpr(value)
-        elif key == "^FlattenArray":
-            out = self._replace_flattenarr(value)
+        elif key == "^FlattenOnce":
+            out = self._replace_flattenonce(value)
         elif key == "ActorTemplates":
             self._parse_templates(value)
         elif key == "ActorFromTemplate":
@@ -330,8 +330,8 @@ class _WorkloadParser(object):
             )
             raise ParseException(msg)
 
-    def _replace_flattenarr(self, input):
-        OP_KEY = "^FlattenArray"
+    def _replace_flattenonce(self, input):
+        OP_KEY = "^FlattenOnce"
 
         parsed_values = self._recursive_parse(input)
 

--- a/src/lamplib/src/tests/test_preprocess.py
+++ b/src/lamplib/src/tests/test_preprocess.py
@@ -628,3 +628,71 @@ Param1: &Param1 {^Parameter: {Name: "Name1", Default: 100}}
 Test: {^NumExpr: {withExpression: "a - b", andValues: {a: *Param1, b: "25"}}}
 """
         self._assertParseException(yaml_input)
+
+    def test_flatten_array_valid_type_arrays(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Document:
+  ^FlattenArray:
+  - 1
+  - "2"
+  - [3, "4"]
+  - ^FlattenArray: [5, [6, "7", ["8", 9]]]
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Document:
+- 1
+- '2'
+- 3
+- '4'
+- 5
+- 6
+- '7'
+- - '8'
+  - 9
+"""
+
+        self._assertYaml(yaml_input, expected)
+
+    def test_flatten_array_valid_type_dict(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Document:
+  ^FlattenArray:
+    1: 2
+    3: 4
+    5: 6
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Document:
+- 1
+- 3
+- 5
+"""
+
+        self._assertYaml(yaml_input, expected)
+
+    def test_flatten_array_invalid_type_int(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Document:
+  ^FlattenArray: 1
+"""
+
+        self._assertParseException(yaml_input)
+
+    def test_flatten_array_valid_type_str(self):
+        yaml_input = """SchemaVersion: 2018-07-01
+Document:
+  ^FlattenArray: "12345"
+"""
+
+        expected = """SchemaVersion: '2018-07-01'
+Document:
+- '1'
+- '2'
+- '3'
+- '4'
+- '5'
+"""
+
+        self._assertYaml(yaml_input, expected)

--- a/src/lamplib/src/tests/test_preprocess.py
+++ b/src/lamplib/src/tests/test_preprocess.py
@@ -632,11 +632,11 @@ Test: {^NumExpr: {withExpression: "a - b", andValues: {a: *Param1, b: "25"}}}
     def test_flatten_array_valid_type_arrays(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Document:
-  ^FlattenArray:
+  ^FlattenOnce:
   - 1
   - "2"
   - [3, "4"]
-  - ^FlattenArray: [5, [6, "7", ["8", 9]]]
+  - ^FlattenOnce: [5, [6, "7", ["8", 9, [], [], [1], [[[1]], [False], [""]]]]]
 """
 
         expected = """SchemaVersion: '2018-07-01'
@@ -650,6 +650,12 @@ Document:
 - '7'
 - - '8'
   - 9
+  - []
+  - []
+  - - 1
+  - - - - 1
+    - - false
+    - - ''
 """
 
         self._assertYaml(yaml_input, expected)
@@ -657,7 +663,7 @@ Document:
     def test_flatten_array_valid_type_dict(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Document:
-  ^FlattenArray:
+  ^FlattenOnce:
     1: 2
     3: 4
     5: 6
@@ -675,7 +681,7 @@ Document:
     def test_flatten_array_invalid_type_int(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Document:
-  ^FlattenArray: 1
+  ^FlattenOnce: 1
 """
 
         self._assertParseException(yaml_input)
@@ -683,7 +689,7 @@ Document:
     def test_flatten_array_valid_type_str(self):
         yaml_input = """SchemaVersion: 2018-07-01
 Document:
-  ^FlattenArray: "12345"
+  ^FlattenOnce: "12345"
 """
 
         expected = """SchemaVersion: '2018-07-01'


### PR DESCRIPTION
**Jira Ticket:** PERF-4517

**Whats Changed:**  
Implement the `^FlattenArray` key, which reduces the dimensionality of an array by 1. For example:
- `[1, 2, 3, 4, 5, 6, 7, 8, 9]` -> `[1, 2, 3, 4, 5, 6, 7, 8, 9]`
- `[[1, 2, 3], 4, 5, 6, [7, [8, 9]]]` -> `[1, 2, 3, 4, 5, 6, 7, [8, 9]]`
- `"123456789"` -> `[1, 2, 3, 4, 5, 6, 7, 8, 9]`

**Patch testing results:**  
If applicable, link a patch test showing code changes running successfully