### PR TITLE
PERF-3784: Replace RunCommand by CrudActor in query workloads

### DIFF
--- a/src/phases/query/RunLargeArithmeticOp.yml
+++ b/src/phases/query/RunLargeArithmeticOp.yml
@@ -8,12 +8,12 @@ Description: |
 Multiply:
   Repeat: 10
   Database: {^Parameter: {Name: "Database", Default: "test"}}
+  Collection: {^Parameter: {Name: "Collection", Default: "Collection0"}}
   Operations:
   - OperationMetricsName: {^Parameter: {Name: "Name", Default: "RunMultiply"}}
-    OperationName: RunCommand
+    OperationName: aggregate
     OperationCommand:
-      aggregate: {^Parameter: {Name: "Collection", Default: "Collection0"}}
-      pipeline: [
+      Pipeline: [
         {
           $group: {
             _id: {
@@ -22,4 +22,4 @@ Multiply:
           }
         }
       ]
-      cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 3000}}}
+      Cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 3000}}}

--- a/src/workloads/query/ConstantFoldArithmetic.yml
+++ b/src/workloads/query/ConstantFoldArithmetic.yml
@@ -73,7 +73,7 @@ Actors:
   - *Nop
 
 - Name: RunMultiply
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop

--- a/src/workloads/query/CumulativeWindows.yml
+++ b/src/workloads/query/CumulativeWindows.yml
@@ -66,6 +66,7 @@ Actors:
             createIndexes: *Collection
             indexes: [{key: {t: 1}, name: "t"}]
 
+<<<<<<< HEAD
 - SumCumulative:
   LoadConfig: &loadConfig
     Path: "../../phases/query/AggregateExpressions.yml"
@@ -76,6 +77,22 @@ Actors:
       operationMetricsName: SumCumulative
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+- Name: CumulativeWindows
+  Type: CrudActor
+  Threads: 1
+  Phases:
+  - Nop: true
+  - Nop: true
+  - Repeat: 10
+    Database: *db
+    Collection: Collection0
+    Operations:
+    - OperationMetricsName: Sum
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{
             $setWindowFields: {
               sortBy: {t: 1},
@@ -87,6 +104,7 @@ Actors:
               }
             }
           }]
+<<<<<<< HEAD
 
 - AvgCumulative:
   LoadConfig:
@@ -97,6 +115,13 @@ Actors:
       operationMetricsName: AvgCumulative
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: Avg
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{
             $setWindowFields: {
               sortBy: {t: 1},
@@ -108,6 +133,7 @@ Actors:
               }
             }
           }]
+<<<<<<< HEAD
 
 - StdDevPopCumulative:
   LoadConfig:
@@ -118,6 +144,13 @@ Actors:
       operationMetricsName: StdDevPopCumulative
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: StdDevPop
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{
             $setWindowFields: {
               sortBy: {t: 1},
@@ -129,6 +162,7 @@ Actors:
               }
             }
           }]
+<<<<<<< HEAD
 
 - StdDevSampCumulative:
   LoadConfig:
@@ -139,6 +173,13 @@ Actors:
       operationMetricsName: StdDevSampCumulative
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: StdDevSamp
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{
             $setWindowFields: {
               sortBy: {t: 1},
@@ -150,6 +191,7 @@ Actors:
               }
             }
           }]
+<<<<<<< HEAD
 
 - CovPopCumulative:
   LoadConfig:
@@ -160,6 +202,13 @@ Actors:
       operationMetricsName: CovPopCumulative
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: CovPop
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{
             $setWindowFields: {
               sortBy: {t: 1},
@@ -171,6 +220,7 @@ Actors:
               }
             }
           }]
+<<<<<<< HEAD
 
 - CovSampCumulative:
   LoadConfig:
@@ -181,6 +231,13 @@ Actors:
       operationMetricsName: CovSampCumulative
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: CovSamp
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{
             $setWindowFields: {
               sortBy: {t: 1},

--- a/src/workloads/query/DensifyFillCombo.yml
+++ b/src/workloads/query/DensifyFillCombo.yml
@@ -140,7 +140,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestampFillWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -151,12 +151,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyTimestampFillWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: *field,
             range: {
@@ -183,7 +183,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestampFillWithPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -196,12 +196,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyTimestampFillWithPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: *field,
             range: {
@@ -228,7 +228,7 @@ Actors:
   - *Nop
 
 - Name: DensifyNumericFillWithPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -243,12 +243,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyNumericFillWithPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: "numeric",
             range: {
@@ -272,7 +272,7 @@ Actors:
   - *Nop
 
 - Name: DensifyNumericLinearFillNumeric
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -289,12 +289,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyNumericLinearFillNumeric
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: "numeric",
             range: {
@@ -317,7 +317,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestampFillArbitraryValue
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -336,12 +336,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyNumericFillArbitraryValue
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: "numeric",
             range: {

--- a/src/workloads/query/DensifyHours.yml
+++ b/src/workloads/query/DensifyHours.yml
@@ -91,20 +91,36 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: DensifyHours
+- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
   Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operation:
+      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
+      OperationName: RunCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryMaxAllowedDensifyDocs: 10000000
+
+  - *Nop
+
+- Name: DensifyHours
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -116,10 +132,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -131,10 +146,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -147,10 +161,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -163,10 +176,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -179,10 +191,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -195,10 +206,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -210,10 +220,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -225,10 +234,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -241,10 +249,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],

--- a/src/workloads/query/DensifyMilliseconds.yml
+++ b/src/workloads/query/DensifyMilliseconds.yml
@@ -93,20 +93,36 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: DensifyMilliseconds
+- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
   Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operation:
+      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
+      OperationName: RunCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryMaxAllowedDensifyDocs: 10000000
+
+  - *Nop
+
+- Name: DensifyMilliseconds
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -118,10 +134,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -133,10 +148,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -149,10 +163,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -165,10 +178,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -181,10 +193,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -197,10 +208,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -212,10 +222,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -227,10 +236,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -243,10 +251,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],

--- a/src/workloads/query/DensifyMonths.yml
+++ b/src/workloads/query/DensifyMonths.yml
@@ -92,20 +92,36 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: DensifyMonths
+- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
   Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operation:
+      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
+      OperationName: RunCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryMaxAllowedDensifyDocs: 10000000
+
+  - *Nop
+
+- Name: DensifyMonths
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -117,10 +133,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -132,10 +147,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -148,10 +162,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -164,10 +177,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -180,10 +192,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -196,10 +207,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -211,10 +221,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -226,10 +235,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -242,10 +250,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],

--- a/src/workloads/query/DensifyNumeric.yml
+++ b/src/workloads/query/DensifyNumeric.yml
@@ -90,20 +90,36 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: DensifyNumeric
+- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
   Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operation:
+      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
+      OperationName: RunCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryMaxAllowedDensifyDocs: 10000000
+
+  - *Nop
+
+- Name: DensifyNumeric
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -114,10 +130,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -128,10 +143,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -143,10 +157,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -158,10 +171,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -173,10 +185,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -188,10 +199,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -202,10 +212,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -216,10 +225,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -231,10 +239,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],

--- a/src/workloads/query/DensifyTimeseriesCollection.yml
+++ b/src/workloads/query/DensifyTimeseriesCollection.yml
@@ -110,7 +110,7 @@ Actors:
   - *Nop
 
 - Name: DensifyFullSmallStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -119,12 +119,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -148,7 +148,7 @@ Actors:
   - *Nop
 
 - Name: DensifyFullLargeStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -159,12 +159,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -186,7 +186,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeSmallStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -199,12 +199,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -224,7 +224,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeLargeStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -239,12 +239,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -262,7 +262,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeByPartitionSmallStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -279,12 +279,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -301,7 +301,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeByPartitionLargeStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -320,12 +320,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: DensifyTimestamp
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -339,7 +339,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestamp
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -360,12 +360,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: DensifyTimestamp
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: "timestamp",
             range: {

--- a/src/workloads/query/FillTimeseriesCollection.yml
+++ b/src/workloads/query/FillTimeseriesCollection.yml
@@ -98,7 +98,7 @@ Actors:
   - Nop: true
 
 - Name: LocfSingleOutput
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -107,12 +107,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestLocfSingleOutput
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               sortBy: {timestamp: 1},
@@ -135,7 +135,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillSingleOutput
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -146,12 +146,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestLinearFillSingleOutput
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               sortBy: {timestamp: 1},
@@ -172,7 +172,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputsWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -185,12 +185,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestLocfMultipleOutputsWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               partitionBy: {part1: "$part1", part2: "$part2"},
@@ -212,7 +212,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputsWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -227,12 +227,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestMultipleOutputsWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               partitionBy: {part1: "$part1", part2: "$part2"},
@@ -252,7 +252,7 @@ Actors:
   - Nop: true
 
 - Name: MixedMethodsMultipleOutputsWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -269,12 +269,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestMultipleOutputsWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               partitionBy: {part1: "$part1", part2: "$part2"},

--- a/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/LookupWithOnlyUnshardedColls.yml
@@ -43,19 +43,19 @@ Actors:
   - *Nop
 
 - Name: RunLookups
-  Type: RunCommand
+  Type: CrudActor
   Database: *Database
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *Database
+    Collection: Collection0
     Operations:
     - OperationMetricsName: LookupWithCachedPrefixUnshardedToUnsharded
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline:
+        Pipeline:
           [{
             $lookup: {
               from: Collection1,
@@ -70,10 +70,9 @@ Actors:
            {$project: {str: 0, "joined.str": 0}}]
         cursor: {batchSize: *NumDocs}
     - OperationMetricsName: LookupOneToFewUnshardedToUnsharded
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline:
+        Pipeline:
           [
             {$match: {int: {$lte: 4}}},
             {$lookup: {
@@ -86,10 +85,9 @@ Actors:
           ]
         cursor: {batchSize: *NumDocs}
     - OperationMetricsName: LookupOneToManyUnshardedToUnsharded
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline:
+        Pipeline:
           [
             {$match: {int: {$lte: 4}}},
             {$lookup: {

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -70,7 +70,7 @@ Actors:
   - *Nop
 
 - Name: PointQueries
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -78,12 +78,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: PointQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $match: {
             numeric: {^RandomInt: {min: 0, max: 259200}}
           }

--- a/src/workloads/query/SlidingWindows.yml
+++ b/src/workloads/query/SlidingWindows.yml
@@ -61,6 +61,7 @@ Actors:
         Repeat: 1
         Threads: 1
 
+<<<<<<< HEAD
 # Phase 3-N: Run window function benchmarks
 - MovingAvgPositionBased:
   LoadConfig: &loadConfig
@@ -72,10 +73,27 @@ Actors:
       operationMetricsName: MovingAvgPositionBased
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+- Name: SlidingWindows
+  Type: CrudActor
+  Threads: 1
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 10
+    Database: *db
+    Collection: Collection0
+    Operations:
+    - OperationMetricsName: MovingAvgPositionBased
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{$setWindowFields: {
             partitionBy: "$partitionKey",
             sortBy: {time: 1},
             output: {avg: {$avg: "$temp", window: {documents: [-5, 5]}}}}}]
+<<<<<<< HEAD
 
 - MovingAvgTimeBased:
   LoadConfig:
@@ -86,10 +104,18 @@ Actors:
       operationMetricsName: MovingAvgTimeBased
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: MovingAvgTimeBased
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{$setWindowFields: {
             partitionBy: "$partitionKey",
             sortBy: {time: 1},
             output: {avg: {$avg: "$temp", window: {range: [-1, 0], unit: "hour"}}}}}]
+<<<<<<< HEAD
 
 - MinPositionBased:
   LoadConfig:
@@ -100,10 +126,18 @@ Actors:
       operationMetricsName: MinPositionBased
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: MinPositionBased
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{$setWindowFields: {
             partitionBy: "$partitionKey",
             sortBy: {time: 1},
             output: {min: {$min: "$temp", window: {documents: [-5, 5]}}}}}]
+<<<<<<< HEAD
 
 - MinTimeBased:
   LoadConfig:
@@ -114,10 +148,18 @@ Actors:
       operationMetricsName: MinTimeBased
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: MinTimeBased
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{$setWindowFields: {
             partitionBy: "$partitionKey",
             sortBy: {time: 1},
             output: {min: {$min: "$temp", window: {range: [-1, 0], unit: "hour"}}}}}]
+<<<<<<< HEAD
 
 - ExpMovingAvgSmallN:
   LoadConfig:
@@ -128,10 +170,18 @@ Actors:
       operationMetricsName: ExpMovingAvgSmallN
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: ExpMovingAvgSmallN
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{$setWindowFields: {
             partitionBy: "$partitionKey",
             sortBy: {time: 1},
             output: {ema: {$expMovingAvg: {input: "$temp", N: 10}}}}}]
+<<<<<<< HEAD
 
 - ExpMovingAvgLargeN:
   LoadConfig:
@@ -142,10 +192,18 @@ Actors:
       operationMetricsName: ExpMovingAvgLargeN
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: ExpMovingAvgLargeN
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{$setWindowFields: {
             partitionBy: "$partitionKey",
             sortBy: {time: 1},
             output: {ema: {$expMovingAvg: {input: "$temp", N: 500}}}}}]
+<<<<<<< HEAD
 
 - DerivativeSmallWindow:
   LoadConfig:
@@ -156,12 +214,20 @@ Actors:
       operationMetricsName: DerivativeSmallWindow
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: DerivativeSmallWindow
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{$setWindowFields: {
             partitionBy: "$partitionKey",
             sortBy: {time: 1},
             output: {rate: {
               $derivative: {input: "$temp", unit: "second"},
               window: {documents: [-10, 0]}}}}}]
+<<<<<<< HEAD
 
 - DerivativeLargeWindow:
   LoadConfig:
@@ -172,6 +238,13 @@ Actors:
       operationMetricsName: DerivativeLargeWindow
       nopInPhasesUpTo: *MaxPhases
       Pipeline:
+=======
+        cursor: {batchSize: *batchSize}
+    - OperationMetricsName: DerivativeLargeWindow
+      OperationName: aggregate
+      OperationCommand:
+        Pipeline:
+>>>>>>> 654f29f8 (PERF-3784: Replace RunCommand by CrudActor in query workloads)
           [{$setWindowFields: {
             partitionBy: "$partitionKey",
             sortBy: {time: 1},

--- a/src/workloads/query/TimeSeries2dsphere.yml
+++ b/src/workloads/query/TimeSeries2dsphere.yml
@@ -118,7 +118,7 @@ Actors:
   - *Nop
 
 - Name: GeoQueries
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -126,12 +126,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: GeoWithinQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {$match: {location: {$geoWithin: {$centerSphere: [[
             {^RandomDouble: { min: *minX, max: *maxX }},
             {^RandomDouble: { min: *minY, max: *maxY }},
@@ -142,12 +142,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: GeoNearQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {$geoNear: {
             key: 'location',
             near: [

--- a/src/workloads/query/TimeSeriesSortCompound.yml
+++ b/src/workloads/query/TimeSeriesSortCompound.yml
@@ -69,7 +69,7 @@ Actors:
   - *Nop
 
 - Name: Queries
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -77,12 +77,12 @@ Actors:
   - *Nop
   - Repeat: 50
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: SortCompound
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {$sort: {m: 1, t: 1}},
           {$_internalInhibitOptimization: {}},
           {$skip: 1e10},

--- a/src/workloads/query/linearFill.yml
+++ b/src/workloads/query/linearFill.yml
@@ -76,19 +76,19 @@ Actors:
   - Nop: true
 
 - Name: LinearFillWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestSingleOutputWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortField: 1},
             output: {
@@ -110,7 +110,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -119,12 +119,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortDateField: 1},
             output: {
@@ -146,7 +146,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -157,12 +157,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestSingleOutputWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortField: 1},
             partitionBy: "$part1",
@@ -182,7 +182,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -195,12 +195,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortDateField: 1},
             partitionBy: "$part1",
@@ -220,7 +220,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -235,12 +235,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestSingleOutputWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortField: 1},
             partitionBy: {part1: "$part1", part2: "$part2"},
@@ -256,7 +256,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -273,12 +273,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortDateField: 1},
             partitionBy: {part1: "$part1", part2: "$part2"},

--- a/src/workloads/query/locf.yml
+++ b/src/workloads/query/locf.yml
@@ -92,19 +92,19 @@ Actors:
   - Nop: true
 
 - Name: LocfNumericWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestNumericWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -135,7 +135,7 @@ Actors:
   - Nop: true
 
 - Name: LocfRandomTypeWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -144,12 +144,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestRandomTypeWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -178,7 +178,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -189,12 +189,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -225,7 +225,7 @@ Actors:
   - Nop: true
 
 - Name: LocfDateWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -238,12 +238,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDateWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -270,7 +270,7 @@ Actors:
   - Nop: true
 
 - Name: LocfRandomTypeWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -285,12 +285,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestRandomTypeWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -315,7 +315,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -332,12 +332,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -364,7 +364,7 @@ Actors:
   - Nop: true
 
 - Name: LocfStringWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -383,12 +383,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestStringWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -409,7 +409,7 @@ Actors:
   - Nop: true
 
 - Name: LocfRandomTypeWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -430,12 +430,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestRandomTypeWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -454,7 +454,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -477,12 +477,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},


### PR DESCRIPTION
**Jira Ticket:** 
[PERF-3784](https://jira.mongodb.org/browse/PERF-3784)

**Whats Changed:**  
Replace RunCommand by CrudActor in query workloads

**Patch testing results:**  
[evergreen build](https://spruce.mongodb.com/version/64da23273627e0f97108a398/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

**Workload Submission form:**  
NA

**Related PRs:**   
NA
