### PR TITLE
DEVPROD-1626: Use vcpkg patch with libmongoc 1.25.3

### DIFF
--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -200,7 +200,7 @@ class ToolchainDownloader(Downloader):
     #
 
     TOOLCHAIN_BUILD_ID = (
-        "patch_7ea933da9e013e65600f880fd41e2990920ee297_65659a0c30661516d32421ea_23_11_28_07_45_03"
+        "patch_7ea933da9e013e65600f880fd41e2990920ee297_658123f27742ae0685181636_23_12_19_05_02_46"
     )
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 


### PR DESCRIPTION
**Jira Ticket:** DEVPROD-1626

**Whats Changed:**  
Same as #1083, except using libmongoc version 1.25.3 instead of version 1.25.1, to avoid an integer overflow bug.

**Patch testing results:**  
- [sys-perf, only DEVPROD-1626](https://spruce.mongodb.com/version/6581362e61837d06245d2c32/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
	- [Perf Analyzer](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=7d630011-610a-4397-bd34-a3fb50632c54&selected_tab=data-table&percent_filter=0%7C%7C100&z_filter=0%7C%7C10)
- [sys-perf, DEVPROD-2090 & DEVPROD-1626](https://spruce.mongodb.com/version/657f9cd35623434d98df98a0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
	- [Perf Analyzer](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=73e275b4-10e9-4166-b9c4-cfe26a00d20c&selected_tab=data-table&percent_filter=0%7C%7C100&z_filter=0%7C%7C10)
- [sys-perf, only DEVPROD-2090](https://spruce.mongodb.com/version/657f95f17742ae5083e53e67/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
	- [Perf Analyzer](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=17bb5b93-45ca-4644-9072-803ae4414341&selected_tab=data-table&percent_filter=0%7C%7C100&z_filter=0%7C%7C10)

**Related PRs:**
- #1083 
- https://github.com/10gen/vcpkg/pull/34
- https://github.com/mongodb/genny/pull/970