### PR TITLE
PERF-5184 Add workload reproducing an OOM on mongos caused by a cursor storm

### DIFF
--- a/src/lamplib/src/genny/tasks/dry_run.py
+++ b/src/lamplib/src/genny/tasks/dry_run.py
@@ -34,6 +34,7 @@ def dry_run_workload(
         "YCSBLikeQueryableEncrypt5Cf32.yml",
         "YCSBLikeQueryableEncrypt5Cfdefault.yml",
         "ExponentialCompact.yml",
+        "CursorStormMongos.yml"
     ]:
         SLOG.info(f"EVG-21054 skipping dry run for {yaml_file_basename}.", file=yaml_file_path)
         return
@@ -47,8 +48,7 @@ def dry_run_workload(
         "MajorityReads10KThreads.yml",
         "MajorityWrites10KThreads.yml",
         "ConnectionPoolStress.yml",
-        "SinusoidalReadWrites.yml",
-        "CursorStormMongos.yml"
+        "SinusoidalReadWrites.yml"
     ]:
         SLOG.info("TIG-1435 skipping dry run on macOS", file=yaml_file_path)
         return

--- a/src/lamplib/src/genny/tasks/dry_run.py
+++ b/src/lamplib/src/genny/tasks/dry_run.py
@@ -48,6 +48,7 @@ def dry_run_workload(
         "MajorityWrites10KThreads.yml",
         "ConnectionPoolStress.yml",
         "SinusoidalReadWrites.yml",
+        "CursorStormMongos.yml"
     ]:
         SLOG.info("TIG-1435 skipping dry run on macOS", file=yaml_file_path)
         return

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -5,7 +5,7 @@ Description: |
   many heavy cursors. The workload is expected to fail due to host(s) being unreachable as a
   result of mongos running out of memory.
 
-  To achieve this, many threads are then spawned to run aggregate sort on a number of documents.
+  To achieve this, many threads are spawned to run aggregate sort on a number of documents.
   The document size and the number of documents to sort by each thread are tuned so, that the
   operations do not spill to disk [<100MB], and mongos is able to exhaust the cursors on shards
   when pre-filling its buffers [<16MB per shard]. As a result, memory pressure on the shards
@@ -83,7 +83,7 @@ Actors:
           OperationCommand: {dropDatabase: 1}
 
 # Create collection
-- Name: Create
+- Name: CreateCollection
   Type: RunCommand
   Threads: 1
   Phases:
@@ -99,7 +99,7 @@ Actors:
             # Loader default collection name.
             create: Collection0
 
-# Enable sharding
+# Enable sharding & shard collection
 - Name: ShardCollection
   Type: AdminCommand
   Threads: 1
@@ -167,7 +167,7 @@ Actors:
                   }
                 }
               },
-              # Merge-sorting results increases the number of heavy cursors on mongos
+              # Merge-sorting results imposes additional memory pressure on mongos
               {$sort: {b: 1}}]
             cursor: {batchSize: *SortStep}
 

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -5,11 +5,10 @@ Description: |
   many heavy cursors. The workload is expected to fail due to host(s) being unreachable as a
   result of mongos running out of memory.
 
-  To achieve this, many threads are spawned to run aggregate sort on a number of documents.
-  The document size and the number of documents to sort by each thread are tuned so, that the
-  operations do not spill to disk [<100MB], and mongos is able to exhaust the cursors on shards
-  when pre-filling its buffers [<16MB per shard]. As a result, memory pressure on the shards
-  remains low, while it's kept large on the mongos.
+  To achieve this, many threads are spawned to run an unfiltered find on a collection.
+  The number and size of documents in that collection are tuned such, that the mongos is able
+  to exhaust cursors on shards when pre-filling its buffers [<16MB per shard]. As a result, 
+  memory pressure on the shards remains low, while it's kept large on the mongos.
 
 Keywords:
 - scale
@@ -21,50 +20,30 @@ Keywords:
 - out of memory
 
 GlobalDefaults:
-  NumShards: &NumShards 2
-
-  DBName: &DBName memorystress
+  DBName: &DBName test
   # Collection0 is the default collection used by the loader.
-  Namespace: &Namespace memorystress.Collection0
-
-  MaxPhases: &MaxPhases 20
-
-  LoadThreads: &LoadThreads 128
-  LoadBatchSize: &LoadBatchSize 500
-
-  NumberOfDocuments: &NumDocs 20096
-  # NumberOfDocumentsPerWorker = NumberOfDocuments / LoadThreads.
-  NumberOfDocumentsPerWorker: &DocsPerThread 157
-  # Used in Document: a to let the starting value of a = 0.
-  DocumentStartAt: &DocStartAt -157
+  Namespace: &Namespace test.Collection0
+  NumShards: &NumShards 2
   DocSize: &DocSize 168000
-  Document: &Doc
-    # Document number/ID. Starts at *DocStartAt = -*DocsPerThread = -157 because ActorId
-    # starts at 1, and therefore in order for the first output of ^Inc to be 0, "start"
-    # would need to be offset by ActorId * *DocsPerThread = 157.
-    a: {^Inc: {start: *DocStartAt, step: 1, multiplier: *DocsPerThread}}
-    # Random number from [0, NumberOfDocuments].
-    b: {^RandomInt: {min: 0, max: *NumDocs}}
-    # Fill 168 KB.
-    c: {^FastRandomString: {length: *DocSize}}
-
-  # The size of documents to process in a given step should approach 16MB per shard. Therefore, the
-  # number of documents to sort per shard is tuned such that SortStepPerShard * DocSize -> 16 MB.
-  SortStepPerShard: &SortStepPerShard 90
+  # The size of documents that mongos will pre-fatch in a given step should approach 16MB per shard.
+  # Therefore, the number of documents per shard is tuned such that NumDocsPerShard * DocSize -> 16 MB.
+  NumDocsPerShard: &NumDocsPerShard 90
   # With data distributed evenly across shards, the total size of documents to process in a
-  # given step should be equall to NumOfShards * SortStepPerShard.
-  SortStep: &SortStep
+  # given step should be equall to NumOfShards * NumDocsPerShard.
+  TotalNumberOfDocuments: &TotalNumberOfDocuments
     ^NumExpr:
-      withExpression: "num_shards * sort_step_per_shard"
-      andValues: {num_shards: *NumShards, sort_step_per_shard: *SortStepPerShard}
-  SortThreads: &SortThreads 250
-  SortRepeat: &SortRepeat 10
+      withExpression: "num_shards * num_docs_per_shard"
+      andValues: {num_shards: *NumShards, num_docs_per_shard: *NumDocsPerShard}
+  # Use 250 threads to generate memory pressure.
+  TestThreads: &TestThreads 250
+  TestRepeat: &TestRepeat 10
+  MaxPhases: &MaxPhases 5
 
 Clients:
   Default:
     QueryOptions:
       socketTimeoutMS: -1
-      maxPoolSize: 500
+      maxPoolSize: 255
     
 Actors:
 # Drop database to get rid of stale data. Useful when running locally multiple times.
@@ -120,12 +99,12 @@ Actors:
           OperationName: AdminCommand
           OperationCommand:
             shardCollection: *Namespace
-            key: {a: hashed}
+            key: {_id: hashed}
 
-# Load 20,096 documents around 168KB as described by the structure in GlobalDefaults.
+# Load *NumDocs documents around 168KB as described by the structure in GlobalDefaults.
 - Name: LoadDocuments
   Type: Loader
-  Threads: *LoadThreads
+  Threads: 1
   Phases:
     OnlyActiveInPhases:
       Active: [3]
@@ -134,42 +113,30 @@ Actors:
         CollectionCount: 1
         Database: *DBName
         Repeat: 1
-        Document: *Doc
         MultipleThreadsPerCollection: true
-        DocumentCount: *NumDocs
-        BatchSize: *LoadBatchSize
+        DocumentCount: *TotalNumberOfDocuments
+        BatchSize: 500
+        Document:
+          # Fill 168 KB.
+          a: {^FastRandomString: {length: *DocSize}}
 
 # Spawn many threads to test the routers capacity to handle memory pressure.
-- Name: SortMany
+- Name: FindMany
   Type: RunCommand
-  Threads: *SortThreads
+  Threads: *TestThreads
   Phases:
     OnlyActiveInPhases:
       Active: [4]
       NopInPhasesUpTo: *MaxPhases
       PhaseConfig:
-        Repeat: *SortRepeat
+        Repeat: *TestRepeat
         Database: *DBName
         Operations:
-        - OperationMetricsName: SortMany
+        - OperationMetricsName: FindMany
           OperationName: RunCommand
           OperationCommand:
-            # Loader default collection name.
-            aggregate: Collection0
-            pipeline:
-              [{$match:
-                {$expr:
-                  {$let:
-                    {vars:
-                      {start: {^RandomInt: {min: 0, max: *NumDocs}}},
-                    in: {$and: [$gte: ["$a", "$$start"], $lt: ["$a", {$add: ["$$start", *SortStep]}]]}
-                    }
-                  }
-                }
-              },
-              # Merge-sorting results imposes additional memory pressure on mongos
-              {$sort: {b: 1}}]
-            cursor: {batchSize: *SortStep}
+            # Collection0 is the default collection name used by the Loader.
+            find: Collection0
 
 # Commented out because this should not be regularly scheduled, as the task is expected to fail.
 # Uncomment the lines below (and possibly change the build variant) to run the workload.

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -1,0 +1,176 @@
+SchemaVersion: 2018-07-01
+Owner: Service Architecture
+Description: |
+  Used to test performance of the server under heavy memory pressure caused by read
+  operations. This workload is expected to fail due to host(s) being unreachable as a
+  result of mongod(s) running out of memory.
+
+  To achieve this, documents are inserted in the form of {a: <id>, b: <random number>,
+  c: <fill 520 KB>}. Many threads are then spawned to run aggregate sort on a number of
+  documents. The document size and the number of documents to sort by each thread are
+  tuned to be just under 100 MB, which is the memory limit for operations before
+  spilling to disk. The threads would therefore each cause a close-to-max amount of
+  memory to be used. Increasing the number of threads should cause the host(s) that
+  process the operations to fail due to out-of-memory errors.
+
+Keywords:
+- scale
+- memory stress
+- aggregate
+- sort
+- insert
+- fail
+- oom
+- out of memory
+
+GlobalDefaults:
+  dbname: &DBName memorystress
+  MaxPhases: &MaxPhases 20
+
+  # Many of these values are either arbitrary or multiples of other variables. It is only
+  # important to keep the DocSize and SortStep (number of documents to sort) close to 100 MB
+  # so each thread can use as much memory as possible when sorting.
+
+  LoadThreads: &LoadThreads 128
+  LoadBatchSize: &LoadBatchSize 500
+
+  NumberOfDocuments: &NumDocs 20096
+  # NumberOfDocumentsPerWorker = NumberOfDocuments / LoadThreads.
+  NumberOfDocumentsPerWorker: &DocsPerThread 157
+  # Used in Document: a to let the starting value of a = 0.
+  DocumentStartAt: &DocStartAt -157
+  DocSize: &DocSize 520000
+  Document: &Doc
+    # Document number/ID. Starts at *DocStartAt = -*DocsPerThread = -157 because ActorId
+    # starts at 1, and therefore in order for the first output of ^Inc to be 0, "start"
+    # would need to be offset by ActorId * *DocsPerThread = 157.
+    a: {^Inc: {start: *DocStartAt, step: 1, multiplier: *DocsPerThread}}
+    # Random number from [0, NumberOfDocuments].
+    b: {^RandomInt: {min: 0, max: *NumDocs}}
+    # Fill 520 KB.
+    c: {^FastRandomString: {length: *DocSize}}
+
+  # Number of documents to sort by each thread. Tuned so that *SortStep * *DocSize < 100 MB,
+  # which is the maximum memory a sort query is allowed to use before spilling to disk.
+  SortStep: &SortStep 180
+  SortBatchSize: &SortBatchSize 180
+  SortThreads: &SortThreads 250
+  SortRepeat: &SortRepeat 5
+
+Clients:
+  Default:
+    QueryOptions:
+      socketTimeoutMS: -1
+      maxPoolSize: 500
+    
+Actors:
+# Drop database to get rid of stale data. Useful when running locally multiple times.
+- Name: Setup
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *DBName
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand: {dropDatabase: 1}
+
+# Create collection
+- Name: Create
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [1]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: *DBName
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            create: Collection0
+
+# Enable sharding
+- Name: ShardCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: 1
+        Database: admin
+        OnlyRunInInstance: sharded
+        Operations:
+        - OperationMetricsName: EnableSharding
+          OperationName: AdminCommand
+          OperationCommand:
+            enableSharding: *DBName
+        - OperationMetricsName: ShardCollection
+          OperationName: AdminCommand
+          OperationCommand:
+            shardCollection: memorystress.Collection0
+            key: {a: hashed}
+
+# Load 20,096 documents around 520KB as described by the structure in GlobalDefaults.
+- Name: LoadDocuments
+  Type: Loader
+  Threads: *LoadThreads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [3]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        CollectionCount: 1
+        Database: *DBName
+        Repeat: 1
+        Document: *Doc
+        MultipleThreadsPerCollection: true
+        DocumentCount: *NumDocs
+        BatchSize: *LoadBatchSize
+
+# Spawn many threads to sort enough documents to test server's capacity to handle memory pressure.
+- Name: SortMany
+  Type: RunCommand
+  Threads: *SortThreads
+  Phases:
+    OnlyActiveInPhases:
+      Active: [4]
+      NopInPhasesUpTo: *MaxPhases
+      PhaseConfig:
+        Repeat: *SortRepeat
+        Database: *DBName
+        Operations:
+        - OperationMetricsName: SortMany
+          OperationName: RunCommand
+          OperationCommand:
+            # Loader default collection name.
+            aggregate: Collection0
+            # Sort *SortStep number of documents starting from a randomly chosen 'a'.
+            pipeline:
+              [{$match:
+                {$expr:
+                  {$let:
+                    {vars:
+                      {start: {^RandomInt: {min: 0, max: *NumDocs}}},
+                    in: {$and: [$gte: ["$a", "$$start"], $lt: ["$a", {$add: ["$$start", *SortStep]}]]}
+                    }
+                  }
+                }
+              },
+              {$sort: {b: 1}}]
+            cursor: {batchSize: *SortBatchSize}
+
+# Commented out because this should not be regularly scheduled, as the task is expected to fail.
+# Uncomment the lines below (and possibly change the build variant) to run the workload.
+# AutoRun:
+# - When:
+#     mongodb_setup:
+#       $eq:
+#       - shard-lite

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Service Architecture
+Owner: "@mongodb/query"
 Description: |
   Used to test performance of the router under memory pressure caused by accumulating
   many heavy cursors. The workload is expected to fail due to host(s) being unreachable as a

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -1,35 +1,21 @@
 SchemaVersion: 2018-07-01
 Owner: Service Architecture
 Description: |
-  Used to test performance of the server under heavy memory pressure caused by read
-  operations. This workload is expected to fail due to host(s) being unreachable as a
-  result of mongod(s) running out of memory.
-
-  To achieve this, documents are inserted in the form of {a: <id>, b: <random number>,
-  c: <fill 520 KB>}. Many threads are then spawned to run aggregate sort on a number of
-  documents. The document size and the number of documents to sort by each thread are
-  tuned to be just under 100 MB, which is the memory limit for operations before
-  spilling to disk. The threads would therefore each cause a close-to-max amount of
-  memory to be used. Increasing the number of threads should cause the host(s) that
-  process the operations to fail due to out-of-memory errors.
+  Used to test performance of the router under heavy memory pressure caused by accumulating
+  many heavy cursors. This workload is expected to fail due to host(s) being unreachable as a
+  result of mongos running out of memory.
 
 Keywords:
 - scale
 - memory stress
-- aggregate
-- sort
-- insert
-- fail
+- cursor storm
+- mongos
 - oom
 - out of memory
 
 GlobalDefaults:
   dbname: &DBName memorystress
   MaxPhases: &MaxPhases 20
-
-  # Many of these values are either arbitrary or multiples of other variables. It is only
-  # important to keep the DocSize and SortStep (number of documents to sort) close to 100 MB
-  # so each thread can use as much memory as possible when sorting.
 
   LoadThreads: &LoadThreads 128
   LoadBatchSize: &LoadBatchSize 500
@@ -39,7 +25,7 @@ GlobalDefaults:
   NumberOfDocumentsPerWorker: &DocsPerThread 157
   # Used in Document: a to let the starting value of a = 0.
   DocumentStartAt: &DocStartAt -157
-  DocSize: &DocSize 520000
+  DocSize: &DocSize 168000
   Document: &Doc
     # Document number/ID. Starts at *DocStartAt = -*DocsPerThread = -157 because ActorId
     # starts at 1, and therefore in order for the first output of ^Inc to be 0, "start"
@@ -47,11 +33,13 @@ GlobalDefaults:
     a: {^Inc: {start: *DocStartAt, step: 1, multiplier: *DocsPerThread}}
     # Random number from [0, NumberOfDocuments].
     b: {^RandomInt: {min: 0, max: *NumDocs}}
-    # Fill 520 KB.
+    # Fill 168 KB.
     c: {^FastRandomString: {length: *DocSize}}
 
-  # Number of documents to sort by each thread. Tuned so that *SortStep * *DocSize < 100 MB,
-  # which is the maximum memory a sort query is allowed to use before spilling to disk.
+  # MongoS holds a cursor with a size of up to 16MB when fetching data from each shard.
+  # Therefore, with data evenly distributed across shards, the size of all documents to fetch in a step 
+  # should approach <num_of_shards> * 16MB. With 2 shards placed in the test topology,  
+  # the number of documents to process by each thread is tuned so that *SortStep * *DocSize ~= 32 MB,
   SortStep: &SortStep 180
   SortBatchSize: &SortBatchSize 180
   SortThreads: &SortThreads 250
@@ -118,7 +106,7 @@ Actors:
             shardCollection: memorystress.Collection0
             key: {a: hashed}
 
-# Load 20,096 documents around 520KB as described by the structure in GlobalDefaults.
+# Load 20,096 documents around 168KB as described by the structure in GlobalDefaults.
 - Name: LoadDocuments
   Type: Loader
   Threads: *LoadThreads
@@ -135,7 +123,7 @@ Actors:
         DocumentCount: *NumDocs
         BatchSize: *LoadBatchSize
 
-# Spawn many threads to sort enough documents to test server's capacity to handle memory pressure.
+# Spawn many threads to sort enough documents to test the routers capacity to handle memory pressure.
 - Name: SortMany
   Type: RunCommand
   Threads: *SortThreads
@@ -152,7 +140,8 @@ Actors:
           OperationCommand:
             # Loader default collection name.
             aggregate: Collection0
-            # Sort *SortStep number of documents starting from a randomly chosen 'a'.
+            # TODO: Investigate how precisely this query will be served by mongos.
+            # How many cursors will mongos open when merging results?
             pipeline:
               [{$match:
                 {$expr:

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -1,20 +1,32 @@
 SchemaVersion: 2018-07-01
 Owner: Service Architecture
 Description: |
-  Used to test performance of the router under heavy memory pressure caused by accumulating
-  many heavy cursors. This workload is expected to fail due to host(s) being unreachable as a
+  Used to test performance of the router under memory pressure caused by accumulating
+  many heavy cursors. The workload is expected to fail due to host(s) being unreachable as a
   result of mongos running out of memory.
+
+  To achieve this, many threads are then spawned to run aggregate sort on a number of documents.
+  The document size and the number of documents to sort by each thread are tuned so, that the
+  operations do not spill to disk [<100MB], and mongos is able to exhaust the cursors on shards
+  when pre-filling its buffers [<16MB per shard]. As a result, memory pressure on the shards
+  remains low, while it's kept large on the mongos.
 
 Keywords:
 - scale
 - memory stress
 - cursor storm
 - mongos
+- fail
 - oom
 - out of memory
 
 GlobalDefaults:
-  dbname: &DBName memorystress
+  NumShards: &NumShards 2
+
+  DBName: &DBName memorystress
+  # Collection0 is the default collection used by the loader.
+  Namespace: &Namespace memorystress.Collection0
+
   MaxPhases: &MaxPhases 20
 
   LoadThreads: &LoadThreads 128
@@ -36,14 +48,17 @@ GlobalDefaults:
     # Fill 168 KB.
     c: {^FastRandomString: {length: *DocSize}}
 
-  # When fetching data from shards, mongos holds a cursor using up to 16MB per shard.
-  # Therefore, with data evenly distributed across shards, the size of all documents to fetch in a step 
-  # should approach <num_of_shards> * 16MB. With 2 shards placed in the test topology,  
-  # the number of documents to process by each thread is tuned so that *SortStep * *DocSize ~= 32 MB,
-  SortStep: &SortStep 180
-  SortBatchSize: &SortBatchSize 180
+  # The size of documents to process in a given step should approach 16MB per shard. Therefore, the
+  # number of documents to sort per shard is tuned such that SortStepPerShard * DocSize -> 16 MB.
+  SortStepPerShard: &SortStepPerShard 90
+  # With data distributed evenly across shards, the total size of documents to process in a
+  # given step should be equall to NumOfShards * SortStepPerShard.
+  SortStep: &SortStep
+    ^NumExpr:
+      withExpression: "num_shards * sort_step_per_shard"
+      andValues: {num_shards: *NumShards, sort_step_per_shard: *SortStepPerShard}
   SortThreads: &SortThreads 250
-  SortRepeat: &SortRepeat 5
+  SortRepeat: &SortRepeat 10
 
 Clients:
   Default:
@@ -81,6 +96,7 @@ Actors:
         Operations:
         - OperationName: RunCommand
           OperationCommand:
+            # Loader default collection name.
             create: Collection0
 
 # Enable sharding
@@ -103,7 +119,7 @@ Actors:
         - OperationMetricsName: ShardCollection
           OperationName: AdminCommand
           OperationCommand:
-            shardCollection: memorystress.Collection0
+            shardCollection: *Namespace
             key: {a: hashed}
 
 # Load 20,096 documents around 168KB as described by the structure in GlobalDefaults.
@@ -123,7 +139,7 @@ Actors:
         DocumentCount: *NumDocs
         BatchSize: *LoadBatchSize
 
-# Spawn many threads to sort enough documents to test the routers capacity to handle memory pressure.
+# Spawn many threads to test the routers capacity to handle memory pressure.
 - Name: SortMany
   Type: RunCommand
   Threads: *SortThreads
@@ -151,9 +167,9 @@ Actors:
                   }
                 }
               },
