### PR TITLE
EVG-20698 QuiesceActor reports error if srv mongodb uri is in use.

### DIFF
--- a/src/cast_core/src/QuiesceActor.cpp
+++ b/src/cast_core/src/QuiesceActor.cpp
@@ -65,7 +65,16 @@ QuiesceActor::QuiesceActor(genny::ActorContext& context)
     : Actor{context},
       _totalQuiesces{context.operation("Quiesce", QuiesceActor::id())},
       _client{context.client()},
-      _loop{context} {}
+      _loop{context} {
+
+    std::string srv = "mongodb+srv://";
+    auto uri_prefix = _client->uri().to_string().substr(0, srv.length());
+
+    if (uri_prefix == srv) {
+        throw InvalidConfigurationException(
+            "QuiesceActor does not support 'mongodb+srv://' connection URI.");
+    }
+}
 
 namespace {
 auto registerQuiesceActor = Cast::registerDefault<QuiesceActor>();

--- a/src/cast_core/src/QuiesceActor.cpp
+++ b/src/cast_core/src/QuiesceActor.cpp
@@ -67,10 +67,7 @@ QuiesceActor::QuiesceActor(genny::ActorContext& context)
       _client{context.client()},
       _loop{context} {
 
-    std::string srv = "mongodb+srv://";
-    auto uri_prefix = _client->uri().to_string().substr(0, srv.length());
-
-    if (uri_prefix == srv) {
+    if (_client->uri().to_string().find("mongodb+srv://") == 0){
         throw InvalidConfigurationException(
             "QuiesceActor does not support 'mongodb+srv://' connection URI.");
     }


### PR DESCRIPTION
**Jira Ticket:** EVG-20698

**Whats Changed:**  

QuiesceActor uses Topology, which needs to access cluster members directly. Currently, the URIs for the members are constructed using "protocol://member_fqdn:port", where protocol is either "mongodb" or "mongodb+srv". When "mongodb+srv" is used (for Atlas related tests), the resulted URIs are invalid because mongodb+srv shall not include port numbers.

This change is to report the error during QuiesceAcor initialization (in the constructor) so that:
- The users understand what the issue is.
- Tests with wrong mongo URIs (i.e. the srv ones)  fail at the beginning *not* when QuiesceActor actually start to work.

**Patch testing results:**  
None