### PR TITLE
SERVER-81260: custom throughput reporter for streams

### DIFF
--- a/src/cast_core/include/cast_core/actors/StreamStatsReporter.hpp
+++ b/src/cast_core/include/cast_core/actors/StreamStatsReporter.hpp
@@ -1,0 +1,82 @@
+// Copyright 2023-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HEADER_D5EB1FAB_E817_43DE_A126_FCC6995B4C3C_INCLUDED
+#define HEADER_D5EB1FAB_E817_43DE_A126_FCC6995B4C3C_INCLUDED
+
+#include <string_view>
+
+#include <mongocxx/pool.hpp>
+
+#include <gennylib/Actor.hpp>
+#include <gennylib/Orchestrator.hpp>
+#include <gennylib/PhaseLoop.hpp>
+#include <gennylib/context.hpp>
+
+#include <metrics/metrics.hpp>
+
+namespace genny::actor {
+
+/**
+ * Periodically polls (every 250ms) the stream processor's stats from the
+ * mongostream instance (`streams_getStats`) until the expected document count
+ * is met. This is needed because stream processing is fully async so we need to
+ * rely on metrics emitted from the stream processor itself in order to get proper
+ * numbers on throughput.
+ *
+ * Throughput for a stream processor is measured based on the input rate of
+ * the stream processor, so in our case it'll be based on the `inputMessageCount`
+ * and `inputMessageBytes` stats in the `streams_getStats` response.
+ *
+ * ```yaml
+ * SchemaVersion: 2017-07-01
+ * Actors:
+ * - Name: StreamStatsReporter
+ *   Type: StreamStatsReporter
+ *   Database: test
+ *   Phases:
+ *   - Repeat: 1
+ *     StreamProcessorName: sp
+ *     ExpectedDocumentCount: 1000000
+ * ```
+ *
+ * Owner: @atlas-streams
+ */
+class StreamStatsReporter : public Actor {
+public:
+    explicit StreamStatsReporter(ActorContext& context);
+    ~StreamStatsReporter() = default;
+
+    void run() override;
+
+    static std::string_view defaultName() {
+        return "StreamStatsReporter";
+    }
+
+private:
+    mongocxx::pool::entry _client;
+
+    // Recorded based on the response of `streams_getStats` from the mongostream
+    // instance.
+    genny::metrics::Operation _throughput;
+
+    /** @private */
+    struct PhaseConfig;
+    PhaseLoop<PhaseConfig> _loop;
+    genny::Orchestrator& _orchestrator;
+};
+
+}  // namespace genny::actor
+
+#endif  // HEADER_D5EB1FAB_E817_43DE_A126_FCC6995B4C3C_INCLUDED

