### PR TITLE
PERF-4695 Add filter_with_complex_logical_expression and array_traversal to 3-Node ReplSet variants

### DIFF
--- a/src/workloads/query/ArrayTraversal.yml
+++ b/src/workloads/query/ArrayTraversal.yml
@@ -272,6 +272,7 @@ AutoRun:
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats
+      - replica
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/FilterWithComplexLogicalExpression.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpression.yml
@@ -785,6 +785,7 @@ AutoRun:
       - standalone-sampling-bonsai
       - standalone-sbe
       - standalone-query-stats
+      - replica
     branch_name:
       $neq:
       - v4.0


### PR DESCRIPTION
**Jira Ticket:** [PERF-4685](https://jira.mongodb.org/browse/PERF-4695)

**Whats Changed:**  
- The Genny workloads filter_with_complex_logical_expression and array_traversal will now run on the 3-Node ReplSet variants.
- There was some discussion between query and performance regarding whether the high-value CQF workloads should be added to the 3-Node ReplSet variants and if corresponding 3-Node Bonsai variants should also be created. We've decided to add the workloads to the 3-Node ReplSet variants to build up a history and have opened a follow-up ticket ([PERF-4866](https://jira.mongodb.org/browse/PERF-4866)) to analyse the resulting noise and revisit moving the _high-value_ CQF workloads away from standalone variants to the 3-Nodes.

**Patch Testing Results:**  
- [Evergreen patch](https://spruce.mongodb.com/version/6541288f0ae6062e7c4c252d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)