### PR TITLE
PERF-4986 Fix value distribution for dbcheck workload

### DIFF
--- a/src/phases/replication/startup/StartupPhasesTemplate.yml
+++ b/src/phases/replication/startup/StartupPhasesTemplate.yml
@@ -13,10 +13,11 @@ Document: &Doc
   x: 0
   y: 1000 # Same key for all documents.
   z: {^RandomInt: {min: 0, max: 2147483647}}  # This is for max int for low probability of conflicts
-  int0: &int {^RandomInt: {distribution: binomial, t: 200, p: 0.5}}
+  int0: &int {^RandomInt: {min: 0, max: 2147483647}}
   int1: *int
   int2: *int
-  int3: *int
+  # Generates numbers from [0, 200] which will result in multiple docs with the same value.
+  int3: {^RandomInt: {distribution: binomial, t: 200, p: 0.5}}
   int4: *int
   int5: *int
   int6: *int


### PR DESCRIPTION
Fix data distribution to only make one field (`int3`) have many docs with the same value to for the [sameKey dbcheck](https://github.com/mongodb/genny/blob/5e0f1bcab55d5fcbe105f2f689189a67a9959450/src/workloads/replication/dbcheck/dbcheck_40GB.yml#L222) test.