### PR TITLE
DEVPROD-3617: Allow users to specify a task to run on task generation.

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -165,6 +165,7 @@ tasks:
 
 - name: t_lint_python
   commands:
+  - func: f_fetch_source
   - func: f_lint_python
 
 - name: t_cmake_test
@@ -253,7 +254,7 @@ task_groups:
   # run after t_compile_and_dry_run.
   - t_compile_and_dry_run
   - t_python_test
-  #- t_lint_python
+  - t_lint_python
   #- t_lint_workloads
   - t_cmake_test
 
@@ -268,7 +269,7 @@ task_groups:
   tasks:
   - t_compile
   - t_python_test
-  #- t_lint_python
+  - t_lint_python
   #- t_lint_workloads
   - t_cmake_test
   - t_integration_test_single_node_replset

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -254,7 +254,7 @@ task_groups:
   # run after t_compile_and_dry_run.
   - t_compile_and_dry_run
   - t_python_test
-  - t_lint_python
+  #- t_lint_python
   #- t_lint_workloads
   - t_cmake_test
 
@@ -269,7 +269,7 @@ task_groups:
   tasks:
   - t_compile
   - t_python_test
-  - t_lint_python
+  #- t_lint_python
   #- t_lint_workloads
   - t_cmake_test
   - t_integration_test_single_node_replset

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -63,7 +63,7 @@ def cli(ctx: click.Context, verbose: bool) -> None:
     help=(
         "Specify the linux distro you're on; if your system isn't available,"
         " please contact us at #performance-tooling-users. Specify not-linux for macOS."
-        " If no value is specified, it will be autodetected." 
+        " If no value is specified, it will be autodetected."
     ),
 )
 @click.option(

--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -109,7 +109,9 @@ def _create_metrics():
     os.makedirs(_METRICS_PATH, exist_ok=True)
 
 
-def export(workspace_root: str, genny_repo_root: str, input_path: str, output_path: Optional[str] = None):
+def export(
+    workspace_root: str, genny_repo_root: str, input_path: str, output_path: Optional[str] = None
+):
     args = _get_export_args(
         workspace_root=workspace_root,
         genny_repo_root=genny_repo_root,
@@ -119,7 +121,9 @@ def export(workspace_root: str, genny_repo_root: str, input_path: str, output_pa
     subprocess.run(args, check=True)
 
 
-def translate(workspace_root: str, genny_repo_root: str, input_path: str, output_path: Optional[str] = None):
+def translate(
+    workspace_root: str, genny_repo_root: str, input_path: str, output_path: Optional[str] = None
+):
     args = _get_translate_args(
         workspace_root=workspace_root,
         genny_repo_root=genny_repo_root,

--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -129,6 +129,11 @@ class CurrentBuildInfo:
         return f"CurrentBuildInfo: {self.conts}"
 
 
+class VariantTask(NamedTuple):
+    variant: str
+    task: str
+
+
 class GeneratedTask(NamedTuple):
     name: str
     bootstrap_key: Optional[str]
@@ -243,7 +248,7 @@ class Workload:
 
     def all_tasks(self) -> List[GeneratedTask]:
         """
-        :return: all possible tasks that have an AutoRun block, irrespective of the current 
+        :return: all possible tasks that have an AutoRun block, irrespective of the current
         build-variant etc.
         """
         if not self.auto_run_info:
@@ -541,9 +546,20 @@ class ConfigWriter:
 
     @staticmethod
     def configure_variant_tasks(
-        config: Configuration, tasks: List[GeneratedTask], variant: str, activate: bool = None
+        config: Configuration,
+        tasks: List[GeneratedTask],
+        variant: str,
+        activate_all: Optional[bool] = None,
+        activate_tasks: Set[VariantTask] = frozenset(),
     ) -> None:
-        config.variant(variant).tasks([TaskSpec(task.name).activate(activate) for task in tasks])
+        all_tasks = []
+        for task in tasks:
+            if VariantTask(variant, task.name) in activate_tasks:
+                should_activate = True
+            else:
+                should_activate = activate_all
+            all_tasks.append(TaskSpec(task.name).activate(should_activate))
+        config.variant(variant).tasks(all_tasks)
 
     @staticmethod
     def configure_all_tasks_modern(config: Configuration, tasks: List[GeneratedTask]) -> None:

--- a/src/lamplib/src/genny/tasks/auto_tasks_all.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_all.py
@@ -11,13 +11,17 @@ from genny.tasks.auto_tasks import (
     Repo,
     ConfigWriter,
     YamlReader,
+    VariantTask,
 )
 
 SLOG = structlog.get_logger(__name__)
 
-def get_all_builds(global_expansions: dict[str, str], project_file_path: str) -> List[CurrentBuildInfo]:
+
+def get_all_builds(
+    global_expansions: dict[str, str], project_file_path: str
+) -> List[CurrentBuildInfo]:
     """
-    Attempts to compute the expansions 
+    Attempts to compute the expansions
     """
     with open(project_file_path) as project_file:
         project = yaml.safe_load(project_file)
@@ -32,29 +36,45 @@ def get_all_builds(global_expansions: dict[str, str], project_file_path: str) ->
             all_builds.append(CurrentBuildInfo(build_info_dict))
     return all_builds
 
-def create_configuration(repo: Repo, builds: List[CurrentBuildInfo], no_activate: bool):
+
+def create_configuration(
+    repo: Repo, builds: List[CurrentBuildInfo], no_activate: bool, activate_tasks: List[VariantTask]
+):
     all_tasks = repo.all_tasks()
     config = Configuration()
     ConfigWriter.configure_all_tasks_modern(config, all_tasks)
-    activate_param = False if no_activate else None
+    activate_all_param = False if no_activate else None
     for build in builds:
 
         build_tasks = repo.variant_tasks(build)
         if len(build_tasks) > 0:
             SLOG.info(f"Generating auto-tasks for variant: {build.variant}")
-            ConfigWriter.configure_variant_tasks(config, build_tasks, build.variant, activate=activate_param)
+            ConfigWriter.configure_variant_tasks(
+                config,
+                build_tasks,
+                build.variant,
+                activate_all=activate_all_param,
+                activate_tasks=activate_tasks,
+            )
         else:
             SLOG.info(f"No auto-tasks for variant: {build.variant}")
     return config
+
 
 def main(project_files: List[str], workspace_root: str, no_activate: bool) -> None:
     reader = YamlReader()
     try:
         global_expansions = reader.load(workspace_root, "expansions.yml")
     except FileNotFoundError:
-        SLOG.error(f"Evergreen expansions file {os.path.join(workspace_root, 'expansions.yml')} does not exist. Ensure this file exists and that it is in the correct location.")
+        SLOG.error(
+            f"Evergreen expansions file {os.path.join(workspace_root, 'expansions.yml')} does not exist. Ensure this file exists and that it is in the correct location."
+        )
         sys.exit(1)
     execution = int(global_expansions["execution"])
+    activate_tasks = set(
+        VariantTask(*item.strip().split(":"))
+        for item in global_expansions.get("activate_generated_tasks", "").split(",")
+    )
     builds = []
     for project_file in project_files:
         builds.extend(get_all_builds(global_expansions, project_file))
@@ -62,6 +82,6 @@ def main(project_files: List[str], workspace_root: str, no_activate: bool) -> No
     lister = WorkloadLister(workspace_root=workspace_root)
     repo = Repo(lister=lister, reader=reader, workspace_root=workspace_root)
 
-    config = create_configuration(repo, builds, no_activate)
+    config = create_configuration(repo, builds, no_activate, activate_tasks)
     output_file = os.path.join(workspace_root, "build", "TaskJSON", "Tasks.json")
     ConfigWriter.write_config(execution, config, output_file)

--- a/src/lamplib/src/genny/tasks/auto_tasks_all.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_all.py
@@ -71,10 +71,14 @@ def main(project_files: List[str], workspace_root: str, no_activate: bool) -> No
         )
         sys.exit(1)
     execution = int(global_expansions["execution"])
-    activate_tasks = set(
-        VariantTask(*item.strip().split(":"))
-        for item in global_expansions.get("activate_generated_tasks", "").split(",")
-    )
+
+    variant_task_names = global_expansions.get("activate_generated_tasks", "").split(",")
+    activate_tasks = set()
+    for name in variant_task_names:
+        variant_name, task_name = name.strip().split(":")
+        variant_task = VariantTask(variant_name, task_name)
+        activate_tasks.add(variant_task)
+
     builds = []
     for project_file in project_files:
         builds.extend(get_all_builds(global_expansions, project_file))

--- a/src/lamplib/src/tests/test_auto_tasks_all.py
+++ b/src/lamplib/src/tests/test_auto_tasks_all.py
@@ -14,6 +14,7 @@ from genny.tasks.auto_tasks import (
     Repo,
     ConfigWriter,
     YamlReader,
+    VariantTask,
 )
 from genny.tasks.auto_tasks_all import create_configuration, get_all_builds
 import genny.tasks.auto_tasks_all
@@ -220,14 +221,104 @@ class AutoTasksTests(BaseTestClass):
         expected = {}
 
         repo = Repo(lister, reader, workspace_root=".")
-        config = create_configuration(repo, build_infos, False)
+        config = create_configuration(repo, build_infos, False, [])
+
+        parsed = json.loads(config.to_json())
+        self.assertEqual(EXPECTED, parsed)
+
+    def test_generate_all_activate_tasks(self):
+        """
+        Tests generating all tasks for a given parsed list of variants in a config file, and
+        activating a specific test using activate_generated_tasks.
+        """
+        self.maxDiff = None
+        EXPECTED = {
+            "tasks": [
+                {
+                    "name": "task_a",
+                    "commands": [
+                        TIMEOUT_COMMAND,
+                        {
+                            "func": "f_run_dsi_workload",
+                            "vars": {
+                                "test_control": "task_a",
+                                "auto_workload_path": "src/genny/src/workloads/src/TaskA.yml",
+                            },
+                        },
+                    ],
+                    "priority": 5,
+                },
+                {
+                    "name": "task_b",
+                    "commands": [
+                        TIMEOUT_COMMAND,
+                        {
+                            "func": "f_run_dsi_workload",
+                            "vars": {
+                                "test_control": "task_b",
+                                "auto_workload_path": "src/genny/src/workloads/src/TaskB.yml",
+                            },
+                        },
+                    ],
+                    "priority": 5,
+                },
+            ],
+            "buildvariants": [
+                {
+                    "name": "a",
+                    "tasks": [
+                        {
+                            "name": "task_a",
+                            "activate": True,
+                        }
+                    ],
+                },
+                {"name": "b", "tasks": [{"name": "task_b"}]},
+            ],
+            "exec_timeout_secs": 64800,
+        }
+
+        workload_files = [
+            make_auto_run("TaskA", "a_setup"),
+            make_auto_run("TaskB", "b_setup"),
+        ]
+
+        reader: YamlReader = MockReader(workload_files)
+        lister: WorkloadLister = MagicMock(name="lister", spec=WorkloadLister, instance=True)
+
+        lister.all_workload_files.return_value = [v.base_name for v in workload_files]
+        lister.modified_workload_files.return_value = [
+            v.base_name for v in workload_files if v.modified
+        ]
+
+        build_infos = [
+            CurrentBuildInfo(
+                {
+                    "build_variant": "a",
+                    "mongodb_setup": "a_setup",
+                    "execution": "0",
+                }
+            ),
+            CurrentBuildInfo(
+                {
+                    "build_variant": "b",
+                    "mongodb_setup": "b_setup",
+                    "execution": "0",
+                }
+            ),
+        ]
+
+        expected = {}
+
+        repo = Repo(lister, reader, workspace_root=".")
+        config = create_configuration(repo, build_infos, False, [VariantTask("a", "task_a")])
 
         parsed = json.loads(config.to_json())
         self.assertEqual(EXPECTED, parsed)
 
     def test_parse_project_file(self):
         """
-        Simple test for parsing a YAML project file from Evergreen. Checks that we can find both 
+        Simple test for parsing a YAML project file from Evergreen. Checks that we can find both
         build variants and get the expansions from each of them.
         """
 


### PR DESCRIPTION
This adds an activate_generated_tasks parameter, which allows for specifying variant/task pairs as part of the version parameters. auto_task_all will generate all of those variant/task pairs with activate:true s that they are automatically run.

Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** DEVPROD-3617

**Whats Changed:**  
This adds an activate_generated_tasks parameter, which allows
for specifying variant/task pairs as part of the version
parameters. auto_task_all will generate all of those variant/task
pairs with activate:true so that they are automatically run.

**Patch testing results:**  
If applicable, link a patch test showing code changes running successfully

https://spruce.mongodb.com/version/659dcd8fa4cf477e674acaa1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

array_traversal and large_scale_long_lived in the patch above were activated automatically by this code.

**Workload Submission form:**  
If applicable, only required if there is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)

