### PR TITLE
PERF-5124: Add workload for $in with different array lengths

### DIFF
--- a/src/workloads/query/InWithVariedArraySize.yml
+++ b/src/workloads/query/InWithVariedArraySize.yml
@@ -17,11 +17,10 @@ GlobalDefaults:
   Collection: &Collection Collection0
   DocumentCount: &DocumentCount 1e6
   MaxPhases: &MaxPhases 7
-  # This is internalQueryMaxScansToExplode - 3, since we append the generated array to [1, 2, 3] so
-  # we can actually match "int".
   internalQueryMaxScansToExplode: &internalQueryMaxScansToExplode 197
-  InUptoMaxScansToExplode: &InUptoMaxScansToExplode {$in: {^Concat: {arrays: [[1, 2, 3], {^Array: {of: {^Inc: {start: 4}}, number: {^Inc: {start: 0, end: *internalQueryMaxScansToExplode}}}}]}}}
-  InAboveMaxScansToExplode: &InAboveMaxScansToExplode {$in:  {^Concat: {arrays: [[1, 2, 3], {^Array: {of: {^Inc: {start: 4}}, number: {^Inc: {start: *internalQueryMaxScansToExplode, end: 2000}}}}]}}}
+  randomIntUptoDocCount: &randomIntUptoDocCount {^RandomInt: {min: 0, max: 1000000}}
+  InUptoMaxScansToExplode: &InUptoMaxScansToExplode {$in: {^Array: {of: *randomIntUptoDocCount, number: {^Inc: {start: 0, end: *internalQueryMaxScansToExplode}}}}}
+  InAboveMaxScansToExplode: &InAboveMaxScansToExplode {$in: {^Array: {of: *randomIntUptoDocCount, number: {^Inc: {start: *internalQueryMaxScansToExplode, end: 2000}}}}}
 
 ActorTemplates:
 - TemplateName: FindQueryTemplate
@@ -67,7 +66,7 @@ Actors:
         - OperationName: drop
 
 - Name: InsertData
-  Type: Loader
+  Type: MonotonicSingleLoader
   Threads: 4
   Phases:
     OnlyActiveInPhases:
@@ -81,9 +80,8 @@ Actors:
         DocumentCount: *DocumentCount
         BatchSize: 1000
         Document:
-          int: {^Choose: {from: [1, 2, 3, -1, -2], deterministic: true}}
           randomDouble: &randomDouble {^RandomDouble: {distribution: normal, mean: 100, sigma: 20}}
-          anotherRandomdouble: *randomDouble
+          anotherRandomDouble: *randomDouble
 
 # Phase 2: Ensure all data is synced to disk.
 - Name: Quiesce
@@ -107,7 +105,7 @@ Actors:
       name: "InArrayWithLessThanMaxScansToExplodeElemsUnindexed"
       active: 3
       repeat: 200
-      filter: {int: *InUptoMaxScansToExplode}
+      filter: {_id: *InUptoMaxScansToExplode}
 
 - ActorFromTemplate:
     TemplateName: FindQueryTemplate
@@ -115,7 +113,7 @@ Actors:
       name: "InArrayWithMoreThanMaxScansToExplodeElemsUnindexed"
       active: 4
       repeat: 2000
-      filter: {int: *InAboveMaxScansToExplode}
+      filter: {_id: *InAboveMaxScansToExplode}
 
 - Name: CreateIndexes
   Type: RunCommand
@@ -132,20 +130,12 @@ Actors:
           OperationCommand:
             createIndexes: *Collection
             indexes:
-            - key: {int: 1}
-              name: int_1
             - key: {randomDouble: 1}
               name: randomDouble_1
             - key: {anotherRandomDouble: 1}
               name: anotherRandomDouble_1
-            - key: {int: 1, randomDouble: 1}
-              name: int_1_randomDouble_1
-            - key: {int: 1, anotherRandomDouble: 1}
-              name: int_1_anotherRandomDouble_1
             - key: {randomDouble: 1, anotherRandomDouble: 1}
               name: randomDouble_1_anotherRandomDouble_1
-            - key: {int: 1, randomDouble: 1, anotherRandomDouble: 1}
-              name: int_1_randomDouble_1_anotherRandomDouble_1
 
 - ActorFromTemplate:
     TemplateName: FindQueryTemplate
@@ -153,7 +143,7 @@ Actors:
       name: "InArrayWithLessThanMaxScansToExplodeElemsIndexed"
       active: 6
       repeat: 200
-      filter: {randomDouble: {$eq: 100}, int: *InUptoMaxScansToExplode}
+      filter: {randomDouble: {$eq: 100}, _id: *InUptoMaxScansToExplode}
 
 - ActorFromTemplate:
     TemplateName: FindQueryTemplate
@@ -161,7 +151,7 @@ Actors:
       name: "InArrayWithMoreThanMaxScansToExplodeElemsIndexed"
       active: 7
       repeat: 2000
-      filter: {randomDouble: {$eq: 100}, int: *InAboveMaxScansToExplode}
+      filter: {randomDouble: {$eq: 100}, _id: *InAboveMaxScansToExplode}
 
 AutoRun:
 - When:

--- a/src/workloads/query/InWithVariedArraySize.yml
+++ b/src/workloads/query/InWithVariedArraySize.yml
@@ -31,15 +31,15 @@ ActorTemplates:
     Threads: 1
     Phases:
       OnlyActiveInPhases:
-        Active: [{^Parameter: {Name: "active", Default: -1}}]
+        Active: [{^Parameter: {Name: "active", Default: {unused: "Invalid phase number."}}}]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Repeat: {^Parameter: {Name: "repeat", Default: 200}}
+          Repeat: {^Parameter: {Name: "repeat", Default: {unused: "Invalid repeat value."}}}
           Collection: *Collection
           Operations:
           - OperationName: find
             OperationCommand:
-              Filter: {^Parameter: {Name: "filter", Default: {}}}
+              Filter: {^Parameter: {Name: "filter", Default: {unused: "Invalid filter."}}}
               Options:
                 Sort: '{"anotherRandomDouble": {"$numberInt": "1"}}'
 
@@ -162,9 +162,4 @@ AutoRun:
       - standalone-classic-query-engine
       - standalone-sbe
     branch_name:
-      $neq:
-      - v4.0
-      - v4.2
-      - v4.4
-      - v5.0
-      - v6.0
+      $gte: v7.0

--- a/src/workloads/query/InWithVariedArraySize.yml
+++ b/src/workloads/query/InWithVariedArraySize.yml
@@ -15,10 +15,10 @@ Keywords:
 GlobalDefaults:
   Database: &Database test
   Collection: &Collection Collection0
-  DocumentCount: &DocumentCount 1e6
+  DocumentCount: &DocumentCount 1000000
   MaxPhases: &MaxPhases 7
   internalQueryMaxScansToExplode: &internalQueryMaxScansToExplode 197
-  randomIntUptoDocCount: &randomIntUptoDocCount {^RandomInt: {min: 0, max: 1000000}}
+  randomIntUptoDocCount: &randomIntUptoDocCount {^RandomInt: {min: 0, max: *DocumentCount}}
   InUptoMaxScansToExplode: &InUptoMaxScansToExplode {$in: {^Array: {of: *randomIntUptoDocCount, number: {^Inc: {start: 0, end: *internalQueryMaxScansToExplode}}}}}
   InAboveMaxScansToExplode: &InAboveMaxScansToExplode {$in: {^Array: {of: *randomIntUptoDocCount, number: {^Inc: {start: *internalQueryMaxScansToExplode, end: 2000}}}}}
 
@@ -134,8 +134,15 @@ Actors:
               name: randomDouble_1
             - key: {anotherRandomDouble: 1}
               name: anotherRandomDouble_1
+            - key: {_id: 1, randomDouble: 1}
+              name: _id_1_randomDouble_1
+            - key: {_id: 1, anotherRandomDouble: 1}
+              name: _id_1_anotherRandomDouble_1
             - key: {randomDouble: 1, anotherRandomDouble: 1}
               name: randomDouble_1_anotherRandomDouble_1
+            - key: {_id: 1, randomDouble: 1, anotherRandomDouble: 1}
+              name: _id_1_randomDouble_1_anotherRandomDouble_1
+
 
 - ActorFromTemplate:
     TemplateName: FindQueryTemplate

