### PR TITLE
PERF-4796: Run query stats workload on shard-single variants

### DIFF
--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -214,6 +214,9 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone
+      # TODO PERF-4951 Enable sharded versions with multiple mongos.
+      # - shard
+      # - shard-lite
       - shard-single
       - single-replica
       - replica

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -214,9 +214,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone
-      # TODO PERF-4796 re-enable the sharded versions.
-      # - shard
-      # - shard-lite
+      - shard-single
       - single-replica
       - replica
       - atlas-like-replica.2022-10


### PR DESCRIPTION
**Jira Ticket:** PERF-4796

**Whats Changed:**  
Runs query stats workloads on variants that use the shard-single mongodb_setup file

**Patch testing results:**  
[🌲 ](https://spruce.mongodb.com/version/65650b51d6d80aacc1471789/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&statuses=success&variant=%5Elinux-shard-single.2022-11%24)
 (only look at shard single variant)

This will run every Tuesday and Thursday.