--- a/src/cast_core/src/StreamStatsReporter.cpp
+++ b/src/cast_core/src/StreamStatsReporter.cpp
@@ -1,0 +1,116 @@
+// Copyright 2023-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cast_core/actors/StreamStatsReporter.hpp>
+
+#include <memory>
+
+#include <yaml-cpp/yaml.h>
+
+#include <bsoncxx/array/view.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <metrics/operation.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/database.hpp>
+
+#include <boost/log/trivial.hpp>
+#include <boost/throw_exception.hpp>
+
+#include <gennylib/Cast.hpp>
+#include <gennylib/MongoException.hpp>
+#include <gennylib/context.hpp>
+
+#include <value_generators/DocumentGenerator.hpp>
+
+namespace genny::actor {
+
+namespace {
+
+// Poll interval for `streams_getStats`.
+static constexpr std::chrono::milliseconds kPollInterval{1000ms};
+
+}; // namespace
+
+struct StreamStatsReporter::PhaseConfig {
+    mongocxx::database database;
+    bsoncxx::document::value statsCommand = bsoncxx::from_json("{}");
+
+    int64_t expectedDocumentCount{0};
+
+    PhaseConfig(PhaseContext& phaseContext, mongocxx::database&& db, ActorId id)
+        : database{db}, expectedDocumentCount{phaseContext["ExpectedDocumentCount"].to<int64_t>()} {
+        int threads = phaseContext.actor()["Threads"].to<int>();
+        if (threads != 1) {
+            BOOST_THROW_EXCEPTION(InvalidConfigurationException("StreamStatsReporter only allows 1 thread"));
+        }
+
+        auto repeat = phaseContext["Repeat"].maybe<int>();
+        if (!repeat || *repeat != 1) {
+            BOOST_THROW_EXCEPTION(InvalidConfigurationException("StreamStatsReporter only allows a single repeat"));
+        }
+
+        std::string streamProcessorName = phaseContext["StreamProcessorName"].to<std::string>();
+        bsoncxx::builder::stream::document builder;
+        statsCommand = builder << "streams_getStats" << "" << "name" << streamProcessorName << bsoncxx::builder::stream::finalize;
+    }
+};
+
+void StreamStatsReporter::run() {
+    for (auto&& config : _loop) {
+        for (const auto&& _ : config) {
+            auto throughput = _throughput.start();
+
+            int64_t inputMessageCount{0};
+            double inputMessageBytes{0};
+            while (_orchestrator.continueRunning()) {
+                auto reply = config->database.run_command(config->statsCommand.view());
+                BOOST_LOG_TRIVIAL(debug) << "stats reply: " << bsoncxx::to_json(reply);
+
+                inputMessageCount = reply.view()["inputMessageCount"].get_int64();
+                inputMessageBytes = reply.view()["inputMessageSize"].get_double();
+                if (inputMessageCount >= config->expectedDocumentCount) {
+                    break;
+                }
+
+                _orchestrator.sleepUntilOrPhaseEnd(std::chrono::steady_clock::now() + kPollInterval, config.phaseNumber());
+            }
+
+            throughput.addDocuments(inputMessageCount);
+            throughput.addIterations(inputMessageCount);
+            throughput.addBytes(inputMessageBytes);
+            throughput.success();
+        }
+    }
+}
+
+StreamStatsReporter::StreamStatsReporter(genny::ActorContext& context)
+    : Actor{context},
+      _throughput{context.operation("Throughput", StreamStatsReporter::id())},
+      _client{std::move(
+          context.client(context.get("ClientName").maybe<std::string>().value_or("Default")))},
+      _loop{context, (*_client)[context["Database"].to<std::string>()], StreamStatsReporter::id()},
+      _orchestrator{context.orchestrator()} {}
+
+namespace {
+//
+// This tells the "global" cast about our actor using the defaultName() method
+// in the header file.
+//
+auto registerStreamStatsReporter = Cast::registerDefault<StreamStatsReporter>();
+}  // namespace
+}  // namespace genny::actor

--- a/src/cast_core/test/StreamStatsReporter_test.cpp
+++ b/src/cast_core/test/StreamStatsReporter_test.cpp
@@ -1,0 +1,89 @@
+// Copyright 2023-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+
+#include <boost/exception/diagnostic_information.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+#include <testlib/MongoTestFixture.hpp>
+#include <testlib/ActorHelper.hpp>
+#include <testlib/helpers.hpp>
+
+#include <gennylib/context.hpp>
+
+namespace genny {
+namespace {
+using namespace genny::testing;
+namespace bson_stream = bsoncxx::builder::stream;
+
+TEST_CASE_METHOD(MongoTestFixture, "StreamStatsReporter successfully connects to a MongoDB instance.",
+          "[streams][StreamStatsReporter]") {
+
+    dropAllDatabases();
+    auto db = client.database("mydb");
+
+    NodeSource nodes = NodeSource(R"(
+        SchemaVersion: 2018-07-01
+        Clients:
+          Default:
+            URI: )" + MongoTestFixture::connectionUri().to_string() + R"(
+        Actors:
+        - Name: StreamStatsReporter
+          Type: StreamStatsReporter
+          Database: mydb
+          Phases:
+          - Repeat: 1
+            StreamProcessorName: sp
+            ExpectedDocumentCount: 1
+    )", __FILE__);
+
+
+    SECTION("Runs successfully") {
+        try {
+            auto startCommand = bsoncxx::builder::stream::document{}
+                << "streams_startStreamProcessor" << ""
+                << "name" << "sp"
+                << "pipeline" << bsoncxx::builder::stream::open_array
+                << bsoncxx::builder::stream::open_document
+                << "$source" << bsoncxx::builder::stream::open_document << "connectionName" << "__testMemory" << bsoncxx::builder::stream::close_document
+                << bsoncxx::builder::stream::close_document
+                << bsoncxx::builder::stream::open_document
+                << "$emit" << bsoncxx::builder::stream::open_document << "connectionName" << "__testMemory" << bsoncxx::builder::stream::close_document
+                << bsoncxx::builder::stream::close_document
+                << bsoncxx::builder::stream::close_array
+                << "connections" << bsoncxx::builder::stream::open_array
+                << bsoncxx::builder::stream::open_document
+                << "name" << "__testMemory"
+                << "type" << "in_memory"
+                << "options" << bsoncxx::builder::stream::open_document << bsoncxx::builder::stream::close_document
+                << bsoncxx::builder::stream::close_document
+                << bsoncxx::builder::stream::close_array
+                << bsoncxx::builder::stream::finalize;
+            db.run_command(startCommand.view());
+
+            // Just run to make sure that we don't crash.
+            genny::ActorHelper ah(nodes.root(), 1);
+            ah.run([](const genny::WorkloadContext& wc) { wc.actors()[0]->run(); });
+        } catch (const std::exception& e) {
+            auto diagInfo = boost::diagnostic_information(e);
+            INFO("CAUGHT " << diagInfo);
+            FAIL(diagInfo);
+        }
+    }
+}
+}  // namespace
+}  // namespace genny

--- a/src/workloads/docs/StreamStatsReporter.yml
+++ b/src/workloads/docs/StreamStatsReporter.yml
@@ -1,19 +1,20 @@
 SchemaVersion: 2018-07-01
-Owner: "@10gen/altas-streams"
+Owner: "@10gen/atlas-streams"
 Description: |
-  Streaming pipeline that runs a very simple single stage projection pipeline. This
-  is meant to represent the most barebone use case for streaming.
-
-Keywords:
-- streams
+  Generates load against a stream processor and has a stats reporter actor that will
+  report stats about that stream processor after the insert phase is complete since
+  the processing is fully async.
 
 GlobalDefaults:
-  DatabaseName: &DatabaseName "test"
-  StreamProcessorName: &StreamProcessorName "sp"
-
-  # Use 16 inserter threads that insert 100 batches of 1k documents, so
-  # total of 1.6M documents.
-  NumThreads: &NumThreads 16
+  DatabaseName: &DatabaseName test
+  StreamProcessorName: &StreamProcessorName sp1
+  Document: &Document
+    id: {^Inc: { start: 1000 }}
+  BatchSize: &BatchSize 1000
+  Batch1000x: &Batch1000x {^Array: { number: *BatchSize, of: *Document }}
+  NumBatches: &NumBatches 1000
+  NumThreads: &NumThreads 8
+  ExpectedDocumentCount: &ExpectedDocumentCount 8000000
 
 Actors:
 - Name: Setup
@@ -31,14 +32,6 @@ Actors:
         name: *StreamProcessorName
         pipeline: [
           { $source: { connectionName: "__testMemory" } },
-          {
-            $project: {
-              auction: 1,
-              bidder: 1,
-              dateTime: 1,
-              price: { $multiply: ["$price", 0.908] }
-            }
-          },
           { $emit: { connectionName: "__testMemory" } }
         ]
         connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
@@ -54,40 +47,35 @@ Actors:
         streams_stopStreamProcessor: ""
         name: *StreamProcessorName
 
-- Name: Insert_Batch100x
+- Name: Inserter
   Type: RunCommand
-  Threads: *NumThreads
+  Threads: 8
   Phases:
   - Phase: 0
     Nop: true
   - Phase: 1
-    LoadConfig:
-      Path: ./InsertBidsTemplate.yml
-      Key: InsertBids
-      Parameters:
-        Database: *DatabaseName
-        StreamProcessorName: *StreamProcessorName
+    Database: test
+    Repeat: *NumBatches
+    Operations:
+    - OperationMetricsName: Insert
+      OperationName: RunCommand
+      OperationCommand:
+        streams_testOnlyInsert: ""
+        name: *StreamProcessorName
+        documents: *Batch1000x
   - Phase: 2
     Nop: true
 
-- Name: Stats
+- Name: StreamStatsReporter
   Type: StreamStatsReporter
-  Database: *DatabaseName
   Threads: 1
+  Database: test
   Phases:
   - Phase: 0
     Nop: true
   - Phase: 1
     Repeat: 1
     StreamProcessorName: *StreamProcessorName
-    ExpectedDocumentCount: 1600000
+    ExpectedDocumentCount: *ExpectedDocumentCount
   - Phase: 2
     Nop: true
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone-streams
-    branch_name:
-      $gte: v7.2

--- a/src/workloads/streams/HighestBid.yml
+++ b/src/workloads/streams/HighestBid.yml
@@ -13,6 +13,10 @@ GlobalDefaults:
   DatabaseName: &DatabaseName "test"
   StreamProcessorName: &StreamProcessorName "sp"
 
+  # Use 16 inserter threads that insert 100 batches of 1k documents, so
+  # total of 1.6M documents.
+  NumThreads: &NumThreads 16
+
 Actors:
 - Name: Setup
   Type: RunCommand
@@ -75,9 +79,9 @@ Actors:
         streams_stopStreamProcessor: ""
         name: *StreamProcessorName
 
-- Name: Insert_Batch1000x
+- Name: Insert_Batch100x
   Type: RunCommand
-  Threads: 32
+  Threads: *NumThreads
   Phases:
   - Phase: 0
     Nop: true
@@ -88,7 +92,20 @@ Actors:
       Parameters:
         Database: *DatabaseName
         StreamProcessorName: *StreamProcessorName
-        Duration: 1 minute
+  - Phase: 2
+    Nop: true
+
+- Name: Stats
+  Type: StreamStatsReporter
+  Database: *DatabaseName
+  Threads: 1
+  Phases:
+  - Phase: 0
+    Nop: true
+  - Phase: 1
+    Repeat: 1
+    StreamProcessorName: *StreamProcessorName
+    ExpectedDocumentCount: 1600000
   - Phase: 2
     Nop: true
 

--- a/src/workloads/streams/InsertBidsTemplate.yml
+++ b/src/workloads/streams/InsertBidsTemplate.yml
@@ -8,25 +8,26 @@ GlobalDefaults:
   StreamProcessorName: &StreamProcessorName sp
 
   Channel: &Channel {^RandomInt: { min: 0, max: 10000 }}
-  Urls: &Urls {^Cycle: { ofLength: 10000, fromGenerator: {^FormatString: { format: "https://www.nexmark.com/%s/%s/%s/item.htm?query=1&channel_id=%d", withArgs: [
+  Url: &Url {^FormatString: { format: "https://www.nexmark.com/%s/%s/%s/item.htm?query=1&channel_id=%d", withArgs: [
     {^RandomString: { length: {^RandomInt: { min: 3, max: 5 }}}},
     {^RandomString: { length: {^RandomInt: { min: 3, max: 5 }}}},
     {^RandomString: { length: {^RandomInt: { min: 3, max: 5 }}}},
     *Channel
-  ]}}}}
+  ]}}
 
   Document: &Document
     auction: {^Inc: { start: 1000 }}
     bidder: {^Inc: { start: 1000 }}
     price: {^RandomDouble: {min: 100, max: 100000000}}
     channel: *Channel
-    url: *Urls
+    url: *Url
     dateTime: {^IncDate: { start: "2023-01-01T00:00:00.000", step: 10 }}
 
-  Batch1000x: &Batch1000x {^Array: { number: 1000, of: *Document }}
+  Batch10x: &Batch10x [*Document, *Document, *Document, *Document, *Document, *Document, *Document, *Document, *Document, *Document]
+  Batch100x: &Batch100x {^FlattenOnce: [*Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x]}
 
 InsertBids:
-  Duration: {^Parameter: { Name: "Duration", Default: "1 minute" }}
+  Repeat: {^Parameter: { Name: "Repeat", Default: 1000 }}
   Database: {^Parameter: { Name: "Database", Default: *DatabaseName }}
   Operations:
   - OperationMetricsName: Insert
@@ -34,4 +35,4 @@ InsertBids:
     OperationCommand:
       streams_testOnlyInsert: ""
       name: {^Parameter: { Name: "StreamProcessorName", Default: *StreamProcessorName }}
-      documents: *Batch1000x
+      documents: *Batch100x

--- a/src/workloads/streams/Selection.yml
+++ b/src/workloads/streams/Selection.yml
@@ -12,6 +12,10 @@ GlobalDefaults:
   DatabaseName: &DatabaseName "test"
   StreamProcessorName: &StreamProcessorName "sp"
 
+  # Use 16 inserter threads that insert 100 batches of 1k documents, so
+  # total of 1.6M documents.
+  NumThreads: &NumThreads 16
+
 Actors:
 - Name: Setup
   Type: RunCommand
@@ -55,9 +59,9 @@ Actors:
         streams_stopStreamProcessor: ""
         name: *StreamProcessorName
 
-- Name: Insert_Batch1000x
+- Name: Insert_Batch100x
   Type: RunCommand
-  Threads: 32
+  Threads: *NumThreads
   Phases:
   - Phase: 0
     Nop: true
@@ -68,7 +72,20 @@ Actors:
       Parameters:
         Database: *DatabaseName
         StreamProcessorName: *StreamProcessorName
-        Duration: 1 minute
+  - Phase: 2
+    Nop: true
+
+- Name: Stats
+  Type: StreamStatsReporter
+  Database: *DatabaseName
+  Threads: 1
+  Phases:
+  - Phase: 0
+    Nop: true
+  - Phase: 1
+    Repeat: 1
+    StreamProcessorName: *StreamProcessorName
+    ExpectedDocumentCount: 1600000
   - Phase: 2
     Nop: true
 

--- a/src/workloads/streams/UrlAggregation.yml
+++ b/src/workloads/streams/UrlAggregation.yml
@@ -12,6 +12,10 @@ GlobalDefaults:
   DatabaseName: &DatabaseName "test"
   StreamProcessorName: &StreamProcessorName "sp"
 
+  # Use 16 inserter threads that insert 100 batches of 1k documents, so
+  # total of 1.6M documents.
+  NumThreads: &NumThreads 16
+
 Actors:
 - Name: Setup
   Type: RunCommand
@@ -77,9 +81,9 @@ Actors:
         streams_stopStreamProcessor: ""
         name: *StreamProcessorName
 
-- Name: Insert_Batch1000x
+- Name: Insert_Batch100x
   Type: RunCommand
-  Threads: 32
+  Threads: *NumThreads
   Phases:
   - Phase: 0
     Nop: true
@@ -90,7 +94,20 @@ Actors:
       Parameters:
         Database: *DatabaseName
         StreamProcessorName: *StreamProcessorName
-        Duration: 1 minute
+  - Phase: 2
+    Nop: true
+
+- Name: Stats
+  Type: StreamStatsReporter
+  Database: *DatabaseName
+  Threads: 1
+  Phases:
+  - Phase: 0
+    Nop: true
+  - Phase: 1
+    Repeat: 1
+    StreamProcessorName: *StreamProcessorName
+    ExpectedDocumentCount: 1600000
   - Phase: 2
     Nop: true
 

--- a/src/workloads/streams/YahooBenchmark.yml
+++ b/src/workloads/streams/YahooBenchmark.yml
@@ -18,6 +18,11 @@ GlobalDefaults:
   RandomUUID: &RandomUUID {^RandomString: { length: 16 }}
   StreamProcessorName: &StreamProcessorName "sp"
 
+  # Use 16 inserter threads that insert 100 batches of 1k documents, so
+  # total of 1.6M documents.
+  NumThreads: &NumThreads 16
+  NumBatches: &NumBatches 1000
+
   AdIds: &AdIds             {^Cycle: { ofLength: 1000, fromGenerator: *RandomUUID }}
   CampaignIds: &CampaignIds {^Cycle: { ofLength: 100, fromGenerator: *RandomUUID }}
 
@@ -31,7 +36,8 @@ GlobalDefaults:
     eventTime:  {^IncDate: { start: "2023-01-01T00:00:00.000", step: 10 }}
     ipAddress:  {^IP: {}}
 
-  Batch1000x: &Batch1000x {^Array: { number: 1000, of: *Document }}
+  Batch10x: &Batch10x [*Document, *Document, *Document, *Document, *Document, *Document, *Document, *Document, *Document, *Document]
+  Batch100x: &Batch100x {^FlattenOnce: [*Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x, *Batch10x]}
 
 Actors:
 - Name: Setup
@@ -95,14 +101,14 @@ Actors:
         streams_stopStreamProcessor: ""
         name: *StreamProcessorName
 
-- Name: Insert_Batch1000x
+- Name: Insert_Batch100x
   Type: RunCommand
-  Threads: 32
+  Threads: *NumThreads
   Phases:
     - Phase: 0
       Nop: true
     - Phase: 1
-      Duration: 1 minute
+      Repeat: *NumBatches
       Database: *DatabaseName
       Operations:
       - OperationMetricsName: Insert
@@ -110,9 +116,23 @@ Actors:
         OperationCommand:
           streams_testOnlyInsert: ""
           name: *StreamProcessorName
-          documents: *Batch1000x
+          documents: *Batch100x
     - Phase: 2
       Nop: true
+
+- Name: Stats
+  Type: StreamStatsReporter
+  Database: *DatabaseName
+  Threads: 1
+  Phases:
+  - Phase: 0
+    Nop: true
+  - Phase: 1
+    Repeat: 1
+    StreamProcessorName: *StreamProcessorName
+    ExpectedDocumentCount: 1600000
+  - Phase: 2
+    Nop: true
 
 AutoRun:
 - When:


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [SERVER-81260](https://jira.mongodb.org/browse/SERVER-81260)

**Whats Changed:**  
Introducing a new actor that periodically polls metrics from a mongo streams instance and records the throughput metrics returned in the genny operation metrics. The actor doesn't exit until the conditional expected document count is met. We need this because stream processing is asynchronous, so the best way to measure throughput here is pulling output throughput metrics from the stream process itself.

**Patch testing results:**  
If applicable, link a patch test showing code changes running successfully

**Related PRs:**   
If applicable, link related PRs
