### PR TITLE
DEVPROD-4593 Default to enabling optimisations and using release vcpkg libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,15 @@ cmake_policy(SET CMP0110 OLD)
 # src/CMakeList.txt, src/gennylib/CMakeLists.txt and src/gennylib/src/version.cpp
 project(genny VERSION 0.0.1 LANGUAGES CXX)
 
+# Many of the wrapped usages of Genny do not set the build type, so we default
+# to Release, which is likely what they want.
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+endif()
+
+# Include Genny toolchain cmake file, now build type is set
+include(${GENNY_TOOLCHAIN_DIR}/scripts/buildsystems/vcpkg.cmake)
+
 # Include our local cmake folder in the module path
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -134,7 +134,7 @@ should look something like this:
 ```bash
 -G some-build-system \
 -DCMAKE_PREFIX_PATH=/data/mci/gennytoolchain/installed/x64-osx-shared \
--DCMAKE_TOOLCHAIN_FILE=/data/mci/gennytoolchain/scripts/buildsystems/vcpkg.cmake \
+-DGENNY_TOOLCHAIN_DIR=/data/mci/gennytoolchain/ \
 -DVCPKG_TARGET_TRIPLET=x64-osx-static
 ```
 

--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -177,15 +177,10 @@ def cmake(
         ),
     ]
 
-    cmake_toolchain_file = os.path.join(
-        toolchain_info.toolchain_dir, "scripts/buildsystems/vcpkg.cmake"
-    )
-
     cmake_cmd += [
         "-DGENNY_WORKSPACE_ROOT={}".format(workspace_root),
-        # "-DGENNY_REPO_ROOT={}".format(genny_repo_root),  # Not needed (yet).
+        "-DGENNY_TOOLCHAIN_DIR={}".format(toolchain_info.toolchain_dir),
         "-DCMAKE_PREFIX_PATH={}".format(";".join(cmake_prefix_paths)),
-        "-DCMAKE_TOOLCHAIN_FILE={}".format(cmake_toolchain_file),
         "-DCMAKE_EXPORT_COMPILE_COMMANDS=1",
         f"-DVCPKG_TARGET_TRIPLET={toolchain_info.triplet_arch}-{toolchain_info.triplet_os}",
     ]


### PR DESCRIPTION
**Ticket**: [DEVPROD-4593](https://jira.mongodb.org/browse/DEVPROD-4593): _Fix Genny compiling without optimization and linking against libraries with debug symbols_

Genny's compilation does not set a default `CMAKE_BUILD_TYPE`, meaning it doesn't build with any optimisations set, nor does it build with debug symbols. Regrettably, when `vcpkg` is imported, the lack of a default causes CMake to link against the `gennytoolchain` debug libraries.

The requirement to set `CMAKE_BUILD_TYPE=Release` for build optimisations doesn't seem to be widely known among users of Genny, and linking the toolchain against debug libraries is inappropriate as a default behavior.

#### What's changed

- The generated `vcpkg` toolchain is imported into Genny's CMake system. This allows it to recognize any variables set in the CMake process along with any variables set in the CLI arguments.
- If not already set, the `CMAKE_BUILD_TYPE` defaults to `Release`.

#### Testing

Compile time with this PR was measured at ~2 min 40s ([here](https://evergreen.mongodb.com/task_log_raw/sys_perf_perf_3_node_replSet.arm.aws.2023_11_mixed_workloads_genny_rate_limited_high_value_patch_48a18fad18098b7ef67e65f763382ddc75320e47_65cda4883e8e86c4da93818b_24_02_15_05_46_24/0?type=T)) and without at ~1 min 40s ([here](https://spruce.mongodb.com/task/sys_perf_perf_3_node_replSet.arm.aws.2023_11_mixed_workloads_genny_5757f2e4ce595e3de14e6cc91d972ec9d1678f40_24_02_15_11_59_31/logs?execution=0&sortBy=STATUS&sortDir=ASC)). This was on a `r6g.2xlarge` with 5000 IOPS. This is 1 minute of extra overhead compiling.

There is a Performance Analyser test against high-value workloads available [here](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz?comparison_id=665c50c2-5c89-4181-984d-572eae14a543). I observed a change greater than 0.5 standard deviations in several metrics.

| **variant**                                     | **task**                                              | **test**                                    | **args**                               | **measurement**                |     **z_score** |
|:--------------------------------------------|:--------------------------------------------------|:----------------------------------------|:-----------------------------------|:---------------------------|------------:|
| perf-3-node-replSet.arm.aws-11         | expressive_queries_high_value                     | RunQueries.QueryWithProjectionWithIndex | {}                                 | Latency95thPercentile      |    -3.00382 |
| perf-3-node-replSet.arm.aws-11         | expressive_queries_high_value                     | RunQueries.QueryWithProjectionWithIndex | {}                                 | OperationThroughput        |     12.6143 |
| perf-3-node-replSet.arm.aws-11         | large_indexed_ins_high_value                      | FindLargeIn.find                        | {}                                 | OperationThroughput        |     1.09022 |
| perf-3-node-replSet.arm.aws-11         | load_test_high_value                              | InitialNoIndexes.TotalBulkInsert        | {}                                 | Latency95thPercentile      |    -14.4569 |
| perf-3-node-replSet.arm.aws-11         | load_test_high_value                              | InitialNoIndexes.TotalBulkInsert        | {}                                 | OperationThroughput        |     16.5204 |
| perf-3-node-replSet.arm.aws-11         | majority_reads10_k_threads_high_value             | WritingActor_90_10.WriteDocs            | {}                                 | Latency95thPercentile      |   -0.606211 |
| perf-3-node-replSet.arm.aws-11         | majority_reads10_k_threads_high_value             | ReadingActor_90_10.ReadDocs             | {}                                 | Latency95thPercentile      |    0.508891 |
| perf-3-node-replSet.arm.aws-11         | majority_reads10_k_threads_high_value             | WritingActor_90_10.WriteDocs            | {}                                 | OperationThroughput        |    0.743113 |
| perf-shard-lite-fle.arm.aws-11         | medical_workload_diagnosis_50_50_high_value       | InsertActor.FSM.query                   | {}                                 | OperationThroughput        |     29.8414 |
| perf-3-node-replSet-intel.intel.aws-11 | mixed_workloads_genny_rate_limited_high_value     | mixed_workloads_genny_rate_limited      | {"genny_phase_id": 2, "mongod": 2} | system cpu user (%) - mean |   -0.601603 |
| perf-3-node-replSet-intel.intel.aws-11 | mixed_workloads_genny_rate_limited_high_value     | mixed_workloads_genny_rate_limited      | {"genny_phase_id": 2, "mongod": 1} | system cpu user (%) - mean |   -0.683848 |
| perf-3-node-replSet-intel.intel.aws-11 | mixed_workloads_genny_rate_limited_high_value     | Find_250.findOne                        | {}                                 | Latency50thPercentile      |    -2.17444 |
| perf-3-node-replSet.arm.aws-11         | mixed_workloads_genny_rate_limited_high_value     | mixed_workloads_genny_rate_limited      | {"genny_phase_id": 2, "mongod": 2} | system cpu user (%) - mean |    -1.24776 |
| perf-3-node-replSet.arm.aws-11         | mixed_workloads_genny_rate_limited_high_value     | mixed_workloads_genny_rate_limited      | {"genny_phase_id": 2, "mongod": 1} | system cpu user (%) - mean |    -1.10271 |
| perf-3-node-replSet.arm.aws-11         | mixed_workloads_genny_rate_limited_high_value     | mixed_workloads_genny_rate_limited      | {"genny_phase_id": 2, "mongod": 0} | system cpu user (%) - mean |   -0.647131 |
| perf-3-node-replSet.arm.aws-11         | mixed_workloads_genny_rate_limited_high_value     | Find_250.findOne                        | {}                                 | Latency95thPercentile      |   -0.897709 |
| perf-3-node-replSet.arm.aws-11         | mixed_workloads_genny_rate_limited_high_value     | Find_250.findOne                        | {}                                 | Latency50thPercentile      |    -2.40254 |
| perf-3-node-replSet.arm.aws-11         | mixed_workloads_genny_rate_limited_high_value     | mixed_workloads_genny_rate_limited      | {"genny_phase_id": 0, "mongod": 2} | system cpu user (%) - mean |    0.668843 |
| perf-3-node-replSet.arm.aws-11         | mixed_workloads_genny_rate_limited_high_value     | Update_250.updateOne                    | {}                                 | Latency95thPercentile      |   -0.733831 |
| perf-3-node-replSet.arm.aws-11         | mixed_workloads_genny_rate_limited_high_value     | Update_250.updateOne                    | {}                                 | Latency50thPercentile      |   -0.804057 |
| perf-3-node-replSet.arm.aws-11         | time_series_sort_high_value                       | Queries.SortQueryBoundedSort            | {}                                 | Latency50thPercentile      | -0.00468112 |
| perf-3-node-replSet.arm.aws-11         | time_series_sort_high_value                       | Queries.SortQueryBoundedSort            | {}                                 | OperationThroughput        |    0.090991 |
| perf-shard-lite-fle.arm.aws-11         | ycsb_like_queryable_encrypt1_cfdefault_high_value | ShardCollection.EnableSharding          | {}                                 | Latency95thPercentile      |   -0.591381 |
| perf-shard-lite-fle.arm.aws-11         | ycsb_like_queryable_encrypt1_cfdefault_high_value | YCSBLikeread50update.writes          | {}                                 | Latency95thPercentile      |    0.454819 |
| perf-shard-lite-fle.arm.aws-11         | ycsb_like_queryable_encrypt1_cfdefault_high_value | YCSBLikeread50update.writes          | {}                                 | OperationThroughput        |   -0.095896 |
| perf-shard-lite-fle.arm.aws-11         | ycsb_like_queryable_encrypt1_cfdefault_high_value | ShardCollection.EnableSharding          | {}                                 | OperationThroughput        |    0.477017 |
