### PR TITLE
[doc] snappy must be installed manually on Mac

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -59,6 +59,7 @@ Ensure you have installed [Homebrew](https://brew.sh/)
 
 xcode-select --install
 brew install zstd
+brew install snappy
 
 # Necessary because the cmake in vcpkg is unsigned and can't be copied between machines
 brew install cmake


### PR DESCRIPTION
**Jira Ticket:** EVG-19799

**Whats Changed:**  
Temporary measure while waiting for snappy to be added to Genny toolchain.