### PR TITLE
PERF-4589: Have IDHack workloads run for 100 seconds

### DIFF
--- a/src/phases/query/IDHack.yml
+++ b/src/phases/query/IDHack.yml
@@ -12,7 +12,7 @@ IDHackObjectIdTemplate:
       Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
       NopInPhasesUpTo: {^Parameter: {Name: "NopInPhasesUpTo", Default: 99}}
       PhaseConfig:
-        Duration: 1 minute
+        Duration: 100 seconds
         Database: {^Parameter: {Name: "Database", Default: test}}
         Collection: {^Parameter: {Name: "Collection", Default: Collection0}}
         Operations:

--- a/src/phases/query/IDHack.yml
+++ b/src/phases/query/IDHack.yml
@@ -12,6 +12,8 @@ IDHackObjectIdTemplate:
       Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
       NopInPhasesUpTo: {^Parameter: {Name: "NopInPhasesUpTo", Default: 99}}
       PhaseConfig:
+          # Our testing suggested the first ~20 seconds of this actor shows a lot of noise before
+          # stabilizing - 100s should gather sufficient post-noise data.
         Duration: 100 seconds
         Database: {^Parameter: {Name: "Database", Default: test}}
         Collection: {^Parameter: {Name: "Collection", Default: Collection0}}

--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -29,6 +29,8 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
+          # Our testing suggested the first ~20 seconds of this actor shows a lot of noise before
+          # stabilizing - 100s should gather sufficient post-noise data.
           Duration: 100 seconds
           Database: *Database
           Collection: *Collection

--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -29,7 +29,7 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Duration: 5 minutes
+          Duration: 100 seconds
           Database: *Database
           Collection: *Collection
           Operations:

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -30,6 +30,8 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "Need to specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
+          # Our testing suggested the first ~20 seconds of this actor shows a lot of noise before
+          # stabilizing - 100s should gather sufficient post-noise data.
           Duration: 100 seconds
           Database: {^Parameter: {Name: "Database", Default: *Database}}
           Collection: {^Parameter: {Name: "Collection", Default: *Collection}}

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -30,7 +30,7 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "Need to specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Duration: 5 minutes
+          Duration: 100 seconds
           Database: {^Parameter: {Name: "Database", Default: *Database}}
           Collection: {^Parameter: {Name: "Collection", Default: *Collection}}
           Operations:

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -27,7 +27,7 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Duration: 5 minutes
+          Duration: 100 seconds
           Database: *Database
           Collection: *Collection
           Operations:

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -27,6 +27,8 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
+          # Our testing suggested the first ~20 seconds of this actor shows a lot of noise before
+          # stabilizing - 100s should gather sufficient post-noise data.
           Duration: 100 seconds
           Database: *Database
           Collection: *Collection


### PR DESCRIPTION
[lil evg patch](https://spruce.mongodb.com/version/64e761ca9ccd4ed58281782c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)