### PR TITLE
PERF-4956: Create genny workload for $group with distinct semantics

### DIFF
--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -155,3 +155,15 @@ Actors:
       Name: "GroupBottomN"
       OnlyActiveInPhase: 11
       Pipeline: [{$group: {_id: "$a", accum: {$bottomN: {n: 1, output: ["$b"], sortBy: {b: 1}}}}}]
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone-all-feature-flags
+      - standalone
+      - shard
+      - shard-lite
+      - single-replica
+      - replica
+      - atlas-like-replica.2022-10

--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -1,11 +1,9 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
 Description: |
-  This workload tests performance of $group queries with distinct like semantics, meaning they will
-  execute with a DISTINCT_SCAN. Currently this is supported for $group + $sort and only with the
-  $first and $last accumulators. In PM-3163 this will be extended to $top, $topN and $bottom,
-  $bottomN accumulators so we are including those here in order to see performance changes once that
-  is implemented.
+  This workloads covers $group queries with distinct-like semantics, meaning that only a single document
+  is selected from each group. Depending on the details of the query and available indexes, the query might
+  be optimized to use DISTINCT_SCAN plan.
 
 Clients:
   Default:
@@ -37,11 +35,10 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Duration: 30 seconds
+          Repeat: 100
           Collection: *Collection
           Operations:
-          - OperationMetricsName: DistinctExecutionMetrics
-            OperationName: aggregate
+          - OperationName: aggregate
             OperationCommand:
               Pipeline: {^Parameter: {Name: "Pipeline", Default: []}}
 
@@ -78,9 +75,9 @@ Actors:
         BatchSize: 1000
         Document:
           _id: {^Inc: {start: 0, step: 1}}
-          a: {^RandomInt: {min: 0, max: 500}}
-          b: {^RandomInt: {min: 0, max: 500}}
-          c: {^RandomInt: {min: 0, max: 500}}
+          a: {^RandomInt: {min: 0, max: 100}}
+          b: {^RandomInt: {min: 0, max: 100}}
+          c: {^RandomInt: {min: 0, max: 100}}
         Indexes:
           - keys: {a: 1, b: 1, c: 1}
 
@@ -88,44 +85,44 @@ Actors:
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "DistinctGroup"
+      Name: "Group"
       OnlyActiveInPhase: 2
       Pipeline: [{$group: {_id: "$a"}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "DistinctGroupSort"
+      Name: "GroupSort"
       OnlyActiveInPhase: 3
       Pipeline: [{$sort: {a: 1}}, {$group: {_id: "$a"}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "DistinctGroupSortFirst"
+      Name: "GroupSortFirst"
       OnlyActiveInPhase: 4
       Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$first: "$b"}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "DistinctGroupSortFirstFullDocument"
+      Name: "GroupSortFirstFullDocument"
       OnlyActiveInPhase: 5
-      Pipeline: [{$sort: {a: 1, b: 1, c: 1}}, {$group: {_id: "$a", accum: {$first: "$$ROOT"}}}]
+      Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$first: "$$ROOT"}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "DistinctGroupSortLast"
+      Name: "GroupSortLast"
       OnlyActiveInPhase: 6
-      Pipeline: [{$sort: {a: -1, b: -1}}, {$group: {_id: "$a", accum: {$last: "$b"}}}]
+      Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$last: "$b"}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "DistinctGroupSortLastFullDocument"
+      Name: "GroupSortLastFullDocument"
       OnlyActiveInPhase: 7
-      Pipeline: [{$sort: {a: 1, b: 1, c: 1}}, {$group: {_id: "$a", accum: {$last: "$$ROOT"}}}]
+      Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$last: "$$ROOT"}}}]
 
 # The following do not yet use DISTINCT_SCAN, but they will after SERVER-84347.
 - ActorFromTemplate:
@@ -160,10 +157,5 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - standalone-all-feature-flags
-      - standalone
-      - shard
-      - shard-lite
-      - single-replica
       - replica
-      - atlas-like-replica.2022-10
+      - replica-all-feature-flags

--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -1,0 +1,157 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This workload tests performance of $group queries with distinct like semantics, meaning they will
+  execute with a DISTINCT_SCAN. Currently this is supported for $group + $sort and only with the
+  $first and $last accumulators. In PM-3163 this will be extended to $top, $topN and $bottom,
+  $bottomN accumulators so we are including those here in order to see performance changes once that
+  is implemented.
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 2000
+
+Keywords:
+- Distinct
+- Group
+- First
+- Last
+- Top
+- Bottom
+
+GlobalDefaults:
+  Database: &Database test
+  Collection: &Collection Collection0
+  MaxPhases: &MaxPhases 11
+
+ActorTemplates:
+- TemplateName: RunAggCommand
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "RunAggCommand"}}
+    Type: CrudActor
+    Database: *Database
+    Threads: 32
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Duration: 30 seconds
+          Collection: *Collection
+          Operations:
+          - OperationMetricsName: DistinctExecutionMetrics
+            OperationName: aggregate
+            OperationCommand:
+              Pipeline: {^Parameter: {Name: "Pipeline", Default: []}}
+
+Actors:
+# Clear any pre-existing collection state.
+- Name: ClearCollection
+  Type: CrudActor
+  Database: *Database
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Collection: *Collection
+        Operations:
+        - OperationName: drop
+
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        MultipleThreadsPerCollection: true
+        CollectionCount: 1
+        DocumentCount: 5000
+        BatchSize: 1000
+        Document:
+          _id: {^Inc: {start: 0, step: 1}}
+          a: {^RandomInt: {min: 0, max: 500}}
+          b: {^RandomInt: {min: 0, max: 500}}
+          c: {^RandomInt: {min: 0, max: 500}}
+        Indexes:
+          - keys: {a: 1, b: 1, c: 1}
+
+# The following use a DISTINCT_SCAN.
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "DistinctGroup"
+      OnlyActiveInPhase: 2
+      Pipeline: [{$group: {_id: "$a"}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "DistinctGroupSort"
+      OnlyActiveInPhase: 3
+      Pipeline: [{$sort: {a: 1}}, {$group: {_id: "$a"}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "DistinctGroupSortFirst"
+      OnlyActiveInPhase: 4
+      Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$first: "$b"}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "DistinctGroupSortFirstFullDocument"
+      OnlyActiveInPhase: 5
+      Pipeline: [{$sort: {a: 1, b: 1, c: 1}}, {$group: {_id: "$a", accum: {$first: "$$ROOT"}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "DistinctGroupSortLast"
+      OnlyActiveInPhase: 6
+      Pipeline: [{$sort: {a: -1, b: -1}}, {$group: {_id: "$a", accum: {$last: "$b"}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "DistinctGroupSortLastFullDocument"
+      OnlyActiveInPhase: 7
+      Pipeline: [{$sort: {a: 1, b: 1, c: 1}}, {$group: {_id: "$a", accum: {$last: "$$ROOT"}}}]
+
+# The following do not yet use DISTINCT_SCAN, but they will after SERVER-84347.
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupTop"
+      OnlyActiveInPhase: 8
+      Pipeline: [{$group: {_id: "$a", accum: {$top: {output: ["$b"], sortBy: {b: 1}}}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupBottom"
+      OnlyActiveInPhase: 9
+      Pipeline: [{$group: {_id: "$a", accum: {$bottom: {output: ["$b"], sortBy: {b: 1}}}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupTopN"
+      OnlyActiveInPhase: 10
+      Pipeline: [{$group: {_id: "$a", accum: {$topN: {n: 1, output: ["$b"], sortBy: {b: 1}}}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupBottomN"
+      OnlyActiveInPhase: 11
+      Pipeline: [{$group: {_id: "$a", accum: {$bottomN: {n: 1, output: ["$b"], sortBy: {b: 1}}}}}]

--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -35,7 +35,7 @@ ActorTemplates:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Repeat: 100
+          Repeat: 500
           Collection: *Collection
           Operations:
           - OperationName: aggregate

--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -5,11 +5,6 @@ Description: |
   is selected from each group. Depending on the details of the query and available indexes, the query might
   be optimized to use DISTINCT_SCAN plan.
 
-Clients:
-  Default:
-    QueryOptions:
-      maxPoolSize: 2000
-
 Keywords:
 - Distinct
 - Group
@@ -17,11 +12,13 @@ Keywords:
 - Last
 - Top
 - Bottom
+- timeseries
+- aggregate
 
 GlobalDefaults:
   Database: &Database test
   Collection: &Collection Collection0
-  MaxPhases: &MaxPhases 11
+  MaxPhases: &MaxPhases 17
 
 ActorTemplates:
 - TemplateName: RunAggCommand
@@ -29,7 +26,7 @@ ActorTemplates:
     Name: {^Parameter: {Name: "Name", Default: "RunAggCommand"}}
     Type: CrudActor
     Database: *Database
-    Threads: 32
+    Threads: 4
     Phases:
       OnlyActiveInPhases:
         Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: {unused: "please specify in which phases this actor should be active."}}}]
@@ -71,7 +68,7 @@ Actors:
         Database: *Database
         MultipleThreadsPerCollection: true
         CollectionCount: 1
-        DocumentCount: 5000
+        DocumentCount: 1e6
         BatchSize: 1000
         Document:
           _id: {^Inc: {start: 0, step: 1}}
@@ -79,7 +76,7 @@ Actors:
           b: {^RandomInt: {min: 0, max: 100}}
           c: {^RandomInt: {min: 0, max: 100}}
         Indexes:
-          - keys: {a: 1, b: 1, c: 1}
+          - keys: {a: 1, b: 1}
 
 # The following use a DISTINCT_SCAN.
 - ActorFromTemplate:
@@ -99,59 +96,101 @@ Actors:
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "GroupSortFirst"
+      Name: "GroupSortFirstCovered"
       OnlyActiveInPhase: 4
       Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$first: "$b"}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "GroupSortFirstFullDocument"
+      Name: "GroupSortFirstFetched"
       OnlyActiveInPhase: 5
-      Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$first: "$$ROOT"}}}]
+      Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$first: "$c"}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "GroupSortLast"
+      Name: "GroupSortLastCovered"
       OnlyActiveInPhase: 6
       Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$last: "$b"}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "GroupSortLastFullDocument"
+      Name: "GroupSortLastFetched"
       OnlyActiveInPhase: 7
-      Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$last: "$$ROOT"}}}]
+      Pipeline: [{$sort: {a: 1, b: 1}}, {$group: {_id: "$a", accum: {$last: "$c"}}}]
 
 # The following do not yet use DISTINCT_SCAN, but they will after SERVER-84347.
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "GroupTop"
+      Name: "GroupTopCovered"
       OnlyActiveInPhase: 8
       Pipeline: [{$group: {_id: "$a", accum: {$top: {output: ["$b"], sortBy: {b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "GroupBottom"
+      Name: "GroupTopFetched"
       OnlyActiveInPhase: 9
+      Pipeline: [{$group: {_id: "$a", accum: {$top: {output: ["$c"], sortBy: {b: 1}}}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupBottomCovered"
+      OnlyActiveInPhase: 10
       Pipeline: [{$group: {_id: "$a", accum: {$bottom: {output: ["$b"], sortBy: {b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "GroupTopN"
-      OnlyActiveInPhase: 10
+      Name: "GroupBottomFetched"
+      OnlyActiveInPhase: 11
+      Pipeline: [{$group: {_id: "$a", accum: {$bottom: {output: ["$c"], sortBy: {b: 1}}}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupTopNCovered"
+      OnlyActiveInPhase: 12
       Pipeline: [{$group: {_id: "$a", accum: {$topN: {n: 1, output: ["$b"], sortBy: {b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
-      Name: "GroupBottomN"
-      OnlyActiveInPhase: 11
+      Name: "GroupTopNFetched"
+      OnlyActiveInPhase: 13
+      Pipeline: [{$group: {_id: "$a", accum: {$topN: {n: 1, output: ["$c"], sortBy: {b: 1}}}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupBottomNCovered"
+      OnlyActiveInPhase: 14
       Pipeline: [{$group: {_id: "$a", accum: {$bottomN: {n: 1, output: ["$b"], sortBy: {b: 1}}}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupBottomNFetched"
+      OnlyActiveInPhase: 15
+      Pipeline: [{$group: {_id: "$a", accum: {$bottomN: {n: 1, output: ["$c"], sortBy: {b: 1}}}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupMin"
+      OnlyActiveInPhase: 16
+      Pipeline: [{$group: {_id: "$a", accum: {$min: "$b"}}}]
+
+- ActorFromTemplate:
+    TemplateName: RunAggCommand
+    TemplateParameters:
+      Name: "GroupMax"
+      OnlyActiveInPhase: 17
+      Pipeline: [{$group: {_id: "$a", accum: {$max: "$b"}}}]
 
 AutoRun:
 - When:


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [PERF-4956](https://jira.mongodb.org/browse/PERF-4956)

**Whats Changed:**  
Added a wrokload which tests various $group with distinct like semantics, as well as with $top and $bottom accumulators which will be updated to also use DISTINCT_SCAN.

**Sys-Perf Patch** 
https://spruce.mongodb.com/version/658d0dfb850e617aeccc2832/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

I also added the results of one run onto this spreadsheet: 
https://docs.google.com/spreadsheets/d/1Y53LpA64G0egL5JRa5QH19Hr9QVGmntSg3KUOoez_PQ/edit#gid=0
We can see that the commands that don't use distinct scan are slower than those that do. Once I finish [SERVER-84347](https://jira.mongodb.org/browse/SERVER-84347), I can run this workload and see the %diff.
