### PR TITLE
PERF-3784 Replace RunCommand by CrudActor in query workloads

### DIFF
--- a/src/phases/query/RunLargeArithmeticOp.yml
+++ b/src/phases/query/RunLargeArithmeticOp.yml
@@ -8,12 +8,12 @@ Description: |
 Multiply:
   Repeat: 10
   Database: {^Parameter: {Name: "Database", Default: "test"}}
+  Collection: {^Parameter: {Name: "Collection", Default: "Collection0"}}
   Operations:
   - OperationMetricsName: {^Parameter: {Name: "Name", Default: "RunMultiply"}}
-    OperationName: RunCommand
+    OperationName: aggregate
     OperationCommand:
-      aggregate: {^Parameter: {Name: "Collection", Default: "Collection0"}}
-      pipeline: [
+      Pipeline: [
         {
           $group: {
             _id: {
@@ -22,4 +22,5 @@ Multiply:
           }
         }
       ]
-      cursor: {batchSize: {^Parameter: {Name: "BatchSize", Default: 3000}}}
+      Options: 
+        BatchSize:  {^Parameter: {Name: "BatchSize", Default: 3000}}

--- a/src/workloads/query/ConstantFoldArithmetic.yml
+++ b/src/workloads/query/ConstantFoldArithmetic.yml
@@ -73,7 +73,7 @@ Actors:
   - *Nop
 
 - Name: RunMultiply
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop

--- a/src/workloads/query/DensifyFillCombo.yml
+++ b/src/workloads/query/DensifyFillCombo.yml
@@ -9,7 +9,7 @@ Description: |
 
 GlobalDefaults:
   dbname: &db test
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "timestamp"
   index: &index
     keys: {timestamp: 1}
@@ -60,7 +60,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 10}}
       timestamp: {^RandomDate: {min: "2021-01-01T00:00:00.000Z", max: "2021-01-01T00:00:20.000Z"}}
@@ -140,7 +140,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestampFillWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -151,12 +151,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyTimestampFillWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: *field,
             range: {
@@ -171,8 +171,9 @@ Actors:
             }
           }
         ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+        Options: 
+          BatchSize:  *limit
+          AllowDiskUse: true
   - *Nop
   - *Nop
   - *Nop
@@ -183,7 +184,7 @@ Actors:
   - *Nop
 
 - Name: DensifyTimestampFillWithPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -196,12 +197,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyTimestampFillWithPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: *field,
             range: {
@@ -216,10 +217,12 @@ Actors:
               toFillRandomType: {method: "locf"},
             },
             partitionByFields: ["partitionKey"]
-          }
+          },
+          $limit: *limit
         ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+        Options: 
+          BatchSize:  *limit
+          AllowDiskUse: true
   - *Nop
   - *Nop
   - *Nop
@@ -228,7 +231,7 @@ Actors:
   - *Nop
 
 - Name: DensifyNumericFillWithPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -243,12 +246,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyNumericFillWithPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: "numeric",
             range: {
@@ -262,17 +265,19 @@ Actors:
               toFillRandomType: {method: "locf"},
             },
             partitionByFields: ["partitionKey"]
-          }
+          },
+          $limit: *limit
         ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+        Options: 
+          BatchSize:  *limit
+          AllowDiskUse: true
   - *Nop
   - *Nop
   - *Nop
   - *Nop
 
 - Name: DensifyNumericLinearFillNumeric
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -289,12 +294,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyNumericLinearFillNumeric
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: "numeric",
             range: {
@@ -309,15 +314,17 @@ Actors:
                 method: "linear"
               }
             },
-          }
+          },
+          $limit: *limit
         ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+        Options: 
+          BatchSize:  *limit
+          AllowDiskUse: true
   - *Nop
   - *Nop
 
 - Name: DensifyTimestampFillArbitraryValue
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -336,12 +343,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDensifyNumericFillArbitraryValue
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           $densify: {
             field: "numeric",
             range: {
@@ -355,10 +362,12 @@ Actors:
                 value: "0"
               },
             },
-          }
+          },
+          $limit: *limit
         ]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+        Options: 
+          BatchSize:  *limit
+          AllowDiskUse: true
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyHours.yml
+++ b/src/workloads/query/DensifyHours.yml
@@ -43,7 +43,7 @@ Description: |
 GlobalDefaults:
   dbname: &db test
   MaxPhases: &MaxPhases 20
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "hours"
   unitName: &unit "hour"
   index: &index
@@ -67,7 +67,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       # Test a subset of units that have different characteristics.
@@ -92,19 +92,19 @@ Actors:
   - *Nop
 
 - Name: DensifyHours
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -113,13 +113,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -128,13 +130,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -144,13 +148,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -160,13 +166,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -176,13 +184,15 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -192,13 +202,15 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -207,13 +219,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -222,13 +236,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -238,13 +254,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -254,8 +272,11 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyMilliseconds.yml
+++ b/src/workloads/query/DensifyMilliseconds.yml
@@ -45,7 +45,7 @@ Description: |
 GlobalDefaults:
   dbname: &db test
   MaxPhases: &MaxPhases 20
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "milliseconds"
   unitName: &unit "millisecond"
   index: &index
@@ -69,7 +69,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       # Test a subset of units that have different characteristics.
@@ -94,19 +94,19 @@ Actors:
   - *Nop
 
 - Name: DensifyMilliseconds
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -115,13 +115,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -130,13 +132,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -146,13 +150,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -162,13 +168,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -178,13 +186,15 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -194,13 +204,15 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -209,13 +221,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -224,13 +238,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -240,13 +256,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -256,8 +274,11 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyMonths.yml
+++ b/src/workloads/query/DensifyMonths.yml
@@ -44,7 +44,7 @@ Description: |
 GlobalDefaults:
   dbname: &db test
   MaxPhases: &MaxPhases 20
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "months"
   unitName: &unit "month"
   index: &index
@@ -68,7 +68,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       # Test a subset of units that have different characteristics.
@@ -93,19 +93,19 @@ Actors:
   - *Nop
 
 - Name: DensifyMonths
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -114,13 +114,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -129,13 +131,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -145,13 +149,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -161,13 +167,15 @@ Actors:
               unit: *unit
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -177,13 +185,15 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -193,13 +203,15 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -208,13 +220,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -223,13 +237,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -239,13 +255,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -255,8 +273,11 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyNumeric.yml
+++ b/src/workloads/query/DensifyNumeric.yml
@@ -45,7 +45,7 @@ Description: |
 GlobalDefaults:
   dbname: &db test
   MaxPhases: &MaxPhases 20
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "number"
   unitName: &unit null
   index: &index
@@ -66,7 +66,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 10000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       # Test a subset of units that have different characteristics.
@@ -91,19 +91,19 @@ Actors:
   - *Nop
 
 - Name: DensifyNumeric
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -111,13 +111,15 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -126,12 +128,12 @@ Actors:
             }
           }
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -140,13 +142,15 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: FullByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -155,13 +159,15 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: PartitionedByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -170,13 +176,15 @@ Actors:
               step: *smallStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: PartitionedByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -185,13 +193,15 @@ Actors:
               step: *largeStep
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -199,13 +209,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -213,13 +225,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -228,13 +242,15 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
     - OperationMetricsName: ExplicitRangeByPartitionLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -243,8 +259,11 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
 
 AutoRun:
 - When:

--- a/src/workloads/query/DensifyTimeseriesCollection.yml
+++ b/src/workloads/query/DensifyTimeseriesCollection.yml
@@ -6,7 +6,7 @@ Description: |
 
 GlobalDefaults:
   dbname: &db test
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "numeric"
   index: &index
     keys: {numeric: 1}
@@ -84,7 +84,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 100000
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       partitionKey: {^RandomInt: {min: 1, max: 100}}
       timestamp: {^IncDate: {start: "2021-01-01T00:00:00.000", step: 400}}
@@ -110,7 +110,7 @@ Actors:
   - *Nop
 
 - Name: DensifyFullSmallStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -119,12 +119,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -132,8 +132,11 @@ Actors:
               step: *smallStep,
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
   - *Nop
   - *Nop
   - *Nop
@@ -148,7 +151,7 @@ Actors:
   - *Nop
 
 - Name: DensifyFullLargeStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -159,12 +162,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: FullLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -172,8 +175,11 @@ Actors:
               step: *smallStep,
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
   - *Nop
   - *Nop
   - *Nop
@@ -186,7 +192,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeSmallStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -199,12 +205,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: ExplicitRangeSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -212,8 +218,11 @@ Actors:
               bounds: *bounds,
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
   - *Nop
   - *Nop
   - *Nop
@@ -224,7 +233,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeLargeStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -239,12 +248,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: ExplicitRangeLargeStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -252,8 +261,11 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
   - *Nop
   - *Nop
   - *Nop
@@ -262,7 +274,7 @@ Actors:
   - *Nop
 
 - Name: DensifyExplicitRangeByPartitionSmallStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -279,12 +291,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: ExplicitRangeByPartitionSmallStep
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             partitionByFields: ["partitionKey"],
@@ -293,15 +305,18 @@ Actors:
               bounds: *bounds
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
   - *Nop
   - *Nop
   - *Nop
   - *Nop
 
 - Name: DensifyExplicitRangeByPartitionLargeStep
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -320,12 +335,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: DensifyTimestamp
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: *field,
             range: {
@@ -333,13 +348,16 @@ Actors:
               bounds: "full"
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
   - *Nop
   - *Nop
 
 - Name: DensifyTimestamp
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -360,12 +378,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: DensifyTimestamp
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $densify: {
             field: "timestamp",
             range: {
@@ -374,8 +392,11 @@ Actors:
               bounds: "full"
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
 
 AutoRun:
 - When:

--- a/src/workloads/query/FillTimeseriesCollection.yml
+++ b/src/workloads/query/FillTimeseriesCollection.yml
@@ -98,7 +98,7 @@ Actors:
   - Nop: true
 
 - Name: LocfSingleOutput
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -107,12 +107,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestLocfSingleOutput
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               sortBy: {timestamp: 1},
@@ -135,7 +135,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillSingleOutput
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -146,12 +146,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestLinearFillSingleOutput
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               sortBy: {timestamp: 1},
@@ -172,7 +172,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputsWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -185,12 +185,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestLocfMultipleOutputsWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               partitionBy: {part1: "$part1", part2: "$part2"},
@@ -212,7 +212,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputsWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -227,12 +227,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestMultipleOutputsWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               partitionBy: {part1: "$part1", part2: "$part2"},
@@ -252,7 +252,7 @@ Actors:
   - Nop: true
 
 - Name: MixedMethodsMultipleOutputsWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -269,12 +269,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: TestMultipleOutputsWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {
             $fill: {
               partitionBy: {part1: "$part1", part2: "$part2"},

--- a/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/LookupWithOnlyUnshardedColls.yml
@@ -43,19 +43,19 @@ Actors:
   - *Nop
 
 - Name: RunLookups
-  Type: RunCommand
+  Type: CrudActor
   Database: *Database
   Phases:
   - *Nop
   - *Nop
   - Repeat: 10
     Database: *Database
+    Collection: Collection0
     Operations:
     - OperationMetricsName: LookupWithCachedPrefixUnshardedToUnsharded
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline:
+        Pipeline:
           [{
             $lookup: {
               from: Collection1,
@@ -66,14 +66,17 @@ Actors:
               ],
               as: joined
             }
-          },
-           {$project: {str: 0, "joined.str": 0}}]
-        cursor: {batchSize: *NumDocs}
+          }, {
+            $project: {str: 0, "joined.str": 0}
+          }, {
+          $limit: *NumDocs
+          }]
+        Options: 
+          BatchSize:  *NumDocs
     - OperationMetricsName: LookupOneToFewUnshardedToUnsharded
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline:
+        Pipeline:
           [
             {$match: {int: {$lte: 4}}},
             {$lookup: {
@@ -81,15 +84,17 @@ Actors:
               let: {int0: "$int"},
               pipeline: [{$match: {$expr: {$eq: ["$$int0", "$int"]}}}],
               as: "joined"
-            }},
-            {$project: {str: 0, "joined.str": 0}}
-          ]
-        cursor: {batchSize: *NumDocs}
+            }}, {
+            $project: {str: 0, "joined.str": 0}
+            }, {
+            $limit: *NumDocs
+          }]
+        Options: 
+          BatchSize:  *NumDocs
     - OperationMetricsName: LookupOneToManyUnshardedToUnsharded
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline:
+        Pipeline:
           [
             {$match: {int: {$lte: 4}}},
             {$lookup: {
@@ -97,10 +102,14 @@ Actors:
               let: {smallInt0: "$smallInt"},
               pipeline: [{$match: {$expr: {$eq: ["$$smallInt0", "$smallInt"]}}}],
               as: "joined"
-            }},
-            {$project: {str: 0, "joined.str": 0}}
+            }}, {
+            $project: {str: 0, "joined.str": 0}
+            }, {
+            $limit: *NumDocs
+            }
           ]