-              # Blocking sort increases the number of heavy cursors kept in the system at once.
+              # Merge-sorting results increases the number of heavy cursors on mongos
               {$sort: {b: 1}}]
-            cursor: {batchSize: *SortBatchSize}
+            cursor: {batchSize: *SortStep}
 
 # Commented out because this should not be regularly scheduled, as the task is expected to fail.
 # Uncomment the lines below (and possibly change the build variant) to run the workload.

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -36,7 +36,7 @@ GlobalDefaults:
     # Fill 168 KB.
     c: {^FastRandomString: {length: *DocSize}}
 
-  # MongoS holds a cursor with a size of up to 16MB when fetching data from each shard.
+  # When fetching data from shards, mongos holds a cursor using up to 16MB per shard.
   # Therefore, with data evenly distributed across shards, the size of all documents to fetch in a step 
   # should approach <num_of_shards> * 16MB. With 2 shards placed in the test topology,  
   # the number of documents to process by each thread is tuned so that *SortStep * *DocSize ~= 32 MB,
@@ -140,8 +140,6 @@ Actors:
           OperationCommand:
             # Loader default collection name.
             aggregate: Collection0
-            # TODO: Investigate how precisely this query will be served by mongos.
-            # How many cursors will mongos open when merging results?
             pipeline:
               [{$match:
                 {$expr:
@@ -153,6 +151,7 @@ Actors:
                   }
                 }
               },
+              # Blocking sort increases the number of heavy cursors kept in the system at once.
               {$sort: {b: 1}}]
             cursor: {batchSize: *SortBatchSize}
 

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -25,11 +25,11 @@ GlobalDefaults:
   Namespace: &Namespace test.Collection0
   NumShards: &NumShards 2
   DocSize: &DocSize 168000
-  # The size of documents that mongos will pre-fatch in a given step should approach 16MB per shard.
+  # The size of documents that mongos will pre-fetch in a given step should approach 16MB per shard.
   # Therefore, the number of documents per shard is tuned such that NumDocsPerShard * DocSize -> 16 MB.
   NumDocsPerShard: &NumDocsPerShard 90
   # With data distributed evenly across shards, the total size of documents to process in a
-  # given step should be equall to NumOfShards * NumDocsPerShard.
+  # given step should be equall to NumShards * NumDocsPerShard.
   TotalNumberOfDocuments: &TotalNumberOfDocuments
     ^NumExpr:
       withExpression: "num_shards * num_docs_per_shard"
@@ -61,7 +61,7 @@ Actors:
         - OperationName: RunCommand
           OperationCommand: {dropDatabase: 1}
 
-# Create collection
+# Create collection.
 - Name: CreateCollection
   Type: RunCommand
   Threads: 1
@@ -78,7 +78,7 @@ Actors:
             # Loader default collection name.
             create: Collection0
 
-# Enable sharding & shard collection
+# Enable sharding & shard collection.
 - Name: ShardCollection
   Type: AdminCommand
   Threads: 1
@@ -101,7 +101,7 @@ Actors:
             shardCollection: *Namespace
             key: {_id: hashed}
 
-# Load *NumDocs documents around 168KB as described by the structure in GlobalDefaults.
+# Load *TotalNumberOfDocuments documents of around 168KB each.
 - Name: LoadDocuments
   Type: Loader
   Threads: 1


### PR DESCRIPTION
Jira Ticket: [PERF-5184](https://jira.mongodb.org/browse/PERF-5184)

Whats Changed:
Add a new workload reproducing an OOM on mongos caused by a cursor storm.

Workload Submission form:
If applicable, only required if is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)