### PR TITLE
DEVPROD-2654: Don't generate tasks if no AutoRun block.

### DIFF
--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -246,7 +246,7 @@ class Workload:
         :return: all possible tasks irrespective of the current build-variant etc.
         """
         if not self.auto_run_info:
-            return [GeneratedTask(self.snake_case_base_name, None, None, self)]
+            return []
 
         tasks = []
         for block in self.auto_run_info:

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -161,34 +161,6 @@ class AutoTasksTests(BaseTestClass):
                 "exec_timeout_secs": 64800,
                 "tasks": [
                     {
-                        "name": "empty_unmodified",
-                        "commands": [
-                            TIMEOUT_COMMAND,
-                            {
-                                "func": "f_run_dsi_workload",
-                                "vars": {
-                                    "test_control": "empty_unmodified",
-                                    "auto_workload_path": "src/genny/src/workloads/scale/EmptyUnmodified.yml",
-                                },
-                            },
-                        ],
-                        "priority": 5,
-                    },
-                    {
-                        "name": "empty_unmodified_other",
-                        "commands": [
-                            TIMEOUT_COMMAND,
-                            {
-                                "func": "f_run_dsi_workload",
-                                "vars": {
-                                    "test_control": "empty_unmodified_other",
-                                    "auto_workload_path": "src/other/src/workloads/scale/EmptyUnmodifiedOther.yml",
-                                },
-                            },
-                        ],
-                        "priority": 5,
-                    },
-                    {
                         "name": "multi_a",
                         "commands": [
                             TIMEOUT_COMMAND,


### PR DESCRIPTION
We shouldn't generate a global task for any workload that doesn't have an AutoRun block. These tasks aren't usable and pollute the namespace.

Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** DEVPROD-2654

**Whats Changed:**  
Don't generate a global task definition for Genny Workloads that don't have an AutoRun block. There is no reason to do this and it pollutes the global task namespace.

**Patch testing results:**  

https://spruce.mongodb.com/version/655432d83066159f7eed78fa/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The above patch is the fix for a naming conflict that was happening as part of PM-3362, since the "search" task name that was generated by Genny conflicted with an existing task.

**Workload Submission form:**  
If applicable, only required if there is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)

**Related PRs:**   
If applicable, link related PRs

