### PR TITLE
PERF-5152 Update query-stats setups in AutoRun

### DIFF
--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -28,4 +28,5 @@ AutoRun:
       - standalone
       - standalone-classic-query-engine
       - standalone-dsi-integration-test
+      - standalone-query-stats
       - standalone-sbe

--- a/src/workloads/execution/ClusteredCollection.yml
+++ b/src/workloads/execution/ClusteredCollection.yml
@@ -21,11 +21,15 @@ AutoRun:
       $eq:
       - standalone
       - standalone-all-feature-flags
+      - standalone-query-stats
       - replica
       - replica-all-feature-flags
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09
       - shard
       - shard-lite-all-feature-flags
+      - shard-query-stats
     branch_name:
       $gte:  v5.3

--- a/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+++ b/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
@@ -21,11 +21,15 @@ AutoRun:
       $eq:
       - standalone
       - standalone-all-feature-flags
+      - standalone-query-stats
       - replica
       - replica-all-feature-flags
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09
       - shard
       - shard-lite-all-feature-flags
+      - shard-query-stats
     branch_name:
       $gte: v5.3

--- a/src/workloads/execution/MultiPlanning.yml
+++ b/src/workloads/execution/MultiPlanning.yml
@@ -122,5 +122,6 @@ AutoRun:
         - standalone
         - standalone-all-feature-flags
         - standalone-classic-query-engine
+        - standalone-query-stats
         - standalone-sbe
 

--- a/src/workloads/query/AggregateExpressions.yml
+++ b/src/workloads/query/AggregateExpressions.yml
@@ -985,6 +985,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     branch_name:
       $neq:

--- a/src/workloads/query/ArrayTraversal.yml
+++ b/src/workloads/query/ArrayTraversal.yml
@@ -269,6 +269,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai
+      - standalone-query-stats
       - standalone-sampling-bonsai
       - standalone-sbe
       - replica

--- a/src/workloads/query/CollScanComplexPredicateLarge.yml
+++ b/src/workloads/query/CollScanComplexPredicateLarge.yml
@@ -19,6 +19,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai
+      - standalone-query-stats
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/CollScanComplexPredicateMedium.yml
+++ b/src/workloads/query/CollScanComplexPredicateMedium.yml
@@ -19,6 +19,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai
+      - standalone-query-stats
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/CollScanComplexPredicateSmall.yml
+++ b/src/workloads/query/CollScanComplexPredicateSmall.yml
@@ -19,6 +19,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai
+      - standalone-query-stats
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -19,6 +19,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai
+      - standalone-query-stats
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
@@ -18,6 +18,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe

--- a/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
@@ -19,6 +19,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai
+      - standalone-query-stats
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -189,9 +189,11 @@ AutoRun:
       - atlas
       - atlas-like-replica.2022-10
       - replica
+      - replica-query-stats-rate-limit
       - single-replica
       - standalone
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     atlas_setup:
       $neq:

--- a/src/workloads/query/FilterWithComplexLogicalExpression.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpression.yml
@@ -39,6 +39,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe

--- a/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
@@ -39,6 +39,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe

--- a/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
@@ -39,6 +39,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe

--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -132,6 +132,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     branch_name:
       $neq:

--- a/src/workloads/query/LookupNLJ.yml
+++ b/src/workloads/query/LookupNLJ.yml
@@ -337,6 +337,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     branch_name:
       $neq:

--- a/src/workloads/query/LookupSBEPushdown.yml
+++ b/src/workloads/query/LookupSBEPushdown.yml
@@ -437,6 +437,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     branch_name:
       $neq:

--- a/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/query/LookupSBEPushdownINLJMisc.yml
@@ -386,6 +386,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     branch_name:
       $neq:

--- a/src/workloads/query/MatchFilters.yml
+++ b/src/workloads/query/MatchFilters.yml
@@ -27,6 +27,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai
+      - standalone-query-stats
       - standalone-sampling-bonsai
       - standalone-sbe
     atlas_setup:

--- a/src/workloads/query/MatchFiltersSmall.yml
+++ b/src/workloads/query/MatchFiltersSmall.yml
@@ -26,6 +26,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-heuristic-bonsai
       - standalone-sampling-bonsai
       - standalone-sbe

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -95,7 +95,7 @@ Actors:
         }, {
           $limit: *limit
         }]
