### PR TITLE
PERF-4942 Enable CreateIndex, CreateBigIndex and ExternalSort workloads for standalone-all-feature-flag variant

### DIFF
--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -103,6 +103,7 @@ AutoRun:
       - replica-all-feature-flags
       - single-replica
       - standalone
+      - standalone-all-feature-flags
     atlas_setup:
       $neq:
       - M30-repl

--- a/src/workloads/execution/CreateIndex.yml
+++ b/src/workloads/execution/CreateIndex.yml
@@ -130,10 +130,11 @@ AutoRun:
       - atlas
       - atlas-like-replica.2022-10
       - replica
-      - single-replica
-      - standalone
       - shard
       - shard-lite
+      - single-replica
+      - standalone
+      - standalone-all-feature-flags
     atlas_setup:
       $neq:
       - M30-repl

--- a/src/workloads/query/ExternalSort.yml
+++ b/src/workloads/query/ExternalSort.yml
@@ -103,9 +103,10 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone
+      - standalone-all-feature-flags
       - standalone-classic-query-engine
-      - standalone-sbe
       - standalone-query-stats
+      - standalone-sbe
     branch_name:
       $neq:
       - v4.0


### PR DESCRIPTION
**Jira Ticket:** PERF-4942

**Whats Changed:**  
Enable CreateIndex, CreateBigIndex and ExternalSort workloads for standalone-all-feature-flag variant

**Patch testing results:**  
https://spruce.mongodb.com/version/656719e8e3c33182d9590cff/tasks