### PR TITLE
PERF-4546: Add sharded IDHACK to Genny workloads

### DIFF
--- a/src/phases/query/IDHack.yml
+++ b/src/phases/query/IDHack.yml
@@ -1,0 +1,39 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  Defines common configurations for IDHack query workloads.
+
+IDHackObjectIdTemplate:
+  Name: {^Parameter: {Name: "Name", Default: "IDHackObjectId"}}
+  Type: CrudActor
+  Threads: {^Parameter: {Name: "Threads", Default: 1}}
+  Phases:
+    OnlyActiveInPhases:
+      Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
+      NopInPhasesUpTo: {^Parameter: {Name: "NopInPhasesUpTo", Default: 99}}
+      PhaseConfig:
+        Duration: 15 seconds
+        Database: {^Parameter: {Name: "Database", Default: test}}
+        Collection: {^Parameter: {Name: "Collection", Default: Collection0}}
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {_id: {^ObjectId: {^FormatString: {"format": "%07d%s", "withArgs": [{^RandomInt: {min: 0, max: 9999999}}, "bbbbbbbbbbbbbbbbb"]}}}}
+
+LoadObjectIdTemplate:
+  Name: {^Parameter: {Name: "Name", Default: "LoadObjectIDs"}}
+  Type: Loader
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
+      NopInPhasesUpTo: {^Parameter: {Name: "NopInPhasesUpTo", Default: 99}}
+      PhaseConfig:
+        Repeat: 1
+        Database: {^Parameter: {Name: "Database", Default: test}}
+        MultipleThreadsPerCollection: true
+        CollectionCount: 1
+        DocumentCount: {^Parameter: {Name: "DocumentCount", Default: 10000000}}
+        BatchSize: 1000
+        Document:
+          _id: {^ObjectId: {^FormatString: {"format": "%07d%s", "withArgs": [{^Inc: {start: -2000000, multiplier: 1000000}}, "bbbbbbbbbbbbbbbbb"]}}}

--- a/src/phases/query/IDHack.yml
+++ b/src/phases/query/IDHack.yml
@@ -12,7 +12,7 @@ IDHackObjectIdTemplate:
       Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
       NopInPhasesUpTo: {^Parameter: {Name: "NopInPhasesUpTo", Default: 99}}
       PhaseConfig:
-        Duration: 15 seconds
+        Duration: 1 minute
         Database: {^Parameter: {Name: "Database", Default: test}}
         Collection: {^Parameter: {Name: "Collection", Default: Collection0}}
         Operations:

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -43,7 +43,7 @@ Actors:
       OnlyActiveInPhase: 1
       NopInPhasesUpTo: *MaxPhases
       Database: *Database
-      DocumentCount: 1000
+      DocumentCount: 10000000
 
 - Name: Quiesce
   Type: QuiesceActor

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -17,25 +17,6 @@ GlobalDefaults:
   Collection: &Collection Collection0
   MaxPhases: &MaxPhases 5
 
-ActorTemplates:
-- TemplateName: IDHACK
-  Config:
-    Name: {^Parameter: {Name: "Name", Default: "IDHackQuery"}}
-    Type: CrudActor
-    Threads: {^Parameter: {Name: "Threads", Default: 1}}
-    Phases:
-      OnlyActiveInPhases:
-        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
-        NopInPhasesUpTo: *MaxPhases
-        PhaseConfig:
-          Duration: 5 minutes
-          Database: *Database
-          Collection: *Collection
-          Operations:
-          - OperationName: find
-            OperationCommand:
-              Filter: {_id: {^ObjectId: {^FormatString: {"format": "%07d%s", "withArgs": [{^RandomInt: {min: 0, max: 9999999}}, "bbbbbbbbbbbbbbbbb"]}}}}
-
 Actors:
 # Clear any pre-existing collection state.
 - Name: ClearCollection
@@ -53,22 +34,16 @@ Actors:
         Operations:
         - OperationName: drop
 
-- Name: LoadObjectIDs
-  Type: Loader
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [1]
+- LoadObjectIDs:
+  LoadConfig:
+    Path: "../../phases/query/IDHack.yml"
+    Key: LoadObjectIdTemplate
+    Parameters:
+      Name: LoadObjectIDs
+      OnlyActiveInPhase: 1
       NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Repeat: 1
-        Database: *Database
-        MultipleThreadsPerCollection: true
-        CollectionCount: 1
-        DocumentCount: 10000000
-        BatchSize: 1000
-        Document:
-          _id: {^ObjectId: {^FormatString: {"format": "%07d%s", "withArgs": [{^Inc: {start: -2000000, multiplier: 1000000}}, "bbbbbbbbbbbbbbbbb"]}}}
+      Database: *Database
+      DocumentCount: 1000
 
 - Name: Quiesce
   Type: QuiesceActor
@@ -81,26 +56,39 @@ Actors:
       PhaseConfig:
         Repeat: 1
 
-- ActorFromTemplate:
-    TemplateName: IDHACK
-    TemplateParameters:
+- IDHack32Threads:
+  LoadConfig: &loadIdHackConfig
+    Path: "../../phases/query/IDHack.yml"
+    Key: IDHackObjectIdTemplate
+    Parameters:
       Name: IDHack32Threads
       Threads: 32
       OnlyActiveInPhase: 3
+      NopInPhasesUpTo: *MaxPhases
+      Database: *Database
+      Collection: *Collection
 
-- ActorFromTemplate:
-    TemplateName: IDHACK
-    TemplateParameters:
+- IDHack128Threads:
+  LoadConfig:
+    <<: *loadIdHackConfig
+    Parameters:
       Name: IDHack128Threads
       Threads: 128
       OnlyActiveInPhase: 4
+      NopInPhasesUpTo: *MaxPhases
+      Database: *Database
+      Collection: *Collection
 
-- ActorFromTemplate:
-    TemplateName: IDHACK
-    TemplateParameters:
+- IDHack256Threads:
+  LoadConfig:
+    <<: *loadIdHackConfig
+    Parameters:
       Name: IDHack256Threads
       Threads: 256
       OnlyActiveInPhase: 5
+      NopInPhasesUpTo: *MaxPhases
+      Database: *Database
+      Collection: *Collection
 
 AutoRun:
 - When:

--- a/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
@@ -49,7 +49,7 @@ Actors:
       OnlyActiveInPhase: 1
       NopInPhasesUpTo: *MaxPhases
       Database: *Database
-      DocumentCount: 1000
+      DocumentCount: 10000000
 
 - Name: Quiesce
   Type: QuiesceActor

--- a/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
@@ -69,7 +69,7 @@ Actors:
     Parameters:
       Name: IDHack32Threads
       Threads: 32
-      OnlyActiveInPhase: 5
+      OnlyActiveInPhase: 3
       NopInPhasesUpTo: *MaxPhases
       Database: *Database
       Collection: *Collection
@@ -91,7 +91,7 @@ Actors:
     Parameters:
       Name: IDHack256Threads
       Threads: 256
-      OnlyActiveInPhase: 3
+      OnlyActiveInPhase: 5
       NopInPhasesUpTo: *MaxPhases
       Database: *Database
       Collection: *Collection

--- a/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
@@ -1,0 +1,121 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload tests performance of IDHACK on queries with OID _id on a sharded collection.
+
+KeyWords:
+- IDHACK
+- OID
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2000
+
+GlobalDefaults:
+  Database: &Database test
+  Collection: &Collection Collection0
+  Namespace: &Namespace test.Collection0
+  MaxPhases: &MaxPhases 5
+
+ActorTemplates:
+- TemplateName: IDHACK
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "IDHackQuery"}}
+    Type: CrudActor
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Duration: 15 seconds
+          Database: *Database
+          Collection: *Collection
+          Operations:
+          - OperationName: find
+            OperationCommand:
+              Filter: {_id: {^ObjectId: {^FormatString: {"format": "%07d%s", "withArgs": [{^RandomInt: {min: 0, max: 9999999}}, "bbbbbbbbbbbbbbbbb"]}}}}
+
+Actors:
+# Clear any pre-existing collection state.
+- Name: CreateShardedCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Operations:
+        - OperationName: AdminCommand
+          OperationMetricsName: EnableSharding
+          OperationCommand:
+            enableSharding: *Database
+        - OperationName: AdminCommand
+          OperationMetricsName: ShardCollection
+          OperationCommand:
+            shardCollection: *Namespace
+            key: {_id: "hashed"}
+            numInitialChunks: 12
+
+- Name: LoadObjectIDs
+  Type: Loader
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        MultipleThreadsPerCollection: true
+        CollectionCount: 1
+        DocumentCount: 10000000
+        BatchSize: 1000
+        Document:
+          _id: {^ObjectId: {^FormatString: {"format": "%07d%s", "withArgs": [{^Inc: {start: -2000000, multiplier: 1000000}}, "bbbbbbbbbbbbbbbbb"]}}}
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+
+- ActorFromTemplate:
+    TemplateName: IDHACK
+    TemplateParameters:
+      Name: IDHack32Threads
+      Threads: 32
+      OnlyActiveInPhase: 3
+
+- ActorFromTemplate:
+    TemplateName: IDHACK
+    TemplateParameters:
+      Name: IDHack128Threads
+      Threads: 128
+      OnlyActiveInPhase: 4
+
+- ActorFromTemplate:
+    TemplateName: IDHACK
+    TemplateParameters:
+      Name: IDHack256Threads
+      Threads: 256
+      OnlyActiveInPhase: 5
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard
+      - shard-query-stats
+      - shard-limited-query-stats
+      - shard-lite
+      - shard-lite-query-stats
+      - shard-lite-limited-query-stats

--- a/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
@@ -18,27 +18,7 @@ GlobalDefaults:
   Namespace: &Namespace test.Collection0
   MaxPhases: &MaxPhases 5
 
-ActorTemplates:
-- TemplateName: IDHACK
-  Config:
-    Name: {^Parameter: {Name: "Name", Default: "IDHackQuery"}}
-    Type: CrudActor
-    Threads: {^Parameter: {Name: "Threads", Default: 1}}
-    Phases:
-      OnlyActiveInPhases:
-        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
-        NopInPhasesUpTo: *MaxPhases
-        PhaseConfig:
-          Duration: 15 seconds
-          Database: *Database
-          Collection: *Collection
-          Operations:
-          - OperationName: find
-            OperationCommand:
-              Filter: {_id: {^ObjectId: {^FormatString: {"format": "%07d%s", "withArgs": [{^RandomInt: {min: 0, max: 9999999}}, "bbbbbbbbbbbbbbbbb"]}}}}
-
 Actors:
-# Clear any pre-existing collection state.
 - Name: CreateShardedCollection
   Type: AdminCommand
   Threads: 1
@@ -60,22 +40,16 @@ Actors:
             key: {_id: "hashed"}
             numInitialChunks: 12
 
-- Name: LoadObjectIDs
-  Type: Loader
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [1]
+- LoadObjectIDs:
+  LoadConfig:
+    Path: "../../phases/query/IDHack.yml"
+    Key: LoadObjectIdTemplate
+    Parameters:
+      Name: LoadObjectIDs
+      OnlyActiveInPhase: 1
       NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Repeat: 1
-        Database: *Database
-        MultipleThreadsPerCollection: true
-        CollectionCount: 1
-        DocumentCount: 10000000
-        BatchSize: 1000
-        Document:
-          _id: {^ObjectId: {^FormatString: {"format": "%07d%s", "withArgs": [{^Inc: {start: -2000000, multiplier: 1000000}}, "bbbbbbbbbbbbbbbbb"]}}}
+      Database: *Database
+      DocumentCount: 1000
 
 - Name: Quiesce
   Type: QuiesceActor
@@ -88,26 +62,39 @@ Actors:
       PhaseConfig:
         Repeat: 1
 
-- ActorFromTemplate:
-    TemplateName: IDHACK
-    TemplateParameters:
+- IDHack32Threads:
+  LoadConfig: &loadIdHackConfig
+    Path: "../../phases/query/IDHack.yml"
+    Key: IDHackObjectIdTemplate
+    Parameters:
       Name: IDHack32Threads
       Threads: 32
-      OnlyActiveInPhase: 3
+      OnlyActiveInPhase: 5
+      NopInPhasesUpTo: *MaxPhases
+      Database: *Database
+      Collection: *Collection
 
-- ActorFromTemplate:
-    TemplateName: IDHACK
-    TemplateParameters:
+- IDHack128Threads:
+  LoadConfig:
+    <<: *loadIdHackConfig
+    Parameters:
       Name: IDHack128Threads
       Threads: 128
       OnlyActiveInPhase: 4
+      NopInPhasesUpTo: *MaxPhases
+      Database: *Database
+      Collection: *Collection
 
-- ActorFromTemplate:
-    TemplateName: IDHACK
-    TemplateParameters:
+- IDHack256Threads:
+  LoadConfig:
+    <<: *loadIdHackConfig
+    Parameters:
       Name: IDHack256Threads
       Threads: 256
-      OnlyActiveInPhase: 5
+      OnlyActiveInPhase: 3
+      NopInPhasesUpTo: *MaxPhases
+      Database: *Database
+      Collection: *Collection
 
 AutoRun:
 - When:


### PR DESCRIPTION
**Whats Changed:**  
Added an IDHack workload on a sharded collection. Since much of the logic is shared with the existing `TenMDocCollection_ObjectId` workload, I factored some of the shared templates into `src/phases/query/IDHack.yml`.

[Evergreen patch](https://spruce.mongodb.com/version/64db88347742ae0c65d8a85e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
