### PR TITLE
SERVER-88082 Add workloads for WriteType::WriteWithoutShardKeyWithId

### DIFF
--- a/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+++ b/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
@@ -120,7 +120,7 @@ Actors:
         OperationCommand:
           update: Collection0
           updates:
-            { ^Parameter: { Name: "Operations", Default: *WriteOps10x } }
+            { ^Parameter: { Name: "Operations", Default: *WriteOps1000x } }
           ordered: false
 
 AutoRun:

--- a/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+++ b/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
@@ -124,7 +124,7 @@ Actors:
         OperationCommand:
           update: Collection0
           updates:
-            { ^Parameter: { Name: "Operations", Default: *WriteOps1000x } }
+            { ^Parameter: { Name: "Operations", Default: *UpdateOps1000x } }
           ordered: false
 
 AutoRun:

--- a/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+++ b/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
@@ -10,9 +10,19 @@ Description: |
 
   The inserted documents have the following form:
 
-      {_id: 10, oldKey: 20, newKey: 30, counter: 0, padding: 'random string of bytes ...'}
+      {_id: 10, oldKey: 20, newKey: 30, counter: 0, padding: 'random string of bytes to bring the docs up to 8 to 10 KB...'}
 
-  The collection is sharded on {oldKey: 'hashed'}.
+  The collection is sharded on {oldKey: 'hashed'}. The metrics to watchout for here are P50, P99 operation latencies and overall throughput.
+
+Keywords:
+- RunCommand
+- sharded
+- Loader
+- insert
+- update
+- updateOne
+- batch
+- latency
 
 GlobalDefaults:
   - &Nop {Nop: true}
@@ -31,34 +41,28 @@ GlobalDefaults:
   - &ShardKeyValueMin 1
   - &ShardKeyValueMax 1000
 
-  - &Document {
-      oldKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}},
-      newKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}},
-      counter: 0,
-    }
-
-  - &WriteOp {
+  - &UpdateOp {
     q: {_id: {^RandomInt: {min: 1, max: *DocumentCount}}}, u: {$inc: {counter: 1}}
   }
 
-  - &WriteOps10x [
-      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
-      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
+  - &UpdateOps10x [
+      *UpdateOp, *UpdateOp, *UpdateOp, *UpdateOp, *UpdateOp,
+      *UpdateOp, *UpdateOp, *UpdateOp, *UpdateOp, *UpdateOp,
     ]
 
-  - &WriteOps100x {
+  - &UpdateOps100x {
       ^FlattenOnce:
         [
-          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
-          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
+          *UpdateOps10x, *UpdateOps10x, *UpdateOps10x, *UpdateOps10x, *UpdateOps10x,
+          *UpdateOps10x, *UpdateOps10x, *UpdateOps10x, *UpdateOps10x, *UpdateOps10x,
         ]
     }
 
-  - &WriteOps1000x {
+  - &UpdateOps1000x {
       ^FlattenOnce:
         [
-          *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x,
-          *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x,
+          *UpdateOps100x, *UpdateOps100x, *UpdateOps100x, *UpdateOps100x, *UpdateOps100x,
+          *UpdateOps100x, *UpdateOps100x, *UpdateOps100x, *UpdateOps100x, *UpdateOps100x,
         ]
     }
 

--- a/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+++ b/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
@@ -1,0 +1,134 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/sharding"
+Description: |
+  Runs the batched updateOne writes of type WithoutShardKeyWithId with a batch size of 1000.
+
+  The workload consists of 3 phases:
+    1. Creating an empty sharded collection distributed across all shards in the cluster.
+    2. Populating the sharded collection with data.
+    3. Running updateOne operations of type WriteWithoutShardKeyWithId.
+
+  The inserted documents have the following form:
+
+      {_id: 10, oldKey: 20, newKey: 30, counter: 0, padding: 'random string of bytes ...'}
+
+  The collection is sharded on {oldKey: 'hashed'}.
+
+GlobalDefaults:
+  - &Nop {Nop: true}
+
+  - &Database test
+  # Collection0 is the default collection populated by the MonotonicSingleLoader.
+  - &Collection Collection0
+  - &Namespace test.Collection0
+
+  # Note that the exact document size may exceed ApproxDocumentSize because of field names and other
+  # fields in the document.
+  - &ApproxDocumentSize 10000  # = 10kB
+  - &ApproxDocumentSize80Pct 8000  # = 8kB
+  - &DocumentCount 100000  # for an approximate total of 1GB
+
+  - &ShardKeyValueMin 1
+  - &ShardKeyValueMax 1000
+
+  - &Document {
+      oldKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}},
+      newKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}},
+      counter: 0,
+    }
+
+  - &WriteOp {
+    q: {_id: {^RandomInt: {min: 1, max: *DocumentCount}}}, u: {$inc: {counter: 1}}
+  }
+
+  - &WriteOps10x [
+      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
+      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
+    ]
+
+  - &WriteOps100x {
+      ^FlattenOnce:
+        [
+          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
+          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
+        ]
+    }
+
+  - &WriteOps1000x {
+      ^FlattenOnce:
+        [
+          *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x,
+          *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x,
+        ]
+    }
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 600
+
+Actors:
+- Name: CreateShardedCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationMetricsName: EnableSharding
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: *Database
+    - OperationMetricsName: ShardCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: *Namespace
+        # Hashed sharding will pre-split the chunk ranges and evenly distribute them across all of
+        # the shards.
+        key: {oldKey: hashed}
+  - *Nop
+  - *Nop
+
+- Name: LoadInitialData
+  Type: MonotonicSingleLoader
+  Threads: 100
+  Phases:
+  - *Nop
+  - Repeat: 1
+    BatchSize: 1000
+    DocumentCount: *DocumentCount
+    Database: *Database
+    Document:
+      oldKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}}
+      newKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}}
+      counter: 0
+      padding: {^FastRandomString: {length: {^RandomInt: {min: *ApproxDocumentSize80Pct, max: *ApproxDocumentSize}}}}
+  - *Nop
+
+- Name: WriteCollection
+  Type: RunCommand
+  Threads: 450
+  Database: *Database
+  Phases:
+  - *Nop
+  - *Nop
+  - MetricsName: UpdateOneMetrics
+    Duration: 200 seconds
+    Collection: *Collection
+    Operations:
+      - OperationName: RunCommand
+        OperationCommand:
+          update: Collection0
+          updates:
+            { ^Parameter: { Name: "Operations", Default: *WriteOps10x } }
+          ordered: false
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard
+      - shard-lite
+      - shard-lite-all-feature-flags
+    branch_name:
+      $gte: v8.0

--- a/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+++ b/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
@@ -11,9 +11,20 @@ Description: |
 
   The inserted documents have the following form:
 
-      {_id: 10, oldKey: 20, newKey: 30, counter: 0, padding: 'random string of bytes ...'}
+      {_id: 10, oldKey: 20, newKey: 30, counter: 0, padding: 'random string of bytes to bring the docs up to 8 to 10 KB...'}
 
-  The collection is sharded on {oldKey: 'hashed'}.
+  The collection is sharded on {oldKey: 'hashed'}.  The metrics to watchout for here are P50, P99 operation latencies and overall throughput.
+
+Keywords:
+- CrudActor
+- sharded
+- Loader
+- insert
+- update
+- updateOne
+- batch
+- bulkWrite
+- latency
 
 GlobalDefaults:
   - &Nop {Nop: true}
@@ -32,36 +43,30 @@ GlobalDefaults:
   - &ShardKeyValueMin 1
   - &ShardKeyValueMax 1000
 
-  - &Document {
-      oldKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}},
-      newKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}},
-      counter: 0,
-    }
-
-  - &WriteOp { 
+  - &UpdateOp { 
       WriteCommand: updateOne,
       Filter: {_id: {^RandomInt: {min: 1, max: *DocumentCount}}},
       Update: {$inc: {counter: 1}},
     }
 
-  - &WriteOps10x [
-      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
-      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
+  - &UpdateOps10x [
+      *UpdateOp, *UpdateOp, *UpdateOp, *UpdateOp, *UpdateOp,
+      *UpdateOp, *UpdateOp, *UpdateOp, *UpdateOp, *UpdateOp,
     ]
 
-  - &WriteOps100x {
+  - &UpdateOps100x {
       ^FlattenOnce:
         [
-          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
-          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
+          *UpdateOps10x, *UpdateOps10x, *UpdateOps10x, *UpdateOps10x, *UpdateOps10x,
+          *UpdateOps10x, *UpdateOps10x, *UpdateOps10x, *UpdateOps10x, *UpdateOps10x,
         ]
     }
 
-  - &WriteOps1000x {
+  - &UpdateOps1000x {
       ^FlattenOnce:
         [
-          *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x,
-          *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x,
+          *UpdateOps100x, *UpdateOps100x, *UpdateOps100x, *UpdateOps100x, *UpdateOps100x,
+          *UpdateOps100x, *UpdateOps100x, *UpdateOps100x, *UpdateOps100x, *UpdateOps100x,
         ]
     }
 

--- a/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+++ b/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
@@ -1,0 +1,137 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/sharding"
+Description: |
+  Runs the batched updateOne writes of type WithoutShardKeyWithId with a batch size of 1000 using 
+  bulkWrite command.
+
+  The workload consists of 3 phases:
+    1. Creating an empty sharded collection distributed across all shards in the cluster.
+    2. Populating the sharded collection with data.
+    3. Running updateOne writes of type WriteWithoutShardKeyWithId.
+
+  The inserted documents have the following form:
+
+      {_id: 10, oldKey: 20, newKey: 30, counter: 0, padding: 'random string of bytes ...'}
+
+  The collection is sharded on {oldKey: 'hashed'}.
+
+GlobalDefaults:
+  - &Nop {Nop: true}
+
+  - &Database test
+  # Collection0 is the default collection populated by the MonotonicSingleLoader.
+  - &Collection Collection0
+  - &Namespace test.Collection0
+
+  # Note that the exact document size may exceed ApproxDocumentSize because of field names and other
+  # fields in the document.
+  - &ApproxDocumentSize 10000  # = 10kB
+  - &ApproxDocumentSize80Pct 8000  # = 8kB
+  - &DocumentCount 100000  # for an approximate total of 1GB
+
+  - &ShardKeyValueMin 1
+  - &ShardKeyValueMax 1000
+
+  - &Document {
+      oldKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}},
+      newKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}},
+      counter: 0,
+    }
+
+  - &WriteOp { 
+      WriteCommand: updateOne,
+      Filter: {_id: {^RandomInt: {min: 1, max: *DocumentCount}}},
+      Update: {$inc: {counter: 1}},
+    }
+
+  - &WriteOps10x [
+      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
+      *WriteOp, *WriteOp, *WriteOp, *WriteOp, *WriteOp,
+    ]
+
+  - &WriteOps100x {
+      ^FlattenOnce:
+        [
+          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
+          *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x, *WriteOps10x,
+        ]
+    }
+
+  - &WriteOps1000x {
+      ^FlattenOnce:
+        [
+          *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x,
+          *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x, *WriteOps100x,
+        ]
+    }
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 600
+      
+Actors:
+- Name: CreateShardedCollection
+  Type: AdminCommand
+  Threads: 1
+  Phases:
+  - Repeat: 1
+    Database: admin
+    Operations:
+    - OperationMetricsName: EnableSharding
+      OperationName: AdminCommand
+      OperationCommand:
+        enableSharding: *Database
+    - OperationMetricsName: ShardCollection
+      OperationName: AdminCommand
+      OperationCommand:
+        shardCollection: *Namespace
+        # Hashed sharding will pre-split the chunk ranges and evenly distribute them across all of
+        # the shards.
+        key: {oldKey: hashed}
+  - *Nop
+  - *Nop
+
+- Name: LoadInitialData
+  Type: MonotonicSingleLoader
+  Threads: 100
+  Phases:
+  - *Nop
+  - Repeat: 1
+    BatchSize: 1000
+    DocumentCount: *DocumentCount
+    Database: *Database
+    Document:
+      oldKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}}
+      newKey: {^RandomInt: {min: *ShardKeyValueMin, max: *ShardKeyValueMax}}
+      counter: 0
+      padding: {^FastRandomString: {length: {^RandomInt: {min: *ApproxDocumentSize80Pct, max: *ApproxDocumentSize}}}}
+  - *Nop
+
+- Name: WriteCollection
+  Type: CrudActor
+  Threads: 450
+  Database: *Database
+  Phases:
+  - *Nop
+  - *Nop
+  - MetricsName: UpdateOneMetrics
+    Duration: 200 seconds
+    Collection: *Collection
+    Operations:
+      - OperationName: bulkWrite
+        OperationCommand:
+          WriteOperations:
+            { ^Parameter: { Name: "Operations", Default: *WriteOps1000x } }
+          Options:
+            Ordered: false
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - shard
+      - shard-lite
+      - shard-lite-all-feature-flags
+    branch_name:
+      $gte: v8.0

