### PR TITLE
PERF-3784: Replace RunCommand by CrudActor in query workloads

### DIFF
--- a/src/phases/query/RunLargeArithmeticOp.yml
+++ b/src/phases/query/RunLargeArithmeticOp.yml
@@ -8,12 +8,12 @@ Description: |
 Multiply:
   Repeat: 10
   Database: {^Parameter: {Name: "Database", Default: "test"}}
+  Collection: {^Parameter: {Name: "Collection", Default: "Collection0"}}
   Operations:
   - OperationMetricsName: {^Parameter: {Name: "Name", Default: "RunMultiply"}}
-    OperationName: RunCommand
+    OperationName: aggregate
     OperationCommand:
-      aggregate: {^Parameter: {Name: "Collection", Default: "Collection0"}}
-      pipeline: [
+      Pipeline: [
         {
           $group: {
             _id: {
@@ -22,4 +22,4 @@ Multiply:
           }
         }
       ]
-      cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 3000}}}
+      Cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 3000}}}

--- a/src/workloads/query/1.js
+++ b/src/workloads/query/1.js
@@ -1,0 +1,44 @@
+{
+    "t": {"$date": "2023-11-03T14:57:28.414+00:00"}, "s": "I", "c": "COMMAND", "id": 51803,
+        "ctx": "conn7", "msg": "Slow query", "attr": {
+            "type": "command",
+            "ns": "test.Collection0",
+            "appName": "Genny",
+            "command": {
+                "getMore": 5830736535248202730,
+                "collection": "Collection0",
+                "$db": "test",
+                "lsid": {"id": {"$uuid": "7e937d21-55a5-4006-b777-3f60f97fd4bc"}}
+            },
+            "originatingCommand": {
+                "aggregate": "Collection0",
+                "pipeline": [{
+                    "$densify": {
+                        "field": "hours",
+                        "partitionByFields": ["partitionKey"],
+                        "range": {"bounds": "full", "step": 3, "unit": "hour"}
+                    }
+                }],
+                "cursor": {},
+                "$db": "test",
+                "lsid": {"id": {"$uuid": "7e937d21-55a5-4006-b777-3f60f97fd4bc"}}
+            },
+            "planSummary": "IXSCAN { hours: 1 }",
+            "cursorid": 5830736535248202730,
+            "keysExamined": 0,
+            "docsExamined": 0,
+            "fromPlanCache": true,
+            "nBatches": 1,
+            "numYields": 0,
+            "nreturned": 322215,
+            "queryHash": "414A328E",
+            "planCacheKey": "C34F9A6F",
+            "queryFramework": "sbe",
+            "reslen": 16777265,
+            "locks": {},
+            "cpuNanos": 391946806,
+            "remote": "127.0.0.1:33768",
+            "protocol": "op_msg",
+            "durationMillis": 391
+        }
+}

--- a/src/workloads/query/ConstantFoldArithmetic.yml
+++ b/src/workloads/query/ConstantFoldArithmetic.yml
@@ -73,7 +73,7 @@ Actors:
   - *Nop
 
 - Name: RunMultiply
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop

--- a/src/workloads/query/DensifyFillCombo.yml
+++ b/src/workloads/query/DensifyFillCombo.yml
@@ -9,7 +9,7 @@ Description: |
 
 GlobalDefaults:
   dbname: &db test
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "timestamp"
   index: &index
     keys: {timestamp: 1}
@@ -60,7 +60,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 10}}
       timestamp: {^RandomDate: {min: "2021-01-01T00:00:00.000Z", max: "2021-01-01T00:00:20.000Z"}}
@@ -171,7 +171,7 @@ Actors:
             }
           }
         ]
-        cursor: {batchSize: *batchSize}
+        cursor: {batchSize: *limit}
         allowDiskUse: true
   - *Nop
   - *Nop
@@ -216,9 +216,9 @@ Actors:
               toFillRandomType: {method: "locf"},
             },
             partitionByFields: ["partitionKey"]
-          }
+          },
+          $limit: *limit
         ]
-        cursor: {batchSize: *batchSize}
         allowDiskUse: true
   - *Nop
   - *Nop
@@ -262,9 +262,9 @@ Actors:
               toFillRandomType: {method: "locf"},
             },
             partitionByFields: ["partitionKey"]
-          }
+          },
+          $limit: *limit
         ]
-        cursor: {batchSize: *batchSize}
         allowDiskUse: true
   - *Nop
   - *Nop
@@ -309,9 +309,9 @@ Actors:
                 method: "linear"
               }
             },
-          }
+          },
+          $limit: *limit
         ]
-        cursor: {batchSize: *batchSize}
         allowDiskUse: true
   - *Nop
   - *Nop
@@ -355,9 +355,9 @@ Actors:
                 value: "0"
               },
             },
-          }
+          },
+          $limit: *limit
         ]
-        cursor: {batchSize: *batchSize}
         allowDiskUse: true
 
 AutoRun:

--- a/src/workloads/query/DensifyFillCombo.yml
+++ b/src/workloads/query/DensifyFillCombo.yml
@@ -140,7 +140,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestampFillWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -151,12 +151,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyTimestampFillWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: *field,
             range: {
@@ -183,7 +183,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestampFillWithPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -196,12 +196,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyTimestampFillWithPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: *field,
             range: {
@@ -228,7 +228,7 @@ Actors:
   - *Nop
 
 - Name: DensifyNumericFillWithPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -243,12 +243,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyNumericFillWithPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: "numeric",
             range: {
@@ -272,7 +272,7 @@ Actors:
   - *Nop
 
 - Name: DensifyNumericLinearFillNumeric
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -289,12 +289,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyNumericLinearFillNumeric
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: "numeric",
             range: {
@@ -317,7 +317,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestampFillArbitraryValue
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -336,12 +336,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyNumericFillArbitraryValue
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: "numeric",
             range: {

--- a/src/workloads/query/DensifyHours.yml
+++ b/src/workloads/query/DensifyHours.yml
@@ -91,22 +91,6 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
-  Type: RunCommand
-  Threads: 1
-  Phases:
-  - *Nop
-  - Repeat: 1
-    Database: admin
-    Operation:
-      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
-      OperationName: RunCommand
-      OperationCommand:
-        setParameter: 1
-        internalQueryMaxAllowedDensifyDocs: 10000000
-
-  - *Nop
-
 - Name: DensifyHours
   Type: CrudActor
   Threads: 1

--- a/src/workloads/query/DensifyHours.yml
+++ b/src/workloads/query/DensifyHours.yml
@@ -91,20 +91,36 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: DensifyHours
+- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
   Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operation:
+      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
+      OperationName: RunCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryMaxAllowedDensifyDocs: 10000000
+
+  - *Nop
+
+- Name: DensifyHours
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -116,10 +132,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -131,10 +146,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -147,10 +161,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -163,10 +176,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -179,10 +191,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -195,10 +206,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -210,10 +220,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -225,10 +234,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -241,10 +249,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],

--- a/src/workloads/query/DensifyHours.yml
+++ b/src/workloads/query/DensifyHours.yml
@@ -43,7 +43,7 @@ Description: |
 GlobalDefaults:
   dbname: &db test
   MaxPhases: &MaxPhases 20
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "hours"
   unitName: &unit "hour"
   index: &index
@@ -67,7 +67,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       # Test a subset of units that have different characteristics.
@@ -113,8 +113,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -127,8 +128,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -142,8 +144,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -157,8 +160,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -172,8 +176,9 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -187,8 +192,9 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -201,8 +207,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -215,8 +222,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -230,8 +238,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -245,8 +254,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyMilliseconds.yml
+++ b/src/workloads/query/DensifyMilliseconds.yml
@@ -45,7 +45,7 @@ Description: |
 GlobalDefaults:
   dbname: &db test
   MaxPhases: &MaxPhases 20
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "milliseconds"
   unitName: &unit "millisecond"
   index: &index
@@ -69,7 +69,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       # Test a subset of units that have different characteristics.
@@ -115,8 +115,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -129,8 +130,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -144,8 +146,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -159,8 +162,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -174,8 +178,9 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -189,8 +194,9 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -203,8 +209,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -217,8 +224,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -232,8 +240,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -247,8 +256,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyMilliseconds.yml
+++ b/src/workloads/query/DensifyMilliseconds.yml
@@ -93,20 +93,36 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: DensifyMilliseconds
+- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
   Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operation:
+      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
+      OperationName: RunCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryMaxAllowedDensifyDocs: 10000000
+
+  - *Nop
+
+- Name: DensifyMilliseconds
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -118,10 +134,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -133,10 +148,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -149,10 +163,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -165,10 +178,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -181,10 +193,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -197,10 +208,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -212,10 +222,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -227,10 +236,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -243,10 +251,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],

--- a/src/workloads/query/DensifyMilliseconds.yml
+++ b/src/workloads/query/DensifyMilliseconds.yml
@@ -93,22 +93,6 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
-  Type: RunCommand
-  Threads: 1
-  Phases:
-  - *Nop
-  - Repeat: 1
-    Database: admin
-    Operation:
-      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
-      OperationName: RunCommand
-      OperationCommand:
-        setParameter: 1
-        internalQueryMaxAllowedDensifyDocs: 10000000
-
-  - *Nop
-
 - Name: DensifyMilliseconds
   Type: CrudActor
   Threads: 1

--- a/src/workloads/query/DensifyMonths.yml
+++ b/src/workloads/query/DensifyMonths.yml
@@ -92,22 +92,6 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
-  Type: RunCommand
-  Threads: 1
-  Phases:
-  - *Nop
-  - Repeat: 1
-    Database: admin
-    Operation:
-      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
-      OperationName: RunCommand
-      OperationCommand:
-        setParameter: 1
-        internalQueryMaxAllowedDensifyDocs: 10000000
-
-  - *Nop
-
 - Name: DensifyMonths
   Type: CrudActor
   Threads: 1

--- a/src/workloads/query/DensifyMonths.yml
+++ b/src/workloads/query/DensifyMonths.yml
@@ -44,7 +44,7 @@ Description: |
 GlobalDefaults:
   dbname: &db test
   MaxPhases: &MaxPhases 20
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "months"
   unitName: &unit "month"
   index: &index
@@ -68,7 +68,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       # Test a subset of units that have different characteristics.
@@ -114,8 +114,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -128,8 +129,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -143,8 +145,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -158,8 +161,9 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -173,8 +177,9 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -188,8 +193,9 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -202,8 +208,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -216,8 +223,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -231,8 +239,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -246,8 +255,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyMonths.yml
+++ b/src/workloads/query/DensifyMonths.yml
@@ -92,20 +92,36 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: DensifyMonths
+- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
   Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operation:
+      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
+      OperationName: RunCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryMaxAllowedDensifyDocs: 10000000
+
+  - *Nop
+
+- Name: DensifyMonths
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -117,10 +133,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -132,10 +147,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -148,10 +162,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -164,10 +177,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -180,10 +192,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -196,10 +207,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -211,10 +221,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -226,10 +235,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -242,10 +250,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],

--- a/src/workloads/query/DensifyNumeric.yml
+++ b/src/workloads/query/DensifyNumeric.yml
@@ -90,22 +90,6 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
-  Type: RunCommand
-  Threads: 1
-  Phases:
-  - *Nop
-  - Repeat: 1
-    Database: admin
-    Operation:
-      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
-      OperationName: RunCommand
-      OperationCommand:
-        setParameter: 1
-        internalQueryMaxAllowedDensifyDocs: 10000000
-
-  - *Nop
-
 - Name: DensifyNumeric
   Type: CrudActor
   Threads: 1

--- a/src/workloads/query/DensifyNumeric.yml
+++ b/src/workloads/query/DensifyNumeric.yml
@@ -45,7 +45,7 @@ Description: |
 GlobalDefaults:
   dbname: &db test
   MaxPhases: &MaxPhases 20
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "number"
   unitName: &unit null
   index: &index
@@ -66,7 +66,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       # Test a subset of units that have different characteristics.
@@ -111,8 +111,9 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -125,7 +126,7 @@ Actors:
             }
           }
         }]
