### PR TITLE
PERF-4881 Add genny workload targeting block processing

### DIFF
--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -14,15 +14,15 @@ GlobalDefaults:
   Database: &database test
   Collection: &collection Collection0
   DocumentCount: &documentCount 1e6
-  Repeat: &repeat 100
+  Repeat: &repeat 20
   Threads: &threads 1
-  MaxPhases: &maxPhases 11
+  MaxPhases: &maxPhases 10
   MetaCount: &metaCount 10
 
 Clients:
   Default:
     QueryOptions:
-      maxPoolSize: 4000 # With 8 threads we need a larger pool.
+      maxPoolSize: 400
 
 Actors:
   # Clear any pre-existing collection state.
@@ -140,7 +140,7 @@ Actors:
           Database: *database
           Collection: *collection
           Operations:
-            - OperationMetricsName:
+            - OperationMetricsName: TsBPBasicMatchOnNestedField
               OperationName: aggregate
               OperationCommand:
                 Pipeline:
@@ -162,7 +162,7 @@ Actors:
           Database: *database
           Collection: *collection
           Operations:
-            - OperationMetricsName:
+            - OperationMetricsName: TsBPNarrowMatchOnNestedField
               OperationName: aggregate
               OperationCommand:
                 Pipeline:
@@ -184,7 +184,7 @@ Actors:
           Database: *database
           Collection: *collection
           Operations:
-            - OperationMetricsName:
+            - OperationMetricsName: TsBPAndMatchOnNestedFields
               OperationName: aggregate
               OperationCommand:
                 Pipeline:
@@ -215,7 +215,7 @@ Actors:
           Database: *database
           Collection: *collection
           Operations:
-            - OperationMetricsName:
+            - OperationMetricsName: TsBPOrMatchOnNestedField
               OperationName: aggregate
               OperationCommand:
                 Pipeline:
@@ -246,7 +246,7 @@ Actors:
           Database: *database
           Collection: *collection
           Operations:
-            - OperationMetricsName:
+            - OperationMetricsName: TsBPMatchOnNestedFieldAndTime
               OperationName: aggregate
               OperationCommand:
                 Pipeline:
@@ -267,12 +267,12 @@ Actors:
                     { $count: "count" },
                   ]
 
-  # TODO: The $or $eq on obj.measurement1 gets converted to a $in so this query can't run in
+  # TODO SERVER-83057: The $or $eq on obj.measurement1 gets converted to a $in so this query can't run in
   # block processing. When it runs through SBE "normally", the filter gets created in a random order
   # leading to consistently inconsistent query durations depending on which field gets evaluated
   # first. Evaluating the filter on obj.measurement1 is fastest, while evaluating the filter on
   # obj.measurement3 is slowest.
-  # - Name: MatchOnMuipleNestedFields
+  # - Name: MatchOnMultipleNestedFields
   #   Type: CrudActor
   #   Database: *database
   #   Threads: *threads
@@ -285,7 +285,7 @@ Actors:
   #         Database: *database
   #         Collection: *collection
   #         Operations:
-  #           - OperationMetricsName:
+  #           - OperationMetricsName: TsBPMatchOnMultipleNestedFields
   #             OperationName: aggregate
   #             OperationCommand:
   #               Pipeline:
@@ -310,8 +310,6 @@ Actors:
   #                   { $count: "count" },
   #                 ]
 
-  # The $match will be handled by block processing, but the pipeline from $group onwards will be
-  # handled by regular SBE execution.
   - Name: MatchGroupSort
     Type: CrudActor
     Database: *database
@@ -325,7 +323,7 @@ Actors:
           Database: *database
           Collection: *collection
           Operations:
-            - OperationMetricsName:
+            - OperationMetricsName: TsBPMatchGroupSort
               OperationName: aggregate
               OperationCommand:
                 Pipeline:

--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -1,0 +1,342 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query-execution"
+Description: |
+  This workload runs queries on time-series collections that can at least partially run with block
+  processing. At the moment, only queries with a $match prefix are eligible for block processing.
+  The dataset used for this workload is artificial/fabricated. Currently focuses on nested fields
+  since matching on top level fields is already tested in other workloads.
+
+Keywords:
+  - timeseries
+  - aggregate
+
+GlobalDefaults:
+  Database: &database test
+  Collection: &collection Collection0
+  DocumentCount: &documentCount 1e6
+  Repeat: &repeat 50
+  Threads: &threads 1
+  MaxPhases: &maxPhases 11
+  MetaCount: &metaCount 10
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 4000 # With 8 threads we need a larger pool.
+
+Actors:
+  # Clear any pre-existing collection state.
+  - Name: ClearCollection
+    Type: CrudActor
+    Database: *database
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [0]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: 1
+          Threads: 1
+          Collection: *collection
+          Operations:
+            - OperationName: drop
+
+  - Name: CreateTimeseriesCollection
+    Type: RunCommand
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [1]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: 1
+          Database: *database
+          Operation:
+            OperationMetricsName: CreateTimeseriesCollection
+            OperationName: RunCommand
+            OperationCommand:
+              {
+                create: *collection,
+                timeseries:
+                  {
+                    timeField: "time",
+                    metaField: "meta",
+                    granularity: "seconds",
+                  },
+              }
+
+  - Name: InsertData
+    Type: Loader
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [2]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: 1
+          Threads: 1
+          Database: *database
+          CollectionCount: 1
+          DocumentCount: *documentCount
+          BatchSize: 1000
+          Document:
+            time:
+              ^IncDate:
+                start: 2022-01-01
+                # 100ms step ensures full bucket of 1000 documents under the "seconds" granularity.
+                step: 100
+            meta:
+              metaField1:
+                ^Cycle:
+                  ofLength: *metaCount
+                  fromGenerator:
+                    ^RandomString:
+                      length: 6
+                      alphabet: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+              metaField2:
+                ^Cycle:
+                  ofLength: *metaCount
+                  fromGenerator:
+                    ^RandomString:
+                      length: 6
+                      alphabet: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            obj:
+              {
+                measurement1: { ^RandomInt: { min: 0, max: 10 } },
+                measurement2: { ^RandomDouble: { min: 0, max: 100 } },
+                measurement3: { ^RandomDouble: { min: 0, max: 1000 } },
+              }
+            array1:
+              [
+                { ^RandomDouble: { min: 0, max: 100 } },
+                { ^RandomDouble: { min: 0, max: 100 } },
+              ]
+
+  # Phase 2: Ensure all data is synced to disk.
+  - Name: Quiesce
+    Type: QuiesceActor
+    Threads: 1
+    Database: *database
+    Phases:
+      OnlyActiveInPhases:
+        Active: [3]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: 1
+          Threads: 1
+
+  # Run queries that will at least partially run with block processing
+  - Name: BasicMatchOnNestedField
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [4]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    { $match: { "obj.measurement2": { $gt: 50 } } },
+                    { $count: "count" },
+                  ]
+
+  - Name: NarrowMatchOnNestedField
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [5]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    { $match: { "obj.measurement2": { $gte: 45, $lt: 55 } } },
+                    { $count: "count" },
+                  ]
+
+  - Name: AndMatchOnNestedField
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [6]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $match:
+                        {
+                          $and:
+                            [
+                              { "obj.measurement3": { $gt: 100 } },
+                              { "obj.measurement3": { $lt: 300 } },
+                            ],
+                        },
+                    },
+                    { $count: "count" },
+                  ]
+
+  - Name: OrMatchOnNestedField
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [7]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $match:
+                        {
+                          $or:
+                            [
+                              { "obj.measurement3": { $lt: 100 } },
+                              { "obj.measurement3": { $gt: 900 } },
+                            ],
+                        },
+                    },
+                    { $count: "count" },
+                  ]
+
+  - Name: MatchOnNestedFieldAndTime
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [8]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $match:
+                        {
+                          $and:
+                            [
+                              {
+                                "time":
+                                  { $lt: { ^Date: "2022-01-02T00:00:00" } },
+                              },
+                              { "obj.measurement2": { $gte: 25 } },
+                            ],
+                        },
+                    },
+                    { $count: "count" },
+                  ]
+
+  - Name: MatchOnMuipleNestedFields
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [9]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $match:
+                        {
+                          $and:
+                            [
+                              {
+                                $or:
+                                  [
+                                    { "obj.measurement1": 4 },
+                                    { "obj.measurement1": 9 },
+                                  ],
+                              },
+                              { "obj.measurement2": { $lte: 175 } },
+                              { "obj.measurement3": { $gt: 100, $lt: 800 } },
+                            ],
+                        },
+                    },
+                    { $count: "count" },
+                  ]
+
+  # The $match will be handled by block processing, but the pipeline from $group onwards will be
+  # handled by regular SBE execution.
+  - Name: MatchGroupSort
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [10]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $match:
+                        { "time": { $lt: { ^Date: "2022-01-02T00:00:00" } } },
+                    },
+                    {
+                      $group:
+                        {
+                          "_id":
+                            { $dateTrunc: { "date": "$time", "unit": "hour" } },
+                          "max_measurement1": { $max: "$obj.measurement1" },
+                        },
+                    },
+                    { $sort: { "_id": 1 } },
+                    { $count: "count" },
+                  ]

--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -126,217 +126,222 @@ Actors:
           Repeat: 1
           Threads: 1
 
-  # Run queries that will at least partially run with block processing
-  - Name: BasicMatchOnNestedField
-    Type: CrudActor
-    Database: *database
-    Threads: *threads
-    Phases:
-      OnlyActiveInPhases:
-        Active: [4]
-        NopInPhasesUpTo: *maxPhases
-        PhaseConfig:
-          Repeat: *repeat
-          Database: *database
-          Collection: *collection
-          Operations:
-            - OperationMetricsName:
-              OperationName: aggregate
-              OperationCommand:
-                Pipeline:
-                  [
-                    { $match: { "obj.measurement2": { $gt: 50 } } },
-                    { $count: "count" },
-                  ]
+  # # Run queries that will at least partially run with block processing
+  # - Name: BasicMatchOnNestedField
+  #   Type: CrudActor
+  #   Database: *database
+  #   Threads: *threads
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [4]
+  #       NopInPhasesUpTo: *maxPhases
+  #       PhaseConfig:
+  #         Repeat: *repeat
+  #         Database: *database
+  #         Collection: *collection
+  #         Operations:
+  #           - OperationMetricsName:
+  #             OperationName: aggregate
+  #             OperationCommand:
+  #               Pipeline:
+  #                 [
+  #                   { $match: { "obj.measurement2": { $gt: 50 } } },
+  #                   { $count: "count" },
+  #                 ]
 
-  - Name: NarrowMatchOnNestedField
-    Type: CrudActor
-    Database: *database
-    Threads: *threads
-    Phases:
-      OnlyActiveInPhases:
-        Active: [5]
-        NopInPhasesUpTo: *maxPhases
-        PhaseConfig:
-          Repeat: *repeat
-          Database: *database
-          Collection: *collection
-          Operations:
-            - OperationMetricsName:
-              OperationName: aggregate
-              OperationCommand:
-                Pipeline:
-                  [
-                    { $match: { "obj.measurement2": { $gte: 45, $lt: 55 } } },
-                    { $count: "count" },
-                  ]
+  # - Name: NarrowMatchOnNestedField
+  #   Type: CrudActor
+  #   Database: *database
+  #   Threads: *threads
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [5]
+  #       NopInPhasesUpTo: *maxPhases
+  #       PhaseConfig:
+  #         Repeat: *repeat
+  #         Database: *database
+  #         Collection: *collection
+  #         Operations:
+  #           - OperationMetricsName:
+  #             OperationName: aggregate
+  #             OperationCommand:
+  #               Pipeline:
+  #                 [
+  #                   { $match: { "obj.measurement2": { $gte: 45, $lt: 55 } } },
+  #                   { $count: "count" },
+  #                 ]
 
-  - Name: AndMatchOnNestedField
-    Type: CrudActor
-    Database: *database
-    Threads: *threads
-    Phases:
-      OnlyActiveInPhases:
-        Active: [6]
-        NopInPhasesUpTo: *maxPhases
-        PhaseConfig:
-          Repeat: *repeat
-          Database: *database
-          Collection: *collection
-          Operations:
-            - OperationMetricsName:
-              OperationName: aggregate
-              OperationCommand:
-                Pipeline:
-                  [
-                    {
-                      $match:
-                        {
-                          $and:
-                            [
-                              { "obj.measurement3": { $gt: 100 } },
-                              { "obj.measurement3": { $lt: 300 } },
-                            ],
-                        },
-                    },
-                    { $count: "count" },
-                  ]
+  # - Name: AndMatchOnNestedField
+  #   Type: CrudActor
+  #   Database: *database
+  #   Threads: *threads
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [6]
+  #       NopInPhasesUpTo: *maxPhases
+  #       PhaseConfig:
+  #         Repeat: *repeat
+  #         Database: *database
+  #         Collection: *collection
+  #         Operations:
+  #           - OperationMetricsName:
+  #             OperationName: aggregate
+  #             OperationCommand:
+  #               Pipeline:
+  #                 [
+  #                   {
+  #                     $match:
+  #                       {
+  #                         $and:
+  #                           [
+  #                             { "obj.measurement3": { $gt: 100 } },
+  #                             { "obj.measurement3": { $lt: 300 } },
+  #                           ],
+  #                       },
+  #                   },
+  #                   { $count: "count" },
+  #                 ]
 
-  - Name: OrMatchOnNestedField
-    Type: CrudActor
-    Database: *database
-    Threads: *threads
-    Phases:
-      OnlyActiveInPhases:
-        Active: [7]
-        NopInPhasesUpTo: *maxPhases
-        PhaseConfig:
-          Repeat: *repeat
-          Database: *database
-          Collection: *collection
-          Operations:
-            - OperationMetricsName:
-              OperationName: aggregate
-              OperationCommand:
-                Pipeline:
-                  [
-                    {
-                      $match:
-                        {
-                          $or:
-                            [
-                              { "obj.measurement3": { $lt: 100 } },
-                              { "obj.measurement3": { $gt: 900 } },
-                            ],
-                        },
-                    },
-                    { $count: "count" },
-                  ]
+  # - Name: OrMatchOnNestedField
+  #   Type: CrudActor
+  #   Database: *database
+  #   Threads: *threads
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [7]
+  #       NopInPhasesUpTo: *maxPhases
+  #       PhaseConfig:
+  #         Repeat: *repeat
+  #         Database: *database
+  #         Collection: *collection
+  #         Operations:
+  #           - OperationMetricsName:
+  #             OperationName: aggregate
+  #             OperationCommand:
+  #               Pipeline:
+  #                 [
+  #                   {
+  #                     $match:
+  #                       {
+  #                         $or:
+  #                           [
+  #                             { "obj.measurement3": { $lt: 100 } },
+  #                             { "obj.measurement3": { $gt: 900 } },
+  #                           ],
+  #                       },
+  #                   },
+  #                   { $count: "count" },
+  #                 ]
 
-  - Name: MatchOnNestedFieldAndTime
-    Type: CrudActor
-    Database: *database
-    Threads: *threads
-    Phases:
-      OnlyActiveInPhases:
-        Active: [8]
-        NopInPhasesUpTo: *maxPhases
-        PhaseConfig:
-          Repeat: *repeat
-          Database: *database
-          Collection: *collection
-          Operations:
-            - OperationMetricsName:
-              OperationName: aggregate
-              OperationCommand:
-                Pipeline:
-                  [
-                    {
-                      $match:
-                        {
-                          $and:
-                            [
-                              {
-                                "time":
-                                  { $lt: { ^Date: "2022-01-02T00:00:00" } },
-                              },
-                              { "obj.measurement2": { $gte: 25 } },
-                            ],
-                        },
-                    },
-                    { $count: "count" },
-                  ]
+  # - Name: MatchOnNestedFieldAndTime
+  #   Type: CrudActor
+  #   Database: *database
+  #   Threads: *threads
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [8]
+  #       NopInPhasesUpTo: *maxPhases
+  #       PhaseConfig:
+  #         Repeat: *repeat
+  #         Database: *database
+  #         Collection: *collection
+  #         Operations:
+  #           - OperationMetricsName:
+  #             OperationName: aggregate
+  #             OperationCommand:
+  #               Pipeline:
+  #                 [
+  #                   {
+  #                     $match:
+  #                       {
+  #                         $and:
+  #                           [
+  #                             {
+  #                               "time":
+  #                                 { $lt: { ^Date: "2022-01-02T00:00:00" } },
+  #                             },
+  #                             { "obj.measurement2": { $gte: 25 } },
+  #                           ],
+  #                       },
+  #                   },
+  #                   { $count: "count" },
+  #                 ]
 
