### PR TITLE
PERF-5026: Enable TimeseriesBlockProcessing.yml workload on sys-perf-7.0

### DIFF
--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -411,4 +411,4 @@ AutoRun:
           - replica
           - replica-all-feature-flags
       branch_name:
-        $gte: v7.2
+        $gte: v7.0


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [PERF-5026](https://jira.mongodb.org/browse/PERF-5026)

**Whats Changed:**  
Enabling TimeseriesBlockProcessing workload in 7.0. This is required for timeseries perf dashboard to work.

**Patch testing results:**  
[Evergreen patch](https://spruce.mongodb.com/version/659fb60e562343ebe57cfebc/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
