### PR TITLE
SERVER-83896 Add collscan benchmarks with complex expressions that can be simplified

### DIFF
--- a/src/phases/query/CollScanSimplifiablePredicate.yml
+++ b/src/phases/query/CollScanSimplifiablePredicate.yml
@@ -39,6 +39,8 @@ ActorTemplates:
         Name: {^Parameter: {Name: "Name", Default: "unused"}}
         ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
         Filter:
+          # Generate query of the form:
+          # {$and: [{arr: {$gt: 10}}, {arr: {$gt: 11}}, ..., {arr: {$gt: Width - 1}}]}
           {$and:
             {^Cycle: {
               ofLength: 1,
@@ -59,6 +61,19 @@ ActorTemplates:
         Name: {^Parameter: {Name: "Name", Default: "unused"}}
         ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
         Filter:
+          # Generate query of the form:
+          # {$and: [
+          #   {$or: [{arr: {$gte: 10}}, {f1: {$gte: 10}}, {f2: {$lte: 1}}, {f3: {$lt: 1}}, {f4: {$gt: 10}}]},
+          #   {$or: [{arr: {$gte: 11}}, {f1: {$gte: 11}}, {f2: {$lte: 0}}, {f3: {$lt: 0}}, {f4: {$gt: 11}}]},
+          #   ...,
+          #   {$or: [
+          #     {arr: {$gte: Width - 1}},
+          #     {f1: {$gte: Width - 1}},
+          #     {f2: {$lte: 1 - Width}},
+          #     {f3: {$lt: 1 - Width}},
+          #     {f4: {$gt: Width - 1}}
+          #   ]}
+          # ]}
           {$and:
             {^Cycle: {
               ofLength: 1,
@@ -85,6 +100,19 @@ ActorTemplates:
         Name: {^Parameter: {Name: "Name", Default: "unused"}}
         ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
         Filter:
+          # Generate query of the form:
+          # {$or: [
+          #   {$and: [{arr: {$gte: 10}}, {f1: {$gte: 10}}, {f2: {$lte: 1}}, {f3: {$lt: 1}}, {f4: {$gt: 10}}]},
+          #   {$and: [{arr: {$gte: 11}}, {f1: {$gte: 11}}, {f2: {$lte: 0}}, {f3: {$lt: 0}}, {f4: {$gt: 11}}]},
+          #   ...,
+          #   {$and: [
+          #     {arr: {$gte: Width - 1}},
+          #     {f1: {$gte: Width - 1}},
+          #     {f2: {$lte: 1 - Width}},
+          #     {f3: {$lt: 1 - Width}},
+          #     {f4: {$gt: Width - 1}}
+          #   ]}
+          # ]}
           {$or:
             {^Cycle: {
               ofLength: 1,
@@ -111,6 +139,10 @@ ActorTemplates:
         Name: {^Parameter: {Name: "Name", Default: "unused"}}
         ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
         Filter:
+          # Generate query of the form:
+          # {arr_of_objs: {$elemMatch: {
+          #     $and: [{arr: {$gt: 10}}, {arr: {$gt: 11}}, ..., {arr: {$gt: Width - 1}}]
+          # }}}
           {arr_of_objs: {$elemMatch: {$and:
             {^Cycle: {
               ofLength: 1,
@@ -131,6 +163,19 @@ ActorTemplates:
         Name: {^Parameter: {Name: "Name", Default: "unused"}}
         ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
         Filter:
+          # Generate query of the form:
+          # {arr_of_objs: {$elemMatch: {$and: [
+          #   {$or: [{arr: {$gte: 10}}, {f1: {$gte: 10}}, {f2: {$lte: 1}}, {f3: {$lt: 1}}, {f4: {$gt: 10}}]},
+          #   {$or: [{arr: {$gte: 11}}, {f1: {$gte: 11}}, {f2: {$lte: 0}}, {f3: {$lt: 0}}, {f4: {$gt: 11}}]},
+          #   ...,
+          #   {$or: [
+          #     {arr: {$gte: Width - 1}},
+          #     {f1: {$gte: Width - 1}},
+          #     {f2: {$lte: 1 - Width}},
+          #     {f3: {$lt: 1 - Width}},
+          #     {f4: {$gt: Width - 1}}
+          #   ]}
+          # ]}}}
           {arr_of_objs: {$elemMatch: {$and:
             {^Cycle: {
               ofLength: 1,
@@ -158,6 +203,19 @@ ActorTemplates:
         Name: {^Parameter: {Name: "Name", Default: "unused"}}
         ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
         Filter:
+          # Generate query of the form:
+          # {arr_of_objs: {$elemMatch: {$or: [
+          #   {$and: [{arr: {$gte: 10}}, {f1: {$gte: 10}}, {f2: {$lte: 1}}, {f3: {$lt: 1}}, {f4: {$gt: 10}}]},
+          #   {$and: [{arr: {$gte: 11}}, {f1: {$gte: 11}}, {f2: {$lte: 0}}, {f3: {$lt: 0}}, {f4: {$gt: 11}}]},
+          #   ...,
+          #   {$and: [
+          #     {arr: {$gte: Width - 1}},
+          #     {f1: {$gte: Width - 1}},
+          #     {f2: {$lte: 1 - Width}},
+          #     {f3: {$lt: 1 - Width}},
+          #     {f4: {$gt: Width - 1}}
+          #   ]}
+          # ]}}}
           {arr_of_objs: {$elemMatch: {$or:
             {^Cycle: {
               ofLength: 1,

--- a/src/phases/query/CollScanSimplifiablePredicate.yml
+++ b/src/phases/query/CollScanSimplifiablePredicate.yml
@@ -344,9 +344,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableDNF
     TemplateParameters:
-      Name: SimplifiableDNF1KClauses
+      Name: SimplifiableDNF800Clauses
       ActivePhase: 10
-      Width: 1000
+      Width: 800
 
 - ActorFromTemplate:
     TemplateName: SimplifiableDNF
@@ -366,9 +366,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchConjunction
     TemplateParameters:
-      Name: SimplifiableElemMatchConjunction1KClauses
+      Name: SimplifiableElemMatchConjunction800Clauses
       ActivePhase: 13
-      Width: 1000
+      Width: 800
 
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchConjunction
@@ -388,9 +388,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchCNF
     TemplateParameters:
-      Name: SimplifiableElemMatchCNF1KClauses
+      Name: SimplifiableElemMatchCNF800Clauses
       ActivePhase: 16
-      Width: 1000
+      Width: 800
 
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchCNF
@@ -410,9 +410,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchDNF
     TemplateParameters:
-      Name: SimplifiableElemMatchDNF1KClauses
+      Name: SimplifiableElemMatchDNF800Clauses
       ActivePhase: 19
-      Width: 1000
+      Width: 800
 
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchDNF

--- a/src/phases/query/CollScanSimplifiablePredicate.yml
+++ b/src/phases/query/CollScanSimplifiablePredicate.yml
@@ -30,6 +30,7 @@ ActorTemplates:
             OperationCommand:
               Filter: {^Parameter: {Name: "Filter", Default: {invalid: "invalid"}}}
 
+# Test wide $and predicates with inequality terms that can be simplified.
 - TemplateName: SimplifiableConjunction
   Config:
     ActorFromTemplate:
@@ -49,6 +50,7 @@ ActorTemplates:
             }}
           }
 
+# Test wide $and of $or predicates with comparisons that can be simplified.
 - TemplateName: SimplifiableCNF
   Config:
     ActorFromTemplate:
@@ -74,6 +76,7 @@ ActorTemplates:
             }}
           }
 
+# Test wide $or of $and predicates with comparisons that can be simplified.
 - TemplateName: SimplifiableDNF
   Config:
     ActorFromTemplate:
@@ -99,6 +102,7 @@ ActorTemplates:
             }}
           }
 
+# Test $elemMatch with wide $and predicates with inequality terms that can be simplified.
 - TemplateName: SimplifiableElemMatchConjunction
   Config:
     ActorFromTemplate:
@@ -118,6 +122,7 @@ ActorTemplates:
             }}
           }}}
 
+# Test $elemMatch with wide $and of $or predicates with comparisons that can be simplified.
 - TemplateName: SimplifiableElemMatchCNF
   Config:
     ActorFromTemplate:
@@ -144,6 +149,7 @@ ActorTemplates:
             }}
           }}}
 
+# Test $elemMatch with wide $or of $and predicates with comparisons that can be simplified.
 - TemplateName: SimplifiableElemMatchDNF
   Config:
     ActorFromTemplate:
@@ -201,8 +207,7 @@ Actors:
         DocumentCount: *DocumentCount
         BatchSize: 1000
         Document:
-          # None of these match any of the filters in this workload, forcing each query to scan 
-          # the entire collection.
+          # None of these match any of the filters in this workload.
           a: 1
           arr: [0, 1]
           f1: [1]

--- a/src/phases/query/CollScanSimplifiablePredicate.yml
+++ b/src/phases/query/CollScanSimplifiablePredicate.yml
@@ -1,0 +1,360 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload tests the performance of collection scan queries with complex predicates
+  that can be simplified by the optimizer.
+
+GlobalDefaults:
+  Database: &Database {^Parameter: {Name: Database, Default: unused}}
+  DocumentCount: &DocumentCount {^Parameter: {Name: DocumentCount, Default: -1}}
+  Repeat: &Repeat {^Parameter: {Name: Repeat, Default: -1}}
+  Collection: &Collection Collection0
+  MaxPhases: &MaxPhases 20
+
+ActorTemplates:
+- TemplateName: FindQueryTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "unused"}}
+    Type: CrudActor
+    Database: *Database
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "ActivePhase", Default: -1}}]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Repeat: *Repeat
+          Collection: *Collection
+          Operations:
+          - OperationName: find
+            OperationCommand:
+              Filter: {^Parameter: {Name: "Filter", Default: {invalid: "invalid"}}}
+
+- TemplateName: SimplifiableConjunction
+  Config:
+    ActorFromTemplate:
+      TemplateName: FindQueryTemplate
+      TemplateParameters:
+        Name: {^Parameter: {Name: "Name", Default: "unused"}}
+        ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
+        Filter:
+          {$and:
+            {^Cycle: {
+              ofLength: 1,
+              fromGenerator:
+                {^Array: {of:
+                  {arr: {$gt: {^Inc: {start: 10, step: 1}}}},
+                  number: {^Parameter: {Name: "Width", Default: -1}}
+                }}
+            }}
+          }
+
+- TemplateName: SimplifiableCNF
+  Config:
+    ActorFromTemplate:
+      TemplateName: FindQueryTemplate
+      TemplateParameters:
+        Name: {^Parameter: {Name: "Name", Default: "unused"}}
+        ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
+        Filter:
+          {$and:
+            {^Cycle: {
+              ofLength: 1,
+              fromGenerator:
+                {^Array: {of:
+                  {$or: [
+                    {arr: {$gte: {^Inc: {start: 10}}}},
+                    {f1: {$gte: {^Inc: {start: 10}}}},
+                    {f2: {$lte: {^Inc: {start: 1, step: -1}}}},
+                    {f3: {$lt: {^Inc: {start: 1, step: -1}}}},
+                    {f4: {$gt: {^Inc: {start: 10}}}}
+                  ]},
+                  number: {^Parameter: {Name: "Width", Default: -1}}
+                }}
+            }}
+          }
+
+- TemplateName: SimplifiableDNF
+  Config:
+    ActorFromTemplate:
+      TemplateName: FindQueryTemplate
+      TemplateParameters:
+        Name: {^Parameter: {Name: "Name", Default: "unused"}}
+        ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
+        Filter:
+          {$or:
+            {^Cycle: {
+              ofLength: 1,
+              fromGenerator:
+                {^Array: {of:
+                  {$and: [
+                    {arr: {$gte: {^Inc: {start: 10}}}},
+                    {f1: {$gte: {^Inc: {start: 10}}}},
+                    {f2: {$lte: {^Inc: {start: 1, step: -1}}}},
+                    {f3: {$lt: {^Inc: {start: 1, step: -1}}}},
+                    {f4: {$gt: {^Inc: {start: 10}}}}
+                  ]},
+                  number: {^Parameter: {Name: "Width", Default: -1}}
+                }}
+            }}
+          }
+
+- TemplateName: SimplifiableElemMatchConjunction
+  Config:
+    ActorFromTemplate:
+      TemplateName: FindQueryTemplate
+      TemplateParameters:
+        Name: {^Parameter: {Name: "Name", Default: "unused"}}
+        ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
+        Filter:
+          {arr_of_objs: {$elemMatch: {$and:
+            {^Cycle: {
+              ofLength: 1,
+              fromGenerator:
+                {^Array: {of:
+                  {b: {$gt: {^Inc: {start: 10}}}},
+                  number: {^Parameter: {Name: "Width", Default: -1}}
+                }}
+            }}
+          }}}
+
+- TemplateName: SimplifiableElemMatchCNF
+  Config:
+    ActorFromTemplate:
+      TemplateName: FindQueryTemplate
+      TemplateParameters:
+        Name: {^Parameter: {Name: "Name", Default: "unused"}}
+        ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
+        Filter:
+          {arr_of_objs: {$elemMatch: {$and:
+            {^Cycle: {
+              ofLength: 1,
+              fromGenerator:
+                {^Array: {of:
+                  {$or: [
+                    {b: {$eq: -1}},
+                    {c: {$eq: 0}},
+                    {nested: {f1: {$gte: {^Inc: {start: 10}}}}},
+                    {nested: {f2: {$lte: {^Inc: {start: 0, step: -1}}}}},
+                    {nested: {f3: {$lt: {^Inc: {start: 0, step: -1}}}}},
+                    {nested: {f4: {$gt: {^Inc: {start: 10}}}}},
+                  ]},
+                  number: {^Parameter: {Name: "Width", Default: -1}}
+                }}
+            }}
+          }}}
+
+- TemplateName: SimplifiableElemMatchDNF
+  Config:
+    ActorFromTemplate:
+      TemplateName: FindQueryTemplate
+      TemplateParameters:
+        Name: {^Parameter: {Name: "Name", Default: "unused"}}
+        ActivePhase: {^Parameter: {Name: "ActivePhase", Default: -1}}
+        Filter:
+          {arr_of_objs: {$elemMatch: {$or:
+            {^Cycle: {
+              ofLength: 1,
+              fromGenerator:
+                {^Array: {of:
+                  {$and: [
+                    {b: {$eq: -1}},
+                    {c: {$eq: 0}},
+                    {nested: {f1: {$gte: {^Inc: {start: 10}}}}},
+                    {nested: {f2: {$lte: {^Inc: {start: 0, step: -1}}}}},
+                    {nested: {f3: {$lt: {^Inc: {start: 0, step: -1}}}}},
+                    {nested: {f4: {$gt: {^Inc: {start: 10}}}}},
+                  ]},
+                  number: {^Parameter: {Name: "Width", Default: -1}}
+                }}
+            }}
+          }}}
+
+Actors:
+- Name: ClearCollection
+  Type: CrudActor
+  Database: *Database
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Collection: *Collection
+        Operations:
+        - OperationName: drop
+
+- Name: InsertData
+  Type: Loader
+  Threads: 4
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        MultipleThreadsPerCollection: true
+        CollectionCount: 1
+        DocumentCount: *DocumentCount
+        BatchSize: 1000
+        Document:
+          # None of these match any of the filters in this workload, forcing each query to scan 
+          # the entire collection.
+          a: 1
+          arr: [0, 1]
+          f1: [1]
+          f2: [[1], 2]
+          f3: [[[1], 2], 3]
+          f4: [[[[1], 2], 3], 4]
+          arr_of_objs: [{^Repeat: {count: 10, fromGenerator: {
+            b: 0, c: 1, d: 2, nested: {
+              f1: [1], f2: [[1], 2], f3: [[[1], 2], 3], f4: [[[[1], 2], 3], 4]
+            }
+          }}}]
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableConjunction
+    TemplateParameters:
+      Name: SimplifiableConjunction100Clauses
+      ActivePhase: 3
+      Width: 100
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableConjunction
+    TemplateParameters:
+      Name: SimplifiableConjunction1KClauses
+      ActivePhase: 4
+      Width: 1000
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableConjunction
+    TemplateParameters:
+      Name: SimplifiedConjunction
+      ActivePhase: 5
+      # The above queries can be simplified to contain just 1 clause.
+      Width: 1
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableCNF
+    TemplateParameters:
+      Name: SimplifiableCNF100Clauses
+      ActivePhase: 6
+      Width: 100
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableCNF
+    TemplateParameters:
+      Name: SimplifiableCNF1KClauses
+      ActivePhase: 7
+      Width: 1000
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableCNF
+    TemplateParameters:
+      Name: SimplifiedCNF
+      ActivePhase: 8
+      # The above queries can be simplified to contain just 1 clause.
+      Width: 1
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableDNF
+    TemplateParameters:
+      Name: SimplifiableDNF100Clauses
+      ActivePhase: 9
+      Width: 100
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableDNF
+    TemplateParameters:
+      Name: SimplifiableDNF1KClauses
+      ActivePhase: 10
+      Width: 1000
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableDNF
+    TemplateParameters:
+      Name: SimplifiedDNF
+      ActivePhase: 11
+      # The above queries can be simplified to contain just 1 clause.
+      Width: 1
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableElemMatchConjunction
+    TemplateParameters:
+      Name: SimplifiableElemMatchConjunction100Clauses
+      ActivePhase: 12
+      Width: 100
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableElemMatchConjunction
+    TemplateParameters:
+      Name: SimplifiableElemMatchConjunction1KClauses
+      ActivePhase: 13
+      Width: 1000
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableElemMatchConjunction
+    TemplateParameters:
+      Name: SimplifiedElemMatchConjunction
+      ActivePhase: 14
+      # The above queries can be simplified to contain just 1 clause.
+      Width: 1
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableElemMatchCNF
+    TemplateParameters:
+      Name: SimplifiableElemMatchCNF100Clauses
+      ActivePhase: 15
+      Width: 100
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableElemMatchCNF
+    TemplateParameters:
+      Name: SimplifiableElemMatchCNF1KClauses
+      ActivePhase: 16
+      Width: 1000
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableElemMatchCNF
+    TemplateParameters:
+      Name: SimplifiedElemMatchCNF
+      ActivePhase: 17
+      # The above queries can be simplified to contain just 1 clause.
+      Width: 1
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableElemMatchDNF
+    TemplateParameters:
+      Name: SimplifiableElemMatchDNF100Clauses
+      ActivePhase: 18
+      Width: 100
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableElemMatchDNF
+    TemplateParameters:
+      Name: SimplifiableElemMatchDNF1KClauses
+      ActivePhase: 19
+      Width: 1000
+
+- ActorFromTemplate:
+    TemplateName: SimplifiableElemMatchDNF
+    TemplateParameters:
+      Name: SimplifiedElemMatchDNF
+      ActivePhase: 20
+      # The above queries can be simplified to contain just 1 clause.
+      Width: 1

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -9,7 +9,7 @@ LoadConfig:
   Parameters:
     Database: CollScanWithSimplifiablePredicateLarge
     DocumentCount: 1e6
-    Repeat: 100
+    Repeat: 10
 
 AutoRun:
 - When:

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -1,0 +1,27 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload tests the performance of collection scan queries with complex predicates
+  that can be simplified by the optimizer against a large collection (1M documents).
+
+LoadConfig:
+  Path: ../../phases/query/CollScanSimplifiablePredicate.yml
+  Parameters:
+    Database: CollScanWithSimplifiablePredicateLarge
+    DocumentCount: 1e6
+    Repeat: 100
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
+      - standalone-sampling-bonsai
+      - standalone-sbe
+      - standalone-query-stats
+    branch_name:
+      $gte:
+        v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
@@ -1,0 +1,27 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload tests the performance of collection scan queries with complex predicates
+  that can be simplified by the optimizer against a collection of 10K documents.
+
+LoadConfig:
+  Path: ../../phases/query/CollScanSimplifiablePredicate.yml
+  Parameters:
+    Database: CollScanWithSimplifiablePredicateMedium
+    DocumentCount: 1e4
+    Repeat: 100
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
+      - standalone-sampling-bonsai
+      - standalone-sbe
+      - standalone-query-stats
+    branch_name:
+      $gte:
+        v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
@@ -1,0 +1,27 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload tests the performance of collection scan queries with complex predicates
+  that can be simplified by the optimizer against a small collection (100 documents).
+
+LoadConfig:
+  Path: ../../phases/query/CollScanSimplifiablePredicate.yml
+  Parameters:
+    Database: CollScanWithSimplifiablePredicateSmall
+    DocumentCount: 100
+    Repeat: 100
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
+      - standalone-sampling-bonsai
+      - standalone-sbe
+      - standalone-query-stats
+    branch_name:
+      $gte:
+        v7.3


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** SERVER-83896

**Whats Changed:**  
Added benchmarks with complex expressions that can (at least in theory) be simplified by the optimizer. These benchmarks are run against collections of different sizes (100, 10K and 1M documents).

**Patch testing results:**  
Running [here](https://spruce.mongodb.com/version/6576ef0d306615e62bf91bf4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

**Workload Submission form:**  
Done.

**Related PRs:**   
- https://github.com/mongodb/genny/pull/1081
- https://github.com/mongodb/genny/pull/1079
