### PR TITLE
PERF-4994 disable RunMatchExpressionOrWith50000Clauses

### DIFF
--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -129,13 +129,14 @@ Actors:
       ActivePhase: 7
       NumberOfClauses: 10000
 
-- ActorFromTemplate:
-    TemplateName: MatchExpressionWithOrClausesTemplate
-    TemplateParameters:
-      Name: RunMatchExpressionOrWith50000Clauses
-      Repeat: 10
-      ActivePhase: 8
-      NumberOfClauses: 50000
+// TODO: PERF-4993
+#- ActorFromTemplate:
+#    TemplateName: MatchExpressionWithOrClausesTemplate
+#    TemplateParameters:
+#      Name: RunMatchExpressionOrWith50000Clauses
+#      Repeat: 10
+#      ActivePhase: 8
+#      NumberOfClauses: 50000
 
 AutoRun:
 - When:


### PR DESCRIPTION
Disables RunMatchExpressionOrWith50000Clauses workload to make sure that the tests complete