-        Options: 
+        Options:
           BatchSize:  *limit
 
 AutoRun:
@@ -104,6 +104,7 @@ AutoRun:
       $eq:
       - replica
       - replica-all-feature-flags
+      - replica-query-stats-rate-limit
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -117,9 +117,13 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone
+      - standalone-query-stats
       - shard
+      - shard-query-stats
       - shard-lite
       - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09

--- a/src/workloads/query/ProjectParse.yml
+++ b/src/workloads/query/ProjectParse.yml
@@ -103,6 +103,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     branch_name:
       $gte:

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -214,13 +214,18 @@ AutoRun:
     mongodb_setup:
       $eq:
       - standalone
+      - standalone-query-stats
       # TODO PERF-4951 Enable sharded versions with multiple mongos.
       # - shard
       # - shard-lite
+      # - shard-query-stats
       - shard-single
       - single-replica
       - replica
+      - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09
     branch_name:
       $gte:
         v7.0

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -223,4 +223,4 @@ AutoRun:
       - atlas-like-replica.2022-10
     branch_name:
       $gte:
-        v7.1
+        v7.0

--- a/src/workloads/query/QueryStatsQueryShapes.yml
+++ b/src/workloads/query/QueryStatsQueryShapes.yml
@@ -136,7 +136,10 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone
+      - standalone-query-stats
       - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09

--- a/src/workloads/query/RepeatedPathTraversal.yml
+++ b/src/workloads/query/RepeatedPathTraversal.yml
@@ -19,6 +19,7 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone-classic-query-engine
       - standalone-heuristic-bonsai
+      - standalone-query-stats
       - standalone-sampling-bonsai
       - standalone-sbe
     branch_name:

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -172,9 +172,13 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone
+      - standalone-query-stats
       - shard
       - shard-lite
+      - shard-query-stats
       - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09

--- a/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_Agg.yml
@@ -96,9 +96,13 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone
+      - standalone-query-stats
       - shard
+      - shard-query-stats
       - shard-lite
       - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
@@ -108,9 +108,13 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone
+      - standalone-query-stats
       - shard
+      - shard-query-stats
       - shard-lite
       - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
@@ -109,9 +109,13 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone
+      - standalone-query-stats
       - shard
+      - shard-query-stats
       - shard-lite
       - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -96,9 +96,13 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone
+      - standalone-query-stats
       - shard
       - shard-lite
+      - shard-query-stats
       - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09

--- a/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
@@ -101,3 +101,4 @@ AutoRun:
       $eq:
       - shard
       - shard-lite
+      - shard-query-stats

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -109,9 +109,13 @@ AutoRun:
       $eq:
       - standalone-all-feature-flags
       - standalone
+      - standalone-query-stats
       - shard
       - shard-lite
+      - shard-query-stats
       - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -264,6 +264,7 @@ AutoRun:
       - shard-lite
       - standalone
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     atlas_setup:
       $neq:

--- a/src/workloads/query/VariadicAggregateExpressions.yml
+++ b/src/workloads/query/VariadicAggregateExpressions.yml
@@ -602,6 +602,7 @@ AutoRun:
       - standalone
       - standalone-all-feature-flags
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     branch_name:
       $neq:

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -137,6 +137,7 @@ AutoRun:
       - single-replica
       - standalone
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     atlas_setup:
       $neq:

--- a/src/workloads/scale/LargeIndexedIns.yml
+++ b/src/workloads/scale/LargeIndexedIns.yml
@@ -64,6 +64,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
+      - replica-query-stats-rate-limit
       - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -89,6 +89,8 @@ AutoRun:
       $eq:
       - atlas
       - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09
       - replica
       - replica-all-feature-flags
       - shard
@@ -96,6 +98,7 @@ AutoRun:
       - single-replica-15gbwtcache
       - standalone
       - standalone-classic-query-engine
+      - standalone-query-stats
       - standalone-sbe
     atlas_setup:
       $neq:


### PR DESCRIPTION
This patch is adding the mongodb_setups for the query stats variants to the relevant workloads' AutoRuns. This is a sort of revert of #1090. This is a follow up to https://github.com/10gen/dsi/pull/1545 and https://github.com/10gen/dsi/pull/1545.

sys-perf patch pending