### PR TITLE
SERVER-81260: support ^ClientURI in preprocessing

### DIFF
--- a/src/lamplib/src/genny/tasks/preprocess.py
+++ b/src/lamplib/src/genny/tasks/preprocess.py
@@ -11,7 +11,7 @@ from omegaconf import OmegaConf
 import yaml
 import structlog
 import numexpr
-from typing import Union
+from typing import Any, Dict, Optional, Union
 
 SLOG = structlog.get_logger(__name__)
 # Cannot be in the default config because yaml merges overwrite lists instead of appending.
@@ -98,6 +98,7 @@ class _ContextType(Enum):
 
     Parameter = (1,)
     ActorTemplate = (2,)
+    Client = (3,)
 
 
 class _ParseMode(Enum):
@@ -192,7 +193,7 @@ class _WorkloadParser(object):
         default_uri: str,
         source: YamlSource = YamlSource.File,
         path: Union[Path, str] = "",
-        parse_mode: _ParseMode =_ParseMode.Normal,
+        parse_mode: _ParseMode = _ParseMode.Normal,
     ):
         """Parse the yaml input, assumed to be a file by default."""
 
@@ -243,6 +244,8 @@ class _WorkloadParser(object):
             out = self._replace_flattenonce(value)
         elif key == "^PreprocessorFormatString":
             out = self._replace_formatstr(value)
+        elif key == "^ClientURI":
+            out = self._replace_clienturi(value)
         elif key == "ActorTemplates":
             self._parse_templates(value)
         elif key == "ActorFromTemplate":
@@ -338,9 +341,11 @@ class _WorkloadParser(object):
         parsed_values = self._recursive_parse(input)
 
         try:
-            return [value
-                    for parsed_value in parsed_values
-                    for value in (parsed_value if type(parsed_value) == list else [parsed_value])]
+            return [
+                value
+                for parsed_value in parsed_values
+                for value in (parsed_value if type(parsed_value) == list else [parsed_value])
+            ]
         except TypeError as e:
             msg = f"Invalid value type for '{OP_KEY}', which must be iterable: {input}"
             raise ParseException(msg)
@@ -351,7 +356,9 @@ class _WorkloadParser(object):
         ARGS_KEY = "withArgs"
 
         if FORMAT_KEY not in input:
-            msg = f"Invalid keys for '{OP_KEY}', please set '{FORMAT_KEY}' in following node: {input}"
+            msg = (
+                f"Invalid keys for '{OP_KEY}', please set '{FORMAT_KEY}' in following node: {input}"
+            )
             raise ParseException(msg)
 
         if type(input[FORMAT_KEY]) != str:
@@ -381,6 +388,29 @@ class _WorkloadParser(object):
             )
             raise ParseException(msg)
 
+    def _replace_clienturi(self, input):
+        OP_KEY = "^ClientURI"
+
+        name: Optional[str] = input.get("Name", None)
+        if not name:
+            msg = (
+                "Invalid keys for '^ClientURI', please set the client name as "
+                f"'Name' in the following node: {input}"
+            )
+            raise ParseException(msg)
+
+        client: Optional[Dict[str, Any]] = self._context.get(f"client/{name}", _ContextType.Client)
+        if not client:
+            msg = f"Invalid client name for '^ClientURI', {name} not found"
+            raise ParseException(msg)
+
+        uri: Optional[str] = client.get("URI", None)
+        if not uri:
+            msg = f"Client {name} does not have 'URI' set"
+            raise ParseException(msg)
+
+        return uri
+
     def _parse_templates(self, templates):
         for template_node in templates:
             self._context.insert(
@@ -396,15 +426,18 @@ class _WorkloadParser(object):
 
     def _parse_clients(self, clients):
         clients_dict = self._recursive_parse(clients)
-        for _, client in clients_dict.items():
+        for name, client in clients_dict.items():
             client.setdefault("URI", self._default_uri)
+            self._context.insert(f"client/{name}", client, _ContextType.Client)
         return clients_dict
 
     def _parse_instance(self, instance):
         actor = {}
 
         with self._context.enter():
-            templateNode = self._context.get(self._recursive_parse(instance["TemplateName"]), _ContextType.ActorTemplate)
+            templateNode = self._context.get(
+                self._recursive_parse(instance["TemplateName"]), _ContextType.ActorTemplate
+            )
             if templateNode is None:
                 name = instance["TemplateName"]
                 msg = f"Expected template named {name} but could not be found."

--- a/src/lamplib/src/tests/test_preprocess.py
+++ b/src/lamplib/src/tests/test_preprocess.py
@@ -752,3 +752,27 @@ Document:
 """
 
         self._assertYaml(yaml_input, expected)
+
+    def test_clienturi_reference(self):
+        yaml_input: str = (
+            "Clients:\n"
+            "  Default:\n"
+            "    URI: mongodb://mongod:27017\n"
+            "  Stream:\n"
+            "    URI: mongodb://mongostream:27017\n"
+            "SchemaVersion: 2018-07-01\n"
+            "MongoClientURI: {^ClientURI: { Name: 'Default' }}\n"
+            "MongostreamClientURI: {^ClientURI: { Name: 'Stream' }}"
+        )
+        expected: str = (
+            "Clients:\n"
+            "  Default:\n"
+            "    URI: mongodb://mongod:27017\n"
+            "  Stream:\n"
+            "    URI: mongodb://mongostream:27017\n"
+            "SchemaVersion: '2018-07-01'\n"
+            "MongoClientURI: mongodb://mongod:27017\n"
+            "MongostreamClientURI: mongodb://mongostream:27017\n"
+        )
+
+        self._assertYaml(yaml_input, expected)


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [SERVER-81260](https://jira.mongodb.org/browse/SERVER-81260?filter=-1)

**Whats Changed:**  
Support `^ClientURI` replacement which will replace any instances of `^ClientURI` with the corresponding registered client's URI. The plan is to use this for streams in DSI and have a streams instance create a source operator that consumes a change stream from a mongo VM within the same DSI VPC. But in order for that to work, I need the client URI to be exposed.

Unfortunately the `URI` for each client will be populated during preprocess time in genny `preprocess.py` so the `URI` is not known pre-compile time so we can't anchor/reference the `URI`.

e.g.
```
Clients:
  Default:
    QueryOptions:
      maxPoolSize: 10
  Stream:
    QueryOptions:
      maxPoolSize: 10
   
Actors:
- Name: Setup
  Type: RunCommand
  ClientName: Stream
  Threads: 1
  Phases:
  - Phase: 0
     ...
    Operations:
    - OperationMetricsName: CreateStreamProcessor
      OperationName: RunCommand
      OperationCommand:
        streams_startStreamProcessor: ""
        name: *StreamProcessorName
        pipeline: [
          { $source: { connectionName: "db", db: "test", coll: "input" } },
          ...
        ]
        connections: [{ name: "db", type: "atlas", options: { uri: {^ClientURI: { Name: "Default" } } } }]


- Name: Loader
  Type: Loader
  ClientName: Default
  Threads: 1
  Phases:
  - Phase: 0
     ...
```

**Patch testing results:**  
If applicable, link a patch test showing code changes running successfully

**Related PRs:**   
If applicable, link related PRs