### PR TITLE
SERVER-85660: fix streams passthrough change stream source workload

### DIFF
--- a/src/value_generators/src/DocumentGenerator.cpp
+++ b/src/value_generators/src/DocumentGenerator.cpp
@@ -1480,6 +1480,20 @@ private:
     std::string _actorId;
 };
 
+/** `{^NowTimestamp: {}}` */
+// For Timesamp, the default start value for .increment is 1 and .timestamp is current time since
+// UNIX epoch in seconds. 
+// see https://www.mongodb.com/docs/mongodb-shell/reference/data-types/#timestamp for more details.
+class NowTimestampGenerator : public Generator<bsoncxx::types::b_timestamp> {
+public:
+    NowTimestampGenerator(const Node& node, GeneratorArgs generatorArgs) {}
+    bsoncxx::types::b_timestamp evaluate() override {
+        auto now = std::chrono::system_clock::now();
+        uint32_t nowSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+        return bsoncxx::types::b_timestamp{.increment = 1, .timestamp = nowSinceEpoch};
+    }
+};
+
 /** `{^Now: {}}` */
 class NowGenerator : public Generator<bsoncxx::types::b_date> {
 public:
@@ -2142,6 +2156,7 @@ Out valueGenerator(const Node& node,
  */
 const auto [allParsers,
             arrayParsers,
+            timestampParsers,
             dateParsers,
             doubleParsers,
             intParsers,
@@ -2218,6 +2233,14 @@ const auto [allParsers,
                  BOOST_THROW_EXCEPTION(InvalidValueGeneratorSyntax(msg.str()));
              }
              return literalArrayGenerator<true>(node, generatorArgs);
+         }},
+    };
+
+    // Parsers to look when we request a timestamp parser
+    const static std::map<std::string, Parser<UniqueGenerator<bsoncxx::types::b_timestamp>>> timestampParsers{
+        {"^NowTimestamp",
+         [](const Node& node, GeneratorArgs generatorArgs) {
+             return std::make_unique<NowTimestampGenerator>(node, generatorArgs);
          }},
     };
 
@@ -2340,6 +2363,7 @@ const auto [allParsers,
 
     // Only nonexistent keys are inserted.
     allParsers.insert(arrayParsers.begin(), arrayParsers.end());
+    allParsers.insert(timestampParsers.begin(), timestampParsers.end());
     allParsers.insert(dateParsers.begin(), dateParsers.end());
     allParsers.insert(doubleParsers.begin(), doubleParsers.end());
     allParsers.insert(intParsers.begin(), intParsers.end());
@@ -2349,6 +2373,7 @@ const auto [allParsers,
 
     return std::tie(allParsers,
                     arrayParsers,
+                    timestampParsers,
                     dateParsers,
                     doubleParsers,
                     intParsers,

--- a/src/value_generators/test/DocumentGeneratorTestCases.yml
+++ b/src/value_generators/test/DocumentGeneratorTestCases.yml
@@ -870,6 +870,11 @@ Tests:
       date: {^Now: {}}
     ThenExecuteAndIgnore: true
 
+  - Name: NowTimestamp
+    GivenTemplate:
+      date: {^NowTimestamp: {}}
+    ThenExecuteAndIgnore: true
+
   - Name: Date
     GivenTemplate:
       date: {^Date: "1970-01-01"}

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -152,6 +152,9 @@ Actors:
             # Generate the current Date
             now: {^Now: {}}
 
+            # Generate the current timestamp
+            nowTimestamp: {^NowTimestamp: {}}
+
             # Generate field with a null value
             nullField: {^Null: {}}
 

--- a/src/workloads/streams/Passthrough_ChangeStreamSource.yml
+++ b/src/workloads/streams/Passthrough_ChangeStreamSource.yml
@@ -33,6 +33,12 @@ GlobalDefaults:
     *Channel
   ]}}
 
+  # Used for `startAtOperationTime` when creating the stream processor so that it starts
+  # consuming from the beginning of the mongo collection. It is important that this used
+  # with `FixedGeneratedValue` so that the timestamp is generated before the documents
+  # start being inserted into the mongo collection.
+  StartTimestamp: &StartTimestamp {^FixedGeneratedValue: { fromGenerator: {^NowTimestamp: {}}}}
+
   Document: &Document
     auction: {^Inc: { start: 1000, multipler: 1 }}
     bidder: {^Inc: { start: 1000, multipler: 1 }}
@@ -49,15 +55,16 @@ Actors:
   Threads: *NumThreads
   Phases:
   - Phase: 0
-    Nop: true
-  - Phase: 1
     Repeat: *NumInputDocumentsPerThread
     Collection: *InputCollectionName
     Operations:
     - OperationName: insertOne
       OperationCommand:
         Document: *Document
-  - Phase: 2
+        Options:
+          WriteConcern:
+            Level: Majority
+  - Phase: 1..3
     Nop: true
 
 - Name: Setup
@@ -66,6 +73,8 @@ Actors:
   Threads: 1
   Phases:
   - Phase: 0
+    Nop: true
+  - Phase: 1
     Repeat: 1
     Database: *DatabaseName
     Operations:
@@ -79,7 +88,10 @@ Actors:
             $source: {
               connectionName: "db",
               db: *DatabaseName,
-              coll: *InputCollectionName
+              coll: *InputCollectionName,
+              config: {
+                  startAtOperationTime: *StartTimestamp
+              }
             }
           },
           { $replaceRoot: { newRoot: "$fullDocument" } },
@@ -94,9 +106,9 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "db", type: "atlas", options: { uri: {^ClientURI: { Name: "Default" }}}}]
-  - Phase: 1
-    Nop: true
   - Phase: 2
+    Nop: true
+  - Phase: 3
     Repeat: 1
     Database: *DatabaseName
     Operations:
@@ -112,11 +124,11 @@ Actors:
   Database: *DatabaseName
   Threads: 1
   Phases:
-  - Phase: 0
+  - Phase: 0..1
     Nop: true
-  - Phase: 1
+  - Phase: 2
     Repeat: 1
     StreamProcessorName: *StreamProcessorName
     ExpectedDocumentCount: *ExpectedDocumentCount
-  - Phase: 2
+  - Phase: 3
     Nop: true


### PR DESCRIPTION
Jira Ticket: SERVER-85660

Whats Changed:
The change stream source should only be consumed after all documents have been written and durably persisted in the mongo collection, so the stream processor should be started after all the documents have been added to the source collection. In order to this we need to use startAtOperationTime in the $source.config to tell the stream processor to consume the documents in the change stream source from the beginning. It doesn't seem like there is a great way to generate a BSON timestamp object that mongo IDL likes through genny YAML or through the existing generators, so added {^NowTimestamp: {}} generator for BSON timestamps, similar to BSON date generators. (NOTE: None of the BSON date generators work here because the mongo IDL explicitly wants a BSON timestamp object for startAtOperationTime).

https://spruce.mongodb.com/version/65eb93e00305b9f009bb7f7e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC