### PR TITLE
SERVER-77343 Add Boolean simplification benchmarks

### DIFF
--- a/src/phases/query/BooleanSimplifier.yml
+++ b/src/phases/query/BooleanSimplifier.yml
@@ -1,0 +1,239 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query-optimization"
+
+Description: |
+  This workload measures performance of boolean expressions which can be simplified by
+  the Boolean Simplifier. It is designed to track effectiveness of the simplifier.
+
+RandomSeed: 172547222
+
+GlobalDefaults:
+  Database: &Database {^Parameter: {Name: Database, Default: test}}
+  Collection: &Coll Collection0
+  DocumentCount: &DocumentCount {^Parameter: {Name: DocumentCount, Default: 1e5}}
+  Threads: &Threads 1
+  MaxPhases: &MaxPhases 13
+  Duration: &Duration 2 seconds
+  QueryStringIn: &QueryStringIn [ "HrHCEtBAGnv",
+                                  "pCqgFttJBou",
+                                  "tjOnAuHAOpi",
+                                  "PmqoJGpDFjB",
+                                  "jEkEGEBnICu",
+                                  "kjPIJuEMGjm",
+                                  "nBKiBqKPCJN",
+                                  "BFkCIrIECBt",
+                                  "glhsCMqJPEs",
+                                  "lEMoKmmCiKv"
+                                ]
+  LargeFilterTerms: &LargeFilterTerms 100
+
+ActorTemplates:
+- TemplateName: BenchmarkTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "unused"}}
+    Type: CrudActor
+    Database: *Database
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "ActivePhase", Default: -1}}]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Duration: *Duration
+          Collection: *Coll
+          Operations:
+          - OperationName: find
+            OperationCommand:
+              Filter: {^Parameter: {Name: "Filter", Default: {unused: "please specify a valid filter"}}}
+
+Actors:
+- Name: ClearCollection
+  Type: CrudActor
+  Database: *Database
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Collection: *Coll
+        Operations:
+        - OperationName: drop
+
+- Name: InsertData
+  Type: Loader
+  Threads: 4
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        MultipleThreadsPerCollection: true
+        CollectionCount: 1
+        DocumentCount: *DocumentCount
+        BatchSize: 1000
+        Document:
+          a1: {^RandomInt: {min: 0, max: 100}}
+          b1: {^Inc: {start: 11, step: 2}}
+          a2: {^RandomInt: {min: 0, max: 1000}}
+          b2: 3
+          c2: {^RandomInt: {min: 0, max: 5}}
+          d2: {^RandomInt: {min: 0, max: 5}}
+          e2: 4
+          a3: {^RandomInt: {min: 0, max: 100}}
+          b3: {^RandomInt: {min: 0, max: 100}}
+          c3: {^Array: {of: {^FastRandomString: {length: 11}}, number: 10}}
+        Indexes:
+        - keys: {b1: 1}
+        - keys: {c2: 1, d2: 1}
+
+# Ensure all data is synced to disk.
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+
+# The simplifier optimizes out an $or's branch to single predicate {b1: 2} and makes an Index Scan plan possible.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: SimplifiedOutOrBranch.BM
+      ActivePhase: 3
+      Filter: {$or: [{$and: [{a1: 1}, {a1: {$ne: 1}}]}, {b1: 2}]}
+
+# The simplifier factorizes out common terms and makes a plan with one fetch possible instead
+# of a plan with two fetches. Reducing number of fetch stages can be very beneficial especially
+# if the down-the-plan-tree fetch is not selective.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: SimplifierCollapsesTwoFetchesIntoOne.BM
+      ActivePhase: 4
+      Filter: {a2: 1, $or: [{c2: 1, d2: 2, b2: 3}, {c2: 1, d2: 2, e2: 4}]}
+
+# The simplifier simplifes the filter expression to {a3: 0, b3: 0} which makes evaluating the Filter
+# stage of Collection Scan plan much cheaper.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: SimplifiedCollScanFilter.BM
+      ActivePhase: 5
+      Filter: {
+                $and: [
+                    {b3: 0},
+                    {
+                        $or: [
+                            {a3: 0},
+                            {
+                                $and: [
+                                    {c3: {$in: *QueryStringIn}},
+                                    {c3: {$nin: *QueryStringIn}},
+                                ]
+                            }
+                        ]
+                    },
+                ]
+            }
+
+# The simplifier simplifes the filter expression to {b2: 3, c2: 3, d2: 3} which makes evaluating
+# the Filter stage of Index Scan plan much cheaper.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: SimplifiedIndexScanFilter.BM
+      ActivePhase: 6
+      Filter: {
+                $and: [
+                    {b2: 3},
+                    {c2: 3},
+                    {
+                        $or: [
+                            {d2: 3},
+                            {
+                                $and: [
+                                    {c3: {$in: *QueryStringIn}},
+                                    {c3: {$nin: *QueryStringIn}},
+                                ]
+                            }
+                        ]
+                    },
+                ]
+            }
+
+# The simplifier reduces the filter expression to {c2: 1, d2: 1} which makes possible a covered
+# index scan plan.
+- Name: CoveredQuery.BM
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [7]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: *Coll
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {$or: [{c3: "HrHCEtBAGnv", c2: 1, d2: 1}, {c3: {$ne: "HrHCEtBAGnv"}, c2: 1, d2: 1}]}
+            Projection: {_id: 0, c2: 1, d2: 1}
+
+# Collection scan with very large filter.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: LargeFilterCollectionScan.BM
+      ActivePhase: 8
+      Filter: {$or:
+                {^Array: {of: {$and: [
+                  {"a1": {^RandomInt: {min: 0, max: 5}}},
+                  {"c1": {^RandomInt: {min: 0, max: 5}}}]},
+                          number: *LargeFilterTerms}}}
+
+# Index scan with very large filter.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: LargeFilterIndexScan.BM
+      ActivePhase: 9
+      Filter: {$or:
+                {^Array: {of: {$and: [
+                  {"c2": {^RandomInt: {min: 0, max: 5}}},
+                  {"d2": {^RandomInt: {min: 0, max: 5}}}]},
+                          number: *LargeFilterTerms}}}
+
+# The simplifier reduces the filter expression to $alwaysFalse, which generates EOF plan.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: AlwaysFalse.BM
+      ActivePhase: 10
+      Filter: {$or: [{a1: {$eq: 1, $ne: 1}, b1: 1}, {a1: {$eq: 1, $ne: 1}, b1: {$ne: 1}}]}
+
+# The simplifier reduces the filter expression to $alwaysFalse, which generates EOF plan.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: AlwaysTrue.BM
+      ActivePhase: 11
+      Filter: {$or: [{b1: 1}, {b1: {$ne: 1}}]}
+
+# The simplifier opens up $nor which makes possible Index Scan plans.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: SimplifierOpenNOR.BM
+      ActivePhase: 12
+      Filter: {$nor: [{$or: [{b1: {$ne: 1}}, {b1: {$ne: 1}}]}]}

--- a/src/phases/query/BooleanSimplifier.yml
+++ b/src/phases/query/BooleanSimplifier.yml
@@ -45,6 +45,7 @@ ActorTemplates:
           - OperationName: find
             OperationCommand:
               Filter: {^Parameter: {Name: "Filter", Default: {unused: "please specify a valid filter"}}}
+              Projection: {^Parameter: {Name: "Projection", Default: None}}
 
 Actors:
 - Name: ClearCollection
@@ -173,22 +174,13 @@ Actors:
 
 # The simplifier reduces the filter expression to {c2: 1, d2: 1} which makes possible a covered
 # index scan plan.
-- Name: CoveredQuery.BM
-  Type: CrudActor
-  Database: *Database
-  Threads: *Threads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [7]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Duration: *Duration
-        Collection: *Coll
-        Operations:
-        - OperationName: find
-          OperationCommand:
-            Filter: {$or: [{c3: "HrHCEtBAGnv", c2: 1, d2: 1}, {c3: {$ne: "HrHCEtBAGnv"}, c2: 1, d2: 1}]}
-            Projection: {_id: 0, c2: 1, d2: 1}
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: CoveredQuery.BM
+      ActivePhase: 7
+      Filter: {$or: [{c3: "HrHCEtBAGnv", c2: 1, d2: 1}, {c3: {$ne: "HrHCEtBAGnv"}, c2: 1, d2: 1}]}
+      Projection: {_id: 0, c2: 1, d2: 1}
 
 # Collection scan with very large filter.
 - ActorFromTemplate:

--- a/src/phases/query/BooleanSimplifier.yml
+++ b/src/phases/query/BooleanSimplifier.yml
@@ -12,7 +12,7 @@ GlobalDefaults:
   Collection: &Coll Collection0
   DocumentCount: &DocumentCount {^Parameter: {Name: DocumentCount, Default: 1e5}}
   Threads: &Threads 1
-  MaxPhases: &MaxPhases 13
+  MaxPhases: &MaxPhases 15
   Duration: &Duration 2 seconds
   QueryStringIn: &QueryStringIn [ "HrHCEtBAGnv",
                                   "pCqgFttJBou",
@@ -46,6 +46,20 @@ ActorTemplates:
             OperationCommand:
               Filter: {^Parameter: {Name: "Filter", Default: {unused: "please specify a valid filter"}}}
               Projection: {^Parameter: {Name: "Projection", Default: None}}
+
+- TemplateName: QuiesceTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "unused"}}
+    Type: QuiesceActor
+    Threads: 1
+    Database: *Database
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "ActivePhase", Default: -1}}]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Repeat: 1
+          Threads: 1
 
 Actors:
 - Name: ClearCollection
@@ -88,40 +102,16 @@ Actors:
           a3: {^RandomInt: {min: 0, max: 100}}
           b3: {^RandomInt: {min: 0, max: 100}}
           c3: {^Array: {of: {^FastRandomString: {length: 11}}, number: 10}}
-        Indexes:
-        - keys: {b1: 1}
-        - keys: {c2: 1, d2: 1}
 
 # Ensure all data is synced to disk.
-- Name: Quiesce
-  Type: QuiesceActor
-  Threads: 1
-  Database: *Database
-  Phases:
-    OnlyActiveInPhases:
-      Active: [2]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Repeat: 1
-        Threads: 1
-
-# The simplifier optimizes out an $or's branch to single predicate {b1: 2} and makes an Index Scan plan possible.
 - ActorFromTemplate:
-    TemplateName: BenchmarkTemplate
+    TemplateName: QuiesceTemplate
     TemplateParameters:
-      Name: SimplifiedOutOrBranch.BM
-      ActivePhase: 3
-      Filter: {$or: [{$and: [{a1: 1}, {a1: {$ne: 1}}]}, {b1: 2}]}
+      Name: InsertDataQuiesce
+      ActivePhase: 2
 
-# The simplifier factorizes out common terms and makes a plan with one fetch possible instead
-# of a plan with two fetches. Reducing number of fetch stages can be very beneficial especially
-# if the down-the-plan-tree fetch is not selective.
-- ActorFromTemplate:
-    TemplateName: BenchmarkTemplate
-    TemplateParameters:
-      Name: SimplifierCollapsesTwoFetchesIntoOne.BM
-      ActivePhase: 4
-      Filter: {a2: 1, $or: [{c2: 1, d2: 2, b2: 3}, {c2: 1, d2: 2, e2: 4}]}
+##############################################
+# Run Collection Scan Bechmarks
 
 # The simplifier simplifes the filter expression to {a3: 0, b3: 0} which makes evaluating the Filter
 # stage of Collection Scan plan much cheaper.
@@ -129,7 +119,7 @@ Actors:
     TemplateName: BenchmarkTemplate
     TemplateParameters:
       Name: SimplifiedCollScanFilter.BM
-      ActivePhase: 5
+      ActivePhase: 3
       Filter: {
                 $and: [
                     {b3: 0},
@@ -147,13 +137,76 @@ Actors:
                 ]
             }
 
+# Collection scan with very large filter.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: LargeFilterCollectionScan.BM
+      ActivePhase: 4
+      Filter: {$or:
+                {^Array: {of: {$and: [
+                  {"a1": {^RandomInt: {min: 0, max: 5}}},
+                  {"c1": {^RandomInt: {min: 0, max: 5}}}]},
+                          number: *LargeFilterTerms}}}
+
+##############################################
+# Create Indexes
+
+- Name: CreateIndexes
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            createIndexes: *Coll
+            indexes:
+            - key: {b1: 1}
+              name: b1_1
+            - key: {c2: 1, d2: 1}
+              name: c2_1_d2_1
+
+# Ensure all data is synced to disk.
+- ActorFromTemplate:
+    TemplateName: QuiesceTemplate
+    TemplateParameters:
+      Name: CreateIndexesQuiesce
+      ActivePhase: 6
+
+##############################################
+# Run Index Scan Bechmarks
+
+# The simplifier optimizes out an $or's branch to single predicate {b1: 2} and makes an Index Scan plan possible.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: SimplifiedOutOrBranch.BM
+      ActivePhase: 7
+      Filter: {$or: [{$and: [{a1: 1}, {a1: {$ne: 1}}]}, {b1: 2}]}
+
+# The simplifier factorizes out common terms and makes a plan with one fetch possible instead
+# of a plan with two fetches. Reducing number of fetch stages can be very beneficial especially
+# if the down-the-plan-tree fetch is not selective.
+- ActorFromTemplate:
+    TemplateName: BenchmarkTemplate
+    TemplateParameters:
+      Name: SimplifierCollapsesTwoFetchesIntoOne.BM
+      ActivePhase: 8
+      Filter: {a2: 1, $or: [{c2: 1, d2: 2, b2: 3}, {c2: 1, d2: 2, e2: 4}]}
+
 # The simplifier simplifes the filter expression to {b2: 3, c2: 3, d2: 3} which makes evaluating
 # the Filter stage of Index Scan plan much cheaper.
 - ActorFromTemplate:
     TemplateName: BenchmarkTemplate
     TemplateParameters:
       Name: SimplifiedIndexScanFilter.BM
