### PR TITLE
PERF-4897 Update query stats rate limited auto-run configurations

### DIFF
--- a/src/workloads/execution/ClusteredCollection.yml
+++ b/src/workloads/execution/ClusteredCollection.yml
@@ -22,17 +22,15 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-query-stats
-      - standalone-query-stats-small-rate-limit
       - replica
       - replica-all-feature-flags
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite-all-feature-flags
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats
     branch_name:
       $gte:  v5.3

--- a/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+++ b/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
@@ -22,17 +22,15 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-query-stats
-      - standalone-query-stats-small-rate-limit
       - replica
       - replica-all-feature-flags
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite-all-feature-flags
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats
     branch_name:
       $gte: v5.3

--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -118,16 +118,14 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-query-stats
       - standalone
-      - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/QueryStatsQueryShapes.yml
+++ b/src/workloads/query/QueryStatsQueryShapes.yml
@@ -136,11 +136,11 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone-query-stats
-      - standalone-query-stats-small-rate-limit
       - standalone
       - single-replica
       - single-replica-query-stats
       - replica
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -173,16 +173,14 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-query-stats
       - standalone
-      - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_Agg.yml
@@ -97,16 +97,14 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-query-stats
       - standalone
-      - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
@@ -109,16 +109,14 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-query-stats
       - standalone
-      - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
@@ -110,16 +110,14 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-query-stats
       - standalone
-      - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -97,16 +97,14 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-query-stats
       - standalone
-      - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
@@ -102,7 +102,5 @@ AutoRun:
       $eq:
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -110,16 +110,14 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-query-stats
       - standalone
-      - standalone-query-stats-small-rate-limit
       - shard
       - shard-query-stats
-      - shard-limited-query-stats
       - shard-lite
       - shard-lite-query-stats
-      - shard-lite-limited-query-stats
       - single-replica
       - single-replica-query-stats
       - replica
       - replica-query-stats
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
       - atlas-like-replica-query-stats.2022-10


### PR DESCRIPTION
Replace references to soon-to-be-removed "limited" query stats variants in auto-run configurations with the new `replica-query-stats-rate-limit` template variant. Former limited variants are not applicable after [PERF-4893](https://jira.mongodb.org/browse/PERF-4893) merges, because now all variants will run with a query stats rate limit of 100.

Auto-generated tasks on all query stats variants with the change: [Evergreen](https://spruce.mongodb.com/version/655685f9c9ec4403bc5af600/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
For comparison, auto-generated tasks on all query stats without the change: [Evergreen](https://spruce.mongodb.com/version/65568d6ae3c331850c3f4b79/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
