### PR TITLE
PERF-4889 Remove the 'numInitialChunks' parameter used with 'ShardCollection' command

### DIFF
--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -73,7 +73,6 @@ Actors:
           OperationCommand:
             shardCollection: *Namespace
             key: {_id: "hashed"}
-            numInitialChunks: 12
 
 - Name: Insert
   Type: Loader

--- a/src/workloads/query/GraphLookup.yml
+++ b/src/workloads/query/GraphLookup.yml
@@ -44,13 +44,11 @@ Actors:
       OperationCommand:
         shardCollection: test.Collection0
         key: {b: hashed}
-        numInitialChunks: &NumChunks 6
     - OperationMetricsName: ShardForeignCollection
       OperationName: AdminCommand
       OperationCommand:
         shardCollection: test.Collection2
         key: {b: hashed}
-        numInitialChunks: *NumChunks
     # Disable the balancer so that it can't skew results while the $lookups are running.
     - OperationMetricsName: DisableBalancer
       OperationName: AdminCommand

--- a/src/workloads/query/Lookup.yml
+++ b/src/workloads/query/Lookup.yml
@@ -41,13 +41,11 @@ Actors:
       OperationCommand:
         shardCollection: test.Collection0
         key: {shardKey: hashed}
-        numInitialChunks: &NumChunks 6
     - OperationMetricsName: ShardForeignCollection
       OperationName: AdminCommand
       OperationCommand:
         shardCollection: test.Collection1
         key: {shardKey: hashed}
-        numInitialChunks: *NumChunks
     # Disable the balancer so that it can't skew results while the $lookups are running.
     - OperationMetricsName: DisableBalancer
       OperationName: AdminCommand

--- a/src/workloads/query/LookupColocatedData.yml
+++ b/src/workloads/query/LookupColocatedData.yml
@@ -138,7 +138,7 @@ Actors:
           OperationName: AdminCommand
           OperationCommand:
             enableSharding: *Database
-        # This collection will have data distributed across 6 chunks.
+        # This collection will have data distributed evenly across the shards.
         - OperationMetricsName: ShardLocalCollection
           OperationName: AdminCommand
           OperationCommand:

--- a/src/workloads/query/LookupColocatedData.yml
+++ b/src/workloads/query/LookupColocatedData.yml
@@ -144,14 +144,12 @@ Actors:
           OperationCommand:
             shardCollection: test.ShardedLocal
             key: {*LocalShardKey: hashed}
-            numInitialChunks: 6
         # Here we use 1 chunk. This ensures that all the data for this coll is on one shard.
         - OperationMetricsName: ShardLocalCollectionAllOnOneShard
           OperationName: AdminCommand
           OperationCommand:
             shardCollection: test.ShardedLocalAllOnOneShard
-            key: {*LocalShardKey: hashed}
-            numInitialChunks: 1
+            key: {*LocalShardKey: 1}
         # Disable the balancer so that it can't skew results while the $lookups are running.
         - OperationMetricsName: DisableBalancer
           OperationName: AdminCommand

--- a/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
@@ -38,7 +38,6 @@ Actors:
           OperationCommand:
             shardCollection: *Namespace
             key: {_id: "hashed"}
-            numInitialChunks: 12
 
 - LoadObjectIDs:
   LoadConfig:

--- a/src/workloads/sharding/ReshardCollection.yml
+++ b/src/workloads/sharding/ReshardCollection.yml
@@ -76,7 +76,6 @@ Actors:
         # Hashed sharding will pre-split the chunk ranges and evenly distribute them across all of
         # the shards.
         key: {oldKey: hashed}
-        numInitialChunks: *NumChunks
   - *Nop
   - *Nop
   - *Nop

--- a/src/workloads/sharding/ReshardCollection.yml
+++ b/src/workloads/sharding/ReshardCollection.yml
@@ -32,7 +32,6 @@ GlobalDefaults:
   # TODO: Increase DocumentCount to 4000000 so there will be ~20GB of data inserted on each shard
   # and increase NumReshardedChunks to 400 so there continue to be ~50MB of data per chunk.
   DocumentCount: &DocumentCount 100000  # for an approximate total of 1GB
-  NumChunks: &NumChunks 20              # with approximately 50MB per chunk
 
   ShardKeyValueMin: &ShardKeyValueMin 1
   ShardKeyValueMax: &ShardKeyValueMax 100

--- a/src/workloads/sharding/ReshardCollectionMixed.yml
+++ b/src/workloads/sharding/ReshardCollectionMixed.yml
@@ -81,7 +81,6 @@ Actors:
         # Hashed sharding will pre-split the chunk ranges and evenly distribute them across all of
         # the shards.
         key: {oldKey: hashed}
-        numInitialChunks: *NumChunks
   - *Nop
   - *Nop
   - *Nop

--- a/src/workloads/sharding/ReshardCollectionMixed.yml
+++ b/src/workloads/sharding/ReshardCollectionMixed.yml
@@ -30,7 +30,6 @@ GlobalDefaults:
   ApproxDocumentSize: &ApproxDocumentSize 2000  # = 2kB
   ApproxDocumentSize50Pct: &ApproxDocumentSize50Pct 1000  # = 1kB
   DocumentCount: &DocumentCount 2_000_000  # for an approximate total of 3GB
-  NumChunks: &NumChunks 60                 # with approximately 50MB per chunk
 
   ShardKeyValueMin: &ShardKeyValueMin 1
   # We use 100x the number of chunks so that the $sample aggregation to choose the new split points

--- a/src/workloads/sharding/ReshardCollectionMixed.yml
+++ b/src/workloads/sharding/ReshardCollectionMixed.yml
@@ -32,7 +32,8 @@ GlobalDefaults:
   DocumentCount: &DocumentCount 2_000_000  # for an approximate total of 3GB
 
   ShardKeyValueMin: &ShardKeyValueMin 1
-  # We use 100x the number of chunks so that the $sample aggregation to choose the new split points
+  # We use a large value for 'ShardKeyValueMax', when compared to the number of chunks in the system.
+  # This ensures that the $sample aggregation to choose the new split points,
   # has a wide range of distinct values to choose from. It could be even larger.
   ShardKeyValueMax: &ShardKeyValueMax 6000
 

--- a/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+++ b/src/workloads/sharding/ReshardCollectionReadHeavy.yml
@@ -81,7 +81,6 @@ Actors:
         # Hashed sharding will pre-split the chunk ranges and evenly distribute them across all of
         # the shards.
         key: {oldKey: hashed}
-        numInitialChunks: *NumChunks
   - *Nop
   - *Nop
   - *Nop

--- a/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+++ b/src/workloads/sharding/ReshardCollectionReadHeavy.yml
@@ -30,7 +30,6 @@ GlobalDefaults:
   ApproxDocumentSize: &ApproxDocumentSize 2000  # = 2kB
   ApproxDocumentSize50Pct: &ApproxDocumentSize50Pct 1000  # = 1kB
   DocumentCount: &DocumentCount 8_000_000  # for an approximate total of 12GB
-  NumChunks: &NumChunks 240                # with approximately 50MB per chunk
 
   ShardKeyValueMin: &ShardKeyValueMin 1
   # We use 100x the number of chunks so that the $sample aggregation to choose the new split points

--- a/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+++ b/src/workloads/sharding/ReshardCollectionReadHeavy.yml
@@ -32,7 +32,8 @@ GlobalDefaults:
   DocumentCount: &DocumentCount 8_000_000  # for an approximate total of 12GB
 
   ShardKeyValueMin: &ShardKeyValueMin 1
-  # We use 100x the number of chunks so that the $sample aggregation to choose the new split points
+  # We use a large value for 'ShardKeyValueMax', when compared to the number of chunks in the system.
+  # This ensures that the $sample aggregation to choose the new split points, 
   # has a wide range of distinct values to choose from. It could be even larger.
   ShardKeyValueMax: &ShardKeyValueMax 24_000
 


### PR DESCRIPTION
**Jira Ticket:** [PERF-4889](https://jira.mongodb.org/browse/PERF-4889)

**Whats Changed:**  
The numInitialChunks parameter was deprecated in [SERVER-74747](https://jira.mongodb.org/browse/SERVER-74747), and now 1 chunk per shard is created by default. 
Adjust workloads accordingly. 

**Patch testing results:**  
Example patch run: https://spruce.mongodb.com/version/655f8149e3c3312d2f4f6616/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
