### PR TITLE
DEVPROD-3840: Fix auto_tasks_all to handle empty parameter.

### DIFF
--- a/src/lamplib/src/genny/tasks/auto_tasks_all.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_all.py
@@ -61,6 +61,23 @@ def create_configuration(
     return config
 
 
+def parse_activate_generated_tasks(activate_generated_tasks_param):
+    activate_tasks = set()
+    if not activate_generated_tasks_param:
+        return activate_tasks
+    variant_task_names = activate_generated_tasks_param.split(",")
+    for name in variant_task_names:
+        if ":" not in name:
+            raise ValueError(
+                "Invalid value for 'activate_generated_tasks' param. Value must be of the form 'variant1:task1,variant2:task2'"
+            )
+        variant_name, task_name = name.strip().split(":")
+        variant_task = VariantTask(variant_name, task_name)
+        activate_tasks.add(variant_task)
+
+    return activate_tasks
+
+
 def main(project_files: List[str], workspace_root: str, no_activate: bool) -> None:
     reader = YamlReader()
     try:
@@ -72,12 +89,9 @@ def main(project_files: List[str], workspace_root: str, no_activate: bool) -> No
         sys.exit(1)
     execution = int(global_expansions["execution"])
 
-    variant_task_names = global_expansions.get("activate_generated_tasks", "").split(",")
-    activate_tasks = set()
-    for name in variant_task_names:
-        variant_name, task_name = name.strip().split(":")
-        variant_task = VariantTask(variant_name, task_name)
-        activate_tasks.add(variant_task)
+    activate_tasks = parse_activate_generated_tasks(
+        global_expansions.get("activate_generated_tasks", "")
+    )
 
     builds = []
     for project_file in project_files:

--- a/src/lamplib/src/tests/test_auto_tasks_all.py
+++ b/src/lamplib/src/tests/test_auto_tasks_all.py
@@ -16,7 +16,11 @@ from genny.tasks.auto_tasks import (
     YamlReader,
     VariantTask,
 )
-from genny.tasks.auto_tasks_all import create_configuration, get_all_builds
+from genny.tasks.auto_tasks_all import (
+    create_configuration,
+    get_all_builds,
+    parse_activate_generated_tasks,
+)
 import genny.tasks.auto_tasks_all
 from tests.test_auto_tasks import MockFile, MockReader
 
@@ -423,6 +427,22 @@ buildvariants:
                     }
                 ),
             ],
+        )
+
+    def test_parse_activate_generated_tasks(self):
+        parsed_tasks = parse_activate_generated_tasks("")
+        self.assertEqual(parsed_tasks, set())
+
+        def try_invalid_string():
+            parse_activate_generated_tasks("a:b,c")
+
+        self.assertRaisesRegex(
+            ValueError, "Invalid value for 'activate_generated_tasks'", try_invalid_string
+        )
+
+        parsed_tasks = parse_activate_generated_tasks("variant1:task1,variant2:task2")
+        self.assertEqual(
+            parsed_tasks, set([VariantTask("variant1", "task1"), VariantTask("variant2", "task2")])
         )
 
 


### PR DESCRIPTION
Python string.split on an empty string doesn't return an empty list, so this was crashing task generation. Add some tests, a little bit of error handling, and handle the empty case.

Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** [DEVPROD-3840](https://jira.mongodb.org/browse/DEVPROD-3840)

**Whats Changed:**  
Fix the parsing for the activate_generated_tasks parameter

**Patch testing results:**  
Blank activate_generated_tasls: https://spruce.mongodb.com/version/65a8036dc9ec44646ff8b242/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
Single Task Specified: https://spruce.mongodb.com/version/65a80399d6d80a7ced3a340a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

