### PR TITLE
PERF-5144 Add workload generating write conflicts on large document

### DIFF
--- a/src/lamplib/src/genny/tasks/dry_run.py
+++ b/src/lamplib/src/genny/tasks/dry_run.py
@@ -48,6 +48,7 @@ def dry_run_workload(
         "MajorityWrites10KThreads.yml",
         "ConnectionPoolStress.yml",
         "SinusoidalReadWrites.yml",
+        "UpdateSingleLargeDocumentWith10kThreads.yml",
     ]:
         SLOG.info("TIG-1435 skipping dry run on macOS", file=yaml_file_path)
         return

--- a/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
+++ b/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
@@ -7,6 +7,15 @@ Description: >
   integer field, the command itself is relatively small, so most of the memory pressure should come
   from the query subsystem.
 
+Keywords:
+- CrudActor
+- Loader
+- memory
+- scale
+- stress
+- updateOne
+- WriteConflict
+
 GlobalDefaults:
   MaxPhases: &MaxPhases 2
 
@@ -49,7 +58,7 @@ Actors:
       Active: [1]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        Duration: 3 minutes
+        Blocking: None
         Collection: Collection0
         Operations:
         - OperationName: updateOne

--- a/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
+++ b/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
@@ -1,0 +1,69 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: >
+  The workload inserts a single large document, and tests concurrently updating the same document
+  with many threads. This is intended to test the behavior of the server under heave memory pressure
+  caused by update operations with a high rate of write conflicts. The update operation is on an
+  integer field, the command itself is relatively small, so most of the memory pressure should come
+  from the query subsystem.
+
+GlobalDefaults:
+  MaxPhases: &MaxPhases 2
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 10100
+
+Actors:
+
+# Phases:
+# 1. Insert a single document close to the 16MiB limit.
+# 2. Use 10k threads attempting to update the same document.
+
+- Name: InsertData
+  Type: Loader
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Database: &DB test
+        Repeat: 1
+        Threads: 1
+        CollectionCount: 1  # Collection name will be Collection0, this is not configurable.
+        DocumentCount: 1
+        BatchSize: 1
+        Document:
+          _id: 0
+          data: {^FastRandomString: {length: 16000000}}
+          a: 0
+
+- Name: PerformUpdates
+  Type: CrudActor
+  Database: *DB
+  Threads: 10000
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Duration: 3 minutes
+        Collection: Collection0
+        Operations:
+        - OperationName: updateOne
+          OperationCommand:
+            Filter: {_id: 0 }
+            Update: {$set: {a: { ^RandomInt: { min: 0, max: 10000000 }}}}
+            Options:
+              WriteConcern:
+              Level: majority
+
+# The workload is expected to cause an OOM kill. Keep AutoRun disabled.
+# AutoRun:
+# - When:
+#     mongodb_setup:
+#       $eq:
+#       - single-replica
+

--- a/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
+++ b/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
@@ -58,7 +58,7 @@ Actors:
       Active: [1]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        Blocking: None
+        Duration: 10 minutes
         Collection: Collection0
         Operations:
         - OperationName: updateOne


### PR DESCRIPTION
**Jira Ticket:** [PERF-5144](https://jira.mongodb.org/browse/PERF-5144)

**Whats Changed:**  
Adds a workload with 10k threads attempting to update the same 16MiB document. The large amount of write conflict retries, and the memory which is held while retrying, eventually causes an OOM kill.

**Workload Submission form:**  
If applicable, only required if there is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)
