### PR TITLE
Devprod-2165 redirect and review Poplar outputs

### DIFF
--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -190,10 +190,10 @@ def poplar_grpc(cleanup_metrics: bool, workspace_root: str, genny_repo_root: str
 
 
 def _report_poplar_error(log: TextIO):
-    """Review the log file for fatal errors and print them to stderr.
+    """
+    Review the log file for fatal errors and print them to stderr.
 
     We don't want to print the entire log, just highlight the fatal error(s).
-
     """
 
     log.seek(0)


### PR DESCRIPTION
**Jira Ticket:** DEVPROD-2165

**Whats Changed:**

Redirect the output of Poplar into a log file. When the process finishes, review the log file to:

-   Print any "fatal error" to stderr
-   If the error OOM (or alike), print a message to suggest that the user uses a larger workload instance.

Previously the outputs of Poplar are log at the INFO level. Normally this is not an issue because Poplar prints almost nothing. But, when Poplar hits the OOM issue, it may print a huge stack trace, making it hard to spot the issue. See [this log](https://parsley.mongodb.com/evergreen/sys_perf_perf_1_node_replSet_longRunning.arm.aws.2023_11_llt_mixed_patch_798243406d1f483e46669d7d20f29f4d8f50ba01_65ddb0c20ae6063ec624c105_24_02_27_10_09_37/0/task?bookmarks=0,11604) for an example.

**Patch testing results:**

See the log for [llt\_mixed](https://spruce.mongodb.com/task/sys_perf_perf_1_node_replSet_longRunning.arm.aws.2023_11_llt_mixed_patch_798243406d1f483e46669d7d20f29f4d8f50ba01_65ddb0c20ae6063ec624c105_24_02_27_10_09_37/logs?execution=5)

**Related PRs:**

None