### PR TITLE
EVG-17757: Add function to autodetect distro.

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -53,8 +53,6 @@ buildvariants:
   modules: [mongo]
   run_on:
   - amazon2-build
-  expansions:
-    distro: amazon2
   tasks:
   - name: tg_compile_and_test_with_server
   - name: t_compile_and_dry_run_asan
@@ -64,8 +62,6 @@ buildvariants:
   modules: [mongo]
   run_on:
   - amazon2-arm64-large
-  expansions:
-    distro: amazon2_arm64
   tasks:
   - name: tg_compile_and_test_with_server
   - name: t_compile_and_dry_run_asan
@@ -73,8 +69,6 @@ buildvariants:
 - name: rhel70
   display_name: RHEL 7
   modules: [mongo]
-  expansions:
-    distro: rhel70
   run_on:
   - rhel70
   tasks:
@@ -83,8 +77,6 @@ buildvariants:
 - name: rhel8
   display_name: RHEL 8
   modules: [mongo]
-  expansions:
-    distro: rhel8
   run_on:
   - rhel80-test
   tasks:
@@ -93,8 +85,6 @@ buildvariants:
 - name: ubuntu2204
   display_name: Ubuntu 22.04
   modules: [mongo]
-  expansions:
-    distro: ubuntu2204
   run_on:
   - ubuntu2204-large
   tasks:
@@ -103,8 +93,6 @@ buildvariants:
 - name: ubuntu1804
   display_name: Ubuntu 18.04
   modules: [mongo]
-  expansions:
-    distro: ubuntu1804
   run_on:
   - ubuntu1804-build
   tasks:
@@ -125,16 +113,6 @@ buildvariants:
   - macos-1100-arm64
   tasks:
   - name: tg_compile_and_test_with_server_on_macos
-
-# - name: centos6-perf
-#   display_name: CentOS 6 for Performance
-#   modules: [mongo]
-#   expansions:
-#     distro: rhel62
-#   run_on:
-#   - centos6-perf
-#   tasks:
-#   - name: tg_compile_and_benchmark
 
 
 ##                ⚡️ Tasks ⚡️
@@ -316,7 +294,6 @@ functions:
       args:
       - -v
       - install
-      - --linux-distro=${distro|not-linux}
 
   f_compile_asan:
   - command: subprocess.exec
@@ -325,7 +302,6 @@ functions:
       args:
       - -v
       - install
-      - --linux-distro=${distro|not-linux}
       - --sanitizer=asan
 
   ##

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -45,7 +45,7 @@ def cli(ctx: click.Context, verbose: bool) -> None:
     "-d",
     "--linux-distro",
     required=False,
