### PR TITLE
PERF-5019: Prevent group_like_distinct from running on older versions

### DIFF
--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -198,3 +198,6 @@ AutoRun:
       $eq:
       - replica
       - replica-all-feature-flags
+    branch_name:
+      $gte:
+        v5.2


### PR DESCRIPTION
Jira Ticket: [PERF-5019](https://jira.mongodb.org/browse/PERF-5019)

Whats Changed:
prevent workload from running on older versions before $top was added