-      ActivePhase: 6
+      ActivePhase: 9
       Filter: {
                 $and: [
                     {b2: 3},
@@ -178,28 +231,16 @@ Actors:
     TemplateName: BenchmarkTemplate
     TemplateParameters:
       Name: CoveredQuery.BM
-      ActivePhase: 7
+      ActivePhase: 10
       Filter: {$or: [{c3: "HrHCEtBAGnv", c2: 1, d2: 1}, {c3: {$ne: "HrHCEtBAGnv"}, c2: 1, d2: 1}]}
       Projection: {_id: 0, c2: 1, d2: 1}
-
-# Collection scan with very large filter.
-- ActorFromTemplate:
-    TemplateName: BenchmarkTemplate
-    TemplateParameters:
-      Name: LargeFilterCollectionScan.BM
-      ActivePhase: 8
-      Filter: {$or:
-                {^Array: {of: {$and: [
-                  {"a1": {^RandomInt: {min: 0, max: 5}}},
-                  {"c1": {^RandomInt: {min: 0, max: 5}}}]},
-                          number: *LargeFilterTerms}}}
 
 # Index scan with very large filter.
 - ActorFromTemplate:
     TemplateName: BenchmarkTemplate
     TemplateParameters:
       Name: LargeFilterIndexScan.BM
-      ActivePhase: 9
+      ActivePhase: 11
       Filter: {$or:
                 {^Array: {of: {$and: [
                   {"c2": {^RandomInt: {min: 0, max: 5}}},
@@ -211,7 +252,7 @@ Actors:
     TemplateName: BenchmarkTemplate
     TemplateParameters:
       Name: AlwaysFalse.BM
-      ActivePhase: 10
+      ActivePhase: 12
       Filter: {$or: [{a1: {$eq: 1, $ne: 1}, b1: 1}, {a1: {$eq: 1, $ne: 1}, b1: {$ne: 1}}]}
 
 # The simplifier reduces the filter expression to $alwaysFalse, which generates EOF plan.
@@ -219,7 +260,7 @@ Actors:
     TemplateName: BenchmarkTemplate
     TemplateParameters:
       Name: AlwaysTrue.BM
-      ActivePhase: 11
+      ActivePhase: 13
       Filter: {$or: [{b1: 1}, {b1: {$ne: 1}}]}
 
 # The simplifier opens up $nor which makes possible Index Scan plans.
@@ -227,5 +268,5 @@ Actors:
     TemplateName: BenchmarkTemplate
     TemplateParameters:
       Name: SimplifierOpenNOR.BM
-      ActivePhase: 12
+      ActivePhase: 14
       Filter: {$nor: [{$or: [{b1: {$ne: 1}}, {b1: {$ne: 1}}]}]}

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -12,7 +12,7 @@ GlobalDefaults:
   Collection: &Coll Collection0
   DocumentCount: &DocumentCount 1e5
   Threads: &Threads 1
-  MaxPhases: &MaxPhases 8
+  MaxPhases: &MaxPhases 10
   Duration: &Duration 2 seconds
   QueryStringIn: &QueryStringIn [ "HrHCEtBAGnv",
                                   "pCqgFttJBou",
@@ -25,6 +25,7 @@ GlobalDefaults:
                                   "glhsCMqJPEs",
                                   "lEMoKmmCiKv"
                                 ]
+  LargeFilterTerms: &LargeFilterTerms 100
 
 Actors:
 - Name: ClearCollection
@@ -205,6 +206,48 @@ Actors:
           OperationCommand:
             Filter:  {$or: [{c3: "HrHCEtBAGnv", c2: 1, d2: 1}, {c3: {$ne: "HrHCEtBAGnv"}, c2: 1, d2: 1}]}
             Projection: {_id: 0, c2: 1, d2: 1}
+
+# Collection scan with very large filter.
+- Name: LargeFilterCollectionScan.BM
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [8]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: *Coll
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter:  {$or:
+                {^Array: {of: {$and: [
+                  {"a1": {^RandomInt: {min: 0, max: 5}}},
+                  {"c1": {^RandomInt: {min: 0, max: 5}}}]},
+                          number: 100}}}
+
+# Index scan with very large filter.
+- Name: LargeFilterIndexScan.BM
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [9]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: *Coll
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter:  {$or:
+                {^Array: {of: {$and: [
+                  {"c2": {^RandomInt: {min: 0, max: 5}}},
+                  {"d2": {^RandomInt: {min: 0, max: 5}}}]},
+                          number: 100}}}
 
 AutoRun:
 - When:

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -1,0 +1,103 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query-optimization"
+
+Description: |
+  This workload measures performance of boolean expressions which can be simplified by
+  the Boolean Simplifier. 
+
+GlobalDefaults:
+  Database: &Database test
+  DocumentCount: &DocumentCount 1e5
+  Threads: &Threads 1
+  MaxPhases: &MaxPhases 5
+  Duration: &Duration 2 seconds
+
+Actors:
+- Name: ClearCollection
+  Type: CrudActor
+  Database: *Database
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Collection: Collection0
+        Operations:
+        - OperationName: drop
+
+- Name: InsertData
+  Type: Loader
+  Threads: 4
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        MultipleThreadsPerCollection: true
+        CollectionCount: 1
+        DocumentCount: *DocumentCount
+        BatchSize: 1000
+        Document:
+          a: {^RandomInt: {min: 0, max: 100}}
+          b: {^Inc: {start: 11, step: 2}}
+          c: {^RandomInt: {min: 0, max: 100}}
+          d: {^RandomInt: {min: 0, max: 100}}
+          e: {^RandomInt: {min: 0, max: 10000}}
+          f: {^RandomInt: {min: 0, max: 10000}}
+        Indexes:
+        - keys: {b: 1}
+        - keys: {e: 1, f: 1}
+
+# Ensure all data is synced to disk.
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+
+# The simplifier optimizes out an $or's branch and makes an Index Scan plan possible instead of 
+# CollectionScan one
+- Name: SimplifiedOurOrBranch
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: Collection0
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter:  {"$or": [{"$and": [{"a": 1}, {"a": {"$ne": 1}}]}, {"b": 2}]}
+
+# The simplifier factorizes out common terms and makes a plan with one fetch possible
+# instead of a plan with two fetches.
+- Name: SimplifierCollapsesTwoFetchesIntoOne
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [4]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: Collection0
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter:  {c: 1, $or: [{e:1, f:2, d:3}, {e:1, f:2, e:4}]}

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -101,3 +101,28 @@ Actors:
         - OperationName: find
           OperationCommand:
             Filter:  {c: 1, $or: [{e:1, f:2, d:3}, {e:1, f:2, e:4}]}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - atlas
+      - replica
+      - standalone
+      - standalone-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
+      - standalone-sampling-bonsai
+      - standalone-sbe
+      - standalone-query-stats
+    atlas_setup:
+      $neq:
+      - M30-repl
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0
+      - v7.0
+      - v7.1

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -226,7 +226,7 @@ Actors:
                 {^Array: {of: {$and: [
                   {"a1": {^RandomInt: {min: 0, max: 5}}},
                   {"c1": {^RandomInt: {min: 0, max: 5}}}]},
-                          number: 100}}}
+                          number: *LargeFilterTerms}}}
 
 # Index scan with very large filter.
 - Name: LargeFilterIndexScan.BM
@@ -247,7 +247,7 @@ Actors:
                 {^Array: {of: {$and: [
                   {"c2": {^RandomInt: {min: 0, max: 5}}},
                   {"d2": {^RandomInt: {min: 0, max: 5}}}]},
-                          number: 100}}}
+                          number: *LargeFilterTerms}}}
 
 AutoRun:
 - When:

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -3,7 +3,7 @@ Owner: "@mongodb/query-optimization"
 
 Description: |
   This workload measures performance of boolean expressions which can be simplified by
-  the Boolean Simplifier. It is designed to track effetiveness of the simplifier.
+  the Boolean Simplifier. It is designed to track effectiveness of the simplifier.
 
 RandomSeed: 172547222
 
@@ -121,7 +121,7 @@ Actors:
             Filter:  {a2: 1, $or: [{c2: 1, d2: 2, b2: 3}, {c2: 1, d2: 2, e2: 4}]}
 
 # The simplifier simplifes the filter expression to {a3: 0, b3: 0} which makes evaluating the Filter
-# stage of Collection Scan plan mach cheaper.
+# stage of Collection Scan plan much cheaper.
 - Name: SimplifiedCollScanFilter.BM
   Type: CrudActor
   Database: *Database
@@ -154,7 +154,7 @@ Actors:
             }
 
 # The simplifier simplifes the filter expression to {b2: 3, c2: 3, d2: 3} which makes evaluating
-# the Filter stage of Index Scan plan mach cheaper.
+# the Filter stage of Index Scan plan much cheaper.
 - Name: SimplifiedIndexScanFilter.BM
   Type: CrudActor
   Database: *Database
@@ -187,7 +187,7 @@ Actors:
                 ]
             }
 
-# The simplifier reduces the filter expression to {c2: 1, d2: 1} which makes passible a covered
+# The simplifier reduces the filter expression to {c2: 1, d2: 1} which makes possible a covered
 # index scan plan.
 - Name: CoveredQuery.BM
   Type: CrudActor

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -5,12 +5,25 @@ Description: |
   This workload measures performance of boolean expressions which can be simplified by
   the Boolean Simplifier. 
 
+RandomSeed: 172547222
+
 GlobalDefaults:
   Database: &Database test
   DocumentCount: &DocumentCount 1e5
   Threads: &Threads 1
-  MaxPhases: &MaxPhases 5
+  MaxPhases: &MaxPhases 8
   Duration: &Duration 2 seconds
+  QueryStringIn: &QueryStringIn [ "HrHCEtBAGnv",
+                                  "pCqgFttJBou",
+                                  "tjOnAuHAOpi",
+                                  "PmqoJGpDFjB",
+                                  "jEkEGEBnICu",
+                                  "kjPIJuEMGjm",
+                                  "nBKiBqKPCJN",
+                                  "BFkCIrIECBt",
+                                  "glhsCMqJPEs",
+                                  "lEMoKmmCiKv"
+                                ]
 
 Actors:
 - Name: ClearCollection
@@ -43,15 +56,19 @@ Actors:
         DocumentCount: *DocumentCount
         BatchSize: 1000
         Document:
-          a: {^RandomInt: {min: 0, max: 100}}
-          b: {^Inc: {start: 11, step: 2}}
-          c: {^RandomInt: {min: 0, max: 100}}
-          d: {^RandomInt: {min: 0, max: 100}}
-          e: {^RandomInt: {min: 0, max: 10000}}
-          f: {^RandomInt: {min: 0, max: 10000}}
+          a1: {^RandomInt: {min: 0, max: 100}}
+          b1: {^Inc: {start: 11, step: 2}}
+          a2: {^RandomInt: {min: 0, max: 1000}}
+          b2: 3
+          c2: {^RandomInt: {min: 0, max: 5}}
+          d2: {^RandomInt: {min: 0, max: 5}}
+          e2: 4
+          a3: {^RandomInt: {min: 0, max: 100}}
+          b3: {^RandomInt: {min: 0, max: 100}}
+          c3: {^Array: {of: {^FastRandomString: {length: 11}}, number: 10}}
         Indexes:
-        - keys: {b: 1}
-        - keys: {e: 1, f: 1}
+        - keys: {b1: 1}
+        - keys: {c2: 1, d2: 1}
 
 # Ensure all data is synced to disk.
 - Name: Quiesce
@@ -68,7 +85,7 @@ Actors:
 
 # The simplifier optimizes out an $or's branch and makes an Index Scan plan possible instead of 
 # CollectionScan one
-- Name: SimplifiedOurOrBranch
+- Name: SimplifiedOutOrBranch.BM
   Type: CrudActor
   Database: *Database
   Threads: *Threads
@@ -82,11 +99,11 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {"$or": [{"$and": [{"a": 1}, {"a": {"$ne": 1}}]}, {"b": 2}]}
+            Filter:  {$or: [{$and: [{a1: 1}, {a1: {$ne: 1}}]}, {b1: 2}]}
 
 # The simplifier factorizes out common terms and makes a plan with one fetch possible
 # instead of a plan with two fetches.
-- Name: SimplifierCollapsesTwoFetchesIntoOne
+- Name: SimplifierCollapsesTwoFetchesIntoOne.BM
   Type: CrudActor
   Database: *Database
   Threads: *Threads
@@ -100,7 +117,73 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {c: 1, $or: [{e:1, f:2, d:3}, {e:1, f:2, e:4}]}
+            Filter:  {a2: 1, $or: [{c2: 1, d2: 2, b2: 3}, {c2: 1, d2: 2, e2: 4}]}
+
+- Name: SimplifiedCollScanFilter.BM
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: Collection0
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter:  {
+                $and: [
+                    {b3: 0},
+                    {
+                        $or: [
+                            {a3: 0},
+                            {
+                                $and: [
+                                    {c3: {$in: *QueryStringIn}},
+                                    {c3: {$nin: *QueryStringIn}},
+                                ]
+                            }
+                        ]
+                    },
+                ]
+            }
+
+
+- Name: TrivialOr.BM
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [6]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: Collection0
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter:  {$or: [{}, {}]}
+
+- Name: CoveredQuery.BM
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [7]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: Collection0
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter:  {$or: [{c3: "HrHCEtBAGnv", c2: 1, d2: 1}, {c3: {$ne: "HrHCEtBAGnv"}, c2: 1, d2: 1}]}
+            Projection: {_id: 0, c2: 1, d2: 1}
+
 
 AutoRun:
 - When:
@@ -111,10 +194,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
-      - standalone-heuristic-bonsai
-      - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     atlas_setup:
       $neq:
       - M30-repl

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -309,8 +309,5 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags 
       - standalone-classic-query-engine
-    atlas_setup:
-      $neq:
-      - M30-repl
     branch_name:
       $gte: v7.3

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -3,12 +3,13 @@ Owner: "@mongodb/query-optimization"
 
 Description: |
   This workload measures performance of boolean expressions which can be simplified by
-  the Boolean Simplifier. 
+  the Boolean Simplifier. It is designed to track effetiveness of the simplifier.
 
 RandomSeed: 172547222
 
 GlobalDefaults:
   Database: &Database test
+  Collection: &Coll Collection0
   DocumentCount: &DocumentCount 1e5
   Threads: &Threads 1
   MaxPhases: &MaxPhases 8
@@ -37,7 +38,7 @@ Actors:
       PhaseConfig:
         Repeat: 1
         Threads: 1
-        Collection: Collection0
+        Collection: *Coll
         Operations:
         - OperationName: drop
 
@@ -83,8 +84,7 @@ Actors:
         Repeat: 1
         Threads: 1
 
-# The simplifier optimizes out an $or's branch and makes an Index Scan plan possible instead of 
-# CollectionScan one
+# The simplifier optimizes out an $or's branch to single predicate {b1: 2} and makes an Index Scan plan possible.
 - Name: SimplifiedOutOrBranch.BM
   Type: CrudActor
   Database: *Database
@@ -95,14 +95,15 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *Duration
-        Collection: Collection0
+        Collection: *Coll
         Operations:
         - OperationName: find
           OperationCommand:
             Filter:  {$or: [{$and: [{a1: 1}, {a1: {$ne: 1}}]}, {b1: 2}]}
 
-# The simplifier factorizes out common terms and makes a plan with one fetch possible
-# instead of a plan with two fetches.
+# The simplifier factorizes out common terms and makes a plan with one fetch possible instead
+# of a plan with two fetches. Reducing number of fetch stages can be very beneficial especially
+# if the down-the-plan-tree fetch is not selective.
 - Name: SimplifierCollapsesTwoFetchesIntoOne.BM
   Type: CrudActor
   Database: *Database
@@ -113,12 +114,14 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *Duration
-        Collection: Collection0
+        Collection: *Coll
         Operations:
         - OperationName: find
           OperationCommand:
             Filter:  {a2: 1, $or: [{c2: 1, d2: 2, b2: 3}, {c2: 1, d2: 2, e2: 4}]}
 
+# The simplifier simplifes the filter expression to {a3: 0, b3: 0} which makes evaluating the Filter
+# stage of Collection Scan plan mach cheaper.
 - Name: SimplifiedCollScanFilter.BM
   Type: CrudActor
   Database: *Database
@@ -129,7 +132,7 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *Duration
-        Collection: Collection0
+        Collection: *Coll
         Operations:
         - OperationName: find
           OperationCommand:
@@ -150,8 +153,9 @@ Actors:
                 ]
             }
 
-
-- Name: TrivialOr.BM
+# The simplifier simplifes the filter expression to {b2: 3, c2: 3, d2: 3} which makes evaluating
+# the Filter stage of Index Scan plan mach cheaper.
+- Name: SimplifiedIndexScanFilter.BM
   Type: CrudActor
   Database: *Database
   Threads: *Threads
@@ -161,12 +165,30 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *Duration
-        Collection: Collection0
+        Collection: *Coll
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {$or: [{}, {}]}
+            Filter:  {
+                $and: [
+                    {b2: 3},
+                    {c2: 3},
+                    {
+                        $or: [
+                            {d2: 3},
+                            {
+                                $and: [
+                                    {c3: {$in: *QueryStringIn}},
+                                    {c3: {$nin: *QueryStringIn}},
+                                ]
+                            }
+                        ]
+                    },
+                ]
+            }
 
+# The simplifier reduces the filter expression to {c2: 1, d2: 1} which makes passible a covered
+# index scan plan.
 - Name: CoveredQuery.BM
   Type: CrudActor
   Database: *Database
@@ -177,32 +199,24 @@ Actors:
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Duration: *Duration
-        Collection: Collection0
+        Collection: *Coll
         Operations:
         - OperationName: find
           OperationCommand:
             Filter:  {$or: [{c3: "HrHCEtBAGnv", c2: 1, d2: 1}, {c3: {$ne: "HrHCEtBAGnv"}, c2: 1, d2: 1}]}
             Projection: {_id: 0, c2: 1, d2: 1}
 
-
 AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - atlas
       - replica
+      - single-replica
       - standalone
-      - standalone-all-feature-flags
+      - standalone-all-feature-flags 
       - standalone-classic-query-engine