-        cursor: {batchSize: *batchSize}
+        cursor: {batchSize: *limit}
     - OperationMetricsName: FullByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -138,8 +139,9 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -152,8 +154,9 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -166,8 +169,9 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -180,8 +184,9 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -193,8 +198,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -206,8 +212,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
       OperationName: aggregate
       OperationCommand:
@@ -220,8 +227,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
       OperationName: aggregate
       OperationCommand:
@@ -234,8 +242,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyNumeric.yml
+++ b/src/workloads/query/DensifyNumeric.yml
@@ -90,20 +90,36 @@ Actors:
   - Repeat: 1
   - *Nop
 
-- Name: DensifyNumeric
+- Name: IncreaseInternalQueryMaxAllowedDensifyDocs
   Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: admin
+    Operation:
+      OperationMetricsName: internalQueryMaxAllowedDensifyDocs
+      OperationName: RunCommand
+      OperationCommand:
+        setParameter: 1
+        internalQueryMaxAllowedDensifyDocs: 10000000
+
+  - *Nop
+
+- Name: DensifyNumeric
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -114,10 +130,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -128,10 +143,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -143,10 +157,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -158,10 +171,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -173,10 +185,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -188,10 +199,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -202,10 +212,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -216,10 +225,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -231,10 +239,9 @@ Actors:
         }]
         cursor: {batchSize: *batchSize}
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],

--- a/src/workloads/query/DensifyTimeseriesCollection.yml
+++ b/src/workloads/query/DensifyTimeseriesCollection.yml
@@ -6,7 +6,7 @@ Description: |
 
 GlobalDefaults:
   dbname: &db test
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "numeric"
   index: &index
     keys: {numeric: 1}
@@ -84,7 +84,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 100000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       timestamp: {^IncDate: {start: "2021-01-01T00:00:00.000", step: 400}}
@@ -132,8 +132,9 @@ Actors:
               step: *smallStep,
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
   - *Nop
   - *Nop
   - *Nop
@@ -172,8 +173,9 @@ Actors:
               step: *smallStep,
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
   - *Nop
   - *Nop
   - *Nop
@@ -212,8 +214,9 @@ Actors:
               bounds: *bounds,
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
   - *Nop
   - *Nop
   - *Nop
@@ -252,8 +255,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
   - *Nop
   - *Nop
   - *Nop
@@ -293,8 +297,9 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
   - *Nop
   - *Nop
   - *Nop
@@ -333,8 +338,9 @@ Actors:
               bounds: "full"
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
   - *Nop
   - *Nop
 
@@ -374,8 +380,9 @@ Actors:
               bounds: "full"
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyTimeseriesCollection.yml
+++ b/src/workloads/query/DensifyTimeseriesCollection.yml
@@ -110,7 +110,7 @@ Actors:
   - *Nop
 
 - Name: DensifyFullSmallStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -119,12 +119,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -148,7 +148,7 @@ Actors:
   - *Nop
 
 - Name: DensifyFullLargeStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -159,12 +159,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -186,7 +186,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeSmallStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -199,12 +199,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -224,7 +224,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeLargeStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -239,12 +239,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -262,7 +262,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeByPartitionSmallStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -279,12 +279,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -301,7 +301,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeByPartitionLargeStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -320,12 +320,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: DensifyTimestamp
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -339,7 +339,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestamp
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -360,12 +360,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: DensifyTimestamp
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: "timestamp",
             range: {

--- a/src/workloads/query/FillTimeseriesCollection.yml
+++ b/src/workloads/query/FillTimeseriesCollection.yml
@@ -98,7 +98,7 @@ Actors:
   - Nop: true
 
 - Name: LocfSingleOutput
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -107,12 +107,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestLocfSingleOutput
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               sortBy: {timestamp: 1},
@@ -135,7 +135,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillSingleOutput
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -146,12 +146,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestLinearFillSingleOutput
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               sortBy: {timestamp: 1},
@@ -172,7 +172,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputsWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -185,12 +185,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestLocfMultipleOutputsWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               partitionBy: {part1: "$part1", part2: "$part2"},
@@ -212,7 +212,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputsWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -227,12 +227,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestMultipleOutputsWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               partitionBy: {part1: "$part1", part2: "$part2"},
@@ -252,7 +252,7 @@ Actors:
   - Nop: true
 
 - Name: MixedMethodsMultipleOutputsWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -269,12 +269,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestMultipleOutputsWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               partitionBy: {part1: "$part1", part2: "$part2"},

--- a/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/LookupWithOnlyUnshardedColls.yml
@@ -66,9 +66,11 @@ Actors:
               ],
               as: joined
             }
-          },
-           {$project: {str: 0, "joined.str": 0}}]
-        cursor: {batchSize: *NumDocs}
+          }, {
+            $project: {str: 0, "joined.str": 0}
+          }, {
+          $limit: *NumDocs
+          }]
     - OperationMetricsName: LookupOneToFewUnshardedToUnsharded
       OperationName: aggregate
       OperationCommand:
@@ -80,10 +82,11 @@ Actors:
               let: {int0: "$int"},
               pipeline: [{$match: {$expr: {$eq: ["$$int0", "$int"]}}}],
               as: "joined"