--- a/src/workloads/query/InWithVariedArraySize.yml
+++ b/src/workloads/query/InWithVariedArraySize.yml
@@ -1,0 +1,180 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query-execution"
+Description: |
+  This workload measures performance for $in for arrays of different sizes. We add the array length
+  for $in to the plan cache key since there is a possible explodeForSort optimization till we reach
+  internalQueryMaxScansToExplode that limits the maximum number of explode for sort index scans.
+  This workload measures performance for $in in both these cases, with and without indexes.
+Keywords:
+- in
+- cache
+- parametrization
+- classic
+- sbe
+
+GlobalDefaults:
+  Database: &Database test
+  Collection: &Collection Collection0
+  DocumentCount: &DocumentCount 1e6
+  MaxPhases: &MaxPhases 7
+  # This is internalQueryMaxScansToExplode - 3, since we append the generated array to [1, 2, 3] so
+  # we can actually match "int".
+  internalQueryMaxScansToExplode: &internalQueryMaxScansToExplode 197
+  InUptoMaxScansToExplode: &InUptoMaxScansToExplode {$in: {^Concat: {arrays: [[1, 2, 3], {^Array: {of: {^Inc: {start: 4}}, number: {^Inc: {start: 0, end: *internalQueryMaxScansToExplode}}}}]}}}
+  InAboveMaxScansToExplode: &InAboveMaxScansToExplode {$in:  {^Concat: {arrays: [[1, 2, 3], {^Array: {of: {^Inc: {start: 4}}, number: {^Inc: {start: *internalQueryMaxScansToExplode, end: 2000}}}}]}}}
+
+ActorTemplates:
+- TemplateName: FindQueryTemplate
+  Config:
+    Name: {^Parameter: {Name: "name", Default: "FindQueryTemplate"}}
+    Type: CrudActor
+    Database: *Database
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [{^Parameter: {Name: "active", Default: -1}}]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Repeat: {^Parameter: {Name: "repeat", Default: 200}}
+          Collection: *Collection
+          Operations:
+          - OperationName: find
+            OperationCommand:
+              Filter: {^Parameter: {Name: "filter", Default: {}}}
+              Options:
+                Sort: '{"anotherRandomDouble": {"$numberInt": "1"}}'
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 400
+
+Actors:
+# Clear any pre-existing collection state.
+- Name: ClearCollection
+  Type: CrudActor
+  Database: *Database
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+        Collection: *Collection
+        Operations:
+        - OperationName: drop
+
+- Name: InsertData
+  Type: Loader
+  Threads: 4
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        MultipleThreadsPerCollection: true
+        CollectionCount: 1
+        DocumentCount: *DocumentCount
+        BatchSize: 1000
+        Document:
+          int: {^Choose: {from: [1, 2, 3, -1, -2], deterministic: true}}
+          randomDouble: &randomDouble {^RandomDouble: {distribution: normal, mean: 100, sigma: 20}}
+          anotherRandomdouble: *randomDouble
+
+# Phase 2: Ensure all data is synced to disk.
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *Database
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Threads: 1
+
+# Phase 3-N: Run find with "in" filter for different combinations of arrays with less than
+# maxScansToExplode elements, more than maxScansToExplode elements, and collection with and without
+# indexes.
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      name: "InArrayWithLessThanMaxScansToExplodeElemsUnindexed"
+      active: 3
+      repeat: 200
+      filter: {int: *InUptoMaxScansToExplode}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      name: "InArrayWithMoreThanMaxScansToExplodeElemsUnindexed"
+      active: 4
+      repeat: 2000
+      filter: {int: *InAboveMaxScansToExplode}
+
+- Name: CreateIndexes
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [5]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            createIndexes: *Collection
+            indexes:
+            - key: {int: 1}
+              name: int_1
+            - key: {randomDouble: 1}
+              name: randomDouble_1
+            - key: {anotherRandomDouble: 1}
+              name: anotherRandomDouble_1
+            - key: {int: 1, randomDouble: 1}
+              name: int_1_randomDouble_1
+            - key: {int: 1, anotherRandomDouble: 1}
+              name: int_1_anotherRandomDouble_1
+            - key: {randomDouble: 1, anotherRandomDouble: 1}
+              name: randomDouble_1_anotherRandomDouble_1
+            - key: {int: 1, randomDouble: 1, anotherRandomDouble: 1}
+              name: int_1_randomDouble_1_anotherRandomDouble_1
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      name: "InArrayWithLessThanMaxScansToExplodeElemsIndexed"
+      active: 6
+      repeat: 200
+      filter: {randomDouble: {$eq: 100}, int: *InUptoMaxScansToExplode}
+
+- ActorFromTemplate:
+    TemplateName: FindQueryTemplate
+    TemplateParameters:
+      name: "InArrayWithMoreThanMaxScansToExplodeElemsIndexed"
+      active: 7
+      repeat: 2000
+      filter: {randomDouble: {$eq: 100}, int: *InAboveMaxScansToExplode}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-all-feature-flags
+      - standalone-classic-query-engine
+      - standalone-sbe
+    branch_name:
+      $neq:
+      - v4.0
+      - v4.2
+      - v4.4
+      - v5.0
+      - v6.0


### PR DESCRIPTION
**Jira Ticket:** PERF-5124

**Whats Changed:**  
Added a workload for $in with different array lengths and in the presence and absence of indexes.

**Patch testing results:**
(Latest, 2/27, commit 4): https://spruce.mongodb.com/version/65de34ccd6d80aaff3c3d0f3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

(2/26, Commit 3) https://spruce.mongodb.com/version/65dcf4e29ccd4e6d913d41f0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC