### PR TITLE
PERF-4368 Create a 'bulk-loading' workload

### DIFF
--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -207,6 +207,7 @@ struct InsertOneOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto document = _document();
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1insert__one.html
         return mongocxx::model::insert_one{std::move(document)};
     }
 
@@ -251,7 +252,21 @@ struct UpdateOneOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto update = _update();
-        return mongocxx::model::update_one{std::move(filter), std::move(update)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__one.html
+        mongocxx::model::update_one op{std::move(filter), std::move(update)};
+        if (_options.array_filters()) {
+            op.array_filters(_options.array_filters().value());
+        }
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        if (_options.upsert()) {
+            op.upsert(_options.upsert().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {
@@ -297,7 +312,21 @@ struct UpdateManyOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto update = _update();
-        return mongocxx::model::update_many{std::move(filter), std::move(update)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__many.html
+        mongocxx::model::update_many op{std::move(filter), std::move(update)};
+        if (_options.array_filters()) {
+            op.array_filters(_options.array_filters().value());
+        }
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        if (_options.upsert()) {
+            op.upsert(_options.upsert().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {
@@ -341,7 +370,15 @@ struct DeleteOneOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto filter = _filter();
-        return mongocxx::model::delete_one{std::move(filter)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__one.html
+        mongocxx::model::delete_one op{std::move(filter)};
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {
@@ -379,7 +416,15 @@ struct DeleteManyOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto filter = _filter();
-        return mongocxx::model::delete_many{std::move(filter)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__many.html
+        mongocxx::model::delete_many op{std::move(filter)};
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {
@@ -419,7 +464,18 @@ struct ReplaceOneOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto replacement = _replacement();
-        return mongocxx::model::replace_one{std::move(filter), std::move(replacement)};
+        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1replace__one.html
+        mongocxx::model::replace_one op{std::move(filter), std::move(replacement)};
+        if (_options.collation()) {
+            op.collation(_options.collation().value());
+        }
+        if (_options.hint()) {
+            op.hint(_options.hint().value());
+        }
+        if (_options.upsert()) {
+            op.upsert(_options.upsert().value());
+        }
+        return op;
     }
 
     void run(mongocxx::client_session& session) override {

--- a/src/cast_core/src/CrudActor.cpp
+++ b/src/cast_core/src/CrudActor.cpp
@@ -207,7 +207,6 @@ struct InsertOneOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto document = _document();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1insert__one.html
         return mongocxx::model::insert_one{std::move(document)};
     }
 
@@ -252,21 +251,7 @@ struct UpdateOneOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto update = _update();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__one.html
-        mongocxx::model::update_one op{std::move(filter), std::move(update)};
-        if (_options.array_filters()) {
-            op.array_filters(_options.array_filters().value());
-        }
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
-        if (_options.upsert()) {
-            op.upsert(_options.upsert().value());
-        }
-        return op;
+        return mongocxx::model::update_one{std::move(filter), std::move(update)};
     }
 
     void run(mongocxx::client_session& session) override {
@@ -312,21 +297,7 @@ struct UpdateManyOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto update = _update();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1update__many.html
-        mongocxx::model::update_many op{std::move(filter), std::move(update)};
-        if (_options.array_filters()) {
-            op.array_filters(_options.array_filters().value());
-        }
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
-        if (_options.upsert()) {
-            op.upsert(_options.upsert().value());
-        }
-        return op;
+        return mongocxx::model::update_many{std::move(filter), std::move(update)};
     }
 
     void run(mongocxx::client_session& session) override {
@@ -370,15 +341,7 @@ struct DeleteOneOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto filter = _filter();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__one.html
-        mongocxx::model::delete_one op{std::move(filter)};
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
-        return op;
+        return mongocxx::model::delete_one{std::move(filter)};
     }
 
     void run(mongocxx::client_session& session) override {
@@ -416,15 +379,7 @@ struct DeleteManyOperation : public WriteOperation {
 
     mongocxx::model::write getModel() override {
         auto filter = _filter();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1delete__many.html
-        mongocxx::model::delete_many op{std::move(filter)};
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
-        return op;
+        return mongocxx::model::delete_many{std::move(filter)};
     }
 
     void run(mongocxx::client_session& session) override {
@@ -464,18 +419,7 @@ struct ReplaceOneOperation : public WriteOperation {
     mongocxx::model::write getModel() override {
         auto filter = _filter();
         auto replacement = _replacement();
-        // Available options: http://mongocxx.org/api/current/classmongocxx_1_1model_1_1replace__one.html
-        mongocxx::model::replace_one op{std::move(filter), std::move(replacement)};
-        if (_options.collation()) {
-            op.collation(_options.collation().value());
-        }
-        if (_options.hint()) {
-            op.hint(_options.hint().value());
-        }
-        if (_options.upsert()) {
-            op.upsert(_options.upsert().value());
-        }
-        return op;
+        return mongocxx::model::replace_one{std::move(filter), std::move(replacement)};
     }
 
     void run(mongocxx::client_session& session) override {

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -14,6 +14,8 @@ Description: |
   - normal writes, ~30GB data in the db, many connections, no index
   - normal writes, ~30GB data in the db, many connections, with index
 
+  - BulkWrite Upserts, ~30GB data in the db, many connections, with index
+
 # ---Start Phase Description---
 # 0 Load
 # 1 Measure - BulkWriteSingleConnectionNoIndex
@@ -175,8 +177,7 @@ Actors:
       TemplateParameters:
         Name: Warmup
         Threads: 20
-        #OnlyActiveInPhase: [0, 4, 9, 13, 18, 22, 27]
-        OnlyActiveInPhase: [0]
+        OnlyActiveInPhase: [0, 4, 9, 13, 18, 22, 27]
         Duration: 2 minutes
         Operations: *WriteOps100x
 
@@ -185,8 +186,7 @@ Actors:
     Threads: 1
     Phases:
       OnlyActiveInPhases:
-        #Active: [5, 14, 23, 28]
-        Active: [1]
+        Active: [5, 14, 23, 28]
         NopInPhasesUpTo: *NumPhases
         PhaseConfig:
           Repeat: 1
@@ -202,83 +202,83 @@ Actors:
                   - key: { timestamp: -1 }
                     name: Timestamp
 
-  # - Name: QuiesceActor
-  #   Type: QuiesceActor
-  #   Threads: 1
-  #   Database: *DbName
-  #   Phases:
-  #     OnlyActiveInPhases:
-  #       Active: [3, 8, 12, 17, 21, 26, 31]
-  #       NopInPhasesUpTo: *NumPhases
-  #       PhaseConfig:
-  #         Repeat: 1
+  - Name: QuiesceActor
+    Type: QuiesceActor
+    Threads: 1
+    Database: *DbName
+    Phases:
+      OnlyActiveInPhases:
+        Active: [3, 8, 12, 17, 21, 26, 31]
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Repeat: 1
 
-  # - Name: DeleteCollectionActor
-  #   Type: RunCommand
-  #   Threads: 1
-  #   Phases:
-  #     OnlyActiveInPhases:
-  #       Active: [2, 7, 11, 16, 20, 25, 30]
-  #       NopInPhasesUpTo: *NumPhases
-  #       PhaseConfig:
-  #         Repeat: 1
-  #         Database: *DbName
-  #         Operations:
-  #           - OperationName: RunCommand
-  #             OperationCommand:
-  #               drop: *CollectionName
+  - Name: DeleteCollectionActor
+    Type: RunCommand
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [2, 7, 11, 16, 20, 25, 30]
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Repeat: 1
+          Database: *DbName
+          Operations:
+            - OperationName: RunCommand
+              OperationCommand:
+                drop: *CollectionName
 
-  # - ActorFromTemplate:
-  #     TemplateName: BulkWriterTemplate
-  #     TemplateParameters:
-  #       Name: BulkWriteSingleConnectionNoIndex
-  #       Threads: 1
-  #       OnlyActiveInPhase: [1]
-  #       Duration: 1 minute
-  #       Operations: *WriteOps100x
+  - ActorFromTemplate:
+      TemplateName: BulkWriterTemplate
+      TemplateParameters:
+        Name: BulkWriteSingleConnectionNoIndex
+        Threads: 1
+        OnlyActiveInPhase: [1]
+        Duration: 1 minute
+        Operations: *WriteOps100x
 
-  # - ActorFromTemplate:
-  #     TemplateName: BulkWriterTemplate
-  #     TemplateParameters:
-  #       Name: BulkWriteSingleConnectionWithIndex
-  #       Threads: 1
-  #       OnlyActiveInPhase: [6]
-  #       Duration: 1 minute
-  #       Operations: *WriteOps100x
+  - ActorFromTemplate:
+      TemplateName: BulkWriterTemplate
+      TemplateParameters:
+        Name: BulkWriteSingleConnectionWithIndex
+        Threads: 1
+        OnlyActiveInPhase: [6]
+        Duration: 1 minute
+        Operations: *WriteOps100x
 
-  # - ActorFromTemplate:
-  #     TemplateName: BulkWriterTemplate
-  #     TemplateParameters:
-  #       Name: BulkWriteManyConnectionsNoIndex
-  #       Threads: 20
-  #       OnlyActiveInPhase: [10]
-  #       Duration: 1 minute
-  #       Operations: *WriteOps100x
+  - ActorFromTemplate:
+      TemplateName: BulkWriterTemplate
+      TemplateParameters:
+        Name: BulkWriteManyConnectionsNoIndex
+        Threads: 20
+        OnlyActiveInPhase: [10]
+        Duration: 1 minute
+        Operations: *WriteOps100x
 
-  # - ActorFromTemplate:
-  #     TemplateName: BulkWriterTemplate
-  #     TemplateParameters:
-  #       Name: BulkWriteManyConnectionsWithIndex
-  #       Threads: 20
-  #       OnlyActiveInPhase: [15]
-  #       Duration: 1 minute
-  #       Operations: *WriteOps100x
+  - ActorFromTemplate:
+      TemplateName: BulkWriterTemplate
+      TemplateParameters:
+        Name: BulkWriteManyConnectionsWithIndex
+        Threads: 20
+        OnlyActiveInPhase: [15]
+        Duration: 1 minute
+        Operations: *WriteOps100x
 
-  # - ActorFromTemplate:
-  #     TemplateName: NormalWriterTemplate
-  #     TemplateParameters:
-  #       Name: NormalWriteManyConnectionsNoIndex
-  #       Threads: 30
-  #       OnlyActiveInPhase: [19]
-  #       Duration: 1 minute
+  - ActorFromTemplate:
+      TemplateName: NormalWriterTemplate
+      TemplateParameters:
+        Name: NormalWriteManyConnectionsNoIndex
+        Threads: 30
+        OnlyActiveInPhase: [19]
+        Duration: 1 minute
 
-  # - ActorFromTemplate:
-  #     TemplateName: NormalWriterTemplate
-  #     TemplateParameters:
-  #       Name: NormalWriteManyConnectionsWithIndex
-  #       Threads: 30
-  #       OnlyActiveInPhase: [24]
-  #       Duration: 1 minute
+  - ActorFromTemplate:
+      TemplateName: NormalWriterTemplate
+      TemplateParameters:
+        Name: NormalWriteManyConnectionsWithIndex
+        Threads: 30
+        OnlyActiveInPhase: [24]
+        Duration: 1 minute
 
   - ActorFromTemplate:
       TemplateName: BulkWriterTemplate

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -3,29 +3,31 @@ Owner: "@mongodb/product-perf"
 Description: |
   TODO
 
-  - BulkWrite API, empty db, many connections, no index
-  - BulkWrite API, empty db, many connections, with index
-
   - BulkWrite API, 30GB data, single connection, no index
   - BulkWrite API, 30GB data, single connection, with index
 
-  - BulkWrite API, no index, many connections, 30GB data
-  - BulkWrite API, with index, many connections, 30GB data
+  - BulkWrite API, 30GB data, many connections, no index
+  - BulkWrite API, 30GB data, many connections, with index
 
-  - normal writes, no index, many connections, 30GB data
-  - normal writes, with index, many connections, 30GB data
+  - normal writes, 30GB data, many connections, no index
+  - normal writes, 30GB data, many connections, with index
 
 GlobalDefaults:
-  NumPhases: &NumPhases 3
+  NumPhases: &NumPhases 8
   DbName: &DbName db
   CollectionName: &CollectionName coll
   # Using ^RandomDate for the timestamp is too compute intensive
   WriteOp: &WriteOp {
     WriteCommand: insertOne,
     Document: {
-      sensorId: {^RandomInt: {min: 0, max: 1000}},
+      sensorId: {^RandomInt: {min: 0, max: 1000000000}},
       timestamp: {^RandomInt: {min: 1577836800000, max: 1692020604000}},
-      event: {^Choose: {from: ["EVENT1", "EVENT2", "EVENT3", "EVENT4", "EVENT5"]}}
+      eventId: {^RandomInt: {min: 1, max: 10}},
+      dataField1: {^FastRandomString: {length: 10}},
+      dataField2: {^FastRandomString: {length: 20}},
+      dataField3: {^FastRandomString: {length: 30}},
+      dataField4: {^FastRandomString: {length: 40}},
+      dataField5: {^FastRandomString: {length: 50}},
     }
   }
   # This workload uses a batch size of 100 for the bulk writes.
@@ -54,38 +56,75 @@ ActorTemplates:
     Threads:  {^Parameter: {Name: "Threads", Default: "unset"}}
     Phases:
       OnlyActiveInPhases:
-        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: "unset"}}]
+        Active: {^Parameter: {Name: "OnlyActiveInPhase", Default: "unset"}}
         NopInPhasesUpTo: *NumPhases
         PhaseConfig:
-          Duration: 15 seconds
+          Duration: {^Parameter: {Name: "Duration", Default: "unset"}}
           Database: *DbName
           Collection: *CollectionName
           Operations:
           - OperationName: bulkWrite
             OperationCommand:
               WriteOperations: *WriteOps100x
+# ---Phases---
+# 0 Load
+# 1 Measure - BulkWriteSingleConnectionNoIndex
+# 2 Delete
+# 3 Quiesce
 
+# 4 Load
+# 5 Index
+# 6 Measure - BulkWriteSingleConnectionWithIndex
+# 7 Delete
+# 8 Quiese
 Actors:
+# This loads about 35 GB of data to warm up the DB
 - ActorFromTemplate:
     TemplateName: BulkLoaderTemplate
     TemplateParameters:
-      Name: SingleThreadedBulkLoadEmptyDB
-      Threads: 1
-      OnlyActiveInPhase: 0
+      Name: Warmup
+      Threads: 20
+      OnlyActiveInPhase: [0,4]
+      Duration: 2 minutes
 
-- ActorFromTemplate:
-    TemplateName: BulkLoaderTemplate
-    TemplateParameters:
-      Name: MultiThreadedBulkLoadEmptyDB
-      Threads: 15
-      OnlyActiveInPhase: 3
+- Name: BuildIndexActor
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *DbName
+        Operations:
+        - OperationMetricsName: BulkBuildColumnStoreIndex
+          OperationName: RunCommand
+          OperationCommand:
+            createIndexes: *CollectionName
+            indexes:
+            - key: {sensorId: 1, timestamp: -1}
+              name: SensorAndTimestamp
+            - key: {timestamp: -1}
+              name: Timestamp
+
+- Name: QuiesceActor
+  Type: QuiesceActor
+  Threads: 1
+  Database: *DbName
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3,8]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
 
 - Name: DeleteCollectionActor
   Type: RunCommand
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1,4]
+      Active: [2,7]
       NopInPhasesUpTo: *NumPhases
       PhaseConfig:
         Repeat: 1
@@ -95,13 +134,18 @@ Actors:
           OperationCommand:
             drop: *CollectionName
 
-- Name: QuiesceActor
-  Type: QuiesceActor
-  Threads: 1
-  Database: *DbName
-  Phases:
-    OnlyActiveInPhases:
-      Active: [2,5]
-      NopInPhasesUpTo: *NumPhases
-      PhaseConfig:
-        Repeat: 1
+- ActorFromTemplate:
+    TemplateName: BulkLoaderTemplate
+    TemplateParameters:
+      Name: BulkWriteSingleConnectionNoIndex
+      Threads: 1
+      OnlyActiveInPhase: [1]
+      Duration: 1 minute
+
+- ActorFromTemplate:
+    TemplateName: BulkLoaderTemplate
+    TemplateParameters:
+      Name: BulkWriteSingleConnectionWithIndex
+      Threads: 1
+      OnlyActiveInPhase: [6]
+      Duration: 1 minute

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -12,15 +12,16 @@ Description: |
   - normal writes, 30GB data, many connections, no index
   - normal writes, 30GB data, many connections, with index
 
+  - BulkWrite Upserts, 30GB data, many connections, no index
+  - BulkWrite Upserts, 30GB data, many connections, with index
 GlobalDefaults:
-  NumPhases: &NumPhases 8
-  DbName: &DbName db
-  CollectionName: &CollectionName coll
+  - &NumPhases 26
+  - &DbName db
+  - &CollectionName coll
   # Using ^RandomDate for the timestamp is too compute intensive
-  WriteOp: &WriteOp {
-    WriteCommand: insertOne,
-    Document: {
-      sensorId: {^RandomInt: {min: 0, max: 1000000000}},
+  # TODO 650%
+  - &Document {
+      sensorId: {^RandomInt: {min: 0, max: 200000000}},
       timestamp: {^RandomInt: {min: 1577836800000, max: 1692020604000}},
       eventId: {^RandomInt: {min: 1, max: 10}},
       dataField1: {^FastRandomString: {length: 10}},
@@ -29,15 +30,18 @@ GlobalDefaults:
       dataField4: {^FastRandomString: {length: 40}},
       dataField5: {^FastRandomString: {length: 50}},
     }
+  - &WriteOp {
+    WriteCommand: insertOne,
+    Document: *Document
   }
   # This workload uses a batch size of 100 for the bulk writes.
   # We evaluated the impact of different batch sizes and the document throughput
   # does not appear to be impacted by the batch size.
-  WriteOps10x: &WriteOps10x [
+  - &WriteOps10x [
                      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
                      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
                   ]
-  WriteOps100x: &WriteOps100x {^FlattenOnce: [
+  - &WriteOps100x {^FlattenOnce: [
       *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
       *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
     ]}
@@ -49,7 +53,7 @@ Clients:
       maxPoolSize: 1000
 
 ActorTemplates:
-- TemplateName: BulkLoaderTemplate
+- TemplateName: BulkWriterTemplate
   Config:
     Name: {^Parameter: {Name: "Name", Default: "unset"}}
     Type: CrudActor
@@ -66,6 +70,24 @@ ActorTemplates:
           - OperationName: bulkWrite
             OperationCommand:
               WriteOperations: *WriteOps100x
+- TemplateName: NormalWriterTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "unset"}}
+    Type: CrudActor
+    Threads:  {^Parameter: {Name: "Threads", Default: "unset"}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: {^Parameter: {Name: "OnlyActiveInPhase", Default: "unset"}}
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Duration: {^Parameter: {Name: "Duration", Default: "unset"}}
+          Database: *DbName
+          Collection: *CollectionName
+          Operations:
+            - OperationName: insertOne
+              OperationCommand:
+                Document: *Document
+
 # ---Phases---
 # 0 Load
 # 1 Measure - BulkWriteSingleConnectionNoIndex
@@ -77,14 +99,36 @@ ActorTemplates:
 # 6 Measure - BulkWriteSingleConnectionWithIndex
 # 7 Delete
 # 8 Quiese
+
+# 9 Load
+# 10 Measure - BulkWriteManyConnectionsNoIndex
+# 11 Delete
+# 12 Quiesce
+
+# 13 Load
+# 14 Index
+# 15 Measure - BulkWriteManyConnectionsWithIndex
+# 16 Delete
+# 17 Quiese
+
+# 18 Load
+# 19 Measure - NormalWriteManyConnectionsNoIndex
+# 20 Delete
+# 21 Quiese
+
+# 22 Load
+# 23 Index
+# 24 Measure - NormalWriteManyConnectionsWithIndex
+# 25 Delete
+# 26 Quiese
 Actors:
 # This loads about 35 GB of data to warm up the DB
 - ActorFromTemplate:
-    TemplateName: BulkLoaderTemplate
+    TemplateName: BulkWriterTemplate
     TemplateParameters:
       Name: Warmup
       Threads: 20
-      OnlyActiveInPhase: [0,4]
+      OnlyActiveInPhase: [0,4,9,13, 18, 22]
       Duration: 2 minutes
 
 - Name: BuildIndexActor
@@ -92,7 +136,8 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [5]
+      Active: [5,14, 23]
+      Active: [1]
       NopInPhasesUpTo: *NumPhases
       PhaseConfig:
         Repeat: 1
@@ -114,7 +159,7 @@ Actors:
   Database: *DbName
   Phases:
     OnlyActiveInPhases:
-      Active: [3,8]
+      Active: [3,8,12,17,21,26]
       NopInPhasesUpTo: *NumPhases
       PhaseConfig:
         Repeat: 1
@@ -124,7 +169,7 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [2,7]
+      Active: [2,7,11,16,20,25]
       NopInPhasesUpTo: *NumPhases
       PhaseConfig:
         Repeat: 1
@@ -135,7 +180,7 @@ Actors:
             drop: *CollectionName
 
 - ActorFromTemplate:
-    TemplateName: BulkLoaderTemplate
+    TemplateName: BulkWriterTemplate
     TemplateParameters:
       Name: BulkWriteSingleConnectionNoIndex
       Threads: 1
@@ -143,9 +188,43 @@ Actors:
       Duration: 1 minute
 
 - ActorFromTemplate:
-    TemplateName: BulkLoaderTemplate
+    TemplateName: BulkWriterTemplate
     TemplateParameters:
       Name: BulkWriteSingleConnectionWithIndex
       Threads: 1
       OnlyActiveInPhase: [6]
       Duration: 1 minute
+
+- ActorFromTemplate:
+    TemplateName: BulkWriterTemplate
+    TemplateParameters:
+      Name: BulkWriteManyConnectionsNoIndex
+      Threads: 20
+      OnlyActiveInPhase: [10]
+      Duration: 1 minute
+
+- ActorFromTemplate:
+    TemplateName: BulkWriterTemplate
+    TemplateParameters:
+      Name: BulkWriteManyConnectionsWithIndex
+      Threads: 20
+      OnlyActiveInPhase: [15]
+      Duration: 1 minute
+
+- ActorFromTemplate:
+    TemplateName: NormalWriterTemplate
+    TemplateParameters:
+      Name: NormalWriteManyConnectionsNoIndex
+      Threads: 30
+      OnlyActiveInPhase: [19]
+      Duration: 1 minute
+
+- ActorFromTemplate:
+    TemplateName: NormalWriterTemplate
+    TemplateParameters:
+      Name: NormalWriteManyConnectionsWithIndex
+      Threads: 30
+      OnlyActiveInPhase: [24]
+      Duration: 1 minute
+
+# TODO auto-run

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -78,6 +78,9 @@ GlobalDefaults:
   - &DbName db
   - &CollectionName coll
   - &MeasurementDuration 1 minute
+  - &LoaderDuration 2 minutes
+  - &BulkWriteThreadCount 20
+  - &NormalWriteThreadCount 30
 
   # This document layout leads to ~650% CPU utilization on the genny client,
   # so this is close to the maximum document complexity we can use here.
@@ -135,7 +138,7 @@ ActorTemplates:
     Config:
       Name: { ^Parameter: { Name: "Name", Default: "unset" } }
       Type: CrudActor
-      Threads: { ^Parameter: { Name: "Threads", Default: 20 } }
+      Threads: { ^Parameter: { Name: "Threads", Default: *BulkWriteThreadCount } }
       Phases:
         OnlyActiveInPhases:
           Active:
@@ -150,11 +153,12 @@ ActorTemplates:
                 OperationCommand:
                   WriteOperations:
                     { ^Parameter: { Name: "Operations", Default: *WriteOps100x } }
+
   - TemplateName: NormalWriterTemplate
     Config:
       Name: { ^Parameter: { Name: "Name", Default: "unset" } }
       Type: CrudActor
-      Threads: { ^Parameter: { Name: "Threads", Default: 30 } }
+      Threads: { ^Parameter: { Name: "Threads", Default: *NormalWriteThreadCount } }
       Phases:
         OnlyActiveInPhases:
           Active:
@@ -174,9 +178,9 @@ Actors:
   - ActorFromTemplate:
       TemplateName: BulkWriterTemplate
       TemplateParameters:
-        Name: WarmupLoadData
+        Name: LoadData
         OnlyActiveInPhase: [0, 4, 9, 13, 18, 22, 27]
-        Duration: 2 minutes
+        Duration: *LoaderDuration
 
   - Name: BuildIndexActor
     Type: RunCommand

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -1,0 +1,107 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/product-perf"
+Description: |
+  TODO
+
+  - BulkWrite API, empty db, many connections, no index
+  - BulkWrite API, empty db, many connections, with index
+
+  - BulkWrite API, 30GB data, single connection, no index
+  - BulkWrite API, 30GB data, single connection, with index
+
+  - BulkWrite API, no index, many connections, 30GB data
+  - BulkWrite API, with index, many connections, 30GB data
+
+  - normal writes, no index, many connections, 30GB data
+  - normal writes, with index, many connections, 30GB data
+
+GlobalDefaults:
+  NumPhases: &NumPhases 3
+  DbName: &DbName db
+  CollectionName: &CollectionName coll
+  # Using ^RandomDate for the timestamp is too compute intensive
+  WriteOp: &WriteOp {
+    WriteCommand: insertOne,
+    Document: {
+      sensorId: {^RandomInt: {min: 0, max: 1000}},
+      timestamp: {^RandomInt: {min: 1577836800000, max: 1692020604000}},
+      event: {^Choose: {from: ["EVENT1", "EVENT2", "EVENT3", "EVENT4", "EVENT5"]}}
+    }
+  }
+  # This workload uses a batch size of 100 for the bulk writes.
+  # We evaluated the impact of different batch sizes and the document throughput
+  # does not appear to be impacted by the batch size.
+  WriteOps10x: &WriteOps10x [
+                     *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
+                     *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
+                  ]
+  WriteOps100x: &WriteOps100x {^FlattenOnce: [
+      *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
+      *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
+    ]}
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+      maxPoolSize: 1000
+
+ActorTemplates:
+- TemplateName: BulkLoaderTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "unset"}}
+    Type: CrudActor
+    Threads:  {^Parameter: {Name: "Threads", Default: "unset"}}
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: "unset"}}]
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Duration: 15 seconds
+          Database: *DbName
+          Collection: *CollectionName
+          Operations:
+          - OperationName: bulkWrite
+            OperationCommand:
+              WriteOperations: *WriteOps100x
+
+Actors:
+- ActorFromTemplate:
+    TemplateName: BulkLoaderTemplate
+    TemplateParameters:
+      Name: SingleThreadedBulkLoadEmptyDB
+      Threads: 1
+      OnlyActiveInPhase: 0
+
+- ActorFromTemplate:
+    TemplateName: BulkLoaderTemplate
+    TemplateParameters:
+      Name: MultiThreadedBulkLoadEmptyDB
+      Threads: 15
+      OnlyActiveInPhase: 3
+
+- Name: DeleteCollectionActor
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1,4]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *DbName
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            drop: *CollectionName
+
+- Name: QuiesceActor
+  Type: QuiesceActor
+  Threads: 1
+  Database: *DbName
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2,5]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -3,6 +3,7 @@ Owner: "@mongodb/product-perf"
 Description: |
   This workload tests the performance of the bulkWrite API, and compares it to normal writes.
   It is modeled as a collection of sensor data. It would be common for this use case to do batching using, e.g., AWS SQS.
+  The thread levels for the many connections scenario are tuned for maximum throughput.
 
   It tests the following scenarios:
   - BulkWrite API, ~30GB data in the db, single connection, no index
@@ -57,16 +58,26 @@ Description: |
 # 31 Quiese
 # ---End Phase Description---
 
+Keywords:
+  - bulk insert
+  - bulk write
+  - indexes
+  - upsert
+  - stress
+
 Clients:
   Default:
     QueryOptions:
+      # Without this, the index builds time out
       socketTimeoutMS: -1
+      # The default poolsize of 100 is not enough
       maxPoolSize: 400
 
 GlobalDefaults:
   - &NumPhases 31
   - &DbName db
   - &CollectionName coll
+  - &MeasurementDuration 1 minute
 
   # This document layout leads to ~650% CPU utilization on the genny client,
   # so this is close to the maximum document complexity we can use here.
@@ -124,33 +135,33 @@ ActorTemplates:
     Config:
       Name: { ^Parameter: { Name: "Name", Default: "unset" } }
       Type: CrudActor
-      Threads: { ^Parameter: { Name: "Threads", Default: "unset" } }
+      Threads: { ^Parameter: { Name: "Threads", Default: 20 } }
       Phases:
         OnlyActiveInPhases:
           Active:
             { ^Parameter: { Name: "OnlyActiveInPhase", Default: "unset" } }
           NopInPhasesUpTo: *NumPhases
           PhaseConfig:
-            Duration: { ^Parameter: { Name: "Duration", Default: "unset" } }
+            Duration: { ^Parameter: { Name: "Duration", Default: *MeasurementDuration } }
             Database: *DbName
             Collection: *CollectionName
             Operations:
               - OperationName: bulkWrite
                 OperationCommand:
                   WriteOperations:
-                    { ^Parameter: { Name: "Operations", Default: "unset" } }
+                    { ^Parameter: { Name: "Operations", Default: *WriteOps100x } }
   - TemplateName: NormalWriterTemplate
     Config:
       Name: { ^Parameter: { Name: "Name", Default: "unset" } }
       Type: CrudActor
-      Threads: { ^Parameter: { Name: "Threads", Default: "unset" } }
+      Threads: { ^Parameter: { Name: "Threads", Default: 30 } }
       Phases:
         OnlyActiveInPhases:
           Active:
             { ^Parameter: { Name: "OnlyActiveInPhase", Default: "unset" } }
           NopInPhasesUpTo: *NumPhases
           PhaseConfig:
-            Duration: { ^Parameter: { Name: "Duration", Default: "unset" } }
+            Duration: { ^Parameter: { Name: "Duration", Default: *MeasurementDuration } }
             Database: *DbName
             Collection: *CollectionName
             Operations:
@@ -159,15 +170,13 @@ ActorTemplates:
                   Document: *Document
 
 Actors:
-  # This loads about 35 GB of data to warm up the DB
+  # Each invocation of this actor bulk loads about 35 GB of data to populate the DB
   - ActorFromTemplate:
       TemplateName: BulkWriterTemplate
       TemplateParameters:
-        Name: Warmup
-        Threads: 20
+        Name: WarmupLoadData
         OnlyActiveInPhase: [0, 4, 9, 13, 18, 22, 27]
         Duration: 2 minutes
-        Operations: *WriteOps100x
 
   - Name: BuildIndexActor
     Type: RunCommand
@@ -180,7 +189,7 @@ Actors:
           Repeat: 1
           Database: *DbName
           Operations:
-            - OperationMetricsName: BulkBuildColumnStoreIndex
+            - OperationMetricsName: BuildIndex
               OperationName: RunCommand
               OperationCommand:
                 createIndexes: *CollectionName
@@ -189,17 +198,6 @@ Actors:
                     name: SensorAndTimestamp
                   - key: { timestamp: -1 }
                     name: Timestamp
-
-  - Name: QuiesceActor
-    Type: QuiesceActor
-    Threads: 1
-    Database: *DbName
-    Phases:
-      OnlyActiveInPhases:
-        Active: [3, 8, 12, 17, 21, 26, 31]
-        NopInPhasesUpTo: *NumPhases
-        PhaseConfig:
-          Repeat: 1
 
   - Name: DeleteCollectionActor
     Type: RunCommand
@@ -216,13 +214,23 @@ Actors:
               OperationCommand:
                 drop: *CollectionName
 
+  - Name: QuiesceActor
+    Type: QuiesceActor
+    Threads: 1
+    Database: *DbName
+    Phases:
+      OnlyActiveInPhases:
+        Active: [3, 8, 12, 17, 21, 26, 31]
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Repeat: 1
+
   - ActorFromTemplate:
       TemplateName: BulkWriterTemplate
       TemplateParameters:
         Name: BulkWriteSingleConnectionNoIndex
         Threads: 1
         OnlyActiveInPhase: [1]
-        Duration: 1 minute
         Operations: *WriteOps100x
 
   - ActorFromTemplate:
@@ -231,53 +239,46 @@ Actors:
         Name: BulkWriteSingleConnectionWithIndex
         Threads: 1
         OnlyActiveInPhase: [6]
-        Duration: 1 minute
         Operations: *WriteOps100x
 
   - ActorFromTemplate:
       TemplateName: BulkWriterTemplate
       TemplateParameters:
         Name: BulkWriteManyConnectionsNoIndex
-        Threads: 20
         OnlyActiveInPhase: [10]
-        Duration: 1 minute
         Operations: *WriteOps100x
 
   - ActorFromTemplate:
       TemplateName: BulkWriterTemplate
       TemplateParameters:
         Name: BulkWriteManyConnectionsWithIndex
-        Threads: 20
         OnlyActiveInPhase: [15]
-        Duration: 1 minute
         Operations: *WriteOps100x
 
   - ActorFromTemplate:
       TemplateName: NormalWriterTemplate
       TemplateParameters:
         Name: NormalWriteManyConnectionsNoIndex
-        Threads: 30
         OnlyActiveInPhase: [19]
-        Duration: 1 minute
+        # This test runs longer as it's more noisy
+        Duration: 2 minutes
 
   - ActorFromTemplate:
       TemplateName: NormalWriterTemplate
       TemplateParameters:
         Name: NormalWriteManyConnectionsWithIndex
-        Threads: 30
         OnlyActiveInPhase: [24]
-        Duration: 1 minute
+        # This test runs longer as it's more noisy
+        Duration: 2 minutes
 
   # We only test upserts with an index, as they would require COLSCANs without an index.
-  # 120s * 900,000docs/sec = 108,000,000 docs after warmup (slight overestimation since ids could overlapp).
+  # 120s * 900,000docs/sec = 108,000,000 docs after loading (slight overestimation since ids could overlapp).
   # With 200,000,000 sensorIds, the upserts have a ~50% chance of requiring an insert.
   - ActorFromTemplate:
       TemplateName: BulkWriterTemplate
       TemplateParameters:
         Name: BulkUpsertsManyConnectionsWithIndex
-        Threads: 20
         OnlyActiveInPhase: [29]
-        Duration: 1 minute
         Operations: *UpsertOps100x
 
 AutoRun:

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -136,12 +136,14 @@ GlobalDefaults:
 ActorTemplates:
   - TemplateName: BulkWriterTemplate
     Config:
+      # TODO https://jira.mongodb.org/browse/EVG-20735
       Name: { ^Parameter: { Name: "Name", Default: "unset" } }
       Type: CrudActor
       Threads: { ^Parameter: { Name: "Threads", Default: *BulkWriteThreadCount } }
       Phases:
         OnlyActiveInPhases:
           Active:
+            # TODO https://jira.mongodb.org/browse/EVG-20735
             { ^Parameter: { Name: "OnlyActiveInPhase", Default: "unset" } }
           NopInPhasesUpTo: *NumPhases
           PhaseConfig:
@@ -156,12 +158,14 @@ ActorTemplates:
 
   - TemplateName: NormalWriterTemplate
     Config:
+      # TODO https://jira.mongodb.org/browse/EVG-20735
       Name: { ^Parameter: { Name: "Name", Default: "unset" } }
       Type: CrudActor
       Threads: { ^Parameter: { Name: "Threads", Default: *NormalWriteThreadCount } }
       Phases:
         OnlyActiveInPhases:
           Active:
+            # TODO https://jira.mongodb.org/browse/EVG-20735
             { ^Parameter: { Name: "OnlyActiveInPhase", Default: "unset" } }
           NopInPhasesUpTo: *NumPhases
           PhaseConfig:

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -99,35 +99,23 @@ GlobalDefaults:
     }
   - &UpsertOp {
       WriteCommand: updateOne,
-      Filter: {sensorId: { ^RandomInt: { min: 0, max: 200000000 } }},
-      Update: {$set: {eventId: 0, dataField1: { ^FastRandomString: { length: 10 } }}},
-      OperationOptions: {Upsert: true},
+      Filter: { sensorId: { ^RandomInt: { min: 0, max: 200000000 } } },
+      Update:
+        {
+          $set:
+            { eventId: 0, dataField1: { ^FastRandomString: { length: 10 } } },
+        },
+      OperationOptions: { Upsert: true },
     }
   - &UpsertOps10x [
-      *UpsertOp,
-      *UpsertOp,
-      *UpsertOp,
-      *UpsertOp,
-      *UpsertOp,
-      *UpsertOp,
-      *UpsertOp,
-      *UpsertOp,
-      *UpsertOp,
-      *UpsertOp,
+      *UpsertOp, *UpsertOp, *UpsertOp, *UpsertOp, *UpsertOp,
+      *UpsertOp, *UpsertOp, *UpsertOp, *UpsertOp, *UpsertOp,
     ]
   - &UpsertOps100x {
       ^FlattenOnce:
         [
-          *UpsertOps10x,
-          *UpsertOps10x,
-          *UpsertOps10x,
-          *UpsertOps10x,
-          *UpsertOps10x,
-          *UpsertOps10x,
-          *UpsertOps10x,
-          *UpsertOps10x,
-          *UpsertOps10x,
-          *UpsertOps10x,
+          *UpsertOps10x, *UpsertOps10x, *UpsertOps10x, *UpsertOps10x, *UpsertOps10x,
+          *UpsertOps10x, *UpsertOps10x, *UpsertOps10x, *UpsertOps10x, *UpsertOps10x,
         ],
     }
 
@@ -280,6 +268,9 @@ Actors:
         OnlyActiveInPhase: [24]
         Duration: 1 minute
 
+  # We only test upserts with an index, as they would require COLSCANs without an index.
+  # 120s * 900,000docs/sec = 108,000,000 docs after warmup (slight overestimation since ids could overlapp).
+  # With 200,000,000 sensorIds, the upserts have a ~50% chance of requiring an insert.
   - ActorFromTemplate:
       TemplateName: BulkWriterTemplate
       TemplateParameters:
@@ -288,6 +279,7 @@ Actors:
         OnlyActiveInPhase: [29]
         Duration: 1 minute
         Operations: *UpsertOps100x
+
 AutoRun:
   - When:
       mongodb_setup:

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -1,20 +1,20 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/product-perf"
 Description: |
-  TODO
+  This workload tests the performance of the bulkWrite API, and compares it to normal writes.
+  It is modeled as a collection of sensor data. It would be common for this use case to do batching using, e.g., AWS SQS.
 
-  - BulkWrite API, 30GB data, single connection, no index
-  - BulkWrite API, 30GB data, single connection, with index
+  It tests the following scenarios:
+  - BulkWrite API, ~30GB data in the db, single connection, no index
+  - BulkWrite API, ~30GB data in the db, single connection, with index
 
-  - BulkWrite API, 30GB data, many connections, no index
-  - BulkWrite API, 30GB data, many connections, with index
+  - BulkWrite API, ~30GB data in the db, many connections, no index
+  - BulkWrite API, ~30GB data in the db, many connections, with index
 
-  - normal writes, 30GB data, many connections, no index
-  - normal writes, 30GB data, many connections, with index
+  - normal writes, ~30GB data in the db, many connections, no index
+  - normal writes, ~30GB data in the db, many connections, with index
 
-  - BulkWrite Upserts, 30GB data, many connections, with index
-
-# ---Phase Description---
+# ---Start Phase Description---
 # 0 Load
 # 1 Measure - BulkWriteSingleConnectionNoIndex
 # 2 Delete
@@ -50,17 +50,19 @@ Description: |
 
 # 27 Load
 # 28 Index
-# 29 Measure - BulkUpsertManyConnectionsWithIndex
+# 29 Measure - BulkUpsertsManyConnectionsWithIndex
 # 30 Delete
 # 31 Quiese
+# ---End Phase Description---
 
 Clients:
   Default:
     QueryOptions:
       socketTimeoutMS: -1
+      maxPoolSize: 400
 
 GlobalDefaults:
-  - &NumPhases 26
+  - &NumPhases 31
   - &DbName db
   - &CollectionName coll
 
@@ -83,40 +85,21 @@ GlobalDefaults:
   # does not appear to be impacted by the batch size.
   - &WriteOp { WriteCommand: insertOne, Document: *Document }
   - &WriteOps10x [
-      *WriteOp,
-      *WriteOp,
-      *WriteOp,
-      *WriteOp,
-      *WriteOp,
-      *WriteOp,
-      *WriteOp,
-      *WriteOp,
-      *WriteOp,
-      *WriteOp,
+      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
+      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
     ]
   - &WriteOps100x {
       ^FlattenOnce:
         [
-          *WriteOps10x,
-          *WriteOps10x,
-          *WriteOps10x,
-          *WriteOps10x,
-          *WriteOps10x,
-          *WriteOps10x,
-          *WriteOps10x,
-          *WriteOps10x,
-          *WriteOps10x,
-          *WriteOps10x,
+          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
+          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
         ],
     }
   - &UpsertOp {
       WriteCommand: updateOne,
       Filter: {sensorId: { ^RandomInt: { min: 0, max: 200000000 } }},
       Update: {$set: {eventId: 0, dataField1: { ^FastRandomString: { length: 10 } }}},
-      Options: {Upsert: true},
       OperationOptions: {Upsert: true},
-      WriteOptions: {Upsert: true},
-      UpdateOptions: {Upsert: true},
     }
   - &UpsertOps10x [
       *UpsertOp,
@@ -164,24 +147,8 @@ ActorTemplates:
             Operations:
               - OperationName: bulkWrite
                 OperationCommand:
-                  WriteOperations: { ^Parameter: { Name: "Operations", Default: "unset" } }
-                  Options:
-                    Upsert: true
-                  OperationOptions:
-                    Upsert: true
-                  WriteOptions:
-                    Upsert: true
-                  UpdateOptions:
-                    Upsert: true
-                Options:
-                  Upsert: true
-                OperationOptions:
-                  Upsert: true
-                WriteOptions:
-                  Upsert: true
-                UpdateOptions:
-                  Upsert: true
-  # TODO merge Templates
+                  WriteOperations:
+                    { ^Parameter: { Name: "Operations", Default: "unset" } }
   - TemplateName: NormalWriterTemplate
     Config:
       Name: { ^Parameter: { Name: "Name", Default: "unset" } }
@@ -203,22 +170,22 @@ ActorTemplates:
 
 Actors:
   # This loads about 35 GB of data to warm up the DB
-  # - ActorFromTemplate:
-  #     TemplateName: BulkWriterTemplate
-  #     TemplateParameters:
-  #       Name: Warmup
-  #       Threads: 20
-  #       #OnlyActiveInPhase: [0, 4, 9, 13, 18, 22]
-  #       OnlyActiveInPhase: [0]
-  #       Duration: 2 minutes
-  #       Operations: *WriteOps100x
+  - ActorFromTemplate:
+      TemplateName: BulkWriterTemplate
+      TemplateParameters:
+        Name: Warmup
+        Threads: 20
+        #OnlyActiveInPhase: [0, 4, 9, 13, 18, 22, 27]
+        OnlyActiveInPhase: [0]
+        Duration: 2 minutes
+        Operations: *WriteOps100x
 
   - Name: BuildIndexActor
     Type: RunCommand
     Threads: 1
     Phases:
       OnlyActiveInPhases:
-        # Active: [5, 14, 23]
+        #Active: [5, 14, 23, 28]
         Active: [1]
         NopInPhasesUpTo: *NumPhases
         PhaseConfig:
@@ -241,7 +208,7 @@ Actors:
   #   Database: *DbName
   #   Phases:
   #     OnlyActiveInPhases:
-  #       Active: [3, 8, 12, 17, 21, 26]
+  #       Active: [3, 8, 12, 17, 21, 26, 31]
   #       NopInPhasesUpTo: *NumPhases
   #       PhaseConfig:
   #         Repeat: 1
@@ -251,7 +218,7 @@ Actors:
   #   Threads: 1
   #   Phases:
   #     OnlyActiveInPhases:
-  #       Active: [2, 7, 11, 16, 20, 25]
+  #       Active: [2, 7, 11, 16, 20, 25, 30]
   #       NopInPhasesUpTo: *NumPhases
   #       PhaseConfig:
   #         Repeat: 1
@@ -313,16 +280,16 @@ Actors:
   #       OnlyActiveInPhase: [24]
   #       Duration: 1 minute
 
-# We only test upserts with an index, as they would require COLSCANs without an index.
-# 120s * 900,000docs/sec = 108,000,000 docs after warmup (slight overestimation since ids could overlapp).
-# With 200,000,000 sensorIds, the upserts have a ~50% chance of requiring an insert.
   - ActorFromTemplate:
       TemplateName: BulkWriterTemplate
       TemplateParameters:
-        Name: BulkUpsertManyConnectionsWithIndex
-        Threads: 1
-        OnlyActiveInPhase: [2]
+        Name: BulkUpsertsManyConnectionsWithIndex
+        Threads: 20
+        OnlyActiveInPhase: [29]
         Duration: 1 minute
-        Operations: [*UpsertOp]
-
-# TODO auto-run
+        Operations: *UpsertOps100x
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - replica

--- a/src/workloads/scale/BulkLoading.yml
+++ b/src/workloads/scale/BulkLoading.yml
@@ -12,83 +12,9 @@ Description: |
   - normal writes, 30GB data, many connections, no index
   - normal writes, 30GB data, many connections, with index
 
-  - BulkWrite Upserts, 30GB data, many connections, no index
   - BulkWrite Upserts, 30GB data, many connections, with index
-GlobalDefaults:
-  - &NumPhases 26
-  - &DbName db
-  - &CollectionName coll
-  # Using ^RandomDate for the timestamp is too compute intensive
-  # TODO 650%
-  - &Document {
-      sensorId: {^RandomInt: {min: 0, max: 200000000}},
-      timestamp: {^RandomInt: {min: 1577836800000, max: 1692020604000}},
-      eventId: {^RandomInt: {min: 1, max: 10}},
-      dataField1: {^FastRandomString: {length: 10}},
-      dataField2: {^FastRandomString: {length: 20}},
-      dataField3: {^FastRandomString: {length: 30}},
-      dataField4: {^FastRandomString: {length: 40}},
-      dataField5: {^FastRandomString: {length: 50}},
-    }
-  - &WriteOp {
-    WriteCommand: insertOne,
-    Document: *Document
-  }
-  # This workload uses a batch size of 100 for the bulk writes.
-  # We evaluated the impact of different batch sizes and the document throughput
-  # does not appear to be impacted by the batch size.
-  - &WriteOps10x [
-                     *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
-                     *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
-                  ]
-  - &WriteOps100x {^FlattenOnce: [
-      *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
-      *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
-    ]}
 
-Clients:
-  Default:
-    QueryOptions:
-      socketTimeoutMS: -1
-      maxPoolSize: 1000
-
-ActorTemplates:
-- TemplateName: BulkWriterTemplate
-  Config:
-    Name: {^Parameter: {Name: "Name", Default: "unset"}}
-    Type: CrudActor
-    Threads:  {^Parameter: {Name: "Threads", Default: "unset"}}
-    Phases:
-      OnlyActiveInPhases:
-        Active: {^Parameter: {Name: "OnlyActiveInPhase", Default: "unset"}}
-        NopInPhasesUpTo: *NumPhases
-        PhaseConfig:
-          Duration: {^Parameter: {Name: "Duration", Default: "unset"}}
-          Database: *DbName
-          Collection: *CollectionName
-          Operations:
-          - OperationName: bulkWrite
-            OperationCommand:
-              WriteOperations: *WriteOps100x
-- TemplateName: NormalWriterTemplate
-  Config:
-    Name: {^Parameter: {Name: "Name", Default: "unset"}}
-    Type: CrudActor
-    Threads:  {^Parameter: {Name: "Threads", Default: "unset"}}
-    Phases:
-      OnlyActiveInPhases:
-        Active: {^Parameter: {Name: "OnlyActiveInPhase", Default: "unset"}}
-        NopInPhasesUpTo: *NumPhases
-        PhaseConfig:
-          Duration: {^Parameter: {Name: "Duration", Default: "unset"}}
-          Database: *DbName
-          Collection: *CollectionName
-          Operations:
-            - OperationName: insertOne
-              OperationCommand:
-                Document: *Document
-
-# ---Phases---
+# ---Phase Description---
 # 0 Load
 # 1 Measure - BulkWriteSingleConnectionNoIndex
 # 2 Delete
@@ -121,110 +47,282 @@ ActorTemplates:
 # 24 Measure - NormalWriteManyConnectionsWithIndex
 # 25 Delete
 # 26 Quiese
+
+# 27 Load
+# 28 Index
+# 29 Measure - BulkUpsertManyConnectionsWithIndex
+# 30 Delete
+# 31 Quiese
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+
+GlobalDefaults:
+  - &NumPhases 26
+  - &DbName db
+  - &CollectionName coll
+
+  # This document layout leads to ~650% CPU utilization on the genny client,
+  # so this is close to the maximum document complexity we can use here.
+  # Using ^RandomDate for the timestamp is too compute intensive.
+  - &Document {
+      sensorId: { ^RandomInt: { min: 0, max: 200000000 } },
+      timestamp: { ^RandomInt: { min: 1577836800000, max: 1692020604000 } },
+      eventId: { ^RandomInt: { min: 1, max: 10 } },
+      dataField1: { ^FastRandomString: { length: 10 } },
+      dataField2: { ^FastRandomString: { length: 20 } },
+      dataField3: { ^FastRandomString: { length: 30 } },
+      dataField4: { ^FastRandomString: { length: 40 } },
+      dataField5: { ^FastRandomString: { length: 50 } },
+    }
+
+  # This workload uses a batch size of 100 for the bulk writes.
+  # We evaluated the impact of different batch sizes and the document throughput
+  # does not appear to be impacted by the batch size.
+  - &WriteOp { WriteCommand: insertOne, Document: *Document }
+  - &WriteOps10x [
+      *WriteOp,
+      *WriteOp,
+      *WriteOp,
+      *WriteOp,
+      *WriteOp,
+      *WriteOp,
+      *WriteOp,
+      *WriteOp,
+      *WriteOp,
+      *WriteOp,
+    ]
+  - &WriteOps100x {
+      ^FlattenOnce:
+        [
+          *WriteOps10x,
+          *WriteOps10x,
+          *WriteOps10x,
+          *WriteOps10x,
+          *WriteOps10x,
+          *WriteOps10x,
+          *WriteOps10x,
+          *WriteOps10x,
+          *WriteOps10x,
+          *WriteOps10x,
+        ],
+    }
+  - &UpsertOp {
+      WriteCommand: updateOne,
+      Filter: {sensorId: { ^RandomInt: { min: 0, max: 200000000 } }},
+      Update: {$set: {eventId: 0, dataField1: { ^FastRandomString: { length: 10 } }}},
+      Options: {Upsert: true},
+      OperationOptions: {Upsert: true},
+      WriteOptions: {Upsert: true},
+      UpdateOptions: {Upsert: true},
+    }
+  - &UpsertOps10x [
+      *UpsertOp,
+      *UpsertOp,
+      *UpsertOp,
+      *UpsertOp,
+      *UpsertOp,
+      *UpsertOp,
+      *UpsertOp,
+      *UpsertOp,
+      *UpsertOp,
+      *UpsertOp,
+    ]
+  - &UpsertOps100x {
+      ^FlattenOnce:
+        [
+          *UpsertOps10x,
+          *UpsertOps10x,
+          *UpsertOps10x,
+          *UpsertOps10x,
+          *UpsertOps10x,
+          *UpsertOps10x,
+          *UpsertOps10x,
+          *UpsertOps10x,
+          *UpsertOps10x,
+          *UpsertOps10x,
+        ],
+    }
+
+ActorTemplates:
+  - TemplateName: BulkWriterTemplate
+    Config:
+      Name: { ^Parameter: { Name: "Name", Default: "unset" } }
+      Type: CrudActor
+      Threads: { ^Parameter: { Name: "Threads", Default: "unset" } }
+      Phases:
+        OnlyActiveInPhases:
+          Active:
+            { ^Parameter: { Name: "OnlyActiveInPhase", Default: "unset" } }
+          NopInPhasesUpTo: *NumPhases
+          PhaseConfig:
+            Duration: { ^Parameter: { Name: "Duration", Default: "unset" } }
+            Database: *DbName
+            Collection: *CollectionName
+            Operations:
+              - OperationName: bulkWrite
+                OperationCommand:
+                  WriteOperations: { ^Parameter: { Name: "Operations", Default: "unset" } }
+                  Options:
+                    Upsert: true
+                  OperationOptions:
+                    Upsert: true
+                  WriteOptions:
+                    Upsert: true
+                  UpdateOptions:
+                    Upsert: true
+                Options:
+                  Upsert: true
+                OperationOptions:
+                  Upsert: true
+                WriteOptions:
+                  Upsert: true
+                UpdateOptions:
+                  Upsert: true
+  # TODO merge Templates
+  - TemplateName: NormalWriterTemplate
+    Config:
+      Name: { ^Parameter: { Name: "Name", Default: "unset" } }
+      Type: CrudActor
+      Threads: { ^Parameter: { Name: "Threads", Default: "unset" } }
+      Phases:
+        OnlyActiveInPhases:
+          Active:
+            { ^Parameter: { Name: "OnlyActiveInPhase", Default: "unset" } }
+          NopInPhasesUpTo: *NumPhases
+          PhaseConfig:
+            Duration: { ^Parameter: { Name: "Duration", Default: "unset" } }
+            Database: *DbName
+            Collection: *CollectionName
+            Operations:
+              - OperationName: insertOne
+                OperationCommand:
+                  Document: *Document
+
 Actors:
-# This loads about 35 GB of data to warm up the DB
-- ActorFromTemplate:
-    TemplateName: BulkWriterTemplate
-    TemplateParameters:
-      Name: Warmup
-      Threads: 20
-      OnlyActiveInPhase: [0,4,9,13, 18, 22]
-      Duration: 2 minutes
+  # This loads about 35 GB of data to warm up the DB
+  # - ActorFromTemplate:
+  #     TemplateName: BulkWriterTemplate
+  #     TemplateParameters:
+  #       Name: Warmup
+  #       Threads: 20
+  #       #OnlyActiveInPhase: [0, 4, 9, 13, 18, 22]
+  #       OnlyActiveInPhase: [0]
+  #       Duration: 2 minutes
+  #       Operations: *WriteOps100x
 
-- Name: BuildIndexActor
-  Type: RunCommand
-  Threads: 1
-  Phases:
-    OnlyActiveInPhases:
-      Active: [5,14, 23]
-      Active: [1]
-      NopInPhasesUpTo: *NumPhases
-      PhaseConfig:
-        Repeat: 1
-        Database: *DbName
-        Operations:
-        - OperationMetricsName: BulkBuildColumnStoreIndex
-          OperationName: RunCommand
-          OperationCommand:
-            createIndexes: *CollectionName
-            indexes:
-            - key: {sensorId: 1, timestamp: -1}
-              name: SensorAndTimestamp
-            - key: {timestamp: -1}
-              name: Timestamp
+  - Name: BuildIndexActor
+    Type: RunCommand
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        # Active: [5, 14, 23]
+        Active: [1]
+        NopInPhasesUpTo: *NumPhases
+        PhaseConfig:
+          Repeat: 1
+          Database: *DbName
+          Operations:
+            - OperationMetricsName: BulkBuildColumnStoreIndex
+              OperationName: RunCommand
+              OperationCommand:
+                createIndexes: *CollectionName
+                indexes:
+                  - key: { sensorId: 1, timestamp: -1 }
+                    name: SensorAndTimestamp
+                  - key: { timestamp: -1 }
+                    name: Timestamp
 
-- Name: QuiesceActor
-  Type: QuiesceActor
-  Threads: 1
-  Database: *DbName
-  Phases:
-    OnlyActiveInPhases:
-      Active: [3,8,12,17,21,26]
-      NopInPhasesUpTo: *NumPhases
-      PhaseConfig:
-        Repeat: 1
+  # - Name: QuiesceActor
+  #   Type: QuiesceActor
+  #   Threads: 1
+  #   Database: *DbName
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [3, 8, 12, 17, 21, 26]
+  #       NopInPhasesUpTo: *NumPhases
+  #       PhaseConfig:
+  #         Repeat: 1
 
-- Name: DeleteCollectionActor
-  Type: RunCommand
-  Threads: 1
-  Phases:
-    OnlyActiveInPhases:
-      Active: [2,7,11,16,20,25]
-      NopInPhasesUpTo: *NumPhases
-      PhaseConfig:
-        Repeat: 1
-        Database: *DbName
-        Operations:
-        - OperationName: RunCommand
-          OperationCommand:
-            drop: *CollectionName
+  # - Name: DeleteCollectionActor
+  #   Type: RunCommand
+  #   Threads: 1
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [2, 7, 11, 16, 20, 25]
+  #       NopInPhasesUpTo: *NumPhases
+  #       PhaseConfig:
+  #         Repeat: 1
+  #         Database: *DbName
+  #         Operations:
+  #           - OperationName: RunCommand
+  #             OperationCommand:
+  #               drop: *CollectionName
 
-- ActorFromTemplate:
-    TemplateName: BulkWriterTemplate
-    TemplateParameters:
-      Name: BulkWriteSingleConnectionNoIndex
-      Threads: 1
-      OnlyActiveInPhase: [1]
-      Duration: 1 minute
+  # - ActorFromTemplate:
+  #     TemplateName: BulkWriterTemplate
+  #     TemplateParameters:
+  #       Name: BulkWriteSingleConnectionNoIndex
+  #       Threads: 1
+  #       OnlyActiveInPhase: [1]
+  #       Duration: 1 minute
+  #       Operations: *WriteOps100x
 
-- ActorFromTemplate:
-    TemplateName: BulkWriterTemplate
-    TemplateParameters:
-      Name: BulkWriteSingleConnectionWithIndex
-      Threads: 1
-      OnlyActiveInPhase: [6]
-      Duration: 1 minute
+  # - ActorFromTemplate:
+  #     TemplateName: BulkWriterTemplate
+  #     TemplateParameters:
+  #       Name: BulkWriteSingleConnectionWithIndex
+  #       Threads: 1
+  #       OnlyActiveInPhase: [6]
+  #       Duration: 1 minute
+  #       Operations: *WriteOps100x
 
-- ActorFromTemplate:
-    TemplateName: BulkWriterTemplate
-    TemplateParameters:
-      Name: BulkWriteManyConnectionsNoIndex
-      Threads: 20
-      OnlyActiveInPhase: [10]
-      Duration: 1 minute
+  # - ActorFromTemplate:
+  #     TemplateName: BulkWriterTemplate
+  #     TemplateParameters:
+  #       Name: BulkWriteManyConnectionsNoIndex
+  #       Threads: 20
+  #       OnlyActiveInPhase: [10]
+  #       Duration: 1 minute
+  #       Operations: *WriteOps100x
 
-- ActorFromTemplate:
-    TemplateName: BulkWriterTemplate
-    TemplateParameters:
-      Name: BulkWriteManyConnectionsWithIndex
-      Threads: 20
-      OnlyActiveInPhase: [15]
-      Duration: 1 minute
+  # - ActorFromTemplate:
+  #     TemplateName: BulkWriterTemplate
+  #     TemplateParameters:
+  #       Name: BulkWriteManyConnectionsWithIndex
+  #       Threads: 20
+  #       OnlyActiveInPhase: [15]
+  #       Duration: 1 minute
+  #       Operations: *WriteOps100x
 
-- ActorFromTemplate:
-    TemplateName: NormalWriterTemplate
-    TemplateParameters:
-      Name: NormalWriteManyConnectionsNoIndex
-      Threads: 30
-      OnlyActiveInPhase: [19]
-      Duration: 1 minute
+  # - ActorFromTemplate:
+  #     TemplateName: NormalWriterTemplate
+  #     TemplateParameters:
+  #       Name: NormalWriteManyConnectionsNoIndex
+  #       Threads: 30
+  #       OnlyActiveInPhase: [19]
+  #       Duration: 1 minute
 
-- ActorFromTemplate:
-    TemplateName: NormalWriterTemplate
-    TemplateParameters:
-      Name: NormalWriteManyConnectionsWithIndex
-      Threads: 30
-      OnlyActiveInPhase: [24]
-      Duration: 1 minute
+  # - ActorFromTemplate:
+  #     TemplateName: NormalWriterTemplate
+  #     TemplateParameters:
+  #       Name: NormalWriteManyConnectionsWithIndex
+  #       Threads: 30
+  #       OnlyActiveInPhase: [24]
+  #       Duration: 1 minute
+
+# We only test upserts with an index, as they would require COLSCANs without an index.
+# 120s * 900,000docs/sec = 108,000,000 docs after warmup (slight overestimation since ids could overlapp).
+# With 200,000,000 sensorIds, the upserts have a ~50% chance of requiring an insert.
+  - ActorFromTemplate:
+      TemplateName: BulkWriterTemplate
+      TemplateParameters:
+        Name: BulkUpsertManyConnectionsWithIndex
+        Threads: 1
+        OnlyActiveInPhase: [2]
+        Duration: 1 minute
+        Operations: [*UpsertOp]
 
 # TODO auto-run


### PR DESCRIPTION
This workload tests the performance of the bulkWrite API and compares it to normal writes.
It is modeled as a collection of sensor data. It would be common for this use case to do batching using, e.g., AWS SQS.

It tests the following scenarios:
- BulkWrite API, ~30GB data in the db, single connection, no index
- BulkWrite API, ~30GB data in the db, single connection, with index
- BulkWrite API, ~30GB data in the db, many connections, no index
- BulkWrite API, ~30GB data in the db, many connections, with index
- normal writes, ~30GB data in the db, many connections, no index
- normal writes, ~30GB data in the db, many connections, with index
- BulkWrite Upserts, ~30GB data in the db, many connections, with index

Note: This workload requires the fix from PERF-4583, but wanted to get some eyes on this already.