### PR TITLE
DEVPROD-1625: Compile genny on Amazon Linux 2023 (al2023.0)

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -66,6 +66,24 @@ buildvariants:
   - name: tg_compile_and_test_with_server_on_amz
   - name: t_compile_and_dry_run_asan
 
+- name: amazon2023
+  display_name: Amazon Linux 2023 x64
+  modules: [mongo]
+  run_on:
+  - amazon2023.0-large
+  tasks:
+  - name: tg_compile_and_test_with_server_on_amz
+  - name: t_compile_and_dry_run_asan
+
+- name: amazon2023_arm64
+  display_name: Amazon Linux 2023 arm64
+  modules: [mongo]
+  run_on:
+  - amazon2023.0-arm64-large
+  tasks:
+  - name: tg_compile_and_test_with_server_on_amz
+  - name: t_compile_and_dry_run_asan
+
 - name: rhel70
   display_name: RHEL 7
   modules: [mongo]

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -72,7 +72,7 @@ buildvariants:
   run_on:
   - amazon2023.0-large
   tasks:
-  - name: tg_compile_and_test_with_server_on_amz
+  - name: t_compile_and_dry_run
   - name: t_compile_and_dry_run_asan
 
 - name: amazon2023_arm64
@@ -81,7 +81,7 @@ buildvariants:
   run_on:
   - amazon2023.0-arm64-large
   tasks:
-  - name: tg_compile_and_test_with_server_on_amz
+  - name: t_compile_and_dry_run
   - name: t_compile_and_dry_run_asan
 
 - name: rhel70

--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -218,6 +218,8 @@ class CuratorDownloader(Downloader):
         "amazon2_arm64": "arm",
         "ubuntu2004_arm64": "arm",
         "ubuntu2204_arm64": "arm",
+        "amazon2023": "rhel70",
+        "amazon2023_arm64": "arm",
     }
 
     def __init__(

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -85,6 +85,13 @@ def _detect_distro_amazon(machine, freedesktop_version):
             return "amazon2"
         else:
             raise DistroDetectionError(f"Invalid machine type for Amazon 2: {machine}")
+    elif freedesktop_version == "2023":
+        if machine == "aarch64":
+            return "amazon2023_arm64"
+        elif machine == "x86_64":
+            return "amazon2023"
+        else:
+            raise DistroDetectionError(f"Invalid machine type for Amazon 2023: {machine}")
     else:
         raise DistroDetectionError(f"Invalid version for Amazon Linux: {freedesktop_version}")
 

--- a/src/lamplib/src/genny/tasks/run_tests.py
+++ b/src/lamplib/src/genny/tasks/run_tests.py
@@ -20,6 +20,8 @@ CANNED_ARTIFACTS = {
     "osx": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-macos-x86_64-6.0.0.tgz",
     "amazon2": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-linux-x86_64-amazon2-6.0.0.tgz",
     "amazon2_arm64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2-6.0.0.tgz",
+    "amazon2023": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2023-7.0.2.tgz",
+    "amazon2023_arm64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2023-7.0.2.tgz",
     "ubuntu1804": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-linux-x86_64-ubuntu1804-6.0.0.tgz",
     "ubuntu2004": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-linux-x86_64-ubuntu2004-6.0.0.tgz",
     "rhel70": "https://dsi-donot-remove.s3.us-west-2.amazonaws.com/compile_artifacts/mongodb-linux-x86_64-rhel70-6.0.0.tgz",

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -199,7 +199,9 @@ class ToolchainDownloader(Downloader):
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
     #
 
-    TOOLCHAIN_BUILD_ID = "7ea933da9e013e65600f880fd41e2990920ee297_23_10_03_23_11_48"
+    TOOLCHAIN_BUILD_ID = (
+        "patch_7ea933da9e013e65600f880fd41e2990920ee297_655eaa40e3c3312d2f4df25e_23_11_23_01_26_46"
+    )
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 
     def __init__(


### PR DESCRIPTION
**Jira Ticket:** DEVPROD-1625

**Whats Changed:**

Compile genny on Amazon Linux 2023 (al2023.0).

Things worth noting:

-   `TOOLCHAIN_BUILD_ID` will be updated once [corresponding genny toolchain PR](https://github.com/10gen/vcpkg/pull/31) is merged and a new waterfall build of genny toolchain is done.

-   Why al2023.0 not al2023.2?
    
    Currently, the mongodb toolchain version used by evergreen does not work with al2023.2. The error is the following (on al2023.2, the available SO verison is libffi.so.8):
    
    ```text
    ImportError: libffi.so.6: cannot open shared object file: No such file or
    directory
    ```
    
    The latest mongodb toolchain has alrady been rebuilt on al2023.2 to fix this issue. Hence, when evergreen adopts the latest toolchain (an indication could be being unable to find libffi.so.8), update the `run_on` host to `amazon2023.2-...`.

-   Why we run `resmoke-test` on amazon2 but not al2023?
    -   Firstly, it is unnecessary because we do not run `resmoke-test` on every platform anyways.
    
    -   Secondly, `resmoke-test` works with mongodb 6.0 only (DEVPROD-2925) but we don't have mongodb6.0 for al2023.

**Patch testing results:**

https://spruce.mongodb.com/version/659b840fe3c331c1a9af9d37/tasks
https://spruce.mongodb.com/version/655f1ca4306615976341a21c/tasks

**Related PRs:**

https://github.com/10gen/vcpkg/pull/31
