### PR TITLE
SERVER-87415 Remove run_command__simple workload from sys-perf

### DIFF
--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -20,13 +20,3 @@ Actors:
       OperationCommand:
         insert: myCollection
         documents: [{name: {^RandomString: {length: {^RandomInt: {min: 2, max: 5}}}}, rating: 10, address: someAddress, cuisine: italian}]
-
-AutoRun:
-- When:
-    mongodb_setup:
-      $eq:
-      - standalone
-      - standalone-classic-query-engine
-      - standalone-dsi-integration-test
-      - standalone-query-stats
-      - standalone-sbe


### PR DESCRIPTION
**Ticket:** [SERVER-87415](https://jira.mongodb.org/browse/SERVER-87415)

**Patch:**
[Evergreen patch](https://spruce.mongodb.com/version/65e61ffa3e8e86404efa7789/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) showing that dsi_integ_test_run_command_simple no longer comes up on PERF Standalone ARM AWS 2023-11 and run_command__simple is not auto run on the relevant variants

**Related PRs:**
- [sys-perf changes](https://github.com/10gen/mongo/pull/19555)
- [DSI changes](https://github.com/10gen/dsi/pull/1584)