### PR TITLE
BF-30108: [streams] fix workloads

### DIFF
--- a/src/workloads/streams/CurrencyConversion.yml
+++ b/src/workloads/streams/CurrencyConversion.yml
@@ -37,7 +37,7 @@ Actors:
           },
           { $emit: { connectionName: "__testMemory" } }
         ]
-        connections: []
+        connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
   - Phase: 1
     Nop: true
   - Phase: 2

--- a/src/workloads/streams/HighestBid.yml
+++ b/src/workloads/streams/HighestBid.yml
@@ -60,7 +60,8 @@ Actors:
               bootstrapServers: "localhost:9092",
               isTestKafka: true
             }
-          }
+          },
+          { name: "__testMemory", type: "in_memory", options: {} }
         ]
   - Phase: 1
     Nop: true

--- a/src/workloads/streams/Selection.yml
+++ b/src/workloads/streams/Selection.yml
@@ -42,7 +42,7 @@ Actors:
           { $project: { auction: 1, price: 1 } },
           { $emit: { connectionName: "__testMemory" } }
         ]
-        connections: []
+        connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
   - Phase: 1
     Nop: true
   - Phase: 2

--- a/src/workloads/streams/UrlAggregation.yml
+++ b/src/workloads/streams/UrlAggregation.yml
@@ -62,7 +62,8 @@ Actors:
               bootstrapServers: "localhost:9092",
               isTestKafka: true
             }
-          }
+          },
+          { name: "__testMemory", type: "in_memory", options: {} }
         ]
   - Phase: 1
     Nop: true

--- a/src/workloads/streams/YahooBenchmark.yml
+++ b/src/workloads/streams/YahooBenchmark.yml
@@ -80,7 +80,8 @@ Actors:
               bootstrapServers: "localhost:9092",
               isTestKafka: true
             }
-          }
+          },
+          { name: "__testMemory", type: "in_memory", options: {} }
         ]
   - Phase: 1
     Nop: true


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** BF-30108

**Whats Changed:**  
Fixing existing streaming workloads after a breaking change with the in-memory source operator went out.

**Patch testing results:**  
https://spruce.mongodb.com/version/650dbe26306615d63c508d35/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC