### PR TITLE
SERVER-80476: Add High Value Workloads to Perf Dashboard

### DIFF
--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -189,6 +189,7 @@ AutoRun:
       - atlas
       - atlas-like-replica.2022-10
       - replica
+      - replica-query-stats
       - single-replica
       - standalone
       - standalone-classic-query-engine

--- a/src/workloads/scale/LargeIndexedIns.yml
+++ b/src/workloads/scale/LargeIndexedIns.yml
@@ -64,6 +64,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
+      - replica-query-stats
       - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -120,7 +120,6 @@ AutoRun:
       - atlas
       - atlas-like-replica.2022-10
       - replica
-      - replica-query-stats
     atlas_setup:
       $neq:
       - M10-repl

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -120,6 +120,7 @@ AutoRun:
       - atlas
       - atlas-like-replica.2022-10
       - replica
+      - replica-query-stats
     atlas_setup:
       $neq:
       - M10-repl

--- a/src/workloads/scale/MajorityReads10KThreads.yml
+++ b/src/workloads/scale/MajorityReads10KThreads.yml
@@ -22,6 +22,7 @@ AutoRun:
       $eq:
       - replica
       - replica-all-feature-flags
+      - replica-query-stats
       - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
@@ -190,6 +190,7 @@ AutoRun:
       - replica-all-feature-flags
       - replica-maintenance-events
       - replica-noflowcontrol
+      - replica-query-stats
       - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe


### PR DESCRIPTION
Added the high value workloads to auto run on query stats replica variant

[Evergreen patch](https://spruce.mongodb.com/version/64ed06992a60ed5dc07cb9e9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)