### PR TITLE
PERF-5191 Add workload where multi-planner reads a lot of data to find the correct index

### DIFF
--- a/src/workloads/execution/MultiPlanningReadsALotOfData.yml
+++ b/src/workloads/execution/MultiPlanningReadsALotOfData.yml
@@ -1,0 +1,98 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/server-execution"
+Description: >
+ Create collection with multiple indexes and run queries for which multi planner needs to read a lot
+ of data in order to pick the best plan..
+
+Keywords:
+- indexes
+
+Actors:
+- Name: InitCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: &MaxPhase 2
+      PhaseConfig:
+        Repeat: 1
+        Database: &Database test
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            createIndexes: &Collection Collection0
+            indexes:
+            - key:
+                flag_a: 1
+                flag_b: 1
+              name: flags
+            - key:
+                int_a: 1
+              name: int
+
+- Name: DisablePlanCache
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhase
+      PhaseConfig:
+        Repeat: 1
+        Database: admin
+        Operations:
+        - OperationName: AdminCommand
+          OperationCommand:
+            setParameter: 1
+            internalQueryDisablePlanCache: true
+
+- Name: Insert
+  Type: Loader
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhase
+      PhaseConfig:
+        Repeat: 1
+        Database: *Database
+        Threads: 1
+        CollectionCount: 1
+        DocumentCount: 2e6
+        BatchSize: 1000
+        Document:
+          flag_a: {^RandomInt: {min: 0, max: 1}}
+          flag_b: {^RandomInt: {min: 0, max: 1}}
+          int_a: {^RandomInt: {min: 1, max: 10}}
+          int_b: {^Inc: {}}
+
+- Name: FindWithMultiplanning
+  Type: CrudActor
+  Database: *Database
+  Threads: 4
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhase
+      PhaseConfig:
+      - Repeat: 100
+        Collection: *Collection
+        Operations:
+        - OperationName: find
+          OperationCommand:
+            Filter:
+              flag_a: {^RandomInt: {min: 0, max: 1}}
+              flag_b: {^RandomInt: {min: 0, max: 1}}
+              int_a: {^RandomInt: {min: 1, max: 10}}
+              int_b: {$gte: 1900000}
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+        - standalone
+        - standalone-all-feature-flags
+        - standalone-classic-query-engine
+        - standalone-sbe
+


### PR DESCRIPTION
**Jira Ticket:** [PERF-5191](https://jira.mongodb.org/browse/PERF-5191)

**Whats Changed:**  
New workload.

**Patch testing results:**  
https://spruce.mongodb.com/version/65e08f910ae6062646609831/changes