### PR TITLE
EVG-20548 replace 'get_utf8()' to avoid deprecation warnings

### DIFF
--- a/src/cast_core/src/MoveRandomChunkToRandomShard.cpp
+++ b/src/cast_core/src/MoveRandomChunkToRandomShard.cpp
@@ -87,7 +87,7 @@ void MoveRandomChunkToRandomShard::run() {
 
                 // Find a destination shard different to the source.
                 bsoncxx::document::value notEqualDoc = bsoncxx::builder::stream::document()
-                    << "$ne" << chunk["shard"].get_utf8() << bsoncxx::builder::stream::finalize;
+                    << "$ne" << chunk["shard"].get_string() << bsoncxx::builder::stream::finalize;
                 bsoncxx::document::value shardFilter = bsoncxx::builder::stream::document()
                     << "_id" << notEqualDoc.view() << bsoncxx::builder::stream::finalize;
                 auto numShards = configDatabase["shards"].count_documents(shardFilter.view());
@@ -108,7 +108,7 @@ void MoveRandomChunkToRandomShard::run() {
                     << "moveChunk" << config->collectionNamespace << "bounds"
                     << bsoncxx::builder::stream::open_array << chunk["min"].get_value()
                     << chunk["max"].get_value() << bsoncxx::builder::stream::close_array << "to"
-                    << shard["_id"].get_utf8() << bsoncxx::builder::stream::finalize;
+                    << shard["_id"].get_string() << bsoncxx::builder::stream::finalize;
                 // This is only for better readability when logging.
                 auto bounds = bsoncxx::builder::stream::document()
                     << "bounds" << bsoncxx::builder::stream::open_array << chunk["min"].get_value()
@@ -116,8 +116,8 @@ void MoveRandomChunkToRandomShard::run() {
                     << bsoncxx::builder::stream::finalize;
                 BOOST_LOG_TRIVIAL(info) << "MoveChunkToRandomShardActor moving chunk "
                                         << bsoncxx::to_json(bounds.view())
-                                        << " from: " << chunk["shard"].get_utf8().value.to_string()
-                                        << " to: " << shard["_id"].get_utf8().value.to_string();
+                                        << " from: " << chunk["shard"].get_string().value.to_string()
+                                        << " to: " << shard["_id"].get_string().value.to_string();
                 _client->database("admin").run_command(moveChunkCmd.view());
             } catch (mongocxx::operation_exception& e) {
                 BOOST_THROW_EXCEPTION(MongoException(

--- a/src/cast_core/src/RollingCollections.cpp
+++ b/src/cast_core/src/RollingCollections.cpp
@@ -296,11 +296,11 @@ struct OplogTailer : public RunOperation {
     }
 
     std::optional<long> isRollingOplogEntry(const bsoncxx::document::view& doc) {
-        if (doc["op"].get_utf8().value.to_string() == "c") {
+        if (doc["op"].get_string().value.to_string() == "c") {
             auto object = doc["o"].get_document().value;
             auto it = object.find("create");
             if (it != object.end()) {
-                auto collectionName = object["create"].get_utf8().value.to_string();
+                auto collectionName = object["create"].get_string().value.to_string();
                 if (collectionName.substr(0, 2) == "r_") {
                     // It's a collection we care about,
                     // get the embedded millisecond time.

--- a/src/cast_core/test/CrudActorYamlTestRunner.cpp
+++ b/src/cast_core/test/CrudActorYamlTestRunner.cpp
@@ -114,10 +114,10 @@ void requireEvent(ApmEvent& event, YAML::Node requirements) {
         REQUIRE(expectedCollation.view() == actualCollation.view());
     }
     if (auto hint = requirements["hint"]; hint) {
-        REQUIRE(event.command["hint"].get_utf8().value == hint.as<std::string>());
+        REQUIRE(event.command["hint"].get_string().value == hint.as<std::string>());
     }
     if (auto comment = requirements["comment"]) {
-        REQUIRE(event.command["comment"].get_utf8().value == comment.as<std::string>());
+        REQUIRE(event.command["comment"].get_string().value == comment.as<std::string>());
     }
     if (auto limit = requirements["limit"]) {
         REQUIRE(event.command["limit"].get_int64() == limit.as<int64_t>());
@@ -168,7 +168,7 @@ void requireEvent(ApmEvent& event, YAML::Node requirements) {
         if (isNumeric(w)) {
             REQUIRE(event.command["writeConcern"]["w"].get_int32() == w.as<int32_t>());
         } else {
-            REQUIRE(event.command["writeConcern"]["w"].get_utf8().value == w.as<std::string>());
+            REQUIRE(event.command["writeConcern"]["w"].get_string().value == w.as<std::string>());
         }
     }
     if (auto j = requirements["writeConcern"]["j"]; j) {
@@ -184,7 +184,7 @@ void requireEvent(ApmEvent& event, YAML::Node requirements) {
         REQUIRE(event.command["bypassDocumentValidation"].get_bool() == bypass.as<bool>());
     }
     if (auto readPref = requirements["$readPreference"]["mode"]; readPref) {
-        REQUIRE(event.command["$readPreference"]["mode"].get_utf8().value ==
+        REQUIRE(event.command["$readPreference"]["mode"].get_string().value ==
                 readPref.as<std::string>());
     }
     if (auto staleness = requirements["$readPreference"]["maxStalenessSeconds"]) {

--- a/src/cast_core/test/MoveRandomChunkToRandomShard_test.cpp
+++ b/src/cast_core/test/MoveRandomChunkToRandomShard_test.cpp
@@ -96,7 +96,7 @@ TEST_CASE_METHOD(MongoTestFixture,
                 configDatabase["chunks"].find_one(chunksFilter.view(), chunkFindOptions);
             REQUIRE(chunkOpt.is_initialized());
 
-            auto initialShardId = chunkOpt.get().view()["shard"].get_utf8().value.to_string();
+            auto initialShardId = chunkOpt.get().view()["shard"].get_string().value.to_string();
 
             // Run the actor.
             genny::ActorHelper ah(nodes.root(), 1);
@@ -108,7 +108,7 @@ TEST_CASE_METHOD(MongoTestFixture,
 
             REQUIRE(afterMigrationChunkOpt.is_initialized());
             auto finalShardId =
-                afterMigrationChunkOpt.get().view()["shard"].get_utf8().value.to_string();
+                afterMigrationChunkOpt.get().view()["shard"].get_string().value.to_string();
 
             REQUIRE(initialShardId != finalShardId);
         } catch (const std::exception& e) {

--- a/src/cast_core/test/MultiCollectionQuery_test.cpp
+++ b/src/cast_core/test/MultiCollectionQuery_test.cpp
@@ -73,7 +73,7 @@ TEST_CASE_METHOD(MongoTestFixture, "MultiCollectionQuery", "[standalone][MultiCo
                 REQUIRE(event.command["limit"].get_int64() == 1);
                 REQUIRE(event.command["sort"].get_document().view() ==
                         BasicBson::make_document(BasicBson::kvp("a", 1)));
-                auto readMode = event.command["$readPreference"]["mode"].get_utf8().value;
+                auto readMode = event.command["$readPreference"]["mode"].get_string().value;
                 REQUIRE(std::string(readMode) == "primaryPreferred");
             }
 

--- a/src/gennylib/src/quiesce.cpp
+++ b/src/gennylib/src/quiesce.cpp
@@ -54,9 +54,9 @@ bool waitOplog(v1::Topology& topology) {
             if (members && members.type() == bsoncxx::type::k_array) {
                 bsoncxx::array::view members_view = members.get_array();
                 for (auto member : members_view) {
-                    std::string state(member["stateStr"].get_utf8().value);
+                    std::string state(member["stateStr"].get_string().value);
                     if (state != "PRIMARY" && state != "SECONDARY" && state != "ARBITER") {
-                        std::string name(member["name"].get_utf8().value);
+                        std::string name(member["name"].get_string().value);
                         BOOST_LOG_TRIVIAL(warning)
                             << "Cannot wait oplog, replset member " << name << " is " << state;
                         _successAcc = false;

--- a/src/gennylib/test/encryption_test.cpp
+++ b/src/gennylib/test/encryption_test.cpp
@@ -497,8 +497,8 @@ TEST_CASE("EncryptionContext outputs correct extra options document") {
         REQUIRE_NOTHROW(doc.view()["cryptSharedLibRequired"].get_bool());
         REQUIRE(doc.view()["cryptSharedLibRequired"].get_bool());
         REQUIRE(doc.view()["cryptSharedLibPath"]);
-        REQUIRE_NOTHROW(doc.view()["cryptSharedLibPath"].get_utf8());
-        REQUIRE(doc.view()["cryptSharedLibPath"].get_utf8().value == "/usr/lib/mongo_crypt_v1.so");
+        REQUIRE_NOTHROW(doc.view()["cryptSharedLibPath"].get_string());
+        REQUIRE(doc.view()["cryptSharedLibPath"].get_string().value == "/usr/lib/mongo_crypt_v1.so");
     }
 }
 TEST_CASE("EncryptionContext outputs correct schema map document") {
@@ -552,11 +552,11 @@ TEST_CASE("EncryptionContext outputs correct schema map document") {
     auto doc = encryption.generateSchemaMapDoc();
 
     REQUIRE_NOTHROW(doc.view()["accounts.balances"]["properties"].get_document());
-    REQUIRE_NOTHROW(doc.view()["accounts.balances"]["bsonType"].get_utf8());
+    REQUIRE_NOTHROW(doc.view()["accounts.balances"]["bsonType"].get_string());
 
     auto rootProperties = doc.view()["accounts.balances"]["properties"].get_document();
     REQUIRE_NOTHROW(rootProperties.view()["pii"]["properties"].get_document());
-    REQUIRE_NOTHROW(rootProperties.view()["pii"]["bsonType"].get_utf8());
+    REQUIRE_NOTHROW(rootProperties.view()["pii"]["bsonType"].get_string());
     REQUIRE_NOTHROW(rootProperties.view()["name"].get_document());
 
     auto piiProperties = rootProperties.view()["pii"]["properties"].get_document();
@@ -566,8 +566,8 @@ TEST_CASE("EncryptionContext outputs correct schema map document") {
     REQUIRE(rootProperties.view()["name"].get_document().view() == bsoncxx::from_json(expectedNameSchema));
     REQUIRE(piiProperties.view()["dob"].get_document().view() == bsoncxx::from_json(expectedDobSchema));
     REQUIRE(piiProperties.view()["ssn"].get_document().view() == bsoncxx::from_json(expectedSsnSchema));
-    REQUIRE(doc.view()["accounts.balances"]["bsonType"].get_utf8().value == "object");
-    REQUIRE(rootProperties.view()["pii"]["bsonType"].get_utf8().value == "object");
+    REQUIRE(doc.view()["accounts.balances"]["bsonType"].get_string().value == "object");
+    REQUIRE(rootProperties.view()["pii"]["bsonType"].get_string().value == "object");
 }
 
 TEST_CASE("EncryptionContext outputs correct encrypted fields map document") {
@@ -661,8 +661,8 @@ TEST_CASE("EncryptionContext outputs correct encrypted fields map document") {
     for (auto& subobj : fieldsArray.value) {
         REQUIRE_NOTHROW(subobj.get_document());
         auto subdoc = subobj.get_document();
-        REQUIRE_NOTHROW(subdoc.view()["path"].get_utf8());
-        auto path = subdoc.view()["path"].get_utf8();
+        REQUIRE_NOTHROW(subdoc.view()["path"].get_string());
+        auto path = subdoc.view()["path"].get_string();
 
         auto itr = expectedFieldsMap.find(path.value.to_string());
         REQUIRE(itr != expectedFieldsMap.end());

--- a/src/testlib/include/testlib/helpers.hpp
+++ b/src/testlib/include/testlib/helpers.hpp
@@ -55,7 +55,7 @@ inline std::string toString(int i) {
 template <typename Client>
 inline void dropAllDatabases(Client& client) {
     for (auto&& dbDoc : client.list_databases()) {
-        const auto dbName = dbDoc["name"].get_utf8().value;
+        const auto dbName = dbDoc["name"].get_string().value;
         const auto dbNameString = std::string(dbName);
         if (dbNameString != "admin" && dbNameString != "config" && dbNameString != "local") {
             client.database(dbName).drop();

--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -798,7 +798,7 @@ protected:
 void format_element(boost::format& message, bsoncxx::document::element val) {
     switch (val.type()) {
         case bsoncxx::v_noabi::type::k_utf8:
-            message % val.get_utf8().value.to_string();
+            message % val.get_string().value.to_string();
             return;
         case bsoncxx::type::k_int32:
             message % val.get_int32().value;


### PR DESCRIPTION
**Jira Ticket:** EVG-20548

**Whats Changed:**

Replace bsoncxx's `get_utf8()` with its `get_string()` as the former has been deprecated generates lots of noises during compilation.

****Patch testing results:****

The following patches were run and the `get_utf8()` related deprecation errors disappeared.

-   [a full genny patch test](https://spruce.mongodb.com/version/64d1e7e8d1fe07a79f5fcdea/tasks)
-   [a sys-perf patch task](https://spruce.mongodb.com/task/sys_perf_linux_1_node_replSet.2022_11_insert_remove_patch_b15e8edd21f3249f71cd28f570a4d9c3a9bd734e_64d57235d6d80a0b4adcc766_23_08_11_00_01_35/tests?execution=0&sortBy=STATUS&sortDir=ASC)