-    default="not-linux",
+    default=None,
     type=click.Choice(
         [
             "ubuntu1804",
@@ -62,7 +62,8 @@ def cli(ctx: click.Context, verbose: bool) -> None:
     ),
     help=(
         "Specify the linux distro you're on; if your system isn't available,"
-        " please contact us at #workload-generation. The not-linux value is useful on macOS."
+        " please contact us at #performance-tooling-users. Specify not-linux for macOS."
+        " If no value is specified, it will be autodetected." 
     ),
 )
 @click.option(
@@ -114,6 +115,9 @@ def cmake_compile_install(
 
     from genny.tasks import compile
     from genny import curator
+
+    if linux_distro is None:
+        linux_distro = compile.detect_distro()
 
     curator.ensure_curator_installed(
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
@@ -571,6 +575,7 @@ def auto_tasks(ctx: click.Context, tasks: str):
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
     )
 
+
 @cli.command(
     name="auto-tasks-all",
     help=(
@@ -585,7 +590,9 @@ def auto_tasks(ctx: click.Context, tasks: str):
     required=True,
     help="An evergreen project file, such as system_perf.yml",
 )
-@click.option("--no-activate", default=False, is_flag=True, help="Ensure that generated tasks don't activate")
+@click.option(
+    "--no-activate", default=False, is_flag=True, help="Ensure that generated tasks don't activate"
+)
 @click.pass_context
 def auto_tasks_all(ctx: click.Context, project_file: str, no_activate: bool):
     from genny.tasks import auto_tasks_all

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -33,7 +33,7 @@ def _sanitizer_flags(sanitizer: str, genny_repo_root: str):
     raise ValueError("Unknown sanitizer {}".format(sanitizer))
 
 
-class PlatformDetectionError(Exception):
+class DistroDetectionError(Exception):
     pass
 
 
@@ -44,21 +44,21 @@ def _detect_distro_ubuntu(machine, freedesktop_version):
         elif machine == "x86_64":
             return "ubuntu2204"
         else:
-            raise PlatformDetectionError(f"Invalid machine type for Ubuntu 22.04: {machine}")
+            raise DistroDetectionError(f"Invalid machine type for Ubuntu 22.04: {machine}")
     elif freedesktop_version == "20.04":
         if machine == "aarch64":
             return "ubuntu2004_arm64"
         elif machine == "x86_64":
             return "ubuntu2004"
         else:
-            raise PlatformDetectionError(f"Invalid machine type for Ubunutu 20.04: {machine}")
+            raise DistroDetectionError(f"Invalid machine type for Ubunutu 20.04: {machine}")
     elif freedesktop_version == "18.04":
         if machine == "x86_64":
             return "ubuntu1804"
         else:
-            raise PlatformDetectionError(f"Invalid machine type for Ubuntu 18.04: {machine}")
+            raise DistroDetectionError(f"Invalid machine type for Ubuntu 18.04: {machine}")
     else:
-        raise PlatformDetectionError(f"Invalid version for Ubuntu: {freedesktop_version}")
+        raise DistroDetectionError(f"Invalid version for Ubuntu: {freedesktop_version}")
 
 
 def _detect_distro_rhel(machine, freedesktop_version):
@@ -67,12 +67,12 @@ def _detect_distro_rhel(machine, freedesktop_version):
         if machine == "x86_64":
             return "rhel70"
         else:
-            raise PlatformDetectionError(f"Invalid machine type for RHEL 7.x: {machine}")
+            raise DistroDetectionError(f"Invalid machine type for RHEL 7.x: {machine}")
     elif freedesktop_version.startswith("8."):
         if machine == "x86_64":
             return "rhel8"
         else:
-            raise PlatformDetectionError(f"Invalid machine type for RHEL 8.x: {machine}")
+            raise DistroDetectionError(f"Invalid machine type for RHEL 8.x: {machine}")
 
 
 def _detect_distro_amazon(machine, freedesktop_version):
@@ -82,9 +82,9 @@ def _detect_distro_amazon(machine, freedesktop_version):
         elif machine == "x86_64":
             return "amazon2"
         else:
-            raise PlatformDetectionError(f"Invalid machine type for Amazon 2: {machine}")
+            raise DistroDetectionError(f"Invalid machine type for Amazon 2: {machine}")
     else:
-        raise PlatformDetectionError(f"Invalid version for Amazon Linux: {freedesktop_version}")
+        raise DistroDetectionError(f"Invalid version for Amazon Linux: {freedesktop_version}")
 
 
 def detect_distro():
@@ -105,9 +105,9 @@ def detect_distro():
         elif freedesktop_id == "amzn":
             distro = _detect_distro_amazon(machine, freedesktop_version)
         else:
-            raise PlatformDetectionError(f"Unrecognized Linux distro: {freedesktop_id}")
+            raise DistroDetectionError(f"Unrecognized Linux distro: {freedesktop_id}")
     else:
-        raise PlatformDetectionError(f"Cannot determine distro for system {platform.system()}")
+        raise DistroDetectionError(f"Cannot determine distro for system {platform.system()}")
     SLOG.info(f"Found distro for installation.", distro=distro)
     return distro
 

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -87,6 +87,21 @@ def _detect_distro_amazon(machine, freedesktop_version):
         raise DistroDetectionError(f"Invalid version for Amazon Linux: {freedesktop_version}")
 
 
+def _freedesktop_os_release():
+    """
+    Best effort parser of the freedesktop.org os-release file. 
+
+    This is a little imprecise, but works well enough for all three Linux 
+    distros we support.
+    """
+    result = {}
+    with open ("/etc/os-release") as os_release_file:
+        for line in os_release_file:
+            key, value = line.strip("\n").split("=", 1)
+            value = value.strip("'\"")
+            result[key] = value
+    return result
+
 def detect_distro():
     SLOG.info(f"Distro not specified. Detecting distro.")
 
@@ -95,7 +110,7 @@ def detect_distro():
     if system == "Darwin":
         distro = "not-linux"
     elif system == "Linux":
-        freedesktop_release = platform.freedesktop_os_release()
+        freedesktop_release = _freedesktop_os_release()
         freedesktop_id = freedesktop_release["ID"]
         freedesktop_version = freedesktop_release["VERSION_ID"]
         if freedesktop_id == "ubuntu":

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -100,6 +100,9 @@ def _freedesktop_os_release():
     result = {}
     with open("/etc/os-release") as os_release_file:
         for line in os_release_file:
+            if "=" not in line:
+                # Skip blank lines and any other lines that don't obviously set a value.
+                continue
             key, value = line.strip("\n").split("=", 1)
             value = value.strip("'\"")
             result[key] = value

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -89,21 +89,22 @@ def _detect_distro_amazon(machine, freedesktop_version):
 
 def _freedesktop_os_release():
     """
-    Best effort parser of the freedesktop.org os-release file. 
+    Best effort parser of the freedesktop.org os-release file.
 
-    This is a little imprecise, but works well enough for all three Linux 
+    This is a little imprecise, but works well enough for all three Linux
     distros we support.
 
     This exists to support Python versions less than 3.10. Otherwise it
     can be replaced with platform.freedesktop_os_release().
     """
     result = {}
-    with open ("/etc/os-release") as os_release_file:
+    with open("/etc/os-release") as os_release_file:
         for line in os_release_file:
             key, value = line.strip("\n").split("=", 1)
             value = value.strip("'\"")
             result[key] = value
     return result
+
 
 def detect_distro():
     SLOG.info(f"Distro not specified. Detecting distro.")

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -106,13 +106,13 @@ def detect_distro():
     SLOG.info(f"Distro not specified. Detecting distro.")
 
     system = platform.system()
-    machine = platform.machine()
     if system == "Darwin":
         distro = "not-linux"
     elif system == "Linux":
         freedesktop_release = _freedesktop_os_release()
         freedesktop_id = freedesktop_release["ID"]
         freedesktop_version = freedesktop_release["VERSION_ID"]
+        machine = platform.machine()
         if freedesktop_id == "ubuntu":
             distro = _detect_distro_ubuntu(machine, freedesktop_version)
         elif freedesktop_id == "rhel":

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -73,6 +73,8 @@ def _detect_distro_rhel(machine, freedesktop_version):
             return "rhel8"
         else:
             raise DistroDetectionError(f"Invalid machine type for RHEL 8.x: {machine}")
+    else:
+        raise DistroDetectionError(f"Invalid version for RHEL: {freedesktop_version}")
 
 
 def _detect_distro_amazon(machine, freedesktop_version):

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -93,6 +93,9 @@ def _freedesktop_os_release():
 
     This is a little imprecise, but works well enough for all three Linux 
     distros we support.
+
+    This exists to support Python versions less than 3.10. Otherwise it
+    can be replaced with platform.freedesktop_os_release().
     """
     result = {}
     with open ("/etc/os-release") as os_release_file:


### PR DESCRIPTION
If a distro is not specified, we should be able to autodetect it given the finite number of actual configurations we support.

Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** EVG-17757

**Whats Changed:**  
Autodetects the value to use for distro if it is not specified

**Patch testing results:**  
[This patch](https://spruce.mongodb.com/version/65147562d1fe074855e94159/tasks) shows all the compile tasks running successfully without the distro set 
