### PR TITLE
Remove AutoRun from unnecessary variants in QueryStats.yml

### DIFF
--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -227,10 +227,6 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - standalone-query-stats
-      # TODO PERF-4951 Enable sharded versions with multiple mongos.
-      # - shard-query-stats
-      - replica-query-stats-rate-limit
       - atlas-like-replica-query-stats.2023-09
     branch_name:
       $gte:


### PR DESCRIPTION
The only analysis we'll do for the 7.0 QueryStats backport that involves this workload is in th M60-like variant, so running it elsewhere is not needed.