-        cursor: {batchSize: *NumDocs}
+        Options: 
+          BatchSize:  *NumDocs
 
 AutoRun:
 - When:

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -11,7 +11,7 @@ Description: |
 
 GlobalDefaults:
   dbname: &db test
-  batchSize: &batchSize 30000
+  limit: &limit 30000
   fieldName: &field "numeric"
   index: &index
     keys: {numeric: 1}
@@ -46,7 +46,7 @@ Actors:
     # To get a good signal we need this to be at least bucket size squared.
     # The bucket size is 360. This is 360 * 360 *8. The 8 is just for safety.
     DocumentCount: 1036800
-    BatchSize: *batchSize
+    BatchSize: *limit
     Document:
       # start "2022-01-01" = "2022-01-01T00:00:00Z", step 10000 = size of step 10 seconds or 10,000 millis
       timestamp: {^IncDate: {start: "2022-01-01", step: 40000}}
@@ -70,7 +70,7 @@ Actors:
   - *Nop
 
 - Name: PointQueries
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -78,12 +78,12 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: PointQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $match: {
             numeric: {^RandomInt: {min: 0, max: 259200}}
           }
@@ -92,8 +92,11 @@ Actors:
             _id: 0,
             numeric: 1
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
 
 AutoRun:
 - When:

--- a/src/workloads/query/TimeSeries2dsphere.yml
+++ b/src/workloads/query/TimeSeries2dsphere.yml
@@ -118,7 +118,7 @@ Actors:
   - *Nop
 
 - Name: GeoQueries
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -126,28 +126,27 @@ Actors:
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: GeoWithinQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {$match: {location: {$geoWithin: {$centerSphere: [[
             {^RandomDouble: { min: *minX, max: *maxX }},
             {^RandomDouble: { min: *minY, max: *maxY }},
           ], 0.001]}}}},
           {$skip: 1e5},
         ]
-        cursor: {}
   - *Nop
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: GeoNearQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {$geoNear: {
             key: 'location',
             near: [
@@ -160,7 +159,6 @@ Actors:
           }},
           {$skip: 1e5},
         ]
-        cursor: {}
 
 AutoRun:
 - When:

--- a/src/workloads/query/TimeSeriesSortCompound.yml
+++ b/src/workloads/query/TimeSeriesSortCompound.yml
@@ -69,7 +69,7 @@ Actors:
   - *Nop
 
 - Name: Queries
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - *Nop
@@ -77,18 +77,17 @@ Actors:
   - *Nop
   - Repeat: 50
     Database: *db
+    Collection: *coll
     Operations:
     - OperationMetricsName: SortCompound
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline: [
+        Pipeline: [
           {$sort: {m: 1, t: 1}},
           {$_internalInhibitOptimization: {}},
           {$skip: 1e10},
         ]
-        cursor: {}
-        hint: {m: 1, t: 1}
+        Hint: {m: 1, t: 1}
   - *Nop
 
 AutoRun:

--- a/src/workloads/query/linearFill.yml
+++ b/src/workloads/query/linearFill.yml
@@ -23,7 +23,7 @@ Actors:
     Threads: 1
     CollectionCount: 1
     DocumentCount: 600
-    BatchSize: &batchSize 100
+    BatchSize: &limit 100
     Document:
       part1: {^Choose: {from: [1, 2, 3, 4]}}
       part2: {^Choose: {from: [1, 2, 3, 4]}}
@@ -76,19 +76,19 @@ Actors:
   - Nop: true
 
 - Name: LinearFillWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestSingleOutputWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortField: 1},
             output: {
@@ -96,8 +96,11 @@ Actors:
                 $linearFill: "$numeric"}
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
   - Nop: true
   - Nop: true
   - Nop: true
@@ -110,7 +113,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -119,12 +122,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortDateField: 1},
             output: {
@@ -134,8 +137,11 @@ Actors:
                 $linearFill: "$double"},
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
+        Options: 
+          BatchSize:  *limit
   - Nop: true
   - Nop: true
   - Nop: true
@@ -146,7 +152,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -157,12 +163,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestSingleOutputWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortField: 1},
             partitionBy: "$part1",
@@ -171,9 +177,12 @@ Actors:
                 $linearFill: "$numeric"}
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+        Options: 
+          BatchSize:  *limit
+          AllowDiskUse: true
   - Nop: true
   - Nop: true
   - Nop: true
@@ -182,7 +191,7 @@ Actors:
   - Nop: true
 
 - Name: LinearFillMultipleOutputWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -195,12 +204,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortDateField: 1},
             partitionBy: "$part1",
@@ -211,16 +220,19 @@ Actors:
                 $linearFill: "$integer"},
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+        Options: 
+          BatchSize:  *limit
+          AllowDiskUse: true
   - Nop: true
   - Nop: true
   - Nop: true
   - Nop: true
 
 - Name: LinearFillWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -235,12 +247,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestSingleOutputWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortField: 1},
             partitionBy: {part1: "$part1", part2: "$part2"},
@@ -249,14 +261,17 @@ Actors:
                 $linearFill: "$numeric"}
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+        Options: 
+          BatchSize:  *limit
+          AllowDiskUse: true
   - Nop: true
   - Nop: true
 
 - Name: LinearFillMultipleOutputWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -273,12 +288,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [{
+        Pipeline: [{
           $setWindowFields: {
             sortBy: {sortDateField: 1},
             partitionBy: {part1: "$part1", part2: "$part2"},
@@ -289,9 +304,12 @@ Actors:
                 $linearFill: "$double"},
             }
           }
+        }, {
+          $limit: *limit
         }]
-        cursor: {batchSize: *batchSize}
-        allowDiskUse: true
+        Options: 
+          BatchSize:  *limit
+          AllowDiskUse: true
 
 AutoRun:
 - When:

--- a/src/workloads/query/locf.yml
+++ b/src/workloads/query/locf.yml
@@ -92,19 +92,19 @@ Actors:
   - Nop: true
 
 - Name: LocfNumericWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestNumericWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -116,7 +116,6 @@ Actors:
           },
           {$limit: *limit}
         ]
-        cursor: {}
   - Nop: true
   - Nop: true
   - Nop: true
@@ -135,7 +134,7 @@ Actors:
   - Nop: true
 
 - Name: LocfRandomTypeWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -144,12 +143,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestRandomTypeWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -161,7 +160,6 @@ Actors:
           },
           {$limit: *limit}
         ]
-        cursor: {}
   - Nop: true
   - Nop: true
   - Nop: true
@@ -178,7 +176,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputWithoutPartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -189,12 +187,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithoutPartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -210,7 +208,6 @@ Actors:
           },
           {$limit: *limit}
         ]
-        cursor: {}
   - Nop: true
   - Nop: true
   - Nop: true
@@ -225,7 +222,7 @@ Actors:
   - Nop: true
 
 - Name: LocfDateWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -238,12 +235,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestDateWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -256,8 +253,8 @@ Actors:
           },
           {$limit: *limit}
         ]
-        cursor: {}
-        allowDiskUse: true
+        Options: 
+          AllowDiskUse: true
   - Nop: true
   - Nop: true
   - Nop: true
@@ -270,7 +267,7 @@ Actors:
   - Nop: true
 
 - Name: LocfRandomTypeWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -285,12 +282,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestRandomTypeWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -303,8 +300,8 @@ Actors:
           },
           {$limit: *limit}
         ]
-        cursor: {}
-        allowDiskUse: true
+        Options: 
+          AllowDiskUse: true
   - Nop: true
   - Nop: true
   - Nop: true
@@ -315,7 +312,7 @@ Actors:
   - Nop: true
 
 - Name: LocfMultipleOutputWithSinglePartition
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -332,12 +329,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithSinglePartition
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -354,8 +351,8 @@ Actors:
           },
           {$limit: *limit}
         ]
-        cursor: {}
-        allowDiskUse: true
+        Options: 
+          AllowDiskUse: true
   - Nop: true
   - Nop: true
   - Nop: true
@@ -364,7 +361,7 @@ Actors:
   - Nop: true
 
 - Name: LocfStringWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -383,12 +380,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestStringWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -401,15 +398,15 @@ Actors:
           },
           {$limit: *limit}
         ]
-        cursor: {}
-        allowDiskUse: true
+        Options: 
+          AllowDiskUse: true
   - Nop: true
   - Nop: true
   - Nop: true
   - Nop: true
 
 - Name: LocfRandomTypeWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -430,12 +427,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestRandomTypeWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -448,13 +445,13 @@ Actors:
           },
           {$limit: *limit}
         ]
-        cursor: {}
-        allowDiskUse: true
+        Options: 
+          AllowDiskUse: true
   - Nop: true
   - Nop: true
 
 - Name: LocfMultipleOutputWithMultiplePartitions
-  Type: RunCommand
+  Type: CrudActor
   Threads: 1
   Phases:
   - Nop: true
@@ -477,12 +474,12 @@ Actors:
   - Nop: true
   - Duration: 30 seconds
     Database: *db
+    Collection: Collection0
     Operations:
     - OperationMetricsName: TestMultipleOutputWithMultiplePartitions
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: Collection0
-        pipeline: [
+        Pipeline: [
           {
             $setWindowFields: {
               sortBy: {_id: 1},
@@ -499,8 +496,8 @@ Actors:
           },
           {$limit: *limit}
         ]
-        cursor: {}
-        allowDiskUse: true
+        Options: 
+          AllowDiskUse: true
 
 AutoRun:
 - When:


### PR DESCRIPTION
Jira Ticket:
[PERF-3784](https://jira.mongodb.org/browse/PERF-3784)

Whats Changed:
Replace RunCommand by CrudActor in query workloads

Patch testing results:
[evergreen build](https://spruce.mongodb.com/version/65858d17e3c3317c1525c371)

Workload Submission form:
NA

Related PRs:
NA