### PR TITLE
SERVER-85660: fix streams passthrough change stream source workload

### DIFF
--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -879,6 +879,11 @@ Tests:
     ThenReturns:
     - { "int" : { "$numberLong" : "2000000000"}}
 
+  - Name: NowTimestamp
+    GivenTemplate:
+      date: {^NowTimestamp: {}}
+    ThenExecuteAndIgnore: true
+
   - Name: Now
     GivenTemplate:
       date: {^Now: {}}

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -149,6 +149,9 @@ Actors:
             # See ChooseFromDataset.yml for full documentation on this generator
             airportDataSet: {^ChooseFromDataset: {"path": "./src/genny/src/workloads/datasets/airports_codes.txt"}}
 
+            # Generate the current timestamp
+            nowTimestamp: {^NowTimestamp: {}}
+
             # Generate the current Date
             now: {^Now: {}}
 

--- a/src/workloads/streams/Passthrough_ChangeStreamSource.yml
+++ b/src/workloads/streams/Passthrough_ChangeStreamSource.yml
@@ -33,6 +33,12 @@ GlobalDefaults:
     *Channel
   ]}}
 
+  # Used for `startAtOperationTime` when creating the stream processor so that it starts
+  # consuming from the beginning of the mongo collection. It is important that this used
+  # with `FixedGeneratedValue` so that the timestamp is generated before the documents
+  # start being inserted into the mongo collection.
+  StartTimestamp: &StartTimestamp {^FixedGeneratedValue: { fromGenerator: {^NowTimestamp: {}}}}
+
   Document: &Document
     auction: {^Inc: { start: 1000, multipler: 1 }}
     bidder: {^Inc: { start: 1000, multipler: 1 }}
@@ -49,15 +55,16 @@ Actors:
   Threads: *NumThreads
   Phases:
   - Phase: 0
-    Nop: true
-  - Phase: 1
     Repeat: *NumInputDocumentsPerThread
     Collection: *InputCollectionName
     Operations:
     - OperationName: insertOne
       OperationCommand:
         Document: *Document
-  - Phase: 2
+        Options:
+          WriteConcern:
+            Level: Majority
+  - Phase: 1..3
     Nop: true
 
 - Name: Setup
@@ -66,6 +73,8 @@ Actors:
   Threads: 1
   Phases:
   - Phase: 0
+    Nop: true
+  - Phase: 1
     Repeat: 1
     Database: *DatabaseName
     Operations:
@@ -79,7 +88,10 @@ Actors:
             $source: {
               connectionName: "db",
               db: *DatabaseName,
-              coll: *InputCollectionName
+              coll: *InputCollectionName,
+              config: {
+                  startAtOperationTime: *StartTimestamp
+              }
             }
           },
           { $replaceRoot: { newRoot: "$fullDocument" } },
@@ -94,9 +106,9 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "db", type: "atlas", options: { uri: {^ClientURI: { Name: "Default" }}}}]
-  - Phase: 1
-    Nop: true
   - Phase: 2
+    Nop: true
+  - Phase: 3
     Repeat: 1
     Database: *DatabaseName
     Operations:
@@ -112,11 +124,11 @@ Actors:
   Database: *DatabaseName
   Threads: 1
   Phases:
-  - Phase: 0
+  - Phase: 0..1
     Nop: true
-  - Phase: 1
+  - Phase: 2
     Repeat: 1
     StreamProcessorName: *StreamProcessorName
     ExpectedDocumentCount: *ExpectedDocumentCount
-  - Phase: 2
+  - Phase: 3
     Nop: true


### PR DESCRIPTION
**Jira Ticket:** SERVER-85660

**Whats Changed:**  
The change stream source should only be consumed after all documents have been written and durably persisted in the mongo collection, so the stream processor should be started after all the documents have been added to the source collection. In order to this we need to use `startAtOperationTime` in the $source.config to tell the stream processor to consume the documents in the change stream source from the beginning. It doesn't seem like there is a great way to generate a BSON timestamp object that mongo IDL likes through genny YAML or through the existing generators, so added `{^NowTimestamp: {}}` generator for BSON timestamps, similar to BSON date generators. (NOTE: None of the BSON date generators work here because the mongo IDL explicitly wants a BSON timestamp object for `startAtOperationTime`).

https://spruce.mongodb.com/version/65b1402f5623438e33194272/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC