### PR TITLE
PERF-4583 - Enable setting child-operation properties for BulkWrites

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -207,6 +207,7 @@ struct InsertOneOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto document = _document();
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1insert__one.html
         return mongocxx::model::insert_one{std::move(document)};
     }
 
@@ -251,7 +252,21 @@ struct UpdateOneOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto update = _update();
-        return mongocxx::model::update_one{std::move(filter), std::move(update)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__one.html
+        mongocxx::model::update_one op{std::move(filter), std::move(update)};
+        if (_options.array_filters()) {
+            op.array_filters(_options.array_filters().value());
+        }
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        if (_options.upsert()) {
+            op.upsert(_options.upsert().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {
@@ -297,7 +312,21 @@ struct UpdateManyOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto update = _update();
-        return mongocxx::model::update_many{std::move(filter), std::move(update)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__many.html
+        mongocxx::model::update_many op{std::move(filter), std::move(update)};
+        if (_options.array_filters()) {
+            op.array_filters(_options.array_filters().value());
+        }
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        if (_options.upsert()) {
+            op.upsert(_options.upsert().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {
@@ -341,7 +370,15 @@ struct DeleteOneOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto filter = _filter();
-        return mongocxx::model::delete_one{std::move(filter)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__one.html
+        mongocxx::model::delete_one op{std::move(filter)};
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {
@@ -379,7 +416,15 @@ struct DeleteManyOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto filter = _filter();
-        return mongocxx::model::delete_many{std::move(filter)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__many.html
+        mongocxx::model::delete_many op{std::move(filter)};
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {
@@ -419,7 +464,18 @@ struct ReplaceOneOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto replacement = _replacement();
-        return mongocxx::model::replace_one{std::move(filter), std::move(replacement)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1replace__one.html
+        mongocxx::model::replace_one op{std::move(filter), std::move(replacement)};
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        if (_options.upsert()) {
+            op.upsert(_options.upsert().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -105,9 +105,31 @@ struct BaseOperation {
         ctx.success();
     }
 
-    void setUpsert(mongocxx::model::update_one& model, mongocxx::options::update options) {
+    template <class Model, class Options>
+    void setUpsert(Model& model, Options options) {
         if (options.upsert()) {
             model.upsert(options.upsert().value());
+        }
+    }
+
+    template <class Model, class Options>
+    void setArrayFilters(Model& model, Options options) {
+        if (options.array_filters()) {
+            model.array_filters(options.array_filters().value());
+        }
+    }
+
+    template <class Model, class Options>
+    void setCollation(Model& model, Options options) {
+        if (options.collation()) {
+            model.collation(options.collation().value());
+        }
+    }
+
+    template <class Model, class Options>
+    void setHint(Model& model, Options options) {
+        if (options.hint()) {
+            model.hint(options.hint().value());
         }
     }
 
@@ -258,17 +280,11 @@ struct UpdateOneOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto update = _update();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__one.html
         mongocxx::model::update_one op{std::move(filter), std::move(update)};
-        if (_options.array_filters()) {
-            op.array_filters(_options.array_filters().value());
-        }
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__one.html
+        setArrayFilters(op, _options);
+        setCollation(op, _options);
+        setHint(op, _options);
         setUpsert(op, _options);
         return op;
     }
@@ -316,20 +332,12 @@ struct UpdateManyOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto update = _update();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__many.html
         mongocxx::model::update_many op{std::move(filter), std::move(update)};
-        if (_options.array_filters()) {
-            op.array_filters(_options.array_filters().value());
-        }
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
-        if (_options.upsert()) {
-            op.upsert(_options.upsert().value());
-        }
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__many.html
+        setArrayFilters(op, _options);
+        setCollation(op, _options);
+        setHint(op, _options);
+        setUpsert(op, _options);
         return op;
     }
 
@@ -374,14 +382,10 @@ struct DeleteOneOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto filter = _filter();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__one.html
         mongocxx::model::delete_one op{std::move(filter)};
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__one.html
+        setCollation(op, _options);
+        setHint(op, _options);
         return op;
     }
 
@@ -420,14 +424,10 @@ struct DeleteManyOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto filter = _filter();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__many.html
         mongocxx::model::delete_many op{std::move(filter)};
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__many.html
+        setCollation(op, _options);
+        setHint(op, _options);
         return op;
     }
 
@@ -468,17 +468,11 @@ struct ReplaceOneOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto replacement = _replacement();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1replace__one.html
         mongocxx::model::replace_one op{std::move(filter), std::move(replacement)};
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
-        if (_options.upsert()) {
-            op.upsert(_options.upsert().value());
-        }
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1replace__one.html
+        setCollation(op, _options);
+        setHint(op, _options);
+        setUpsert(op, _options);
         return op;
     }
 

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -105,6 +105,12 @@ struct BaseOperation {
         ctx.success();
     }
 
+    void setUpsert(mongocxx::model::update_one& model, mongocxx::options::update options) {
+        if (options.upsert()) {
+            model.upsert(options.upsert().value());
+        }
+    }
+
     virtual void run(mongocxx::client_session& session) = 0;
     virtual ~BaseOperation() = default;
 };
@@ -263,9 +269,7 @@ struct UpdateOneOperation : public WriteOperation {
         if (_options.hint()) {
             op.hint(_options.hint().value());
         }
-        if (_options.upsert()) {
-            op.upsert(_options.upsert().value());
-        }
+        setUpsert(op, _options);
         return op;
     }
 


### PR DESCRIPTION
The bulk write operation allows setting some properties, such as WriteConcern at the top level instead of for each child-operation within the bulk write:
http://mongocxx.org/api/current/classmongocxx_1_1options_1_1bulk__write.html

Some properties can only be set on the child level, such as upsert:
http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__one.html 

However, Genny currently ignores the properties of child operations when constructing the model, which makes it impossible to, e.g., set upsert for bulk operations.

This PR uses all OperationOptions that are set for a child-operation when creating the operation model, which is used to construct the bulk operation. 

Aside from making it possible to set these values for bulk operations in the first place, this PR also makes Genny more consistent since an operation will now behave the same within a bulk operation as a standalone operation (previously, e.g., copying an operation definition that includes a hint and using it within a bulk operation meant that the hint would not get used).

@rtimmons Feel free to reassign this PR to someone else in case you are not the right person to review this.