--- a/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+++ b/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
@@ -127,7 +127,7 @@ Actors:
       - OperationName: bulkWrite
         OperationCommand:
           WriteOperations:
-            { ^Parameter: { Name: "Operations", Default: *WriteOps1000x } }
+            { ^Parameter: { Name: "Operations", Default: *UpdateOps1000x } }
           Options:
             Ordered: false
 

--- a/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+++ b/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
@@ -1,7 +1,7 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/sharding"
 Description: |
-  Runs the batched updateOne writes of type WithoutShardKeyWithId with a batch size of 1000 using 
+  Runs the batched bulk updateOne writes of type WithoutShardKeyWithId with a batch size of 1000 using
   bulkWrite command.
 
   The workload consists of 3 phases:


### PR DESCRIPTION
**Jira Ticket:** SERVER-88082

**Whats Changed:**  
Added two new workloads to measure performance under PM-3190

**Patch testing results:**  
(https://spruce.mongodb.com/version/65f4b6c4c50c4400078120c8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

**Workload Submission form:**  
[Pre-filled form](https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform?usp=pp_url&entry.1544049958=PM-3190.+This+workload+tests+the+performance+of+batched+writes+without+shard+key+with+_id.&entry.621283182=Master+Only&entry.132161754=sys-perf&entry.1936323232=Linux+Shard+Lite+Cluster+2022-11(2+shards,+2+node+replica+sets,+once+per+day)&entry.1936323232=Linux+3-Shard+Cluster+2022-11+(once+per+week)&entry.1936323232=Linux+Shard+Lite+All+Feature+Flags+2022-11&entry.1482827051=genny+(https://github.com/mongodb/genny)&entry.349286116=UpdateOneMetrics+throughput+and+latency+(P50,+P99)&entry.361971069=This+is+a+new+workload+so+we+would+like+to+establish+a+base+line.+We+have+however+tested+pre+PM-3190+and+post+PM-3190+workloads+and+found+the+comparison+to+be+within+scope+https://docs.google.com/spreadsheets/d/17Tq7zUsB2y86t9gjH2a2WrGuqIZH9KkTuqCnR1lpBp4/edit?userstoinvite%3Dgaraudy.etienne@mongodb.com%26sharingaction%3Dmanageaccess%26role%3Dwriter%23gid%3D0&entry.1838923236=UpdateOneMetrics+throughput+and+latency+(P50,+P99)&entry.605497846=No&entry.538491135=N/A)
