### PR TITLE
PERF-4992 Clean up references to queryStats configurations

### DIFF
--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -29,4 +29,3 @@ AutoRun:
       - standalone-classic-query-engine
       - standalone-dsi-integration-test
       - standalone-sbe
-      - standalone-query-stats

--- a/src/workloads/execution/ClusteredCollection.yml
+++ b/src/workloads/execution/ClusteredCollection.yml
@@ -21,16 +21,11 @@ AutoRun:
       $eq:
       - standalone
       - standalone-all-feature-flags
-      - standalone-query-stats
       - replica
       - replica-all-feature-flags
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10
       - shard
-      - shard-query-stats
       - shard-lite-all-feature-flags
-      - shard-lite-query-stats
     branch_name:
       $gte:  v5.3

--- a/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+++ b/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
@@ -21,16 +21,11 @@ AutoRun:
       $eq:
       - standalone
       - standalone-all-feature-flags
-      - standalone-query-stats
       - replica
       - replica-all-feature-flags
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10
       - shard
-      - shard-query-stats
       - shard-lite-all-feature-flags
-      - shard-lite-query-stats
     branch_name:
       $gte: v5.3

--- a/src/workloads/execution/MultiPlanning.yml
+++ b/src/workloads/execution/MultiPlanning.yml
@@ -123,5 +123,4 @@ AutoRun:
         - standalone-all-feature-flags
         - standalone-classic-query-engine
         - standalone-sbe
-        - standalone-query-stats
 

--- a/src/workloads/query/AggregateExpressions.yml
+++ b/src/workloads/query/AggregateExpressions.yml
@@ -986,7 +986,6 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/ArrayTraversal.yml
+++ b/src/workloads/query/ArrayTraversal.yml
@@ -271,7 +271,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
       - replica
     branch_name:
       $neq:

--- a/src/workloads/query/CollScanComplexPredicateLarge.yml
+++ b/src/workloads/query/CollScanComplexPredicateLarge.yml
@@ -21,7 +21,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $gte:
         v7.3

--- a/src/workloads/query/CollScanComplexPredicateMedium.yml
+++ b/src/workloads/query/CollScanComplexPredicateMedium.yml
@@ -21,7 +21,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $gte:
         v7.3

--- a/src/workloads/query/CollScanComplexPredicateSmall.yml
+++ b/src/workloads/query/CollScanComplexPredicateSmall.yml
@@ -21,7 +21,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $gte:
         v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -21,7 +21,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $gte:
         v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
@@ -21,7 +21,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $gte:
         v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
@@ -21,7 +21,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $gte:
         v7.3

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -189,12 +189,10 @@ AutoRun:
       - atlas
       - atlas-like-replica.2022-10
       - replica
-      - replica-query-stats
       - single-replica
       - standalone
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     atlas_setup:
       $neq:
       - M30-repl

--- a/src/workloads/query/FilterWithComplexLogicalExpression.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpression.yml
@@ -42,7 +42,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
       - replica
     branch_name:
       $neq:

--- a/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
@@ -42,7 +42,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
       - replica
     branch_name:
       $neq:

--- a/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
@@ -42,7 +42,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
       - replica
     branch_name:
       $neq:

--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -133,7 +133,6 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/LookupNLJ.yml
+++ b/src/workloads/query/LookupNLJ.yml
@@ -338,7 +338,6 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/LookupSBEPushdown.yml
+++ b/src/workloads/query/LookupSBEPushdown.yml
@@ -438,7 +438,6 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/query/LookupSBEPushdownINLJMisc.yml
@@ -387,7 +387,6 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/MatchFilters.yml
+++ b/src/workloads/query/MatchFilters.yml
@@ -29,7 +29,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     atlas_setup:
       $neq:
       - M30-repl

--- a/src/workloads/query/MatchFiltersMedium.yml
+++ b/src/workloads/query/MatchFiltersMedium.yml
@@ -29,7 +29,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     atlas_setup:
       $neq:
       - M30-repl

--- a/src/workloads/query/MatchFiltersSmall.yml
+++ b/src/workloads/query/MatchFiltersSmall.yml
@@ -29,7 +29,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     atlas_setup:
       $neq:
       - M30-repl

--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -1,8 +1,8 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
 Description: |
-  This workload tests the performance of expression search for parameter re-use during parameterization. 
-  Before September 2023, parameter re-use had O(n^2) complexity due to using a vector for looking up equivalent expressions. 
+  This workload tests the performance of expression search for parameter re-use during parameterization.
+  Before September 2023, parameter re-use had O(n^2) complexity due to using a vector for looking up equivalent expressions.
   SERVER-79092 fixed this issue by switching over to a map once the amount of expressions reaches a threshold (currently 50).
 
 GlobalDefaults:
@@ -38,7 +38,7 @@ ActorTemplates:
           - OperationName: aggregate
             OperationCommand:
               Pipeline: [
-                {$match: {$or: {^Array: {of: 
+                {$match: {$or: {^Array: {of:
                   {$and: [
                     {a: {$gt: {^Inc: {start: 10}}}},
                     {b: {$gt: {^Inc: {start: 10}}}}
@@ -147,7 +147,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $gte:
         v7.2

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -101,7 +101,6 @@ AutoRun:
       $eq:
       - replica
       - replica-all-feature-flags
-      - replica-query-stats
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -116,16 +116,10 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone-all-feature-flags
-      - standalone-query-stats
       - standalone
       - shard
-      - shard-query-stats
       - shard-lite
-      - shard-lite-query-stats
       - single-replica
-      - single-replica-query-stats
       - replica
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/ProjectParse.yml
+++ b/src/workloads/query/ProjectParse.yml
@@ -104,7 +104,6 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $gte:
         v7.0

--- a/src/workloads/query/QueryStatsQueryShapes.yml
+++ b/src/workloads/query/QueryStatsQueryShapes.yml
@@ -116,7 +116,7 @@ Actors:
     TemplateParameters:
       Name: "OneShape"
       Threads: 32
-      Filter: 
+      Filter:
         # This can be simplified to {a1: 1, a2: 2, x0: {$exists: false}} but we are keeping
         # it the same as the actor with oscillating shapes to rule out performance impact there.
         # Will find around 0.005 * 0.005 * 1e6 = 2.5 documents.
@@ -135,12 +135,8 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone-all-feature-flags
-      - standalone-query-stats
       - standalone
       - single-replica
-      - single-replica-query-stats
       - replica
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/RepeatedPathTraversal.yml
+++ b/src/workloads/query/RepeatedPathTraversal.yml
@@ -213,7 +213,6 @@ AutoRun:
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -171,16 +171,10 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone-all-feature-flags
-      - standalone-query-stats
       - standalone
       - shard
-      - shard-query-stats
       - shard-lite
-      - shard-lite-query-stats
       - single-replica
-      - single-replica-query-stats
       - replica
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_Agg.yml
@@ -95,16 +95,10 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone-all-feature-flags
-      - standalone-query-stats
       - standalone
       - shard
-      - shard-query-stats
       - shard-lite
-      - shard-lite-query-stats
       - single-replica
-      - single-replica-query-stats
       - replica
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
@@ -107,16 +107,10 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone-all-feature-flags
-      - standalone-query-stats
       - standalone
       - shard
-      - shard-query-stats
       - shard-lite
-      - shard-lite-query-stats
       - single-replica
-      - single-replica-query-stats
       - replica
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
@@ -108,16 +108,10 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone-all-feature-flags
-      - standalone-query-stats
       - standalone
       - shard
-      - shard-query-stats
       - shard-lite
-      - shard-lite-query-stats
       - single-replica
-      - single-replica-query-stats
       - replica
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -95,16 +95,10 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone-all-feature-flags
-      - standalone-query-stats
       - standalone
       - shard
-      - shard-query-stats
       - shard-lite
-      - shard-lite-query-stats
       - single-replica
-      - single-replica-query-stats
       - replica
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
@@ -100,6 +100,4 @@ AutoRun:
     mongodb_setup:
       $eq:
       - shard
-      - shard-query-stats
       - shard-lite
-      - shard-lite-query-stats

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -108,16 +108,10 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone-all-feature-flags
-      - standalone-query-stats
       - standalone
       - shard
-      - shard-query-stats
       - shard-lite
-      - shard-lite-query-stats
       - single-replica
-      - single-replica-query-stats
       - replica
-      - replica-query-stats
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -265,7 +265,6 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     atlas_setup:
       $neq:
       - M30-repl

--- a/src/workloads/query/VariadicAggregateExpressions.yml
+++ b/src/workloads/query/VariadicAggregateExpressions.yml
@@ -603,7 +603,6 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -138,7 +138,6 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     atlas_setup:
       $neq:
       - M10-repl

--- a/src/workloads/scale/LargeIndexedIns.yml
+++ b/src/workloads/scale/LargeIndexedIns.yml
@@ -64,7 +64,6 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
-      - replica-query-stats
       - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -89,7 +89,6 @@ AutoRun:
       $eq:
       - atlas
       - atlas-like-replica.2022-10
-      - atlas-like-replica-query-stats.2022-10
       - replica
       - replica-all-feature-flags
       - shard
@@ -98,7 +97,6 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-sbe
-      - standalone-query-stats
     atlas_setup:
       $neq:
       - M10-repl

--- a/src/workloads/scale/MajorityReads10KThreads.yml
+++ b/src/workloads/scale/MajorityReads10KThreads.yml
@@ -22,7 +22,6 @@ AutoRun:
       $eq:
       - replica
       - replica-all-feature-flags
-      - replica-query-stats
       - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -304,7 +304,6 @@ AutoRun:
       - atlas
       - atlas-like-replica.2022-10
       - replica
-      - replica-query-stats
       - replica-1dayhistory-15gbwtcache
       - replica-all-feature-flags
       - replica-maintenance-events

--- a/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
@@ -190,7 +190,6 @@ AutoRun:
       - replica-all-feature-flags
       - replica-maintenance-events
       - replica-noflowcontrol
-      - replica-query-stats
       - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe


### PR DESCRIPTION
**Jira Ticket:** [PERF-4992
](https://jira.mongodb.org/browse/PERF-4992)
**Whats Changed:**  
As the queryStats project is wrapping up, the specific variants used for its testing have been removed, and so its corresponding configuration files from DSI are being removed as well. Because of this, references to said configurations are being removed from Genny workloads too. No testing is being done as only autorun calls are being removed.

**Related PRs:**   
https://github.com/10gen/dsi/pull/1499
https://github.com/10gen/mongo/pull/17634
