### PR TITLE
PERF-4523: Have IDHACK workloads run for 5 minutes instead of 30 seconds

### DIFF
--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -29,7 +29,7 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Duration: 30 seconds
+          Duration: 5 minutes
           Database: *Database
           Collection: *Collection
           Operations:

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -27,7 +27,7 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Duration: 30 seconds
+          Duration: 5 minutes
           Database: *Database
           Collection: *Collection
           Operations:

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -28,7 +28,7 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Duration: 30 seconds
+          Duration: 5 minutes
           Database: *Database
           Collection: *Collection
           Operations:

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -27,7 +27,7 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Duration: 30 seconds
+          Duration: 5 minutes
           Database: *Database
           Collection: *Collection
           Operations:


### PR DESCRIPTION
**Whats Changed:**  
When investigating PERF results from the IDHACK workloads, it often takes many days of repeated runs for the results to stabilize and remove significant noise. By having the workloads run for 5 minutes instead of 30 seconds, we'll be able to narrow down if noise is coming from the find commands, or the hardware, or something else. This hopefully will also help the results stabilize sooner.

**Patch testing results:**  
[Evergreen patch](https://spruce.mongodb.com/version/64d26292562343c2b650cc05/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
