### PR TITLE
PERF-4637 Create a workload that can be affected by the optimization to expression search for parameter reuse

### DIFF
--- a/src/workloads/query/FilterWithComplexLogicalExpression.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpression.yml
@@ -25,6 +25,8 @@ Keywords:
 - QuiesceActor
 - insert
 - find
+- matcher
+- expressions
 
 GlobalDefaults:
   Database: &Database test

--- a/src/workloads/query/FilterWithComplexLogicalExpression.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpression.yml
@@ -25,8 +25,6 @@ Keywords:
 - QuiesceActor
 - insert
 - find
-- matcher
-- expressions
 
 GlobalDefaults:
   Database: &Database test

--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -1,0 +1,150 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload tests the performance of expression search for parameter re-use during parameterization. 
+  Before September 2023, parameter re-use had O(n^2) complexity due to using a vector for looking up equivalent expressions. 
+  SERVER-79092 fixed this issue by switching over to a map once the amount of expressions reaches a threshold (currently 50).
+
+GlobalDefaults:
+  Database: &Database test
+  Collection: &Collection Collection0
+  MaxPhases: &MaxPhases 7
+  DocumentCount: &DocumentCount 10
+
+Keywords:
+- Loader
+- CrudActor
+- QuiesceActor
+- insert
+- Aggregation
+
+ActorTemplates:
+- TemplateName: MatchExpressionWithOrClausesTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "unused"}}
+    Type: CrudActor
+    Database: *Database
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "ActivePhase", Default: -1}}]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Repeat: {^Parameter: {Name: "Repeat", Default: 1}}
+          Collection: *Collection
+          Operations:
+          - OperationName: aggregate
+            OperationCommand:
+              Pipeline: [
+                {$match: {$or: {^Array: {of: 
+                  {$and: [
+                    {a: {$gt: {^Inc: {start: 10}}}},
+                    {b: {$gt: {^Inc: {start: 10}}}}
+                  ]},
+                  number: {^Parameter: {Name: "NumberOfClauses", Default: -1}}
+                }}}}
+              ]
+
+Actors:
+# Clear any pre-existing collection state.
+- Name: ClearCollection
+  Type: CrudActor
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Collection: *Collection
+        Operations:
+        - OperationName: drop
+
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Collection: *Collection
+        Threads: 1
+        CollectionCount: 1
+        DocumentCount: *DocumentCount
+        BatchSize: *DocumentCount
+        Document:
+          a: [0, 1]
+          b: [2, 3]
+          c: 4
+          d: 5
+          object: {}
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+
+- ActorFromTemplate:
+    TemplateName: MatchExpressionWithOrClausesTemplate
+    TemplateParameters:
+      Name: RunMatchExpressionOrWith50Clauses
+      Repeat: 1000
+      ActivePhase: 3
+      NumberOfClauses: 50
+
+- ActorFromTemplate:
+    TemplateName: MatchExpressionWithOrClausesTemplate
+    TemplateParameters:
+      Name: RunMatchExpressionOrWith100Clauses
+      Repeat: 1000
+      ActivePhase: 4
+      NumberOfClauses: 100
+
+- ActorFromTemplate:
+    TemplateName: MatchExpressionWithOrClausesTemplate
+    TemplateParameters:
+      Name: RunMatchExpressionOrWith1000Clauses
+      Repeat: 100
+      ActivePhase: 5
+      NumberOfClauses: 1000
+
+- ActorFromTemplate:
+    TemplateName: MatchExpressionWithOrClausesTemplate
+    TemplateParameters:
+      Name: RunMatchExpressionOrWith10000Clauses
+      Repeat: 10
+      ActivePhase: 6
+      NumberOfClauses: 10000
+
+- ActorFromTemplate:
+    TemplateName: MatchExpressionWithOrClausesTemplate
+    TemplateParameters:
+      Name: RunMatchExpressionOrWith50000Clauses
+      Repeat: 5
+      ActivePhase: 7
+      NumberOfClauses: 50000
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
+      - standalone-sampling-bonsai
+      - standalone-sbe
+      - standalone-query-stats
+    branch_name:
+      $gte:
+        v7.0

--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -146,7 +146,7 @@ Actors:
     TemplateName: MatchExpressionWithOrClausesTemplate
     TemplateParameters:
       Name: RunMatchExpressionOrWith50000Clauses
-      Repeat: 5
+      Repeat: 10
       ActivePhase: 9
       NumberOfClauses: 50000
 

--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -163,4 +163,4 @@ AutoRun:
       - standalone-query-stats
     branch_name:
       $gte:
-        v7.0
+        v7.2

--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -8,7 +8,7 @@ Description: |
 GlobalDefaults:
   Database: &Database test
   Collection: &Collection Collection0
-  MaxPhases: &MaxPhases 7
+  MaxPhases: &MaxPhases 9
   DocumentCount: &DocumentCount 10
 
 Keywords:
@@ -97,9 +97,25 @@ Actors:
 - ActorFromTemplate:
     TemplateName: MatchExpressionWithOrClausesTemplate
     TemplateParameters:
-      Name: RunMatchExpressionOrWith50Clauses
+      Name: RunMatchExpressionOrWith10Clauses
       Repeat: 1000
       ActivePhase: 3
+      NumberOfClauses: 10
+
+- ActorFromTemplate:
+    TemplateName: MatchExpressionWithOrClausesTemplate
+    TemplateParameters:
+      Name: RunMatchExpressionOrWith25Clauses
+      Repeat: 1000
+      ActivePhase: 4
+      NumberOfClauses: 20
+
+- ActorFromTemplate:
+    TemplateName: MatchExpressionWithOrClausesTemplate
+    TemplateParameters:
+      Name: RunMatchExpressionOrWith50Clauses
+      Repeat: 1000
+      ActivePhase: 5
       NumberOfClauses: 50
 
 - ActorFromTemplate:
@@ -107,7 +123,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith100Clauses
       Repeat: 1000
-      ActivePhase: 4
+      ActivePhase: 6
       NumberOfClauses: 100
 
 - ActorFromTemplate:
@@ -115,7 +131,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith1000Clauses
       Repeat: 100
-      ActivePhase: 5
+      ActivePhase: 7
       NumberOfClauses: 1000
 
 - ActorFromTemplate:
@@ -123,7 +139,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith10000Clauses
       Repeat: 10
-      ActivePhase: 6
+      ActivePhase: 8
       NumberOfClauses: 10000
 
 - ActorFromTemplate:
@@ -131,7 +147,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith50000Clauses
       Repeat: 5
-      ActivePhase: 7
+      ActivePhase: 9
       NumberOfClauses: 50000
 
 AutoRun:

--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -17,6 +17,8 @@ Keywords:
 - QuiesceActor
 - insert
 - Aggregation
+- matcher
+- expressions
 
 ActorTemplates:
 - TemplateName: MatchExpressionWithOrClausesTemplate

--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -8,7 +8,7 @@ Description: |
 GlobalDefaults:
   Database: &Database test
   Collection: &Collection Collection0
-  MaxPhases: &MaxPhases 9
+  MaxPhases: &MaxPhases 8
   DocumentCount: &DocumentCount 10
 
 Keywords:
@@ -48,27 +48,12 @@ ActorTemplates:
               ]
 
 Actors:
-# Clear any pre-existing collection state.
-- Name: ClearCollection
-  Type: CrudActor
-  Database: *Database
-  Phases:
-    OnlyActiveInPhases:
-      Active: [0]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Repeat: 1
-        Threads: 1
-        Collection: *Collection
-        Operations:
-        - OperationName: drop
-
 - Name: InsertData
   Type: Loader
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1]
+      Active: [0]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Repeat: 1
@@ -91,7 +76,7 @@ Actors:
   Database: *Database
   Phases:
     OnlyActiveInPhases:
-      Active: [2]
+      Active: [1]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Repeat: 1
@@ -101,7 +86,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith10Clauses
       Repeat: 1000
-      ActivePhase: 3
+      ActivePhase: 2
       NumberOfClauses: 10
 
 - ActorFromTemplate:
@@ -109,7 +94,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith25Clauses
       Repeat: 1000
-      ActivePhase: 4
+      ActivePhase: 3
       NumberOfClauses: 20
 
 - ActorFromTemplate:
@@ -117,7 +102,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith50Clauses
       Repeat: 1000
-      ActivePhase: 5
+      ActivePhase: 4
       NumberOfClauses: 50
 
 - ActorFromTemplate:
@@ -125,7 +110,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith100Clauses
       Repeat: 1000
-      ActivePhase: 6
+      ActivePhase: 5
       NumberOfClauses: 100
 
 - ActorFromTemplate:
@@ -133,7 +118,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith1000Clauses
       Repeat: 100
-      ActivePhase: 7
+      ActivePhase: 6
       NumberOfClauses: 1000
 
 - ActorFromTemplate:
@@ -141,7 +126,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith10000Clauses
       Repeat: 10
-      ActivePhase: 8
+      ActivePhase: 7
       NumberOfClauses: 10000
 
 - ActorFromTemplate:
@@ -149,7 +134,7 @@ Actors:
     TemplateParameters:
       Name: RunMatchExpressionOrWith50000Clauses
       Repeat: 10
-      ActivePhase: 9
+      ActivePhase: 8
       NumberOfClauses: 50000
 
 AutoRun:


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** PERF-4637

**Whats Changed:**  
A new workload was added to test the performance of expression search for parameter re-use during parameterization.

**Patch testing results:**  
https://spruce.mongodb.com/version/64f07cbb1e2d170ed4b21ff3/tasks

**Workload Submission form:**  
Submitted

**Related PRs:**   
[SERVER-79092](https://github.com/10gen/mongo/pull/15219)