### PR TITLE
PERF-4788 Disable MultiShardTransactions for shard-heuristic-bonsai setup

### DIFF
--- a/src/workloads/sharding/MultiShardTransactionsWithManyNamespaces.yml
+++ b/src/workloads/sharding/MultiShardTransactionsWithManyNamespaces.yml
@@ -245,7 +245,6 @@ AutoRun:
     mongodb_setup:
       $eq:
       - shard
-      - shard-heuristic-bonsai
       - shard-lite
       - shard-lite-all-feature-flags
     branch_name:


### PR DESCRIPTION
**Jira Ticket:** 

https://jira.mongodb.org/browse/PERF-4788

**Whats Changed:**  
Disabling MultiShardTransactionsWithManyNamespaces workload for shard-heuristic-bonsai setup

**Patch testing results:**  
* Evergreen patch with task running: https://spruce.mongodb.com/version/65325a810ae606cf1b971138/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
* Evergreen with task not running: https://spruce.mongodb.com/version/65325d01d6d80a0fa49da972/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
