### PR TITLE
EVG-20698 Toplogy replaces mongodb+srv for replica set member URLs

### DIFF
--- a/src/gennylib/src/topology.cpp
+++ b/src/gennylib/src/topology.cpp
@@ -121,6 +121,18 @@ std::string Topology::nameToUri(const std::string& name) {
     }
     nameSet.insert(strippedName);
     _factory.overrideHosts(nameSet);
+
+    // Currently, the only two protocols supported are "mongodb://" and
+    // "mongodb+srv://" (see PoolFactory::Config). Hence, replacing
+    // "mongodb+srv://" with "mongodb://" implies always setting the protocoal
+    // to "mongodb://". Therefore, the following "if" is unnecessary. the The
+    // goal of adding it is to avoid surprises should more protocols are
+    // supported in the future.
+    if (_factory.getOption(PoolFactory::OptionType::kAccessOption, "Protocol") == "mongodb+srv://") {
+        _factory.setOption(PoolFactory::OptionType::kAccessOption,
+                           "Protocol", "mongodb://");
+    }
+
     return _factory.makeUri();
 }
 


### PR DESCRIPTION
**Jira Ticket:** EVG-20698

**Whats Changed:**  

Topology needs to access cluster members directly. Currently, the URIs for the members are constructed using "protocol://member_fqdn:port", where protocol is either "mongodb" or "mongodb+srv". When "mongodb+srv" is used (for Atlas related tests), the resulted URIs are invalid because mongodb+srv shall not include port numbers.

This change is to make Topology to replace "mongodb+srv://" with "mongodb://" because in the Atlas test deployment such URLs appear to work.

While this fix enables tests to run, IMHO this is not the correct approach to handle "mongodb+srv" because clients are not supposed to access members directly. Hence I'd prefer discard this PR and use the change in https://github.com/mongodb/genny/pull/1018

Please let me know how you think.

**Patch testing results:**  
None