-      - standalone-sbe
     atlas_setup:
       $neq:
       - M30-repl
     branch_name:
-      $neq:
-      - v4.0
-      - v4.2
-      - v4.4
-      - v5.0
-      - v7.0
-      - v7.1
+      $gte: v7.3

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -12,7 +12,7 @@ GlobalDefaults:
   Collection: &Coll Collection0
   DocumentCount: &DocumentCount 1e5
   Threads: &Threads 1
-  MaxPhases: &MaxPhases 10
+  MaxPhases: &MaxPhases 13
   Duration: &Duration 2 seconds
   QueryStringIn: &QueryStringIn [ "HrHCEtBAGnv",
                                   "pCqgFttJBou",
@@ -100,7 +100,7 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {$or: [{$and: [{a1: 1}, {a1: {$ne: 1}}]}, {b1: 2}]}
+            Filter: {$or: [{$and: [{a1: 1}, {a1: {$ne: 1}}]}, {b1: 2}]}
 
 # The simplifier factorizes out common terms and makes a plan with one fetch possible instead
 # of a plan with two fetches. Reducing number of fetch stages can be very beneficial especially
@@ -119,7 +119,7 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {a2: 1, $or: [{c2: 1, d2: 2, b2: 3}, {c2: 1, d2: 2, e2: 4}]}
+            Filter: {a2: 1, $or: [{c2: 1, d2: 2, b2: 3}, {c2: 1, d2: 2, e2: 4}]}
 
 # The simplifier simplifes the filter expression to {a3: 0, b3: 0} which makes evaluating the Filter
 # stage of Collection Scan plan much cheaper.
@@ -137,7 +137,7 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {
+            Filter: {
                 $and: [
                     {b3: 0},
                     {
@@ -170,7 +170,7 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {
+            Filter: {
                 $and: [
                     {b2: 3},
                     {c2: 3},
@@ -204,7 +204,7 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {$or: [{c3: "HrHCEtBAGnv", c2: 1, d2: 1}, {c3: {$ne: "HrHCEtBAGnv"}, c2: 1, d2: 1}]}
+            Filter: {$or: [{c3: "HrHCEtBAGnv", c2: 1, d2: 1}, {c3: {$ne: "HrHCEtBAGnv"}, c2: 1, d2: 1}]}
             Projection: {_id: 0, c2: 1, d2: 1}
 
 # Collection scan with very large filter.
@@ -222,7 +222,7 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {$or:
+            Filter: {$or:
                 {^Array: {of: {$and: [
                   {"a1": {^RandomInt: {min: 0, max: 5}}},
                   {"c1": {^RandomInt: {min: 0, max: 5}}}]},
@@ -243,11 +243,62 @@ Actors:
         Operations:
         - OperationName: find
           OperationCommand:
-            Filter:  {$or:
+            Filter: {$or:
                 {^Array: {of: {$and: [
                   {"c2": {^RandomInt: {min: 0, max: 5}}},
                   {"d2": {^RandomInt: {min: 0, max: 5}}}]},
                           number: *LargeFilterTerms}}}
+
+# The simplifier reduces the filter expression to $alwaysFalse, which generates EOF plan.
+- Name: AlwaysFalse.BM
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [10]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: *Coll
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {$or: [{a1: {$eq: 1, $ne: 1}, b1: 1}, {a1: {$eq: 1, $ne: 1}, b1: {$ne: 1}}]}
+
+# The simplifier reduces the filter expression to $alwaysFalse, which generates EOF plan.
+- Name: AlwaysTrue.BM
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [11]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: *Coll
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {$or: [{b1: 1}, {b1: {$ne: 1}}]}
+
+# The simplifier opens up $nor which makes possible Index Scan plans.
+- Name: SimplifierOpenNOR.BM
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [12]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: *Duration
+        Collection: *Coll
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {$nor: [{$or: [{b1: {$ne: 1}}, {b1: {$ne: 1}}]}]}
 
 AutoRun:
 - When:

--- a/src/workloads/query/BooleanSimplifierSmallDataset.yml
+++ b/src/workloads/query/BooleanSimplifierSmallDataset.yml
@@ -8,8 +8,8 @@ Description: |
 LoadConfig:
   Path: ../../phases/query/BooleanSimplifier.yml
   Parameters:
-    Database: BooleanSimplifier
-    DocumentCount: 1e5
+    Database: BooleanSimplifierSmall
+    DocumentCount: 500
 
 AutoRun:
 - When:


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** SERVER-77343

**Whats Changed:**  
Add benchmarks that measure performance of boolean expressions which can be simplified by the Boolean Simplifier. 

**Patch testing results:**  [link](https://spruce.mongodb.com/version/6555d34861837d4298a2e825/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
