### PR TITLE
DEVPROD-2159: Allow multiple files containing variants.

### DIFF
--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -622,18 +622,20 @@ def auto_tasks(ctx: click.Context, tasks: str, dry_run: bool):
 )
 @click.option(
     "--project-file",
+    "project_files",
     required=True,
+    multiple=True,
     help="An evergreen project file, such as system_perf.yml",
 )
 @click.option(
     "--no-activate", default=False, is_flag=True, help="Ensure that generated tasks don't activate"
 )
 @click.pass_context
-def auto_tasks_all(ctx: click.Context, project_file: str, no_activate: bool):
+def auto_tasks_all(ctx: click.Context, project_files: List[str], no_activate: bool):
     from genny.tasks import auto_tasks_all
 
     auto_tasks_all.main(
-        project_file=project_file,
+        project_files=project_files,
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
         no_activate=no_activate,
     )

--- a/src/lamplib/src/genny/tasks/auto_tasks_all.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_all.py
@@ -47,7 +47,7 @@ def create_configuration(repo: Repo, builds: List[CurrentBuildInfo], no_activate
             SLOG.info(f"No auto-tasks for variant: {build.variant}")
     return config
 
-def main(project_file: str, workspace_root: str, no_activate: bool) -> None:
+def main(project_files: List[str], workspace_root: str, no_activate: bool) -> None:
     reader = YamlReader()
     try:
         global_expansions = reader.load(workspace_root, "expansions.yml")
@@ -55,7 +55,9 @@ def main(project_file: str, workspace_root: str, no_activate: bool) -> None:
         SLOG.error(f"Evergreen expansions file {os.path.join(workspace_root, 'expansions.yml')} does not exist. Ensure this file exists and that it is in the correct location.")
         sys.exit(1)
     execution = int(global_expansions["execution"])
-    builds = get_all_builds(global_expansions, project_file)
+    builds = []
+    for project_file in project_files:
+        builds.extend(get_all_builds(global_expansions, project_file))
 
     lister = WorkloadLister(workspace_root=workspace_root)
     repo = Repo(lister=lister, reader=reader, workspace_root=workspace_root)


### PR DESCRIPTION
Since now variants are split across multiple files we need to allow scanning them all.

Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [DEVPROD-2159](https://jira.mongodb.org/browse/DEVPROD-2159)

**Whats Changed:**  
Now that performance tasks are split across multiple files, auto_tasks_all needs to handle parsing tasks/variants from across multiple yaml files.
