### PR TITLE
PERF-4868 Run high value workloads on default sharding perf variants

### DIFF
--- a/src/gennylib/src/topology.cpp
+++ b/src/gennylib/src/topology.cpp
@@ -59,13 +59,15 @@ void ReplSetDescription::accept(TopologyVisitor& v) {
 }
 
 void ConfigSvrDescription::accept(TopologyVisitor& v) {
-    v.onBeforeConfigSvr(*this);
-    for (int i = 0; i < nodes.size() - 1; i++) {
-        nodes[i].accept(v);
-        v.onBetweenMongods(*this);
+    if (!nodes.empty()) {
+        v.onBeforeConfigSvr(*this);
+        for (int i = 0; i < nodes.size() - 1; i++) {
+            nodes[i].accept(v);
+            v.onBetweenMongods(*this);
+        }
+        nodes[nodes.size() - 1].accept(v);
+        v.onAfterConfigSvr(*this);
     }
-    nodes[nodes.size() - 1].accept(v);
-    v.onAfterConfigSvr(*this);
 }
 
 void ShardedDescription::accept(TopologyVisitor& v) {

--- a/src/workloads/query/TimeseriesTsbsOptimizations.yml
+++ b/src/workloads/query/TimeseriesTsbsOptimizations.yml
@@ -276,3 +276,15 @@ Actors:
                         },
                     },
                   ]
+
+  # Prevent DSI from quitting the workload for not outputting anything to stdout.
+  - Name: LoggingActor
+    Type: LoggingActor
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [11]
+        NopInPhasesUpTo: *maxPhases
+        PhaseConfig:
+          LogEvery: 5 minutes
+          Blocking: None


### PR DESCRIPTION
Jira Ticket: [PERF-4868](https://jira.mongodb.org/browse/PERF-4868)

Whats Changed:
In this patch, I've changed it so that we avoid trying to call the configsvr topology visitor if a separate configsvr doesn't exist (because we're now running variants with a config shard). I've also added a LoggingActor to the timeseries query optimizations workload, which was otherwise quitting because there was no output to std::out on the new variants.

Patch testing results:
[patch 1 (a few failures)](https://spruce.mongodb.com/version/6553f27e562343b0a9b5a2b6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[patch 2 - with fix for canaries](https://spruce.mongodb.com/version/655512b8306615ba9bb0b357/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[patch 3 - with fix for tsbs-query-optimization](https://spruce.mongodb.com/version/6555296361837d4298a05823/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

Related PRs:
[SERVER](https://github.com/10gen/mongo/pull/16943)
[DSI](https://github.com/10gen/dsi/pull/1471)
[Workloads](https://github.com/10gen/workloads/pull/130)
