### PR TITLE
EVG-20906: Don't reference undefined variable.

### DIFF
--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -516,7 +516,7 @@ class ConfigWriter:
             if execution != 0:
                 SLOG.warning(
                     "Repeated executions will not re-generate tasks.",
-                    execution=build.execution,
+                    execution=execution,
                 )
 
     @staticmethod

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -4,7 +4,8 @@ import unittest
 import os
 from typing import NamedTuple, List, Optional
 from unittest.mock import MagicMock
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
+from shrub.config import Configuration
 import structlog
 
 from genny.tasks.auto_tasks import (
@@ -894,6 +895,17 @@ class AutoTasksTests(BaseTestClass):
             },
             to_file="./build/TaskJSON/Tasks.json",
         )
+
+    def test_later_execution(self):
+        """Ensures that we exercise the code path warning about task generation not working
+        on later executions and don't throw exceptions."""
+        with patch("builtins.open", mock_open()) as open_mock, patch(
+            "os.makedirs"
+        ) as makedirs_mock, patch("os.unlink") as unlink_mock, patch(
+            "os.path.exists", return_value=False
+        ) as exists_mock:
+            config = Configuration()
+            ConfigWriter.write_config(execution=5, config=config, output_file="fakefile123")
 
 
 def test_dry_run_all_tasks():


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** EVG-20906

**Whats Changed:**  
Use the correct variable when warning about task generation
