### PR TITLE
SERVER-84674 Add queries with longer common path prefixes

### DIFF
--- a/src/phases/query/RepeatedPathTraversal.yml
+++ b/src/phases/query/RepeatedPathTraversal.yml
@@ -71,14 +71,14 @@ Actors:
         DocumentCount: *DocumentCount
         BatchSize: 1000
         Document: {
-          a: [{ ^Repeat: { count: 3, fromGenerator: { b: [&NestedDoc { c: 0, d: 0, e: 0, f: 0, g: 0, h: 0, i: 0, j: 0, k: 0, l: 0}]}}}],
-          # 5 levels deep, every other level repeat twice.
+          a: [{ ^Repeat: { count: 3, fromGenerator: { b: [&InnerDoc { c: 0, d: 0, e: 0, f: 0, g: 0, h: 0, i: 0, j: 0, k: 0, l: 0}]}}}],
+          # 5 levels deep, every other level repeats twice.
           deep5: [
             &f1_ {f1: [
               {f2: [
                 &f3_ {f3: [
                   {f4: [
-                    &f5_ {f5: [*NestedDoc]},
+                    &f5_ {f5: [*InnerDoc]},
                     *f5_,
                   ]},
                 ]},
@@ -98,7 +98,7 @@ Actors:
                         &f7 {f7: [
                           {f8: [
                             &f9 {f9: [
-                              {f10: [*NestedDoc]},
+                              {f10: [*InnerDoc]},
                             ]},
                             *f9,
                           ]},

--- a/src/phases/query/RepeatedPathTraversal.yml
+++ b/src/phases/query/RepeatedPathTraversal.yml
@@ -72,52 +72,45 @@ Actors:
         BatchSize: 1000
         Document: {
           a: [{ ^Repeat: { count: 3, fromGenerator: { b: [&NestedDoc { c: 0, d: 0, e: 0, f: 0, g: 0, h: 0, i: 0, j: 0, k: 0, l: 0}]}}}],
-          # 5 levels deep, each level repeats twice.
+          # 5 levels deep, every other level repeat twice.
           deep5: [
             &f1_ {f1: [
-              &f2_ {f2: [
+              {f2: [
                 &f3_ {f3: [
-                  &f4_ {f4: [
+                  {f4: [
                     &f5_ {f5: [*NestedDoc]},
                     *f5_,
                   ]},
-                  *f4_,
                 ]},
                 *f3_,
               ]},
-              *f2_,
             ]},
             *f1_,
           ],
-          # 10 levels deep, each level repeats twice.
+          # 10 levels deep, every other level repeats twice.
           deep10: [
             &f1 {f1: [
-              &f2 {f2: [
+              {f2: [
                 &f3 {f3: [
-                  &f4 {f4: [
+                  {f4: [
                     &f5 {f5: [
-                      &f6 {f6: [
+                      {f6: [
                         &f7 {f7: [
-                          &f8 {f8: [
+                          {f8: [
                             &f9 {f9: [
-                              &f10 {f10: [*NestedDoc]},
-                              *f10,
+                              {f10: [*NestedDoc]},
                             ]},
                             *f9,
                           ]},
-                          *f8,
                         ]},
                         *f7,
                       ]},
-                      *f6,
                     ]},
                     *f5,
                   ]},
-                  *f4,
                 ]},
                 *f3,
               ]},
-              *f2,
             ]},
             *f1,
           ],

--- a/src/phases/query/RepeatedPathTraversal.yml
+++ b/src/phases/query/RepeatedPathTraversal.yml
@@ -1,0 +1,471 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: >
+  This workload stresses the query execution engine by running queries over a set of paths which
+  share a common prefix. Crucially, these queries never match a document in the collection.
+
+Keywords:
+- Loader
+- CrudActor
+- QuiesceActor
+- insert
+- find
+
+GlobalDefaults:
+  Database: &Database {^Parameter: {Name: Database, Default: unused}}
+  Repeat: &Repeat {^Parameter: {Name: Repeat, Default: -1}}
+  DocumentCount: &DocumentCount {^Parameter: {Name: DocumentCount, Default: -1}}
+  Collection: &Collection Collection0
+  Threads: &Threads 1
+  MaxPhases: &MaxPhases 20
+
+ActorTemplates:
+- TemplateName: FindQueryTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: "unused"}}
+    Type: CrudActor
+    Database: *Database
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "ActivePhase", Default: -1}}]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Repeat: *Repeat
+          Collection: *Collection
+          Operations:
+          - OperationName: find
+            OperationCommand:
+              Filter: {^Parameter: {Name: "Filter", Default: "invalid"}}
+
+Actors:
+# Clear any pre-existing collection state.
+- Name: ClearCollection
+  Type: CrudActor
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Collection: *Collection
+        Operations:
+        - OperationName: drop
+
+# Insert documents with 2 levels of nested arrays where the leaves contain many fields. This test
+# targets workloads where the paths queried share a common prefix ("a.b.c", "a.b.d", and so on).
+- Name: InsertRepeatedPathTraversalData
+  Type: Loader
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Threads: 1
+        CollectionCount: 1
+        DocumentCount: *DocumentCount
+        BatchSize: 1000
+        Document: {
+          a: [{ ^Repeat: { count: 3, fromGenerator: { b: [&NestedDoc { c: 0, d: 0, e: 0, f: 0, g: 0, h: 0, i: 0, j: 0, k: 0, l: 0}]}}}],
+          # 5 levels deep, each level repeats twice.
+          deep5: [
+            &f1_ {f1: [
+              &f2_ {f2: [
+                &f3_ {f3: [
+                  &f4_ {f4: [
+                    &f5_ {f5: [*NestedDoc]},
+                    *f5_,
+                  ]},
+                  *f4_,
+                ]},
+                *f3_,
+              ]},
+              *f2_,
+            ]},
+            *f1_,
+          ],
+          # 10 levels deep, each level repeats twice.
+          deep10: [
+            &f1 {f1: [
+              &f2 {f2: [
+                &f3 {f3: [
+                  &f4 {f4: [
+                    &f5 {f5: [
+                      &f6 {f6: [
+                        &f7 {f7: [
+                          &f8 {f8: [
+                            &f9 {f9: [
+                              &f10 {f10: [*NestedDoc]},
+                              *f10,
+                            ]},
+                            *f9,
+                          ]},
+                          *f8,
+                        ]},
+                        *f7,
+                      ]},
+                      *f6,
+                    ]},
+                    *f5,
+                  ]},
+                  *f4,
+                ]},
+                *f3,
+              ]},
+              *f2,
+            ]},
+            *f1,
+          ],
+        }
+
+- Name: QuiesceRepeatedPathTraversalData
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+
+- Name: AggregationExpressionRepeatedPathTraversal
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Collection: *Collection
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {$expr: {$or: [
+              {$eq: ["$a.b.c", 1]},
+              {$eq: ["$a.b.d", 1]},
+              {$eq: ["$a.b.e", 1]},
+              {$eq: ["$a.b.f", 1]},
+              {$eq: ["$a.b.g", 1]}]}}
+
+- Name: MatchExpressionRepeatedPathTraversal
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [4]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Collection: *Collection
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: { $or: [
+              {"a.b.c": 1},
+              {"a.b.d": 1},
+              {"a.b.e": 1},
+              {"a.b.f": 1},
+              {"a.b.g": 1}]}
+
+- Name: AggregationExpressionRepeatedPathTraversalInequality
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Collection: *Collection
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {$expr:
+                       {$or: [
+                         {$ne: ["$a.b.c", "$a.b.d"]},
+                         {$ne: ["$a.b.d", "$a.b.e"]},
+                         {$ne: ["$a.b.e", "$a.b.f"]},
+                         {$ne: ["$a.b.f", "$a.b.g"]},
+                         {$ne: ["$a.b.g", "$a.b.c"]}]}}
+
+- Name: MatchExpressionRepeatedPathTraversalInequality
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [6]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Collection: *Collection
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {$or: [{"a.b.c": {$ne: 0}},
+                           {"a.b.d": {$ne: 0}},
+                           {"a.b.e": {$ne: 0}},
+                           {"a.b.f": {$ne: 0}},
+                           {"a.b.g": {$ne: 0}}]}
+
+# Double the number of clauses.
+- Name: AggregationExpressionRepeatedPathTraversalWidePredicate
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [7]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Collection: *Collection
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter:
+              {$expr: {$or: [
+                {$eq: ["$a.b.c", 1]},
+                {$eq: ["$a.b.d", 1]},
+                {$eq: ["$a.b.e", 1]},
+                {$eq: ["$a.b.f", 1]},
+                {$eq: ["$a.b.g", 1]},
+                {$eq: ["$a.b.h", 1]},
+                {$eq: ["$a.b.i", 1]},
+                {$eq: ["$a.b.j", 1]},
+                {$eq: ["$a.b.k", 1]},
+                {$eq: ["$a.b.l", 1]}]}}
+
+- Name: MatchExpressionRepeatedPathTraversalWidePredicate
+  Type: CrudActor
+  Database: *Database
+  Threads: *Threads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [8]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: *Repeat
+        Collection: *Collection
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter: {$or: [
+              {"a.b.c": 1},
+              {"a.b.d": 1},
+              {"a.b.e": 1},
+              {"a.b.f": 1},
+              {"a.b.g": 1},
+              {"a.b.h": 1},
+              {"a.b.i": 1},
+              {"a.b.j": 1},
+              {"a.b.k": 1},
+              {"a.b.l": 1}]}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: MatchExpressionRepeatedPathTraversal5LevelsDeep
+      ActivePhase: 9
+      Filter:
+        {$or: [
+          {"deep5.f1.f2.f3.f4.f5.c": 1},
+          {"deep5.f1.f2.f3.f4.f5.d": 1},
+          {"deep5.f1.f2.f3.f4.f5.e": 1},
+          {"deep5.f1.f2.f3.f4.f5.f": 1},
+          {"deep5.f1.f2.f3.f4.f5.g": 1}]}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: MatchExpressionRepeatedPathTraversal10LevelsDeep
+      ActivePhase: 10
+      Filter:
+        {$or: [
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.c": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.d": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.e": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.f": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.g": 1}]}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: MatchExpressionRepeatedPathTraversalInequality5LevelsDeep
+      ActivePhase: 11
+      Filter:
+        {$or: [
+          {"deep5.f1.f2.f3.f4.f5.c": {$ne: 0}},
+          {"deep5.f1.f2.f3.f4.f5.d": {$ne: 0}},
+          {"deep5.f1.f2.f3.f4.f5.e": {$ne: 0}},
+          {"deep5.f1.f2.f3.f4.f5.f": {$ne: 0}},
+          {"deep5.f1.f2.f3.f4.f5.g": {$ne: 0}}]}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: MatchExpressionRepeatedPathTraversalInequality10LevelsDeep
+      ActivePhase: 12
+      Filter:
+        {$or: [
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.c": {$ne: 0}},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.d": {$ne: 0}},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.e": {$ne: 0}},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.f": {$ne: 0}},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.g": {$ne: 0}}]}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: MatchExpressionRepeatedPathTraversalWidePredicate5LevelsDeep
+      ActivePhase: 13
+      Filter:
+        {$or: [
+          {"deep5.f1.f2.f3.f4.f5.c": 1},
+          {"deep5.f1.f2.f3.f4.f5.d": 1},
+          {"deep5.f1.f2.f3.f4.f5.e": 1},
+          {"deep5.f1.f2.f3.f4.f5.f": 1},
+          {"deep5.f1.f2.f3.f4.f5.g": 1},
+          {"deep5.f1.f2.f3.f4.f5.h": 1},
+          {"deep5.f1.f2.f3.f4.f5.i": 1},
+          {"deep5.f1.f2.f3.f4.f5.j": 1},
+          {"deep5.f1.f2.f3.f4.f5.k": 1},
+          {"deep5.f1.f2.f3.f4.f5.l": 1},
+        ]}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: MatchExpressionRepeatedPathTraversalWidePredicate10LevelsDeep
+      ActivePhase: 14
+      Filter:
+        {$or: [
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.c": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.d": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.e": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.f": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.g": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.h": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.i": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.j": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.k": 1},
+          {"deep10.f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.l": 1},
+        ]}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: ElemMatchMatchExpressionRepeatedPathTraversal5LevelsDeep
+      ActivePhase: 15
+      Filter:
+        {deep5: {$elemMatch: {$or: [
+          {"f1.f2.f3.f4.f5.c": 1},
+          {"f1.f2.f3.f4.f5.d": 1},
+          {"f1.f2.f3.f4.f5.e": 1},
+          {"f1.f2.f3.f4.f5.f": 1},
+          {"f1.f2.f3.f4.f5.g": 1}]}}}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: ElemMatchMatchExpressionRepeatedPathTraversal10LevelsDeep
+      ActivePhase: 16
+      Filter:
+        {deep10: {$elemMatch: {$or: [
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.c": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.d": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.e": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.f": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.g": 1}]}}}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: ElemMatchMatchExpressionRepeatedPathTraversalInequality5LevelsDeep
+      ActivePhase: 17
+      Filter:
+        {deep5: {$elemMatch: {$or: [
+          {"f1.f2.f3.f4.f5.c": {$ne: 0}},
+          {"f1.f2.f3.f4.f5.d": {$ne: 0}},
+          {"f1.f2.f3.f4.f5.e": {$ne: 0}},
+          {"f1.f2.f3.f4.f5.f": {$ne: 0}},
+          {"f1.f2.f3.f4.f5.g": {$ne: 0}}]}}}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: ElemMatchMatchExpressionRepeatedPathTraversalInequality10LevelsDeep
+      ActivePhase: 18
+      Filter:
+        {deep10: {$elemMatch: {$or: [
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.c": {$ne: 0}},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.d": {$ne: 0}},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.e": {$ne: 0}},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.f": {$ne: 0}},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.g": {$ne: 0}}]}}}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: ElemMatchMatchExpressionRepeatedPathTraversalWidePredicate5LevelsDeep
+      ActivePhase: 19
+      Filter:
+        {deep5: {$elemMatch: {$or: [
+          {"f1.f2.f3.f4.f5.c": 1},
+          {"f1.f2.f3.f4.f5.d": 1},
+          {"f1.f2.f3.f4.f5.e": 1},
+          {"f1.f2.f3.f4.f5.f": 1},
+          {"f1.f2.f3.f4.f5.g": 1},
+          {"f1.f2.f3.f4.f5.h": 1},
+          {"f1.f2.f3.f4.f5.i": 1},
+          {"f1.f2.f3.f4.f5.j": 1},
+          {"f1.f2.f3.f4.f5.k": 1},
+          {"f1.f2.f3.f4.f5.l": 1},
+        ]}}}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      Name: ElemMatchMatchExpressionRepeatedPathTraversalWidePredicate10LevelsDeep
+      ActivePhase: 20
+      Filter:
+        {deep10: {$elemMatch: {$or: [
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.c": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.d": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.e": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.f": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.g": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.h": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.i": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.j": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.k": 1},
+          {"f1.f2.f3.f4.f5.f6.f7.f8.f9.f10.l": 1},
+        ]}}}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-heuristic-bonsai
+      - standalone-sampling-bonsai
+      - standalone-sbe
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0

--- a/src/phases/query/RepeatedPathTraversal.yml
+++ b/src/phases/query/RepeatedPathTraversal.yml
@@ -72,47 +72,41 @@ Actors:
         BatchSize: 1000
         Document: {
           a: [{ ^Repeat: { count: 3, fromGenerator: { b: [&InnerDoc { c: 0, d: 0, e: 0, f: 0, g: 0, h: 0, i: 0, j: 0, k: 0, l: 0}]}}}],
-          # 5 levels deep, every other level repeats twice.
+          # 5 levels deep
           deep5: [
-            &f1_ {f1: [
+            {f1: [
               {f2: [
-                &f3_ {f3: [
+                {f3: [
                   {f4: [
-                    &f5_ {f5: [*InnerDoc]},
-                    *f5_,
+                    {f5: [*InnerDoc]},
+                    {f5: [*InnerDoc]},
                   ]},
                 ]},
-                *f3_,
               ]},
             ]},
-            *f1_,
           ],
-          # 10 levels deep, every other level repeats twice.
+          # 10 levels deep
           deep10: [
-            &f1 {f1: [
+            {f1: [
               {f2: [
-                &f3 {f3: [
+                {f3: [
                   {f4: [
-                    &f5 {f5: [
+                    {f5: [
                       {f6: [
-                        &f7 {f7: [
+                        {f7: [
                           {f8: [
-                            &f9 {f9: [
+                            {f9: [
+                              {f10: [*InnerDoc]},
                               {f10: [*InnerDoc]},
                             ]},
-                            *f9,
                           ]},
                         ]},
-                        *f7,
                       ]},
                     ]},
-                    *f5,
                   ]},
                 ]},
-                *f3,
               ]},
             ]},
-            *f1,
           ],
         }
 

--- a/src/workloads/query/RepeatedPathTraversalMedium.yml
+++ b/src/workloads/query/RepeatedPathTraversalMedium.yml
@@ -7,7 +7,7 @@ Description: >
 LoadConfig:
   Path: ../../phases/query/RepeatedPathTraversal.yml
   Parameters:
-    Database: RepeatedPathTraversalLarge
+    Database: RepeatedPathTraversalMedium
     DocumentCount: 10000
     Repeat: 1000
 

--- a/src/workloads/query/RepeatedPathTraversalMedium.yml
+++ b/src/workloads/query/RepeatedPathTraversalMedium.yml
@@ -8,8 +8,8 @@ LoadConfig:
   Path: ../../phases/query/RepeatedPathTraversal.yml
   Parameters:
     Database: RepeatedPathTraversalLarge
-    DocumentCount: 1e6
-    Repeat: 50
+    DocumentCount: 10000
+    Repeat: 1000
 
 AutoRun:
 - When:

--- a/src/workloads/query/RepeatedPathTraversalMedium.yml
+++ b/src/workloads/query/RepeatedPathTraversalMedium.yml
@@ -22,8 +22,4 @@ AutoRun:
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:
-      $neq:
-      - v4.0
-      - v4.2
-      - v4.4
-      - v5.0
+      $gte: v5.0

--- a/src/workloads/query/RepeatedPathTraversalSmall.yml
+++ b/src/workloads/query/RepeatedPathTraversalSmall.yml
@@ -7,7 +7,7 @@ Description: >
 LoadConfig:
   Path: ../../phases/query/RepeatedPathTraversal.yml
   Parameters:
-    Database: RepeatedPathTraversalLarge
+    Database: RepeatedPathTraversalSmall
     DocumentCount: 100
     Repeat: 1
 

--- a/src/workloads/query/RepeatedPathTraversalSmall.yml
+++ b/src/workloads/query/RepeatedPathTraversalSmall.yml
@@ -8,8 +8,8 @@ LoadConfig:
   Path: ../../phases/query/RepeatedPathTraversal.yml
   Parameters:
     Database: RepeatedPathTraversalLarge
-    DocumentCount: 1e6
-    Repeat: 50
+    DocumentCount: 100
+    Repeat: 1
 
 AutoRun:
 - When:

--- a/src/workloads/query/RepeatedPathTraversalSmall.yml
+++ b/src/workloads/query/RepeatedPathTraversalSmall.yml
@@ -9,7 +9,7 @@ LoadConfig:
   Parameters:
     Database: RepeatedPathTraversalSmall
     DocumentCount: 100
-    Repeat: 1
+    Repeat: 10000
 
 AutoRun:
 - When:

--- a/src/workloads/query/RepeatedPathTraversalSmall.yml
+++ b/src/workloads/query/RepeatedPathTraversalSmall.yml
@@ -22,8 +22,4 @@ AutoRun:
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:
-      $neq:
-      - v4.0
-      - v4.2
-      - v4.4
-      - v5.0
+      $gte: v5.0


### PR DESCRIPTION
Thanks for submitting a PR to the Genny repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** SERVER-84674

**Whats Changed:**  
Extend the RepeatedPathTraversal workload by:
- Adding queries with longer common path prefixes
- Running it against collections of 100 and 10K documents (it was already running on 1M docs).

**Patch testing results:**  
~[Patch](https://spruce.mongodb.com/version/65aa739f57e85a363231dc2c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)~
[Patch #2](https://spruce.mongodb.com/version/65ae4e0e850e61cdd0aefbe8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)