### PR TITLE
PERF-4520 Correct spelling of Evergreen variant for Big Sur arm64

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -119,7 +119,7 @@ buildvariants:
   - name: tg_compile_and_test_with_server_on_macos
 
 - name: macos-1100-arm64
-  display_name: macOS Bug Sur arm64
+  display_name: macOS Big Sur arm64
   modules: [mongo]
   run_on:
   - macos-1100-arm64


### PR DESCRIPTION
**Jira Ticket:** PERF-4520

**Whats Changed:**  
Update name of Evergreen build variant from "Bug Sur arm64" to "Big Sur arm64"