### PR TITLE
DEVPROD-4562 Update timeout_secs

### DIFF
--- a/src/lamplib/src/genny/tasks/auto_tasks.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks.py
@@ -578,7 +578,7 @@ class ConfigWriter:
                 [
                     CommandDefinition()
                     .command("timeout.update")
-                    .params({"exec_timeout_secs": 86400, "timeout_secs": 7200}),  # 24 hours
+                    .params({"exec_timeout_secs": 86400, "timeout_secs": 86400}),  # 24 hours
                     CommandDefinition().function("f_run_dsi_workload").vars(bootstrap),
                 ]
             )

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -90,7 +90,7 @@ class BaseTestClass(unittest.TestCase):
 
 TIMEOUT_COMMAND = {
     "command": "timeout.update",
-    "params": {"exec_timeout_secs": 86400, "timeout_secs": 7200},
+    "params": {"exec_timeout_secs": 86400, "timeout_secs": 86400},
 }
 
 

--- a/src/lamplib/src/tests/test_auto_tasks_all.py
+++ b/src/lamplib/src/tests/test_auto_tasks_all.py
@@ -70,7 +70,7 @@ class BaseTestClass(unittest.TestCase):
 
 TIMEOUT_COMMAND = {
     "command": "timeout.update",
-    "params": {"exec_timeout_secs": 86400, "timeout_secs": 7200},
+    "params": {"exec_timeout_secs": 86400, "timeout_secs": 86400},
 }
 
 


### PR DESCRIPTION
Auto-generated tasks are currently generated with a 7200 (2h) idle timeout, which can not be overridden by users.

Since this timeout [duplicates DSI's no_output_ms ](https://github.com/10gen/dsi/blob/62d5572cebf887e260fe25231e4decc95db9d9f5/configurations/test_control/defaults.original.yml#L8), my suggestion would be to make timeout_secs equal to exec_timeout_secs, which defacto disables the evergreen idle timeout for these tasks. This way, we only have the DSI idle timeout that can be more easily configured by users.