### PR TITLE
PERF-4991 Reduce size of the largest predicates in CollScanSimplifiablePredicate

### DIFF
--- a/src/phases/query/CollScanSimplifiablePredicate.yml
+++ b/src/phases/query/CollScanSimplifiablePredicate.yml
@@ -300,9 +300,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableConjunction
     TemplateParameters:
-      Name: SimplifiableConjunction1KClauses
+      Name: SimplifiableConjunction400Clauses
       ActivePhase: 4
-      Width: 1000
+      Width: 400
 
 - ActorFromTemplate:
     TemplateName: SimplifiableConjunction
@@ -322,9 +322,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableCNF
     TemplateParameters:
-      Name: SimplifiableCNF1KClauses
+      Name: SimplifiableCNF400Clauses
       ActivePhase: 7
-      Width: 1000
+      Width: 400
 
 - ActorFromTemplate:
     TemplateName: SimplifiableCNF
@@ -344,9 +344,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableDNF
     TemplateParameters:
-      Name: SimplifiableDNF800Clauses
+      Name: SimplifiableDNF400Clauses
       ActivePhase: 10
-      Width: 800
+      Width: 400
 
 - ActorFromTemplate:
     TemplateName: SimplifiableDNF
@@ -366,9 +366,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchConjunction
     TemplateParameters:
-      Name: SimplifiableElemMatchConjunction800Clauses
+      Name: SimplifiableElemMatchConjunction400Clauses
       ActivePhase: 13
-      Width: 800
+      Width: 400
 
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchConjunction
@@ -388,9 +388,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchCNF
     TemplateParameters:
-      Name: SimplifiableElemMatchCNF800Clauses
+      Name: SimplifiableElemMatchCNF400Clauses
       ActivePhase: 16
-      Width: 800
+      Width: 400
 
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchCNF
@@ -410,9 +410,9 @@ Actors:
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchDNF
     TemplateParameters:
-      Name: SimplifiableElemMatchDNF800Clauses
+      Name: SimplifiableElemMatchDNF400Clauses
       ActivePhase: 19
-      Width: 800
+      Width: 400
 
 - ActorFromTemplate:
     TemplateName: SimplifiableElemMatchDNF

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -15,6 +15,7 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
+      - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -15,7 +15,6 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai


### PR DESCRIPTION
[patch](https://spruce.mongodb.com/version/65819146306615863c7ce58a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

I've ran `coll_scan_simplifiable_predicate_large` on the failing variant (`Linux Standalone 2022-11`) 8 times now to ensure it doesn't randomly fail anymore. I'll restart it a few more times before merging.