### PR TITLE
PERF-4656: Add dollar prefix to colocated $lookup let field

### DIFF
--- a/src/workloads/query/LookupColocatedData.yml
+++ b/src/workloads/query/LookupColocatedData.yml
@@ -106,7 +106,7 @@ ActorTemplates:
                 [
                   {$lookup: {
                     from: {^Parameter: {Name: "Coll", Default: "localColl"}},
-                    let: {local_field: "localField"},
+                    let: {local_field: "$localField"},
                     pipeline: [
                       {$match: 
                         {


### PR DESCRIPTION
This patch fixes a typo in the let + pipeline `$lookup` queries. The definition of the let is an expressions, so it must be dollar-prefixed, not a simple string.

Here's the [patch test ](https://spruce.mongodb.com/version/64f221ce850e6109ef514751/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)and corresponding [perf analysis](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=2bd51a4a-eaab-43a9-bffa-83e424dd20de&task_filter=lookup_colocated_data&measurement_filter=Latency50thPercentile&determination_filter=Improved&determination_filter=Regressed&percent_filter=0%7C%7C100&z_filter=0%7C%7C10). 

As I would expect, most `*LetPipeline*` queries get slower because they are matching documents, whereas before they were not matching any. There is one notable exception: `ShardedLetPipeline15k`, which seems to get much faster. I had been looking into this query for a bit because after Ivan's change, almost all of the colocated sharded $lookups got a _lot_ faster. The only exception was `ShardedLetPipeline15k`, which seemed to indicate an issue with the test, since there is no reason this query should be different from `ShardedLetPipeline5k` and `ShardedLocalFieldForeignField15k`. So while I am surprised that my change reveals the improvement, I'm not surprised to see an improvement of this magnitude.