-            }},
-            {$project: {str: 0, "joined.str": 0}}
-          ]
-        cursor: {batchSize: *NumDocs}
+            }}, {
+            $project: {str: 0, "joined.str": 0}
+            }, {
+            $limit: *NumDocs
+          }]
     - OperationMetricsName: LookupOneToManyUnshardedToUnsharded
       OperationName: aggregate
       OperationCommand:
@@ -95,10 +98,12 @@ Actors:
               let: {smallInt0: "$smallInt"},
               pipeline: [{$match: {$expr: {$eq: ["$$smallInt0", "$smallInt"]}}}],
               as: "joined"
-            }},
-            {$project: {str: 0, "joined.str": 0}}
+            }}, {
+            $project: {str: 0, "joined.str": 0}
+            }, {
+            $limit: *NumDocs
+            }
           ]
-        cursor: {batchSize: *NumDocs}
 
 AutoRun:
 - When:

--- a/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/LookupWithOnlyUnshardedColls.yml
@@ -43,19 +43,19 @@ Actors:
   - *Nop
 
 - Name: RunLookups
-  Type: RunCommand
+  Type: CrudActor
   Database: *Database
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *Database
+    Collection: Collection0
     Operations:
     - OperationMetricsName: LookupWithCachedPrefixUnshardedToUnsharded
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline:
+        Pipeline:
           [{
             $lookup: {
               from: Collection1,
@@ -70,10 +70,9 @@ Actors:
            {$project: {str: 0, "joined.str": 0}}]
         cursor: {batchSize: *NumDocs}
     - OperationMetricsName: LookupOneToFewUnshardedToUnsharded
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline:
+        Pipeline:
           [
             {$match: {int: {$lte: 4}}},
             {$lookup: {
@@ -86,10 +85,9 @@ Actors:
           ]
         cursor: {batchSize: *NumDocs}
     - OperationMetricsName: LookupOneToManyUnshardedToUnsharded
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline:
+        Pipeline:
           [
             {$match: {int: {$lte: 4}}},
             {$lookup: {

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -70,7 +70,7 @@ Actors:
   - *Nop
 
 - Name: PointQueries
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -78,12 +78,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: PointQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $match: {
             numeric: {^RandomInt: {min: 0, max: 259200}}
           }

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -11,7 +11,7 @@ Description: |
 
 GlobalDefaults:
   dbname: &db test
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "numeric"
   index: &index
     keys: {numeric: 1}
@@ -92,8 +92,9 @@ Actors:
             _id: 0,
             numeric: 1
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
 
 AutoRun:
 - When:

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -46,7 +46,7 @@ Actors:
     # To get a good signal we need this to be at least bucket size squared.
     # The bucket size is 360. This is 360 * 360 *8. The 8 is just for safety.
     DocumentCount: 1036800
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       # start "2022-01-01" = "2022-01-01T00:00:00Z", step 10000 = size of step 10 seconds or 10,000 millis
       timestamp: {^IncDate: {start: "2022-01-01", step: 40000}}

--- a/src/workloads/query/TimeSeries2dsphere.yml
+++ b/src/workloads/query/TimeSeries2dsphere.yml
@@ -118,7 +118,7 @@ Actors:
   - *Nop
 
 - Name: GeoQueries
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -126,12 +126,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: GeoWithinQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {$match: {location: {$geoWithin: {$centerSphere: [[
             {^RandomDouble: { min: *minX, max: *maxX }},
             {^RandomDouble: { min: *minY, max: *maxY }},
@@ -142,12 +142,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: GeoNearQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {$geoNear: {
             key: 'location',
             near: [

--- a/src/workloads/query/TimeSeries2dsphere.yml
+++ b/src/workloads/query/TimeSeries2dsphere.yml
@@ -138,7 +138,6 @@ Actors:
           ], 0.001]}}}},
           {$skip: 1e5},
         ]
-        cursor: {}
   - *Nop
   - Duration: 30 seconds
     Database: *db
@@ -160,7 +159,6 @@ Actors:
           }},
           {$skip: 1e5},
         ]
-        cursor: {}
 
 AutoRun:
 - When:

--- a/src/workloads/query/TimeSeriesSortCompound.yml
+++ b/src/workloads/query/TimeSeriesSortCompound.yml
@@ -87,8 +87,7 @@ Actors:
           {$_internalInhibitOptimization: {}},
           {$skip: 1e10},
         ]
-        cursor: {}
-        hint: {m: 1, t: 1}
+        Hint: {m: 1, t: 1}
   - *Nop
 
 AutoRun:

--- a/src/workloads/query/TimeSeriesSortCompound.yml
+++ b/src/workloads/query/TimeSeriesSortCompound.yml
@@ -69,7 +69,7 @@ Actors:
   - *Nop
 
 - Name: Queries
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -77,12 +77,12 @@ Actors:
   - *Nop
   - Repeat: 50
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: SortCompound
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {$sort: {m: 1, t: 1}},
           {$_internalInhibitOptimization: {}},
           {$skip: 1e10},

--- a/src/workloads/query/linearFill.yml
+++ b/src/workloads/query/linearFill.yml
@@ -76,19 +76,19 @@ Actors:
   - Nop: true
 
 - Name: LinearFillWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestSingleOutputWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortField: 1},
             output: {
@@ -110,7 +110,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -119,12 +119,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortDateField: 1},
             output: {
@@ -146,7 +146,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -157,12 +157,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestSingleOutputWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortField: 1},
             partitionBy: "$part1",
@@ -182,7 +182,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -195,12 +195,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortDateField: 1},
             partitionBy: "$part1",
@@ -220,7 +220,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -235,12 +235,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestSingleOutputWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortField: 1},
             partitionBy: {part1: "$part1", part2: "$part2"},
@@ -256,7 +256,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -273,12 +273,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortDateField: 1},
             partitionBy: {part1: "$part1", part2: "$part2"},

--- a/src/workloads/query/linearFill.yml
+++ b/src/workloads/query/linearFill.yml
@@ -23,7 +23,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 600
-    BatchSize: &batchSize 100
+    BatchSize: &limit 100
     Document:
       part1: {^Choose: {from: [1, 2, 3, 4]}}
       part2: {^Choose: {from: [1, 2, 3, 4]}}
@@ -96,8 +96,9 @@ Actors:
                 $linearFill: "$numeric"}
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
   - Nop: true
   - Nop: true
   - Nop: true
