### PR TITLE
PERF-5022: Fix sorter for $top and $bottom actors to match index in group_like_distinct

### DIFF
--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -77,6 +77,7 @@ Actors:
           c: {^RandomInt: {min: 0, max: 100}}
         Indexes:
           - keys: {a: 1, b: 1}
+          - keys: {b: 1}
 
 # The following use a DISTINCT_SCAN.
 - ActorFromTemplate:

--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -178,6 +178,7 @@ Actors:
       OnlyActiveInPhase: 15
       Pipeline: [{$group: {_id: "$a", accum: {$bottomN: {n: 1, output: ["$c"], sortBy: {a: 1, b: 1}}}}}]
 
+# Min and max are not included in SERVER-84347, but are here for completeness and for future work.
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:

--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -77,7 +77,6 @@ Actors:
           c: {^RandomInt: {min: 0, max: 100}}
         Indexes:
           - keys: {a: 1, b: 1}
-          - keys: {b: 1}
 
 # The following use a DISTINCT_SCAN.
 - ActorFromTemplate:
@@ -128,56 +127,56 @@ Actors:
     TemplateParameters:
       Name: "GroupTopCovered"
       OnlyActiveInPhase: 8
-      Pipeline: [{$group: {_id: "$a", accum: {$top: {output: ["$b"], sortBy: {b: 1}}}}}]
+      Pipeline: [{$group: {_id: "$a", accum: {$top: {output: ["$b"], sortBy: {a: 1, b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
       Name: "GroupTopFetched"
       OnlyActiveInPhase: 9
-      Pipeline: [{$group: {_id: "$a", accum: {$top: {output: ["$c"], sortBy: {b: 1}}}}}]
+      Pipeline: [{$group: {_id: "$a", accum: {$top: {output: ["$c"], sortBy: {a: 1, b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
       Name: "GroupBottomCovered"
       OnlyActiveInPhase: 10
-      Pipeline: [{$group: {_id: "$a", accum: {$bottom: {output: ["$b"], sortBy: {b: 1}}}}}]
+      Pipeline: [{$group: {_id: "$a", accum: {$bottom: {output: ["$b"], sortBy: {a: 1, b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
       Name: "GroupBottomFetched"
       OnlyActiveInPhase: 11
-      Pipeline: [{$group: {_id: "$a", accum: {$bottom: {output: ["$c"], sortBy: {b: 1}}}}}]
+      Pipeline: [{$group: {_id: "$a", accum: {$bottom: {output: ["$c"], sortBy: {a: 1, b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
       Name: "GroupTopNCovered"
       OnlyActiveInPhase: 12
-      Pipeline: [{$group: {_id: "$a", accum: {$topN: {n: 1, output: ["$b"], sortBy: {b: 1}}}}}]
+      Pipeline: [{$group: {_id: "$a", accum: {$topN: {n: 1, output: ["$b"], sortBy: {a: 1, b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
       Name: "GroupTopNFetched"
       OnlyActiveInPhase: 13
-      Pipeline: [{$group: {_id: "$a", accum: {$topN: {n: 1, output: ["$c"], sortBy: {b: 1}}}}}]
+      Pipeline: [{$group: {_id: "$a", accum: {$topN: {n: 1, output: ["$c"], sortBy: {a: 1, b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
       Name: "GroupBottomNCovered"
       OnlyActiveInPhase: 14
-      Pipeline: [{$group: {_id: "$a", accum: {$bottomN: {n: 1, output: ["$b"], sortBy: {b: 1}}}}}]
+      Pipeline: [{$group: {_id: "$a", accum: {$bottomN: {n: 1, output: ["$b"], sortBy: {a: 1, b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand
     TemplateParameters:
       Name: "GroupBottomNFetched"
       OnlyActiveInPhase: 15
-      Pipeline: [{$group: {_id: "$a", accum: {$bottomN: {n: 1, output: ["$c"], sortBy: {b: 1}}}}}]
+      Pipeline: [{$group: {_id: "$a", accum: {$bottomN: {n: 1, output: ["$c"], sortBy: {a: 1, b: 1}}}}}]
 
 - ActorFromTemplate:
     TemplateName: RunAggCommand


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [PERF-5022](https://jira.mongodb.org/browse/PERF-5022)

**Whats Changed:**  
Added an additional index to match the sorter in the actors for $top and $bottom, so that once https://jira.mongodb.org/browse/SERVER-84347 is complete, these will run with a distinct scan