### PR TITLE
DEVPROD-3024: Revert change that caused BF-30088

### DIFF
--- a/src/gennylib/src/topology.cpp
+++ b/src/gennylib/src/topology.cpp
@@ -179,7 +179,7 @@ void Topology::computeDataMemberConnectionStrings(DBConnection& connection) {
         bsoncxx::array::view passives_view = passives.get_array();
         for (auto member : passives_view) {
             MongodDescription memberDesc;
-            memberDesc.mongodUri = nameToUri(std::string(member.get_string().value));
+            memberDesc.mongodUri = std::string(member.get_string().value);
             if (configSetNames.find(setName) != configSetNames.end()) {
                 memberDesc.clusterType = ClusterType::configSvrMember;
             } else {


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-3024](https://jira.mongodb.org/browse/DEVPROD-3024)

**Whats Changed:**  
Revert change to Genny's topology.cpp introduced in commit [a59e9](https://github.com/mongodb/genny/commit/a59e913c78be766c33f21bbea397a1d385f0bc1a#diff-5c48506c9d216b9fbda30f6f56d6e4df11f0cd077ec2835995beb34038b01d47R180), which caused [BF-30088](https://jira.mongodb.org/browse/BF-30088).

**Patch testing results:**
As changes have been made to the relevant workloads since BF-30088 first happened, I decided to run 2 sys-perf patches, 1 with original workloads and 1 with current state:
-  [Patch with original workloads](https://spruce.mongodb.com/version/6567e7567742ae5bb5713c36/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
- [Patch with current state](https://spruce.mongodb.com/version/65693fb732f4171caf92d6b3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)