-  - Name: MatchOnMuipleNestedFields
-    Type: CrudActor
-    Database: *database
-    Threads: *threads
-    Phases:
-      OnlyActiveInPhases:
-        Active: [9]
-        NopInPhasesUpTo: *maxPhases
-        PhaseConfig:
-          Repeat: *repeat
-          Database: *database
-          Collection: *collection
-          Operations:
-            - OperationMetricsName:
-              OperationName: aggregate
-              OperationCommand:
-                Pipeline:
-                  [
-                    {
-                      $match:
-                        {
-                          $and:
-                            [
-                              {
-                                $or:
-                                  [
-                                    { "obj.measurement1": 4 },
-                                    { "obj.measurement1": 9 },
-                                  ],
-                              },
-                              { "obj.measurement2": { $lte: 175 } },
-                              { "obj.measurement3": { $gt: 100, $lt: 800 } },
-                            ],
-                        },
-                    },
-                    { $count: "count" },
-                  ]
+  # TODO: The $or $eq on obj.measurement1 gets converted to a $in so this query can't run in
+  # block processing. When it runs through SBE "normally", the filter gets created in a random order
+  # leading to consistently inconsistent query durations depending on which field gets evaluated
+  # first. Evaluating the filter on obj.measurement1 is fastest, while evaluating the filter on
+  # obj.measurement3 is slowest.
+  # - Name: MatchOnMuipleNestedFields
+  #   Type: CrudActor
+  #   Database: *database
+  #   Threads: *threads
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [9]
+  #       NopInPhasesUpTo: *maxPhases
+  #       PhaseConfig:
+  #         Repeat: *repeat
+  #         Database: *database
+  #         Collection: *collection
+  #         Operations:
+  #           - OperationMetricsName:
+  #             OperationName: aggregate
+  #             OperationCommand:
+  #               Pipeline:
+  #                 [
+  #                   {
+  #                     $match:
+  #                       {
+  #                         $and:
+  #                           [
+  #                             {
+  #                               $or:
+  #                                 [
+  #                                   { "obj.measurement1": 4 },
+  #                                   { "obj.measurement1": 9 },
+  #                                 ],
+  #                             },
+  #                             { "obj.measurement2": { $lte: 175 } },
+  #                             { "obj.measurement3": { $gt: 100, $lt: 800 } },
+  #                           ],
+  #                       },
+  #                   },
+  #                   { $count: "count" },
+  #                 ]
 
-  # The $match will be handled by block processing, but the pipeline from $group onwards will be
-  # handled by regular SBE execution.
-  - Name: MatchGroupSort
-    Type: CrudActor
-    Database: *database
-    Threads: *threads
-    Phases:
-      OnlyActiveInPhases:
-        Active: [10]
-        NopInPhasesUpTo: *maxPhases
-        PhaseConfig:
-          Repeat: *repeat
-          Database: *database
-          Collection: *collection
-          Operations:
-            - OperationMetricsName:
-              OperationName: aggregate
-              OperationCommand:
-                Pipeline:
-                  [
-                    {
-                      $match:
-                        { "time": { $lt: { ^Date: "2022-01-02T00:00:00" } } },
-                    },
-                    {
-                      $group:
-                        {
-                          "_id":
-                            { $dateTrunc: { "date": "$time", "unit": "hour" } },
-                          "max_measurement1": { $max: "$obj.measurement1" },
-                        },
-                    },
-                    { $sort: { "_id": 1 } },
-                    { $count: "count" },
-                  ]
+  # # The $match will be handled by block processing, but the pipeline from $group onwards will be
+  # # handled by regular SBE execution.
+  # - Name: MatchGroupSort
+  #   Type: CrudActor
+  #   Database: *database
+  #   Threads: *threads
+  #   Phases:
+  #     OnlyActiveInPhases:
+  #       Active: [10]
+  #       NopInPhasesUpTo: *maxPhases
+  #       PhaseConfig:
+  #         Repeat: *repeat
+  #         Database: *database
+  #         Collection: *collection
+  #         Operations:
+  #           - OperationMetricsName:
+  #             OperationName: aggregate
+  #             OperationCommand:
+  #               Pipeline:
+  #                 [
+  #                   {
+  #                     $match:
+  #                       { "time": { $lt: { ^Date: "2022-01-02T00:00:00" } } },
+  #                   },
+  #                   {
+  #                     $group:
+  #                       {
+  #                         "_id":
+  #                           { $dateTrunc: { "date": "$time", "unit": "hour" } },
+  #                         "max_measurement1": { $max: "$obj.measurement1" },
+  #                       },
+  #                   },
+  #                   { $sort: { "_id": 1 } },
+  #                   { $count: "count" },
+  #                 ]

--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -14,7 +14,7 @@ GlobalDefaults:
   Database: &database test
   Collection: &collection Collection0
   DocumentCount: &documentCount 1e6
-  Repeat: &repeat 50
+  Repeat: &repeat 100
   Threads: &threads 1
   MaxPhases: &maxPhases 11
   MetaCount: &metaCount 10

--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -353,4 +353,4 @@ AutoRun:
           - replica
           - replica-all-feature-flags
       branch_name:
-        $gte: v7.1
+        $gte: v7.2

--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -13,7 +13,7 @@ Keywords:
 GlobalDefaults:
   Database: &database test
   Collection: &collection Collection0
-  DocumentCount: &documentCount 1e6
+  DocumentCount: &documentCount 1e7
   Repeat: &repeat 20
   Threads: &threads 1
   MaxPhases: &maxPhases 10
@@ -330,7 +330,7 @@ Actors:
                   [
                     {
                       $match:
-                        { "time": { $lt: { ^Date: "2022-01-02T00:00:00" } } },
+                        { "time": { $lt: { ^Date: "2022-01-08T00:00:00" } } },
                     },
                     {
                       $group:

--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -126,146 +126,146 @@ Actors:
           Repeat: 1
           Threads: 1
 
-  # # Run queries that will at least partially run with block processing
-  # - Name: BasicMatchOnNestedField
-  #   Type: CrudActor
-  #   Database: *database
-  #   Threads: *threads
-  #   Phases:
-  #     OnlyActiveInPhases:
-  #       Active: [4]
-  #       NopInPhasesUpTo: *maxPhases
-  #       PhaseConfig:
-  #         Repeat: *repeat
-  #         Database: *database
-  #         Collection: *collection
-  #         Operations:
-  #           - OperationMetricsName:
-  #             OperationName: aggregate
-  #             OperationCommand:
-  #               Pipeline:
-  #                 [
-  #                   { $match: { "obj.measurement2": { $gt: 50 } } },
-  #                   { $count: "count" },
-  #                 ]
+  # Run queries that will at least partially run with block processing
+  - Name: BasicMatchOnNestedField
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [4]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    { $match: { "obj.measurement2": { $gt: 50 } } },
+                    { $count: "count" },
+                  ]
 
-  # - Name: NarrowMatchOnNestedField
-  #   Type: CrudActor
-  #   Database: *database
-  #   Threads: *threads
-  #   Phases:
-  #     OnlyActiveInPhases:
-  #       Active: [5]
-  #       NopInPhasesUpTo: *maxPhases
-  #       PhaseConfig:
-  #         Repeat: *repeat
-  #         Database: *database
-  #         Collection: *collection
-  #         Operations:
-  #           - OperationMetricsName:
-  #             OperationName: aggregate
-  #             OperationCommand:
-  #               Pipeline:
-  #                 [
-  #                   { $match: { "obj.measurement2": { $gte: 45, $lt: 55 } } },
-  #                   { $count: "count" },
-  #                 ]
+  - Name: NarrowMatchOnNestedField
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [5]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    { $match: { "obj.measurement2": { $gte: 45, $lt: 55 } } },
+                    { $count: "count" },
+                  ]
 
-  # - Name: AndMatchOnNestedField
-  #   Type: CrudActor
-  #   Database: *database
-  #   Threads: *threads
-  #   Phases:
-  #     OnlyActiveInPhases:
-  #       Active: [6]
-  #       NopInPhasesUpTo: *maxPhases
-  #       PhaseConfig:
-  #         Repeat: *repeat
-  #         Database: *database
-  #         Collection: *collection
-  #         Operations:
-  #           - OperationMetricsName:
-  #             OperationName: aggregate
-  #             OperationCommand:
-  #               Pipeline:
-  #                 [
-  #                   {
-  #                     $match:
-  #                       {
-  #                         $and:
-  #                           [
-  #                             { "obj.measurement3": { $gt: 100 } },
-  #                             { "obj.measurement3": { $lt: 300 } },
-  #                           ],
-  #                       },
-  #                   },
-  #                   { $count: "count" },
-  #                 ]
+  - Name: AndMatchOnNestedField
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [6]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $match:
+                        {
+                          $and:
+                            [
+                              { "obj.measurement3": { $gt: 100 } },
+                              { "obj.measurement3": { $lt: 300 } },
+                            ],
+                        },
+                    },
+                    { $count: "count" },
+                  ]
 
-  # - Name: OrMatchOnNestedField
-  #   Type: CrudActor
-  #   Database: *database
-  #   Threads: *threads
-  #   Phases:
-  #     OnlyActiveInPhases:
-  #       Active: [7]
-  #       NopInPhasesUpTo: *maxPhases
-  #       PhaseConfig:
-  #         Repeat: *repeat
-  #         Database: *database
-  #         Collection: *collection
-  #         Operations:
-  #           - OperationMetricsName:
-  #             OperationName: aggregate
-  #             OperationCommand:
-  #               Pipeline:
-  #                 [
-  #                   {
-  #                     $match:
-  #                       {
-  #                         $or:
-  #                           [
-  #                             { "obj.measurement3": { $lt: 100 } },
-  #                             { "obj.measurement3": { $gt: 900 } },
-  #                           ],
-  #                       },
-  #                   },
-  #                   { $count: "count" },
-  #                 ]
+  - Name: OrMatchOnNestedField
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [7]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $match:
+                        {
+                          $or:
+                            [
+                              { "obj.measurement3": { $lt: 100 } },
+                              { "obj.measurement3": { $gt: 900 } },
+                            ],
+                        },
+                    },
+                    { $count: "count" },
+                  ]
 
-  # - Name: MatchOnNestedFieldAndTime
-  #   Type: CrudActor
-  #   Database: *database
-  #   Threads: *threads
-  #   Phases:
-  #     OnlyActiveInPhases:
-  #       Active: [8]
-  #       NopInPhasesUpTo: *maxPhases
-  #       PhaseConfig:
-  #         Repeat: *repeat
-  #         Database: *database
-  #         Collection: *collection
-  #         Operations:
-  #           - OperationMetricsName:
-  #             OperationName: aggregate
-  #             OperationCommand:
-  #               Pipeline:
-  #                 [
-  #                   {
-  #                     $match:
-  #                       {
-  #                         $and:
-  #                           [
-  #                             {
-  #                               "time":
-  #                                 { $lt: { ^Date: "2022-01-02T00:00:00" } },
-  #                             },
-  #                             { "obj.measurement2": { $gte: 25 } },
-  #                           ],
-  #                       },
-  #                   },
-  #                   { $count: "count" },
-  #                 ]
+  - Name: MatchOnNestedFieldAndTime
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [8]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $match:
+                        {
+                          $and:
+                            [
+                              {
+                                "time":
+                                  { $lt: { ^Date: "2022-01-02T00:00:00" } },
+                              },
+                              { "obj.measurement2": { $gte: 25 } },
+                            ],
+                        },
+                    },
+                    { $count: "count" },
+                  ]
 
   # TODO: The $or $eq on obj.measurement1 gets converted to a $in so this query can't run in
   # block processing. When it runs through SBE "normally", the filter gets created in a random order
@@ -310,38 +310,47 @@ Actors:
   #                   { $count: "count" },
   #                 ]
 
-  # # The $match will be handled by block processing, but the pipeline from $group onwards will be
-  # # handled by regular SBE execution.
-  # - Name: MatchGroupSort
-  #   Type: CrudActor
-  #   Database: *database
-  #   Threads: *threads
-  #   Phases:
-  #     OnlyActiveInPhases:
-  #       Active: [10]
-  #       NopInPhasesUpTo: *maxPhases
-  #       PhaseConfig:
-  #         Repeat: *repeat
-  #         Database: *database
-  #         Collection: *collection
-  #         Operations:
-  #           - OperationMetricsName:
-  #             OperationName: aggregate
-  #             OperationCommand:
-  #               Pipeline:
-  #                 [
-  #                   {
-  #                     $match:
-  #                       { "time": { $lt: { ^Date: "2022-01-02T00:00:00" } } },
-  #                   },
-  #                   {
-  #                     $group:
-  #                       {
-  #                         "_id":
-  #                           { $dateTrunc: { "date": "$time", "unit": "hour" } },
-  #                         "max_measurement1": { $max: "$obj.measurement1" },
-  #                       },
-  #                   },
-  #                   { $sort: { "_id": 1 } },
-  #                   { $count: "count" },
-  #                 ]
+  # The $match will be handled by block processing, but the pipeline from $group onwards will be
+  # handled by regular SBE execution.
+  - Name: MatchGroupSort
+    Type: CrudActor
+    Database: *database
+    Threads: *threads
+    Phases:
+      OnlyActiveInPhases:
+        Active: [10]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          Repeat: *repeat
+          Database: *database
+          Collection: *collection
+          Operations:
+            - OperationMetricsName:
+              OperationName: aggregate
+              OperationCommand:
+                Pipeline:
+                  [
+                    {
+                      $match:
+                        { "time": { $lt: { ^Date: "2022-01-02T00:00:00" } } },
+                    },
+                    {
+                      $group:
+                        {
+                          "_id":
+                            { $dateTrunc: { "date": "$time", "unit": "hour" } },
+                          "max_measurement1": { $max: "$obj.measurement1" },
+                        },
+                    },
+                    { $sort: { "_id": 1 } },
+                    { $count: "count" },
+                  ]
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - replica
+          - replica-all-feature-flags
+      branch_name:
+        $gte: v7.1

--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -3,8 +3,8 @@ Owner: "@mongodb/query-execution"
 Description: |
   This workload runs queries on time-series collections that can at least partially run with block
   processing. At the moment, only queries with a $match prefix are eligible for block processing.
-  The dataset used for this workload is artificial/fabricated. Currently focuses on nested fields
-  since matching on top level fields is already tested in other workloads.
+  The dataset used for this workload has uniformly random data so bucket level filtering is
+  ineffective. This stresses turning buckets into blocks and running block based operations on them.
 
 Keywords:
   - timeseries


### PR DESCRIPTION
**Jira Ticket:** [PERF-4881](https://jira.mongodb.org/browse/PERF-4881)

**Whats Changed:**  
Created a workload that runs against uniformly random timeseries data to target SBE block processing.

**Patch testing results:**  
[Evergreen patch](https://spruce.mongodb.com/version/654d26803e8e86df96dc9eec/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

**Workload Submission form:**  
If applicable, only required if there is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)
Form submitted!

**Related PRs:**   
