### PR TITLE
PERF-2540: log the average docs inserted per second

### DIFF
--- a/src/cast_core/src/Loader.cpp
+++ b/src/cast_core/src/Loader.cpp
@@ -170,9 +170,9 @@ void genny::actor::Loader::run() {
                 float seconds = duration.count();
                 BOOST_LOG_TRIVIAL(info) << "Done with load phase. All " << config->numDocuments
                                         << " documents loaded into " << collectionName
-                                        << " duration(seconds) " << seconds
-                                        << std::setprecision(4)
-                                        << " " << (((float) config->numDocuments) / 1000.0) / seconds << "k docs/s";
+                                        << " in " << seconds << " seconds"
+                                        << std::setprecision(5)
+                                        << " at " << ((float) config->numDocuments) / seconds << " docs/s";
                 // Make the index
                 bool _indexReq = false;
                 builder::stream::document builder{};

--- a/src/cast_core/src/Loader.cpp
+++ b/src/cast_core/src/Loader.cpp
@@ -31,6 +31,7 @@
 
 #include <value_generators/DocumentGenerator.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
+#include <chrono>
 
 namespace genny::actor {
 
@@ -142,6 +143,7 @@ void genny::actor::Loader::run() {
                     << "Starting to insert: " << config->numDocuments << " docs "
                     << "into " << collectionName;
                 uint remainingInserts = config->numDocuments;
+                auto start = std::chrono::high_resolution_clock::now();
                 {
                     auto totalOpCtx = _totalBulkLoad.start();
                     while (remainingInserts > 0) {
@@ -163,6 +165,14 @@ void genny::actor::Loader::run() {
                     }
                     totalOpCtx.success();
                 }
+                auto end = std::chrono::high_resolution_clock::now();
+                std::chrono::duration<float> duration = end - start;
+                float seconds = duration.count();
+                BOOST_LOG_TRIVIAL(info) << "Done with load phase. All " << config->numDocuments
+                                        << " documents loaded into " << collectionName
+                                        << " duration(seconds) " << seconds
+                                        << std::setprecision(4)
+                                        << " " << (((float) config->numDocuments) / 1000.0) / seconds << "k docs/s";
                 // Make the index
                 bool _indexReq = false;
                 builder::stream::document builder{};
@@ -188,14 +198,12 @@ void genny::actor::Loader::run() {
                 }
                 auto doc = indexCmd << builder::stream::close_array << builder::stream::finalize;
                 if (_indexReq) {
-                    BOOST_LOG_TRIVIAL(debug)
+                    BOOST_LOG_TRIVIAL(info)
                             << "Building index" << to_json(doc.view());
                     auto indexOpCtx = _indexBuild.start();
                     config->database.run_command(doc.view());
                     indexOpCtx.success();
                 }
-                BOOST_LOG_TRIVIAL(info) << "Done with load phase. All " << config->numDocuments
-                                        << " documents loaded into " << collectionName;
             }
         }
     }

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -13,7 +13,6 @@ GlobalDefaults:
     caid: {^RandomInt: {min: 0, max: 1000}}
     cuid: {^RandomInt: {min: 0, max: 100000}}
     prod: {^RandomInt: {min: 0, max: 10000}}
-    prod2: {^RandomInt: {min: 0, max: 10000}}
     price: {^RandomDouble: {min: 0.0, max: 1000.0}}
     data: {^Join: {array: ["aaaaaaaaaa", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
     c: &string {^FastRandomString: {length: 75}}  # Adjust this so the doc comes out as 200 B.
@@ -25,12 +24,6 @@ GlobalDefaults:
   - keys: {price: 1, cuid: 1}            # Pc
   - keys: {caid: 1, price: 1, cuid: 1}   # Cpc
 
-  EvenMoreIndexes: &EvenMoreIndexes
-  - keys: {prod: 1}
-  - keys: {cuid: 1}
-  - keys: {ts: 1}
-  - keys: {prod2: 1}
-
   # Loader Config.
   LoadThreads: &LoadThreads 8
   CollectionCount: &CollectionCount 8
@@ -38,8 +31,7 @@ GlobalDefaults:
 
   InitialDocumentCount: &InitialNumDocs 10000000
   SecondDocumentCount: &SecondNumDocs 6000000
-  ThirdDocumentCount: &ThirdDocumentCount 2000000
-  FinalDocumentCount: &FinalDocumentCount 1000000
+  FinalDocumentCount: &FinalDocumentCount 2000000
 
 Clients:
   Default:
@@ -95,23 +87,6 @@ Actors:
         Database: *dbname
         Repeat: 1
         Document: *Doc
-        DocumentCount: *ThirdDocumentCount
-        Indexes: *EvenMoreIndexes
-        BatchSize: *LoadBatchSize
-
-- Name: LoadWithEightIndexes
-  Type: Loader
-  Threads: *LoadThreads
-  Phases:
-    OnlyActiveInPhases:
-      Active: [7]
-      NopInPhasesUpTo: *MaxPhases
-      PhaseConfig:
-        Threads: *LoadThreads
-        CollectionCount: *CollectionCount
-        Database: *dbname
-        Repeat: 1
-        Document: *Doc
         DocumentCount: *FinalDocumentCount
         BatchSize: *LoadBatchSize
 
@@ -121,7 +96,7 @@ Actors:
   Database: *dbname
   Phases:
     OnlyActiveInPhases:
-      Active: [0, 2, 4, 6]
+      Active: [0, 2, 4]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Repeat: 1
@@ -132,7 +107,7 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1, 3, 5, 7]
+      Active: [1, 3, 5]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         LogEvery: 10 seconds

--- a/src/workloads/scale/LoadTest.yml
+++ b/src/workloads/scale/LoadTest.yml
@@ -13,6 +13,7 @@ GlobalDefaults:
     caid: {^RandomInt: {min: 0, max: 1000}}
     cuid: {^RandomInt: {min: 0, max: 100000}}
     prod: {^RandomInt: {min: 0, max: 10000}}
+    prod2: {^RandomInt: {min: 0, max: 10000}}
     price: {^RandomDouble: {min: 0.0, max: 1000.0}}
     data: {^Join: {array: ["aaaaaaaaaa", {^FastRandomString: {length: {^RandomInt: {min: 0, max: 10}}}}]}}
     c: &string {^FastRandomString: {length: 75}}  # Adjust this so the doc comes out as 200 B.
@@ -24,6 +25,12 @@ GlobalDefaults:
   - keys: {price: 1, cuid: 1}            # Pc
   - keys: {caid: 1, price: 1, cuid: 1}   # Cpc
 
+  EvenMoreIndexes: &EvenMoreIndexes
+  - keys: {prod: 1}
+  - keys: {cuid: 1}
+  - keys: {ts: 1}
+  - keys: {prod2: 1}
+
   # Loader Config.
   LoadThreads: &LoadThreads 8
   CollectionCount: &CollectionCount 8
@@ -31,7 +38,8 @@ GlobalDefaults:
 
   InitialDocumentCount: &InitialNumDocs 10000000
   SecondDocumentCount: &SecondNumDocs 6000000
-  FinalDocumentCount: &FinalDocumentCount 2000000
+  ThirdDocumentCount: &ThirdDocumentCount 2000000
+  FinalDocumentCount: &FinalDocumentCount 1000000
 
 Clients:
   Default:
@@ -87,6 +95,23 @@ Actors:
         Database: *dbname
         Repeat: 1
         Document: *Doc
+        DocumentCount: *ThirdDocumentCount
+        Indexes: *EvenMoreIndexes
+        BatchSize: *LoadBatchSize
+
+- Name: LoadWithEightIndexes
+  Type: Loader
+  Threads: *LoadThreads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [7]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Threads: *LoadThreads
+        CollectionCount: *CollectionCount
+        Database: *dbname
+        Repeat: 1
+        Document: *Doc
         DocumentCount: *FinalDocumentCount
         BatchSize: *LoadBatchSize
 
@@ -96,7 +121,7 @@ Actors:
   Database: *dbname
   Phases:
     OnlyActiveInPhases:
-      Active: [0, 2, 4]
+      Active: [0, 2, 4, 6]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         Repeat: 1
@@ -107,7 +132,7 @@ Actors:
   Threads: 1
   Phases:
     OnlyActiveInPhases:
-      Active: [1, 3, 5]
+      Active: [1, 3, 5, 7]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
         LogEvery: 10 seconds


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** PERF-2540

**Whats Changed:**  
log the average docs inserted per second

**Patch testing results:**  
Run locally

15:03:06Z>  [2023-12-07 15:03:06.986267] [0x0000ffff7d320fc0] [info]    Phase still progressing (170s)
15:03:16Z>  [2023-12-07 15:03:16.987667] [0x0000ffff7d320fc0] [info]    Phase still progressing (180s)
15:03:25Z>  [2023-12-07 15:03:25.739824] [0x0000fffbed4b1fc0] [info]    Done with load phase. All 10000000 documents loaded into Collection0 duration(seconds) 187.857 53.23k docs/s

**Workload Submission form:**  
Not applicable

**Related PRs:**   
If applicable, link related PRs