@@ -134,8 +135,9 @@ Actors:
                 $linearFill: "$double"},
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
   - Nop: true
   - Nop: true
   - Nop: true
@@ -171,8 +173,9 @@ Actors:
                 $linearFill: "$numeric"}
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
         allowDiskUse: true
   - Nop: true
   - Nop: true
@@ -211,8 +214,9 @@ Actors:
                 $linearFill: "$integer"},
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
         allowDiskUse: true
   - Nop: true
   - Nop: true
@@ -249,8 +253,9 @@ Actors:
                 $linearFill: "$numeric"}
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
         allowDiskUse: true
   - Nop: true
   - Nop: true
@@ -289,8 +294,9 @@ Actors:
                 $linearFill: "$double"},
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
         allowDiskUse: true
 
 AutoRun:

--- a/src/workloads/query/locf.yml
+++ b/src/workloads/query/locf.yml
@@ -92,19 +92,19 @@ Actors:
   - Nop: true
 
 - Name: LocfNumericWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestNumericWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -135,7 +135,7 @@ Actors:
   - Nop: true
 
 - Name: LocfRandomTypeWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -144,12 +144,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestRandomTypeWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -178,7 +178,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -189,12 +189,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -225,7 +225,7 @@ Actors:
   - Nop: true
 
 - Name: LocfDateWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -238,12 +238,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDateWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -270,7 +270,7 @@ Actors:
   - Nop: true
 
 - Name: LocfRandomTypeWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -285,12 +285,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestRandomTypeWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -315,7 +315,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -332,12 +332,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -364,7 +364,7 @@ Actors:
   - Nop: true
 
 - Name: LocfStringWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -383,12 +383,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestStringWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -409,7 +409,7 @@ Actors:
   - Nop: true
 
 - Name: LocfRandomTypeWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -430,12 +430,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestRandomTypeWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -454,7 +454,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -477,12 +477,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},


### PR DESCRIPTION
Jira Ticket:
[PERF-3784](https://jira.mongodb.org/browse/PERF-3784)

Whats Changed:
Replace RunCommand by CrudActor in query workloads

Patch testing results:
[evergreen build](https://spruce.mongodb.com/version/64da23273627e0f97108a398/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

Workload Submission form:
NA

Related PRs:
NA