### PR TITLE
EVG-20582: Error message for running getPlural for a Sequence node

### DIFF
--- a/src/gennylib/include/gennylib/Node.hpp
+++ b/src/gennylib/include/gennylib/Node.hpp
@@ -664,6 +664,18 @@ template <typename T, typename F>
 std::vector<T> Node::getPlural(const std::string& singular,
                                const std::string& plural,
                                F&& f) const {
+
+    if (this->isSequence()) {
+        BOOST_THROW_EXCEPTION(
+            InvalidKeyException(
+                "Try to access key '" + singular + "' or '" + plural + "',"
+                + " but this node is a Sequence not a Map."
+                + " Please double check your config file."
+                + " (see the path to the preprocessed YAML file below.)",
+                singular + "/"+ plural,
+                this));
+    }
+
     std::vector<T> out;
     const auto& pluralValue = (*this)[plural];
     const auto& singValue = (*this)[singular];


### PR DESCRIPTION
**Jira Ticket:** EVG-20582

**Whats Changed:**

If an `actor::PhaseConfig` tries to `getPlural` from a Sequence, report an error message which is different from the default `InvalidKeyException` message. Hopefully this helps users to understand the error better.

**Patch testing results:**

I've run local tests using the configuration with the configuration files mentioned in the ticket EVG-20582.

Originally, the error message is this:

```text
Invalid key 'getPlural('Operation', 'Operations')': Either 'Operation' or 'Operations' required. On node with path
'/Users/lungang.fang/source/genny/build/WorkloadOutput/workload/test.yml/Actors/0/Phases/0': - Repeat: 1
  Database: test
  Operations:
    OperationName: RunCommand
    OperationCommand:
      create: Collection0
      timeseries:
        timeField: t
        metaField: sensorId
        granularity: seconds
- Nop: true
- Nop: true
- Nop: true
- Nop: true
```

The new error message is this:

```text
Invalid key 'Operation/Operations': Try to access key 'Operation' or 'Operations', but this node is a Sequence not a Map. Please double check your
config file. (see the path to the preprocessed YAML file below.)
On node with path '/Users/lungang.fang/source/genny/build/WorkloadOutput/workload/test.yml/Actors/0/Phases/0':
- Repeat: 1
  Database: test
  Operations:
    OperationName: RunCommand
    OperationCommand:
      create: Collection0
      timeseries:
        timeField: t
        metaField: sensorId
        granularity: seconds
- Nop: true
- Nop: true
- Nop: true
- Nop: true
```