### PR TITLE
PERF-4830 Add workloads to test $out and $merge performance

### DIFF
--- a/src/lamplib/src/genny/tasks/dry_run.py
+++ b/src/lamplib/src/genny/tasks/dry_run.py
@@ -22,6 +22,7 @@ def dry_run_workload(
 
     if yaml_file_basename in [
         "MixedWorkloadsGennyStress.yml",
+        "AggregationsOutput.yml",
         "ClusteredCollection.yml",
         "ClusteredCollectionLargeRecordIds.yml",
         "ConnectionsBuildup.yml",

--- a/src/workloads/query/AggregationsOutput.yml
+++ b/src/workloads/query/AggregationsOutput.yml
@@ -501,3 +501,11 @@ Actors:
       StartsAt: 19
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput18
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard
+      - shard-lite
+      - shard-lite-all-feature-flags

--- a/src/workloads/query/AggregationsOutput.yml
+++ b/src/workloads/query/AggregationsOutput.yml
@@ -1,7 +1,6 @@
 # Sharded collection -> Distributed chunk processing
 # coll -> $out (tests raw output)
 # coll -> coll updated with a new field (counter that starts at 0) not susceptible to halloween since it doesn't change recordid
-# coll -> coll with different shard key updated with a new field (counter that starts at 0) not susceptible to halloween since it doesn't change recordid
 # coll -> newColl with a new field (counter that starts at 0) non-merging output to new collection
 #         sharded and non-sharded versions
 
@@ -38,7 +37,7 @@ GlobalDefaults:
   Sharded16KNSS: &Sharded16KNSS test.Sharded16K
   NumDocs: &NumDocs 10_000
   Database: &Database test
-  NumPhases: &NumPhases 100
+  NumPhases: &NumPhases 80
   NumCombinations: &NumCombinations 18 # 3 threads * 3 data sizes * 2 collection source types
 
 Clients:
@@ -120,12 +119,12 @@ ActorTemplates:
       Database: *Database
       Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
       Operations:
-      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_newFieldWithShardKeyChange_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_mergeToNewCollUnsharded_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
         OperationName: aggregate
         OperationCommand:
           Pipeline: [
-            {$addFields: {counter: {$add: [1, '$counter']}, shardKey: {$add: [1, '$shardKey']}}},
-            {$merge: {into: {^Parameter: {Name: "SrcCollection", Default: Collection0}}}}
+            {$addFields: {counter: {$add: [1, '$counter']}}},
+            {$merge: {into: {^FormatString: {format: "%d", withArgs: [{^ActorId: {}}]}}}}
           ]
     - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
         {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 2 + 2", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
@@ -136,31 +135,15 @@ ActorTemplates:
       Database: *Database
       Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
       Operations:
-      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_mergeToNewCollUnsharded_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
-        OperationName: aggregate
-        OperationCommand:
-          Pipeline: [
-            {$addFields: {counter: {$add: [1, '$counter']}, shardKey: {$add: [1, '$shardKey']}}},
-            {$merge: {into: {^FormatString: {format: "%d", withArgs: [{^ActorId: {}}]}}}}
-          ]
-    - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
-        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 3 + 3", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
-        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 4 + 2", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}}
-      ]}}
-      Nop: true
-    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
-      Database: *Database
-      Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
-      Operations:
       - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_mergeToNewCollSharded_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
         OperationName: aggregate
         OperationCommand:
           Pipeline: [
-            {$addFields: {counter: {$add: [1, '$counter']}, shardKey: {$add: [1, '$shardKey']}}},
+            {$addFields: {counter: {$add: [1, '$counter']}}},
             {$merge: {into: {^Parameter: {Name: ShardedCollOutput, Default: *ShardedCollOutput1}}}}
           ]
     - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
-        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 4 + 4", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
+        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 3 + 3", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
         *NumPhases
       ]}}
       Nop: true

--- a/src/workloads/query/AggregationsOutput.yml
+++ b/src/workloads/query/AggregationsOutput.yml
@@ -1,30 +1,18 @@
-# Sharded collection -> Distributed chunk processing
-# coll -> $out (tests raw output)
-# coll -> coll updated with a new field (counter that starts at 0) not susceptible to halloween since it doesn't change recordid
-# coll -> newColl with a new field (counter that starts at 0) non-merging output to new collection
-#         sharded and non-sharded versions
-
-# Same for unsharded
-# All of this with 1, 4, 16 threads AND 1k, 4k, 16k documents. 10k documents per collection should be enough
-# Repeat 5 times for value stability
-
-
-
-
-
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
 Description: |
-  This test exercises the behavior of $lookup when the local and foreign collection data is
-  co-located. In the queries below, for each local document on each shard, the $lookup subpipeline
-  is targeted to the same shard.
-  The workload consists of the following steps:
-    A. Creating empty collections, some unsharded and some sharded.
-    B. Populating collections with data.
-    C. Fsync.
-    D. Running $lookups. This includes pipelines using let/pipeline syntax, pipelines with
-       local/foreign field syntax, pipelines with different $limits, and pipelines run against
-       sharded and unsharded colls.
+  This test exercises both $out and $merge aggregation stages. It does this based on all combinations of the following:
+    A. The src collection is sharded or unsharded
+    B. The document size is either 1K, 4K, or 16K.
+    C. There are 1 thread, 4 threads, or 16 threads doing the same operation.
+  Each actor does the following operations concurrently with other actors at the same stage:
+    A. $out to a collection unique amongst actors.
+       This measures $out performance.
+    B. $merge to the source collection with an updated field value.
+       This measures $merge contention on the same collection.
+    C. $merge to a different unsharded collection unique for each Actor with an updated field value.
+       This measures $merge contention on a separate collection shared by all threads of an Actor.
+
 GlobalDefaults:
   Unsharded1K: &Unsharded1K Unsharded1K
   Unsharded4K: &Unsharded4K Unsharded4K

--- a/src/workloads/query/AggregationsOutput.yml
+++ b/src/workloads/query/AggregationsOutput.yml
@@ -302,7 +302,6 @@ Actors:
           OperationCommand:
             shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput18]}}
             key: {shardKey: "hashed"}
-# TODO: Make a lot of sharded collections
 - Name: Sharded1KLoader
   Type: MonotonicSingleLoader
   Threads: 5

--- a/src/workloads/query/AggregationsOutput.yml
+++ b/src/workloads/query/AggregationsOutput.yml
@@ -1,0 +1,503 @@
+# Sharded collection -> Distributed chunk processing
+# coll -> $out (tests raw output)
+# coll -> coll updated with a new field (counter that starts at 0) not susceptible to halloween since it doesn't change recordid
+# coll -> coll with different shard key updated with a new field (counter that starts at 0) not susceptible to halloween since it doesn't change recordid
+# coll -> newColl with a new field (counter that starts at 0) non-merging output to new collection
+#         sharded and non-sharded versions
+
+# Same for unsharded
+# All of this with 1, 4, 16 threads AND 1k, 4k, 16k documents. 10k documents per collection should be enough
+# Repeat 5 times for value stability
+
+
+
+
+
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test exercises the behavior of $lookup when the local and foreign collection data is
+  co-located. In the queries below, for each local document on each shard, the $lookup subpipeline
+  is targeted to the same shard.
+  The workload consists of the following steps:
+    A. Creating empty collections, some unsharded and some sharded.
+    B. Populating collections with data.
+    C. Fsync.
+    D. Running $lookups. This includes pipelines using let/pipeline syntax, pipelines with
+       local/foreign field syntax, pipelines with different $limits, and pipelines run against
+       sharded and unsharded colls.
+GlobalDefaults:
+  Unsharded1K: &Unsharded1K Unsharded1K
+  Unsharded4K: &Unsharded4K Unsharded4K
+  Unsharded16K: &Unsharded16K Unsharded16K
+  Sharded1K: &Sharded1K Sharded1K
+  Sharded4K: &Sharded4K Sharded4K
+  Sharded16K: &Sharded16K Sharded16K
+  Sharded1KNSS: &Sharded1KNSS test.Sharded1K
+  Sharded4KNSS: &Sharded4KNSS test.Sharded4K
+  Sharded16KNSS: &Sharded16KNSS test.Sharded16K
+  NumDocs: &NumDocs 10_000
+  Database: &Database test
+  NumPhases: &NumPhases 100
+  NumCombinations: &NumCombinations 18 # 3 threads * 3 data sizes * 2 collection source types
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 1024
+
+Documents:
+  Document1K: &1KDoc
+    shardKey: {^RandomInt: {min: 0, max: 16}}
+    text: {^FastRandomString: {length: 1024}}
+  Document4K: &4KDoc
+    shardKey: {^RandomInt: {min: 0, max: 16}}
+    text: {^FastRandomString: {length: 4096}}
+  Document16K: &16KDoc
+    shardKey: {^RandomInt: {min: 0, max: 16}}
+    text: {^FastRandomString: {length: 16384}}
+
+ShardedCollections:
+  - &ShardedCollOutput1 ShardedCollOutput1
+  - &ShardedCollOutput2 ShardedCollOutput2
+  - &ShardedCollOutput3 ShardedCollOutput3
+  - &ShardedCollOutput4 ShardedCollOutput4
+  - &ShardedCollOutput5 ShardedCollOutput5
+  - &ShardedCollOutput6 ShardedCollOutput6
+  - &ShardedCollOutput7 ShardedCollOutput7
+  - &ShardedCollOutput8 ShardedCollOutput8
+  - &ShardedCollOutput9 ShardedCollOutput9
+  - &ShardedCollOutput10 ShardedCollOutput10
+  - &ShardedCollOutput11 ShardedCollOutput11
+  - &ShardedCollOutput12 ShardedCollOutput12
+  - &ShardedCollOutput13 ShardedCollOutput13
+  - &ShardedCollOutput14 ShardedCollOutput14
+  - &ShardedCollOutput15 ShardedCollOutput15
+  - &ShardedCollOutput16 ShardedCollOutput16
+  - &ShardedCollOutput17 ShardedCollOutput17
+  - &ShardedCollOutput18 ShardedCollOutput18
+
+ActorTemplates:
+- TemplateName: AggregationActor
+  Config:
+    Name: {^PreprocessorFormatString: {format: "%s_%d_threads", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+    Type: CrudActor
+    Database: *Database
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Phases:
+    - Phase: {^PreprocessorFormatString: {format: "0..%d", withArgs: [{^Parameter: {Name: StartsAt, Default: 2}}]}}
+      Nop: true
+    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+      Database: *Database
+      Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
+      Operations:
+      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_out_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+        OperationName: aggregate
+        OperationCommand:
+          Pipeline: [{$out: {^FormatString: {format: "%d", withArgs: [{^ActorId: {}}]}}}]
+    - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
+        {^NumExpr: {withExpression: "startsAt + 2", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}}}},
+        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations - 1", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}}
+      ]}}
+      Nop: true
+    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+      Database: *Database
+      Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
+      Operations:
+      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_newField_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+        OperationName: aggregate
+        OperationCommand:
+          Pipeline: [
+            {$addFields: {counter: {$add: [1, '$counter']}}},
+            {$merge: {into: {^Parameter: {Name: "SrcCollection", Default: Collection0}}}}
+          ]
+    - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
+        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 1 + 1", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
+        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 2 + 0", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}}
+      ]}}
+      Nop: true
+    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+      Database: *Database
+      Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
+      Operations:
+      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_newFieldWithShardKeyChange_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+        OperationName: aggregate
+        OperationCommand:
+          Pipeline: [
+            {$addFields: {counter: {$add: [1, '$counter']}, shardKey: {$add: [1, '$shardKey']}}},
+            {$merge: {into: {^Parameter: {Name: "SrcCollection", Default: Collection0}}}}
+          ]
+    - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
+        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 2 + 2", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
+        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 3 + 1", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}}
+      ]}}
+      Nop: true
+    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+      Database: *Database
+      Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
+      Operations:
+      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_mergeToNewCollUnsharded_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+        OperationName: aggregate
+        OperationCommand:
+          Pipeline: [
+            {$addFields: {counter: {$add: [1, '$counter']}, shardKey: {$add: [1, '$shardKey']}}},
+            {$merge: {into: {^FormatString: {format: "%d", withArgs: [{^ActorId: {}}]}}}}
+          ]
+    - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
+        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 3 + 3", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
+        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 4 + 2", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}}
+      ]}}
+      Nop: true
+    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+      Database: *Database
+      Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
+      Operations:
+      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_mergeToNewCollSharded_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+        OperationName: aggregate
+        OperationCommand:
+          Pipeline: [
+            {$addFields: {counter: {$add: [1, '$counter']}, shardKey: {$add: [1, '$shardKey']}}},
+            {$merge: {into: {^Parameter: {Name: ShardedCollOutput, Default: *ShardedCollOutput1}}}}
+          ]
+    - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
+        {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 4 + 4", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
+        *NumPhases
+      ]}}
+      Nop: true
+Actors:
+- Name: Unsharded1KLoader
+  Type: MonotonicSingleLoader
+  Threads: 5
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Collection: *Unsharded1K
+        DocumentCount: *NumDocs
+        BatchSize: 100
+        Document: *1KDoc
+- Name: Unsharded4KLoader
+  Type: MonotonicSingleLoader
+  Threads: 5
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Collection: *Unsharded4K
+        DocumentCount: *NumDocs
+        BatchSize: 100
+        Document: *4KDoc
+- Name: Unsharded16KLoader
+  Type: MonotonicSingleLoader
+  Threads: 5
+  Phases:
+    OnlyActiveInPhases: 
+      Active: [1]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Collection: *Unsharded16K
+        DocumentCount: *NumDocs
+        BatchSize: 100
+        Document: *16KDoc
+
+- Name: ShardCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        # Until EVG-21054 is resolved, using OnlyRunInInstance requires excluding the workload from dry-runs
+        OnlyRunInInstance: sharded
+        Repeat: 1
+        Operations:
+        - OperationName: AdminCommand
+          OperationMetricsName: EnableShardingMetrics
+          OperationCommand:
+            enableSharding: *Database
+        - OperationName: AdminCommand
+          OperationMetricsName: ShardCollection1KMetrics
+          OperationCommand:
+            shardCollection: *Sharded1KNSS
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationMetricsName: ShardCollection4KMetrics
+          OperationCommand:
+            shardCollection: *Sharded4KNSS
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationMetricsName: ShardCollection16KMetrics
+          OperationCommand:
+            shardCollection: *Sharded16KNSS
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput1]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput2]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput3]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput4]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput5]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput6]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput7]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput8]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput9]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput10]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput11]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput12]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput13]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput14]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput15]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput16]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput17]}}
+            key: {shardKey: "hashed"}
+        - OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: {^PreprocessorFormatString: {format: "test.%s", withArgs: [*ShardedCollOutput18]}}
+            key: {shardKey: "hashed"}
+# TODO: Make a lot of sharded collections
+- Name: Sharded1KLoader
+  Type: MonotonicSingleLoader
+  Threads: 5
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Collection: *Sharded1K
+        DocumentCount: *NumDocs
+        BatchSize: 100
+        Document: *1KDoc
+- Name: Sharded4KLoader
+  Type: MonotonicSingleLoader
+  Threads: 5
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Collection: *Sharded4K
+        DocumentCount: *NumDocs
+        BatchSize: 100
+        Document: *4KDoc
+- Name: Sharded16KLoader
+  Type: MonotonicSingleLoader
+  Threads: 5
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *NumPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Collection: *Sharded16K
+        DocumentCount: *NumDocs
+        BatchSize: 100
+        Document: *16KDoc
+
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 1
+      SrcCollection: *Unsharded1K
+      StartsAt: 2
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput1
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 1
+      SrcCollection: *Unsharded4K
+      StartsAt: 3
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput2
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 1
+      SrcCollection: *Unsharded16K
+      StartsAt: 4
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput3
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 4
+      SrcCollection: *Unsharded1K
+      StartsAt: 5
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput4
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 4
+      SrcCollection: *Unsharded4K
+      StartsAt: 6
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput5
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 4
+      SrcCollection: *Unsharded16K
+      StartsAt: 7
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput6
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 16
+      SrcCollection: *Unsharded1K
+      StartsAt: 8
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput7
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 16
+      SrcCollection: *Unsharded4K
+      StartsAt: 9
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput8
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 16
+      SrcCollection: *Unsharded16K
+      StartsAt: 10
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput9
+
+# Sharded colls
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 1
+      SrcCollection: *Sharded1K
+      StartsAt: 11
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput10
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 1
+      SrcCollection: *Sharded4K
+      StartsAt: 12
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput11
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 1
+      SrcCollection: *Sharded16K
+      StartsAt: 13
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput12
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 4
+      SrcCollection: *Sharded1K
+      StartsAt: 14
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput13
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 4
+      SrcCollection: *Sharded4K
+      StartsAt: 15
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput14
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 4
+      SrcCollection: *Sharded16K
+      StartsAt: 16
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput15
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 16
+      SrcCollection: *Sharded1K
+      StartsAt: 17
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput16
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 16
+      SrcCollection: *Sharded4K
+      StartsAt: 18
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput17
+- ActorFromTemplate:
+    TemplateName: AggregationActor
+    TemplateParameters:
+      Threads: 16
+      SrcCollection: *Sharded16K
+      StartsAt: 19
+      NumCombinations: *NumCombinations
+      ShardedCollOutput: *ShardedCollOutput18

--- a/src/workloads/query/AggregationsOutput.yml
+++ b/src/workloads/query/AggregationsOutput.yml
@@ -108,7 +108,7 @@ ActorTemplates:
       Database: *Database
       Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
       Operations:
-      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_out_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+      - OperationMetricsName: plainOutToUnshardedColl
         OperationName: aggregate
         OperationCommand:
           Pipeline: [{$out: {^FormatString: {format: "%d", withArgs: [{^ActorId: {}}]}}}]
@@ -121,7 +121,7 @@ ActorTemplates:
       Database: *Database
       Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
       Operations:
-      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_newField_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+      - OperationMetricsName: selfMergeWithNewField
         OperationName: aggregate
         OperationCommand:
           Pipeline: [
@@ -137,7 +137,7 @@ ActorTemplates:
       Database: *Database
       Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
       Operations:
-      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_mergeToNewCollUnsharded_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+      - OperationMetricsName: mergeToNewCollUnsharded
         OperationName: aggregate
         OperationCommand:
           Pipeline: [
@@ -154,7 +154,7 @@ ActorTemplates:
     #   Database: *Database
     #   Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
     #   Operations:
-    #   - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_mergeToNewCollSharded_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+    #   - OperationMetricsName: mergeToNewCollSharded
     #     OperationName: aggregate
     #     OperationCommand:
     #       Pipeline: [

--- a/src/workloads/query/AggregationsOutput.yml
+++ b/src/workloads/query/AggregationsOutput.yml
@@ -104,7 +104,7 @@ ActorTemplates:
     Phases:
     - Phase: {^PreprocessorFormatString: {format: "0..%d", withArgs: [{^Parameter: {Name: StartsAt, Default: 2}}]}}
       Nop: true
-    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+    - Duration: 20 seconds
       Database: *Database
       Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
       Operations:
@@ -117,7 +117,7 @@ ActorTemplates:
         {^NumExpr: {withExpression: "startsAt + 2 + numCombinations - 1", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}}
       ]}}
       Nop: true
-    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+    - Duration: 20 seconds
       Database: *Database
       Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
       Operations:
@@ -133,7 +133,7 @@ ActorTemplates:
         {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 2 + 0", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}}
       ]}}
       Nop: true
-    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+    - Duration: 20 seconds
       Database: *Database
       Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
       Operations:
@@ -150,7 +150,7 @@ ActorTemplates:
       ]}}
       Nop: true
     # TODO SERVER-84185: Enable this and remove the Nop that follows when sharded output collections are supported without DuplicateKey errors.
-    # - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+    # - Duration: 20 seconds
     #   Database: *Database
     #   Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
     #   Operations:

--- a/src/workloads/query/AggregationsOutput.yml
+++ b/src/workloads/query/AggregationsOutput.yml
@@ -56,7 +56,25 @@ Documents:
     shardKey: {^RandomInt: {min: 0, max: 16}}
     text: {^FastRandomString: {length: 16384}}
 
-ShardedCollections:
+OutputCollections:
+  - &UnshardedCollOutput1 UnshardedCollOutput1
+  - &UnshardedCollOutput2 UnshardedCollOutput2
+  - &UnshardedCollOutput3 UnshardedCollOutput3
+  - &UnshardedCollOutput4 UnshardedCollOutput4
+  - &UnshardedCollOutput5 UnshardedCollOutput5
+  - &UnshardedCollOutput6 UnshardedCollOutput6
+  - &UnshardedCollOutput7 UnshardedCollOutput7
+  - &UnshardedCollOutput8 UnshardedCollOutput8
+  - &UnshardedCollOutput9 UnshardedCollOutput9
+  - &UnshardedCollOutput10 UnshardedCollOutput10
+  - &UnshardedCollOutput11 UnshardedCollOutput11
+  - &UnshardedCollOutput12 UnshardedCollOutput12
+  - &UnshardedCollOutput13 UnshardedCollOutput13
+  - &UnshardedCollOutput14 UnshardedCollOutput14
+  - &UnshardedCollOutput15 UnshardedCollOutput15
+  - &UnshardedCollOutput16 UnshardedCollOutput16
+  - &UnshardedCollOutput17 UnshardedCollOutput17
+  - &UnshardedCollOutput18 UnshardedCollOutput18
   - &ShardedCollOutput1 ShardedCollOutput1
   - &ShardedCollOutput2 ShardedCollOutput2
   - &ShardedCollOutput3 ShardedCollOutput3
@@ -124,24 +142,26 @@ ActorTemplates:
         OperationCommand:
           Pipeline: [
             {$addFields: {counter: {$add: [1, '$counter']}}},
-            {$merge: {into: {^FormatString: {format: "%d", withArgs: [{^ActorId: {}}]}}}}
+            {$merge: {into: {^Parameter: {Name: UnshardedCollOutput, Default: *UnshardedCollOutput1}}}}
           ]
     - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
         {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 2 + 2", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
         {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 3 + 1", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}}
       ]}}
       Nop: true
-    - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
-      Database: *Database
-      Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
-      Operations:
-      - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_mergeToNewCollSharded_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
-        OperationName: aggregate
-        OperationCommand:
-          Pipeline: [
-            {$addFields: {counter: {$add: [1, '$counter']}}},
-            {$merge: {into: {^Parameter: {Name: ShardedCollOutput, Default: *ShardedCollOutput1}}}}
-          ]
+    # TODO SERVER-84185: Enable this and remove the Nop that follows when sharded output collections are supported without DuplicateKey errors.
+    # - Repeat: {^Parameter: {Name: "Repeat", Default: 5}}
+    #   Database: *Database
+    #   Collection: {^Parameter: {Name: "SrcCollection", Default: Collection0}}
+    #   Operations:
+    #   - OperationMetricsName: {^PreprocessorFormatString: {format: "%s_mergeToNewCollSharded_%d", withArgs: [{^Parameter: {Name: "SrcCollection", Default: Collection0}}, {^Parameter: {Name: "Threads", Default: 1}}]}}
+    #     OperationName: aggregate
+    #     OperationCommand:
+    #       Pipeline: [
+    #         {$addFields: {counter: {$add: [1, '$counter']}}},
+    #         {$merge: {into: {^Parameter: {Name: ShardedCollOutput, Default: *ShardedCollOutput1}}}}
+    #       ]
+    - Nop: true
     - Phase: {^PreprocessorFormatString: {format: "%d..%d", withArgs: [
         {^NumExpr: {withExpression: "startsAt + 2 + numCombinations * 3 + 3", andValues: {startsAt: {^Parameter: {Name: StartsAt, Default: 2}}, numCombinations: {^Parameter: {Name: NumCombinations, Default: 1}}}}},
         *NumPhases
@@ -346,6 +366,7 @@ Actors:
       StartsAt: 2
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput1
+      UnshardedCollOutput: *UnshardedCollOutput1
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -354,6 +375,7 @@ Actors:
       StartsAt: 3
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput2
+      UnshardedCollOutput: *UnshardedCollOutput2
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -362,6 +384,7 @@ Actors:
       StartsAt: 4
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput3
+      UnshardedCollOutput: *UnshardedCollOutput3
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -370,6 +393,7 @@ Actors:
       StartsAt: 5
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput4
+      UnshardedCollOutput: *UnshardedCollOutput4
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -378,6 +402,7 @@ Actors:
       StartsAt: 6
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput5
+      UnshardedCollOutput: *UnshardedCollOutput5
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -386,6 +411,7 @@ Actors:
       StartsAt: 7
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput6
+      UnshardedCollOutput: *UnshardedCollOutput6
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -394,6 +420,7 @@ Actors:
       StartsAt: 8
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput7
+      UnshardedCollOutput: *UnshardedCollOutput7
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -402,6 +429,7 @@ Actors:
       StartsAt: 9
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput8
+      UnshardedCollOutput: *UnshardedCollOutput8
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -410,6 +438,7 @@ Actors:
       StartsAt: 10
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput9
+      UnshardedCollOutput: *UnshardedCollOutput9
 
 # Sharded colls
 - ActorFromTemplate:
@@ -420,6 +449,7 @@ Actors:
       StartsAt: 11
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput10
+      UnshardedCollOutput: *UnshardedCollOutput10
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -428,6 +458,7 @@ Actors:
       StartsAt: 12
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput11
+      UnshardedCollOutput: *UnshardedCollOutput11
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -436,6 +467,7 @@ Actors:
       StartsAt: 13
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput12
+      UnshardedCollOutput: *UnshardedCollOutput12
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -444,6 +476,7 @@ Actors:
       StartsAt: 14
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput13
+      UnshardedCollOutput: *UnshardedCollOutput13
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -452,6 +485,7 @@ Actors:
       StartsAt: 15
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput14
+      UnshardedCollOutput: *UnshardedCollOutput14
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -460,6 +494,7 @@ Actors:
       StartsAt: 16
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput15
+      UnshardedCollOutput: *UnshardedCollOutput15
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -468,6 +503,7 @@ Actors:
       StartsAt: 17
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput16
+      UnshardedCollOutput: *UnshardedCollOutput16
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -476,6 +512,7 @@ Actors:
       StartsAt: 18
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput17
+      UnshardedCollOutput: *UnshardedCollOutput17
 - ActorFromTemplate:
     TemplateName: AggregationActor
     TemplateParameters:
@@ -484,6 +521,7 @@ Actors:
       StartsAt: 19
       NumCombinations: *NumCombinations
       ShardedCollOutput: *ShardedCollOutput18
+      UnshardedCollOutput: *UnshardedCollOutput18
 
 AutoRun:
 - When:


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** PERF-4830

**Whats Changed:**  
We're adding a workload to test $out and $merge performance of aggregation output.

**Patch testing results:**  
Evergreen run: https://spruce.mongodb.com/version/657b3b7e2a60ed0495276c2d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

**Workload Submission form:**
I've filled the form and submitted it as it is a new workload.