### PR TITLE
PERF-4312 Add genny workloads for fixed bucketing and count optimizations for timeseries

### DIFF
--- a/src/workloads/query/TimeseriesCount.yml
+++ b/src/workloads/query/TimeseriesCount.yml
@@ -1,0 +1,167 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  The queries in this workload exercise group stage that uses the $count accumulator and the $count aggregation stage. 
+  On FCV greater than or equal to 7.1 $group using $count is optimized to remove the $unpack stage.
+
+Keywords:
+- timeseries
+- aggregate
+- group
+
+GlobalDefaults:
+  Database: &database test
+  Collection: &collection Collection0
+  MaxPhases: &maxPhases 10
+  repeat: &repeat 100
+
+Actors:
+# Clear any pre-existing collection state.
+- Name: ClearCollection
+  Type: CrudActor
+  Database: *database
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Collection: *collection
+        Operations:
+        - OperationName: drop
+
+# Testing during development showed the runtime is greatly affected by the number of measurements per bucket. There is on average 103 
+# measurements per bucket when granularity = "seconds", which was determined is a typical customer bucket.
+- Name: CreateTimeseriesCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *database
+        Operation:
+          OperationMetricsName: CreateTimeseriesCollection
+          OperationName: RunCommand
+          OperationCommand:
+            {create: *collection, timeseries: {timeField: "time", metaField: "symbol", granularity: "seconds"}}
+
+# This template is used by other time-series workloads and will add 1,000,000 documents to the collection.
+- InsertData:
+  LoadConfig:
+    Path: "../../phases/query/GroupStagesOnComputedFields.yml"
+    Key: InsertDataTemplate
+    Parameters:
+      active: [2]
+      nopInPhasesUpTo: *maxPhases
+
+# Phase 3: Ensure all data is synced to disk.
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+
+# Run queries with and without the optimization.
+- Name: GroupCountAccumulatorNoOpt
+  Type: CrudActor
+  Database: *database
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [4]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: *repeat
+        Database: *database
+        Collection: *collection
+        Operations:
+        - OperationMetricsName: 
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [
+              {$_internalInhibitOptimization: {}},
+              {$group: {
+                _id: "$symbol",
+                count: {$count: {}},
+              }}
+            ]
+
+- Name: GroupCountAccumulatorOpt
+  Type: CrudActor
+  Database: *database
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: *repeat
+        Database: *database
+        Collection: *collection
+        Operations:
+        - OperationMetricsName:
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [
+              {$group: {
+                _id: "$symbol",
+                count: {$count: {}},
+              }}
+            ]
+
+- Name: GroupCountAggStageNoOpt
+  Type: CrudActor
+  Database: *database
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [6]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: *repeat
+        Database: *database
+        Collection: *collection
+        Operations:
+        - OperationMetricsName:
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [ {$_internalInhibitOptimization: {}}, {$count: "count"} ]
+
+- Name: GroupCountAggStageOpt
+  Type: CrudActor
+  Database: *database
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [7]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: *repeat
+        Database: *database
+        Collection: *collection
+        Operations:
+        - OperationMetricsName:
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [ {$count: "count"} ]
+
+AutoRun: 
+- When:
+    mongodb_setup:
+      $eq:
+      - replica
+      - replica-all-feature-flags
+    branch_name:
+      $gte:
+        v7.1

--- a/src/workloads/query/TimeseriesCount.yml
+++ b/src/workloads/query/TimeseriesCount.yml
@@ -1,8 +1,9 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
 Description: |
-  The queries in this workload exercise group stage that uses the $count accumulator and the $count aggregation stage. 
-  On FCV greater than or equal to 7.1 $group using $count is optimized to remove the $unpack stage.
+  The queries in this workload exercise group stage that uses the $count accumulator and the $count 
+  aggregation stage. On FCV greater than or equal to 7.1 $group using $count is optimized to remove 
+  the $unpack stage.
 
 Keywords:
 - timeseries
@@ -32,8 +33,9 @@ Actors:
         Operations:
         - OperationName: drop
 
-# Testing during development showed the runtime is greatly affected by the number of measurements per bucket. There is on average 103 
-# measurements per bucket when granularity = "seconds", which was determined is a typical customer bucket.
+# Testing during development showed the runtime is greatly affected by the number of measurements per bucket.
+# There is on average 103  measurements per bucket when granularity = "seconds", which was determined is a 
+# typical customer bucket.
 - Name: CreateTimeseriesCollection
   Type: RunCommand
   Threads: 1
@@ -48,9 +50,9 @@ Actors:
           OperationMetricsName: CreateTimeseriesCollection
           OperationName: RunCommand
           OperationCommand:
-            {create: *collection, timeseries: {timeField: "time", metaField: "symbol", bucketMaxSpanSeconds: 900, bucketRoundingSeconds: 900}}
+            {create: *collection, timeseries: {timeField: "time", metaField: "symbol", granularity: "seconds"}}
 
-# This template is used by other time-series workloads and will add 1,000,000 documents to the collection.
+# This template is used by other timeseries workloads and will add 1000000 documents to the collection.
 - InsertData:
   LoadConfig:
     Path: "../../phases/query/GroupStagesOnComputedFields.yml"

--- a/src/workloads/query/TimeseriesCount.yml
+++ b/src/workloads/query/TimeseriesCount.yml
@@ -6,9 +6,9 @@ Description: |
   the $unpack stage.
 
 Keywords:
-- timeseries
-- aggregate
-- group
+  - timeseries
+  - aggregate
+  - group
 
 GlobalDefaults:
   Database: &database test
@@ -17,110 +17,113 @@ GlobalDefaults:
   repeat: &repeat 100
 
 Actors:
-# Clear any pre-existing collection state.
-- Name: ClearCollection
-  Type: CrudActor
-  Database: *database
-  Threads: 1
-  Phases:
-    OnlyActiveInPhases:
-      Active: [0]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: 1
-        Threads: 1
-        Collection: *collection
-        Operations:
-        - OperationName: drop
+  # Clear any pre-existing collection state. Helpful to avoid errors for local testing.
+  - Name: ClearCollection
+    Type: CrudActor
+    Database: *database
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [0]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: 1
+          Threads: 1
+          Collection: *collection
+          Operations:
+            - OperationName: drop
 
-# Testing during development showed the runtime is greatly affected by the number of measurements per bucket.
-# There is on average 103  measurements per bucket when granularity = "seconds", which was determined is a 
-# typical customer bucket.
-- Name: CreateTimeseriesCollection
-  Type: RunCommand
-  Threads: 1
-  Phases:
-    OnlyActiveInPhases:
-      Active: [1]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: 1
-        Database: *database
-        Operation:
-          OperationMetricsName: CreateTimeseriesCollection
-          OperationName: RunCommand
-          OperationCommand:
-            {create: *collection, timeseries: {timeField: "time", metaField: "symbol", granularity: "seconds"}}
+  # Testing during development showed the runtime is greatly affected by the number of measurements per bucket.
+  # There is on average 103  measurements per bucket when granularity = "seconds", which was determined is a
+  # typical customer bucket.
+  - Name: CreateTimeseriesCollection
+    Type: RunCommand
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [1]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: 1
+          Database: *database
+          Operation:
+            OperationMetricsName: CreateTimeseriesCollection
+            OperationName: RunCommand
+            OperationCommand:
+              {
+                create: *collection,
+                timeseries:
+                  {
+                    timeField: "time",
+                    metaField: "symbol",
+                    granularity: "seconds",
+                  },
+              }
 
-# This template is used by other timeseries workloads and will add 1000000 documents to the collection.
-- InsertData:
-  LoadConfig:
-    Path: "../../phases/query/GroupStagesOnComputedFields.yml"
-    Key: InsertDataTemplate
-    Parameters:
-      active: [2]
-      nopInPhasesUpTo: *maxPhases
+  # This template is used by other timeseries workloads and will add 1000000 documents to the collection.
+  - InsertData:
+    LoadConfig:
+      Path: "../../phases/query/GroupStagesOnComputedFields.yml"
+      Key: InsertDataTemplate
+      Parameters:
+        Active: [2]
+        NopInPhasesUpTo: *maxPhases
 
-# Phase 3: Ensure all data is synced to disk.
-- Name: Quiesce
-  Type: QuiesceActor
-  Threads: 1
-  Database: *database
-  Phases:
-    OnlyActiveInPhases:
-      Active: [3]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: 1
-        Threads: 1
+  # Phase 3: Ensure all data is synced to disk.
+  - Name: Quiesce
+    Type: QuiesceActor
+    Threads: 1
+    Database: *database
+    Phases:
+      OnlyActiveInPhases:
+        Active: [3]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: 1
+          Threads: 1
 
-# Run queries with the optimization.
-- Name: GroupCountAccumulatorOpt
-  Type: CrudActor
-  Database: *database
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [4]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: *repeat
-        Database: *database
-        Collection: *collection
-        Operations:
-        - OperationMetricsName:
-          OperationName: aggregate
-          OperationCommand:
-            Pipeline: [
-              {$group: {
-                _id: "$symbol",
-                count: {$count: {}},
-              }}
-            ]
-- Name: GroupCountAggStageOpt
-  Type: CrudActor
-  Database: *database
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [5]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: *repeat
-        Database: *database
-        Collection: *collection
-        Operations:
-        - OperationMetricsName:
-          OperationName: aggregate
-          OperationCommand:
-            Pipeline: [ {$count: "count"} ]
+  # Run queries with the optimization.
+  - Name: GroupCountAccumulatorOpt
+    Type: CrudActor
+    Database: *database
+    Threads: 10
+    Phases:
+      OnlyActiveInPhases:
+        Active: [4]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline: [{ $group: { _id: null, count: { $count: {} } } }]
 
-AutoRun: 
-- When:
-    mongodb_setup:
-      $eq:
-      - replica
-      - replica-all-feature-flags
-    branch_name:
-      $gte:
-        v7.1
+  - Name: GroupCountAggStageOpt
+    Type: CrudActor
+    Database: *database
+    Threads: 10
+    Phases:
+      OnlyActiveInPhases:
+        Active: [5]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline: [{ $count: "count" }]
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - replica
+          - replica-all-feature-flags
+      branch_name:
+        $gte: v7.1

--- a/src/workloads/query/TimeseriesCount.yml
+++ b/src/workloads/query/TimeseriesCount.yml
@@ -14,10 +14,10 @@ GlobalDefaults:
   Database: &database test
   Collection: &collection Collection0
   MaxPhases: &maxPhases 10
-  repeat: &repeat 100
+  repeat: &repeat 10
 
 Actors:
-  # Clear any pre-existing collection state. Helpful to avoid errors for local testing.
+  # Clear any pre-existing collection state. Helpful to avoid errors during local testing.
   - Name: ClearCollection
     Type: CrudActor
     Database: *database
@@ -66,8 +66,8 @@ Actors:
       Path: "../../phases/query/GroupStagesOnComputedFields.yml"
       Key: InsertDataTemplate
       Parameters:
-        Active: [2]
-        NopInPhasesUpTo: *maxPhases
+        active: [2]
+        nopInPhasesUpTo: *maxPhases
 
   # Phase 3: Ensure all data is synced to disk.
   - Name: Quiesce

--- a/src/workloads/query/TimeseriesCount.yml
+++ b/src/workloads/query/TimeseriesCount.yml
@@ -48,7 +48,7 @@ Actors:
           OperationMetricsName: CreateTimeseriesCollection
           OperationName: RunCommand
           OperationCommand:
-            {create: *collection, timeseries: {timeField: "time", metaField: "symbol", granularity: "seconds"}}
+            {create: *collection, timeseries: {timeField: "time", metaField: "symbol", bucketMaxSpanSeconds: 900, bucketRoundingSeconds: 900}}
 
 # This template is used by other time-series workloads and will add 1,000,000 documents to the collection.
 - InsertData:
@@ -72,8 +72,8 @@ Actors:
         Repeat: 1
         Threads: 1
 
-# Run queries with and without the optimization.
-- Name: GroupCountAccumulatorNoOpt
+# Run queries with the optimization.
+- Name: GroupCountAccumulatorOpt
   Type: CrudActor
   Database: *database
   Threads: 10
@@ -86,30 +86,6 @@ Actors:
         Database: *database
         Collection: *collection
         Operations:
-        - OperationMetricsName: 
-          OperationName: aggregate
-          OperationCommand:
-            Pipeline: [
-              {$_internalInhibitOptimization: {}},
-              {$group: {
-                _id: "$symbol",
-                count: {$count: {}},
-              }}
-            ]
-
-- Name: GroupCountAccumulatorOpt
-  Type: CrudActor
-  Database: *database
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [5]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: *repeat
-        Database: *database
-        Collection: *collection
-        Operations:
         - OperationMetricsName:
           OperationName: aggregate
           OperationCommand:
@@ -119,32 +95,13 @@ Actors:
                 count: {$count: {}},
               }}
             ]
-
-- Name: GroupCountAggStageNoOpt
-  Type: CrudActor
-  Database: *database
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [6]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: *repeat
-        Database: *database
-        Collection: *collection
-        Operations:
-        - OperationMetricsName:
-          OperationName: aggregate
-          OperationCommand:
-            Pipeline: [ {$_internalInhibitOptimization: {}}, {$count: "count"} ]
-
 - Name: GroupCountAggStageOpt
   Type: CrudActor
   Database: *database
   Threads: 10
   Phases:
     OnlyActiveInPhases:
-      Active: [7]
+      Active: [5]
       NopInPhasesUpTo: *maxPhases
       PhaseConfig:
         Repeat: *repeat

--- a/src/workloads/query/TimeseriesFixedBucketing.yml
+++ b/src/workloads/query/TimeseriesFixedBucketing.yml
@@ -8,9 +8,9 @@ Description: |
   and the metaField is "tags". There are 20736000 documents in the collection.
 
 Keywords:
-- timeseries
-- aggregate
-- group
+  - timeseries
+  - aggregate
+  - group
 
 GlobalDefaults:
   Database: &Database test
@@ -21,7 +21,7 @@ GlobalDefaults:
 # The dates below are chosen for different $match queries. The dates in the tsbs dataset are
 # between 2016-01-01 and 2016-01-25. The dates for the queries were chosen to be in the middle of the
 # dataset. Date0 and Date1 should be close together, since we want to measure the performance
-# improvement of removing the 'eventFilter' in the $match queries. 
+# improvement of removing the 'eventFilter' in the $match queries.
 Date0: &DateForBucketAlign
   LoadConfig:
     Path: "../../phases/query/GetBsonDate.yml"
@@ -37,143 +37,212 @@ Date1: &DateForBucketNotAlign
       date: "2016-01-13T01:03:02"
 
 Actors:
-# The data is already loaded into the collection from the dsi configuration.
-- Name: Quiesce
-  Type: QuiesceActor
-  Threads: 1
-  Database: *Database
-  Phases:
-    OnlyActiveInPhases:
-      Active: [0]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: 1
+  # The data is already loaded into the collection from the dsi configuration.
+  - Name: Quiesce
+    Type: QuiesceActor
+    Threads: 1
+    Database: *Database
+    Phases:
+      OnlyActiveInPhases:
+        Active: [0]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: 1
 
-# Testing during development showed no significant changes in runtime between the different 
-# dateTrunc.unit values. We chose "year", so the optimization would  apply for many values of 
-# bucketMaxSpanSeconds, if the user decides to adjust the bucketing parameter.
-- Name: DateTruncYear
-  Type: CrudActor
-  Database: *Database
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [1]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: *Repeat
-        Database: *Database
-        Collection: *Collection
-        Operations:
-        - OperationMetricsName:
-          OperationName: aggregate
-          OperationCommand:
-            Pipeline: [
-              {$group: {
-                _id: {t: {$dateTrunc: {date: "$time", unit: "year"}}},
-                min: {$min: "$usage_steal"},
-                max: {$max: "$usage_steal"}
-              }}
-            ]
-# This actor was used during development to measure the improvement in performance for 
-# the rewrite. However, with tsbs data this actor is very slow and therefore we decided to 
-# remove it from this workload in production.
-# - Name: DateTruncYearNoOpt
-#   Type: CrudActor
-#   Database: *Database
-#   Threads: 10
-#   Phases:
-#     OnlyActiveInPhases:
-#       Active: [2]
-      # NopInPhasesUpTo: *maxPhases
-      # PhaseConfig:
-      #   Repeat: *Repeat
-      #   Database: *Database
-      #   Collection: *Collection
-      #   Operations:
-      #   - OperationMetricsName:
-      #     OperationName: aggregate
-      #     OperationCommand:
-      #       Pipeline: [
-      #         {$_internalInhibitOptimization: {}},
-      #         {$group: {
-      #           _id: {t: {$dateTrunc: {date: "$time", unit: "year"}}},
-      #           min: {$min: "$usage_steal"},
-      #           max: {$max: "$usage_steal"}
-      #         }}
-      #       ]
+  # Testing during development showed no significant changes in runtime between the different
+  # dateTrunc.unit values. We chose "year", so the optimization would  apply for many values of
+  # bucketMaxSpanSeconds, if the user decides to adjust the bucketing parameter.
+  - Name: DateTruncYear
+    Type: CrudActor
+    Database: *Database
+    Threads: 10
+    Phases:
+      OnlyActiveInPhases:
+        Active: [1]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *Repeat
+          Database: *Database
+          Collection: *Collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $group:
+                        {
+                          _id:
+                            {
+                              t:
+                                { $dateTrunc: { date: "$time", unit: "year" } },
+                            },
+                          min: { $min: "$usage_steal" },
+                          max: { $max: "$usage_steal" },
+                        },
+                    },
+                  ]
 
-# $lt query that aligns with the bucket boundaries.
-- Name: MatchLTBucketAlign
-  Type: CrudActor
-  Database: *Database
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [3]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: *Repeat
-        Database: *Database
-        Collection: *Collection
-        Operations:
-        - OperationMetricsName:
-          OperationName: aggregate
-          OperationCommand:
-            Pipeline: [ {$match: {"time": {$lt: *DateForBucketAlign}}}  ]
+  # This actor was used during development to measure the improvement in performance for
+  # the rewrite. However, with tsbs data this actor is very slow and therefore we decided to
+  # remove it from this workload in production.
+  # - Name: DateTruncYearNoOpt
+  #   Type: CrudActor
+  #   Database: *Database
+  #   Threads: 10
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [2]
+  #       NopInPhasesUpTo: *maxPhases
+  #       PhaseConfig:
+  #         Repeat: *Repeat
+  #         Database: *Database
+  #         Collection: *Collection
+  #         Operations:
+  #         - OperationMetricsName:
+  #           OperationName: aggregate
+  #           OperationCommand:
+  #             Pipeline: [
+  #               {$_internalInhibitOptimization: {}},
+  #               {$group: {
+  #     _id: {t: {$dateTrunc: {date: "$time", unit: "year"}}},
+  #     min: {$min: "$usage_steal"},
+  #     max: {$max: "$usage_steal"}
+  #   }}
+  # ]
 
-- Name: MatchLTBucketNotAlign
-  Type: CrudActor
-  Database: *Database
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [4]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: *Repeat
-        Database: *Database
-        Collection: *Collection
-        Operations:
-        - OperationMetricsName:
-          OperationName: aggregate
-          OperationCommand:
-            Pipeline: [ {$match: {"time": {$lt: *DateForBucketNotAlign}}}  ]
+  # $lt query that aligns with the bucket boundaries.
+  - Name: MatchLTBucketAlign
+    Type: CrudActor
+    Database: *Database
+    Threads: 10
+    Phases:
+      OnlyActiveInPhases:
+        Active: [3]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *Repeat
+          Database: *Database
+          Collection: *Collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    { $match: { "time": { $lt: *DateForBucketAlign } } },
+                    {
+                      $group:
+                        {
+                          _id:
+                            {
+                              t:
+                                { $dateTrunc: { date: "$time", unit: "year" } },
+                            },
+                          min: { $min: "$usage_steal" },
+                          max: { $max: "$usage_steal" },
+                        },
+                    },
+                  ]
 
-# gte query that aligns with the bucket boundaries.
-- Name: MatchGTEBucketAlign
-  Type: CrudActor
-  Database: *Database
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [5]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: *Repeat
-        Database: *Database
-        Collection: *Collection
-        Operations:
-        - OperationMetricsName:
-          OperationName: aggregate
-          OperationCommand:
-            Pipeline: [ {$match: {"time": {$gte: *DateForBucketAlign}}}  ]
+  - Name: MatchLTBucketNotAlign
+    Type: CrudActor
+    Database: *Database
+    Threads: 10
+    Phases:
+      OnlyActiveInPhases:
+        Active: [4]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *Repeat
+          Database: *Database
+          Collection: *Collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    { $match: { "time": { $lt: *DateForBucketNotAlign } } },
+                    {
+                      $group:
+                        {
+                          _id:
+                            {
+                              t:
+                                { $dateTrunc: { date: "$time", unit: "year" } },
+                            },
+                          min: { $min: "$usage_steal" },
+                          max: { $max: "$usage_steal" },
+                        },
+                    },
+                  ]
 
-# gte query that aligns with the bucket boundaries.
-- Name: MatchGTEBucketNotAlign
-  Type: CrudActor
-  Database: *Database
-  Threads: 10
-  Phases:
-    OnlyActiveInPhases:
-      Active: [6]
-      NopInPhasesUpTo: *maxPhases
-      PhaseConfig:
-        Repeat: *Repeat
-        Database: *Database
-        Collection: *Collection
-        Operations:
-        - OperationMetricsName:
-          OperationName: aggregate
-          OperationCommand:
-            Pipeline: [ {$match: {"time": {$gte: *DateForBucketNotAlign}}}  ]
+  # gte query that aligns with the bucket boundaries.
+  - Name: MatchGTEBucketAlign
+    Type: CrudActor
+    Database: *Database
+    Threads: 10
+    Phases:
+      OnlyActiveInPhases:
+        Active: [5]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *Repeat
+          Database: *Database
+          Collection: *Collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    { $match: { "time": { $gte: *DateForBucketAlign } } },
+                    {
+                      $group:
+                        {
+                          _id:
+                            {
+                              t:
+                                { $dateTrunc: { date: "$time", unit: "year" } },
+                            },
+                          min: { $min: "$usage_steal" },
+                          max: { $max: "$usage_steal" },
+                        },
+                    },
+                  ]
+
+  # gte query that aligns with the bucket boundaries.
+  - Name: MatchGTEBucketNotAlign
+    Type: CrudActor
+    Database: *Database
+    Threads: 10
+    Phases:
+      OnlyActiveInPhases:
+        Active: [6]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *Repeat
+          Database: *Database
+          Collection: *Collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    { $match: { "time": { $gte: *DateForBucketNotAlign } } },
+                    {
+                      $group:
+                        {
+                          _id:
+                            {
+                              t:
+                                { $dateTrunc: { date: "$time", unit: "year" } },
+                            },
+                          min: { $min: "$usage_steal" },
+                          max: { $max: "$usage_steal" },
+                        },
+                    },
+                  ]

--- a/src/workloads/query/TimeseriesFixedBucketing.yml
+++ b/src/workloads/query/TimeseriesFixedBucketing.yml
@@ -1,0 +1,179 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query-integration"
+Description: |
+  This test exercises the behavior of the time series optimization when the collection has 
+  fixed buckets. This workload uses tsbs data that is imported in the dsi configuration. See 
+  'configurations/test_control/test_control.fixed_bucketing.yml' for all the details.
+  The data is set up with the fixed bucketing parameters set to 3600 and the timeField is "time"
+  and the metaField is "tags". There are 20736000 documents in the collection.
+
+Keywords:
+- timeseries
+- aggregate
+- group
+
+GlobalDefaults:
+  Database: &Database test
+  Collection: &Collection coll
+  maxPhases: &maxPhases 10
+  Repeat: &Repeat 5
+
+# The dates below are chosen for different $match queries. The dates in the tsbs dataset are
+# between 2016-01-01 and 2016-01-25. The dates for the queries were chosen to be in the middle of the
+# dataset. Date0 and Date1 should be close together, since we want to measure the performance
+# improvement of removing the 'eventFilter' in the $match queries. 
+Date0: &DateForBucketAlign
+  LoadConfig:
+    Path: "../../phases/query/GetBsonDate.yml"
+    Key: GetBsonDate
+    Parameters:
+      date: "2016-01-13T01:00:00"
+
+Date1: &DateForBucketNotAlign
+  LoadConfig:
+    Path: "../../phases/query/GetBsonDate.yml"
+    Key: GetBsonDate
+    Parameters:
+      date: "2016-01-13T01:03:02"
+
+Actors:
+# The data is already loaded into the collection from the dsi configuration.
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: 1
+
+# Testing during development showed no significant changes in runtime between the different 
+# dateTrunc.unit values. We chose "year", so the optimization would  apply for many values of 
+# bucketMaxSpanSeconds, if the user decides to adjust the bucketing parameter.
+- Name: DateTruncYear
+  Type: CrudActor
+  Database: *Database
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Database: *Database
+        Collection: *Collection
+        Operations:
+        - OperationMetricsName:
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [
+              {$group: {
+                _id: {t: {$dateTrunc: {date: "$time", unit: "year"}}},
+                min: {$min: "$usage_steal"},
+                max: {$max: "$usage_steal"}
+              }}
+            ]
+# This actor was used during development to measure the improvement in performance for 
+# the rewrite. However, with tsbs data this actor is very slow and therefore we decided to 
+# remove it from this workload in production.
+- Name: DateTruncYearNoOpt
+  Type: CrudActor
+  Database: *Database
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Database: *Database
+        Collection: *Collection
+        Operations:
+        - OperationMetricsName:
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [
+              {$_internalInhibitOptimization: {}},
+              {$group: {
+                _id: {t: {$dateTrunc: {date: "$time", unit: "year"}}},
+                min: {$min: "$usage_steal"},
+                max: {$max: "$usage_steal"}
+              }}
+            ]
+
+# $lt query that aligns with the bucket boundaries.
+# - Name: MatchLTBucketAlign
+#   Type: CrudActor
+#   Database: *Database
+#   Threads: 10
+#   Phases:
+#     OnlyActiveInPhases:
+#       Active: [3]
+#       NopInPhasesUpTo: *maxPhases
+#       PhaseConfig:
+#         Repeat: *Repeat
+#         Database: *Database
+#         Collection: *Collection
+#         Operations:
+#         - OperationMetricsName:
+#           OperationName: aggregate
+#           OperationCommand:
+#             Pipeline: [ {$match: {"time": {$lt: *DateForBucketAlign}}}  ]
+
+# - Name: MatchLTBucketNotAlign
+#   Type: CrudActor
+#   Database: *Database
+#   Threads: 10
+#   Phases:
+#     OnlyActiveInPhases:
+#       Active: [4]
+#       NopInPhasesUpTo: *maxPhases
+#       PhaseConfig:
+#         Repeat: *Repeat
+#         Database: *Database
+#         Collection: *Collection
+#         Operations:
+#         - OperationMetricsName:
+#           OperationName: aggregate
+#           OperationCommand:
+#             Pipeline: [ {$match: {"time": {$lt: *DateForBucketNotAlign}}}  ]
+
+# # gte query that aligns with the bucket boundaries.
+# - Name: MatchGTEBucketAlign
+#   Type: CrudActor
+#   Database: *Database
+#   Threads: 10
+#   Phases:
+#     OnlyActiveInPhases:
+#       Active: [5]
+#       NopInPhasesUpTo: *maxPhases
+#       PhaseConfig:
+#         Repeat: *Repeat
+#         Database: *Database
+#         Collection: *Collection
+#         Operations:
+#         - OperationMetricsName:
+#           OperationName: aggregate
+#           OperationCommand:
+#             Pipeline: [ {$match: {"time": {$gte: *DateForBucketAlign}}}  ]
+
+# # gte query that aligns with the bucket boundaries.
+# - Name: MatchGTEBucketNotAlign
+#   Type: CrudActor
+#   Database: *Database
+#   Threads: 10
+#   Phases:
+#     OnlyActiveInPhases:
+#       Active: [6]
+#       NopInPhasesUpTo: *maxPhases
+#       PhaseConfig:
+#         Repeat: *Repeat
+#         Database: *Database
+#         Collection: *Collection
+#         Operations:
+#         - OperationMetricsName:
+#           OperationName: aggregate
+#           OperationCommand:
+#             Pipeline: [ {$match: {"time": {$gte: *DateForBucketNotAlign}}}  ]

--- a/src/workloads/query/TimeseriesFixedBucketing.yml
+++ b/src/workloads/query/TimeseriesFixedBucketing.yml
@@ -112,7 +112,8 @@ Actors:
   #   }}
   # ]
 
-  # $lt query that aligns with the bucket boundaries.
+  # $lt query that aligns with the bucket boundaries. This allows for further optimization, such as
+  # rewriting the $group stage to occur.
   - Name: MatchLTBucketAlign
     Type: CrudActor
     Database: *Database
@@ -146,6 +147,8 @@ Actors:
                     },
                   ]
 
+  # lt query that does not align with the bucket boundaries. This prevents further optimizations, such as
+  # rewriting the $group stage.
   - Name: MatchLTBucketNotAlign
     Type: CrudActor
     Database: *Database
@@ -163,23 +166,10 @@ Actors:
               OperationName: aggregate
               OperationCommand:
                 Pipeline:
-                  [
-                    { $match: { "time": { $lt: *DateForBucketNotAlign } } },
-                    {
-                      $group:
-                        {
-                          _id:
-                            {
-                              t:
-                                { $dateTrunc: { date: "$time", unit: "year" } },
-                            },
-                          min: { $min: "$usage_steal" },
-                          max: { $max: "$usage_steal" },
-                        },
-                    },
-                  ]
+                  [{ $match: { "time": { $lt: *DateForBucketNotAlign } } }]
 
-  # gte query that aligns with the bucket boundaries.
+  # gte query that aligns with the bucket boundaries. This allows for further optimization, such as
+  # rewriting the $group stage to occur.
   - Name: MatchGTEBucketAlign
     Type: CrudActor
     Database: *Database
@@ -213,7 +203,8 @@ Actors:
                     },
                   ]
 
-  # gte query that aligns with the bucket boundaries.
+  # gte query that does not align with the bucket boundaries. This prevents further optimizations, such as
+  # rewriting the $group stage.
   - Name: MatchGTEBucketNotAlign
     Type: CrudActor
     Database: *Database
@@ -231,18 +222,4 @@ Actors:
               OperationName: aggregate
               OperationCommand:
                 Pipeline:
-                  [
-                    { $match: { "time": { $gte: *DateForBucketNotAlign } } },
-                    {
-                      $group:
-                        {
-                          _id:
-                            {
-                              t:
-                                { $dateTrunc: { date: "$time", unit: "year" } },
-                            },
-                          min: { $min: "$usage_steal" },
-                          max: { $max: "$usage_steal" },
-                        },
-                    },
-                  ]
+                  [{ $match: { "time": { $gte: *DateForBucketNotAlign } } }]

--- a/src/workloads/query/TimeseriesFixedBucketing.yml
+++ b/src/workloads/query/TimeseriesFixedBucketing.yml
@@ -78,13 +78,39 @@ Actors:
 # This actor was used during development to measure the improvement in performance for 
 # the rewrite. However, with tsbs data this actor is very slow and therefore we decided to 
 # remove it from this workload in production.
-- Name: DateTruncYearNoOpt
+# - Name: DateTruncYearNoOpt
+#   Type: CrudActor
+#   Database: *Database
+#   Threads: 10
+#   Phases:
+#     OnlyActiveInPhases:
+#       Active: [2]
+      # NopInPhasesUpTo: *maxPhases
+      # PhaseConfig:
+      #   Repeat: *Repeat
+      #   Database: *Database
+      #   Collection: *Collection
+      #   Operations:
+      #   - OperationMetricsName:
+      #     OperationName: aggregate
+      #     OperationCommand:
+      #       Pipeline: [
+      #         {$_internalInhibitOptimization: {}},
+      #         {$group: {
+      #           _id: {t: {$dateTrunc: {date: "$time", unit: "year"}}},
+      #           min: {$min: "$usage_steal"},
+      #           max: {$max: "$usage_steal"}
+      #         }}
+      #       ]
+
+# $lt query that aligns with the bucket boundaries.
+- Name: MatchLTBucketAlign
   Type: CrudActor
   Database: *Database
   Threads: 10
   Phases:
     OnlyActiveInPhases:
-      Active: [2]
+      Active: [3]
       NopInPhasesUpTo: *maxPhases
       PhaseConfig:
         Repeat: *Repeat
@@ -94,86 +120,60 @@ Actors:
         - OperationMetricsName:
           OperationName: aggregate
           OperationCommand:
-            Pipeline: [
-              {$_internalInhibitOptimization: {}},
-              {$group: {
-                _id: {t: {$dateTrunc: {date: "$time", unit: "year"}}},
-                min: {$min: "$usage_steal"},
-                max: {$max: "$usage_steal"}
-              }}
-            ]
+            Pipeline: [ {$match: {"time": {$lt: *DateForBucketAlign}}}  ]
 
-# $lt query that aligns with the bucket boundaries.
-# - Name: MatchLTBucketAlign
-#   Type: CrudActor
-#   Database: *Database
-#   Threads: 10
-#   Phases:
-#     OnlyActiveInPhases:
-#       Active: [3]
-#       NopInPhasesUpTo: *maxPhases
-#       PhaseConfig:
-#         Repeat: *Repeat
-#         Database: *Database
-#         Collection: *Collection
-#         Operations:
-#         - OperationMetricsName:
-#           OperationName: aggregate
-#           OperationCommand:
-#             Pipeline: [ {$match: {"time": {$lt: *DateForBucketAlign}}}  ]
+- Name: MatchLTBucketNotAlign
+  Type: CrudActor
+  Database: *Database
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [4]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Database: *Database
+        Collection: *Collection
+        Operations:
+        - OperationMetricsName:
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [ {$match: {"time": {$lt: *DateForBucketNotAlign}}}  ]
 
-# - Name: MatchLTBucketNotAlign
-#   Type: CrudActor
-#   Database: *Database
-#   Threads: 10
-#   Phases:
-#     OnlyActiveInPhases:
-#       Active: [4]
-#       NopInPhasesUpTo: *maxPhases
-#       PhaseConfig:
-#         Repeat: *Repeat
-#         Database: *Database
-#         Collection: *Collection
-#         Operations:
-#         - OperationMetricsName:
-#           OperationName: aggregate
-#           OperationCommand:
-#             Pipeline: [ {$match: {"time": {$lt: *DateForBucketNotAlign}}}  ]
+# gte query that aligns with the bucket boundaries.
+- Name: MatchGTEBucketAlign
+  Type: CrudActor
+  Database: *Database
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Database: *Database
+        Collection: *Collection
+        Operations:
+        - OperationMetricsName:
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [ {$match: {"time": {$gte: *DateForBucketAlign}}}  ]
 
-# # gte query that aligns with the bucket boundaries.
-# - Name: MatchGTEBucketAlign
-#   Type: CrudActor
-#   Database: *Database
-#   Threads: 10
-#   Phases:
-#     OnlyActiveInPhases:
-#       Active: [5]
-#       NopInPhasesUpTo: *maxPhases
-#       PhaseConfig:
-#         Repeat: *Repeat
-#         Database: *Database
-#         Collection: *Collection
-#         Operations:
-#         - OperationMetricsName:
-#           OperationName: aggregate
-#           OperationCommand:
-#             Pipeline: [ {$match: {"time": {$gte: *DateForBucketAlign}}}  ]
-
-# # gte query that aligns with the bucket boundaries.
-# - Name: MatchGTEBucketNotAlign
-#   Type: CrudActor
-#   Database: *Database
-#   Threads: 10
-#   Phases:
-#     OnlyActiveInPhases:
-#       Active: [6]
-#       NopInPhasesUpTo: *maxPhases
-#       PhaseConfig:
-#         Repeat: *Repeat
-#         Database: *Database
-#         Collection: *Collection
-#         Operations:
-#         - OperationMetricsName:
-#           OperationName: aggregate
-#           OperationCommand:
-#             Pipeline: [ {$match: {"time": {$gte: *DateForBucketNotAlign}}}  ]
+# gte query that aligns with the bucket boundaries.
+- Name: MatchGTEBucketNotAlign
+  Type: CrudActor
+  Database: *Database
+  Threads: 10
+  Phases:
+    OnlyActiveInPhases:
+      Active: [6]
+      NopInPhasesUpTo: *maxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Database: *Database
+        Collection: *Collection
+        Operations:
+        - OperationMetricsName:
+          OperationName: aggregate
+          OperationCommand:
+            Pipeline: [ {$match: {"time": {$gte: *DateForBucketNotAlign}}}  ]


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** PERF-4312

**Whats Changed:**  
2 new workloads were added. One is to exercise the $count optimization that was added in the fixed bucketing project. One is to measure the performance improvements of the fixed bucketing $dateTrunc optimization that was added. 

**Patch testing results:**  
[Patch link](https://spruce.mongodb.com/version/64efb3df2fbabe81fc81b11f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

[Patch with new variants added](https://spruce.mongodb.com/version/64f739453627e06217b48cd2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

**Workload Submission form:**  
If applicable, only required if there is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)
Form is submitted! 

**Related PRs:**   
[DSI PR](https://github.com/10gen/dsi/pull/1397)
[SERVER PR](https://github.com/10gen/mongo/pull/15380)