### PR TITLE
PERF-5246 Add multiplanner workload where query predicates match no documents

### DIFF
--- a/src/workloads/query/multiplanner/NoResults.yml
+++ b/src/workloads/query/multiplanner/NoResults.yml
@@ -1,0 +1,401 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  The goal of this test is to exercise multiplanning. We create as many indexes as possible, and run a
+  query that makes all of them eligible, so we get as many competing plans as possible. All predicates
+  are very selective (match 0% of the documents). With zero results, we do no hit the EOF optimization
+  and all competing plans hit the works limit instead of document limit.
+
+  We expect classic to have better latency and throughput than SBE on this workload,
+  and we expect the combination of classic planner + SBE execution (PM-3591) to perform about
+  as well as classic.
+
+GlobalDefaults:
+  dbname: &db test
+  # Collection name used for queries.
+  coll: &coll Collection0
+  docCount: &docCount 1e5
+  maxPhase: &maxPhase 7
+  queryRepeats: &queryRepeats 1000
+
+Actors:
+- Name: DropCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *maxPhase
+      PhaseConfig:
+        Repeat: 1
+        Database: *db
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            drop: *coll
+
+- Name: SetQueryKnobs
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryKnobTemplate
+    Parameters:
+        # It's ok for this to run in parallel with 'DropCollection'.
+        # It has to be a separate actor because they target different DBs.
+      active: [0]
+      nopInPhasesUpTo: *maxPhase
+      collection: *coll
+
+- Name: CreateDataset
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: InsertTemplate
+    Parameters:
+      database: *db
+      threads: 1
+      active: [1]
+      nopInPhasesUpTo: *maxPhase
+      repeat: 1
+      collection: *coll
+      docCount: *docCount
+      document: {
+        # Genny's random generators appear to be repeatable, so we might as well
+        # make '_id' explicit to make the overall dataset repeatable. Omitting
+        # '_id' would make it auto-generated based on a timestamp.
+        _id: {^Inc: {start: 0}},
+        x1: &distribution {^RandomDouble: {distribution: uniform, min: 0.0, max: 1.0}},
+        x2: *distribution,
+        x3: *distribution,
+        x4: *distribution,
+        x5: *distribution,
+        x6: *distribution,
+        x7: *distribution,
+        x8: *distribution,
+        x9: *distribution,
+        x10: *distribution,
+        x11: *distribution,
+        x12: *distribution,
+        x13: *distribution,
+        x14: *distribution,
+        x15: *distribution,
+        x16: *distribution,
+        x17: *distribution,
+        x18: *distribution,
+        x19: *distribution,
+        x20: *distribution,
+        x21: *distribution,
+        x22: *distribution,
+        x23: *distribution,
+        x24: *distribution,
+        x25: *distribution,
+        x26: *distribution,
+        x27: *distribution,
+        x28: *distribution,
+        x29: *distribution,
+        x30: *distribution,
+        x31: *distribution,
+        x32: *distribution,
+        x33: *distribution,
+        x34: *distribution,
+        x35: *distribution,
+        x36: *distribution,
+        x37: *distribution,
+        x38: *distribution,
+        x39: *distribution,
+        x40: *distribution,
+        x41: *distribution,
+        x42: *distribution,
+        x43: *distribution,
+        x44: *distribution,
+        x45: *distribution,
+        x46: *distribution,
+        x47: *distribution,
+        x48: *distribution,
+        x49: *distribution,
+        x50: *distribution,
+        x51: *distribution,
+        x52: *distribution,
+        x53: *distribution,
+        x54: *distribution,
+        x55: *distribution,
+        x56: *distribution,
+        x57: *distribution,
+        x58: *distribution,
+        x59: *distribution,
+        x60: *distribution,
+        x61: *distribution,
+        x62: *distribution,
+        x63: *distribution
+      }
+      indexes:
+      - keys: {x1: 1}
+        options: {name: index1}
+      - keys: {x2: 1}
+        options: {name: index2}
+      - keys: {x3: 1}
+        options: {name: index3}
+      - keys: {x4: 1}
+        options: {name: index4}
+      - keys: {x5: 1}
+        options: {name: index5}
+      - keys: {x6: 1}
+        options: {name: index6}
+      - keys: {x7: 1}
+        options: {name: index7}
+      - keys: {x8: 1}
+        options: {name: index8}
+      - keys: {x9: 1}
+        options: {name: index9}
+      - keys: {x10: 1}
+        options: {name: index10}
+      - keys: {x11: 1}
+        options: {name: index11}
+      - keys: {x12: 1}
+        options: {name: index12}
+      - keys: {x13: 1}
+        options: {name: index13}
+      - keys: {x14: 1}
+        options: {name: index14}
+      - keys: {x15: 1}
+        options: {name: index15}
+      - keys: {x16: 1}
+        options: {name: index16}
+      - keys: {x17: 1}
+        options: {name: index17}
+      - keys: {x18: 1}
+        options: {name: index18}
+      - keys: {x19: 1}
+        options: {name: index19}
+      - keys: {x20: 1}
+        options: {name: index20}
+      - keys: {x21: 1}
+        options: {name: index21}
+      - keys: {x22: 1}
+        options: {name: index22}
+      - keys: {x23: 1}
+        options: {name: index23}
+      - keys: {x24: 1}
+        options: {name: index24}
+      - keys: {x25: 1}
+        options: {name: index25}
+      - keys: {x26: 1}
+        options: {name: index26}
+      - keys: {x27: 1}
+        options: {name: index27}
+      - keys: {x28: 1}
+        options: {name: index28}
+      - keys: {x29: 1}
+        options: {name: index29}
+      - keys: {x30: 1}
+        options: {name: index30}
+      - keys: {x31: 1}
+        options: {name: index31}
+      - keys: {x32: 1}
+        options: {name: index32}
+      - keys: {x33: 1}
+        options: {name: index33}
+      - keys: {x34: 1}
+        options: {name: index34}
+      - keys: {x35: 1}
+        options: {name: index35}
+      - keys: {x36: 1}
+        options: {name: index36}
+      - keys: {x37: 1}
+        options: {name: index37}
+      - keys: {x38: 1}
+        options: {name: index38}
+      - keys: {x39: 1}
+        options: {name: index39}
+      - keys: {x40: 1}
+        options: {name: index40}
+      - keys: {x41: 1}
+        options: {name: index41}
+      - keys: {x42: 1}
+        options: {name: index42}
+      - keys: {x43: 1}
+        options: {name: index43}
+      - keys: {x44: 1}
+        options: {name: index44}
+      - keys: {x45: 1}
+        options: {name: index45}
+      - keys: {x46: 1}
+        options: {name: index46}
+      - keys: {x47: 1}
+        options: {name: index47}
+      - keys: {x48: 1}
+        options: {name: index48}
+      - keys: {x49: 1}
+        options: {name: index49}
+      - keys: {x50: 1}
+        options: {name: index50}
+      - keys: {x51: 1}
+        options: {name: index51}
+      - keys: {x52: 1}
+        options: {name: index52}
+      - keys: {x53: 1}
+        options: {name: index53}
+      - keys: {x54: 1}
+        options: {name: index54}
+      - keys: {x55: 1}
+        options: {name: index55}
+      - keys: {x56: 1}
+        options: {name: index56}
+      - keys: {x57: 1}
+        options: {name: index57}
+      - keys: {x58: 1}
+        options: {name: index58}
+      - keys: {x59: 1}
+        options: {name: index59}
+      - keys: {x60: 1}
+        options: {name: index60}
+      - keys: {x61: 1}
+        options: {name: index61}
+      - keys: {x62: 1}
+        options: {name: index62}
+      - keys: {x63: 1}
+        options: {name: index63}
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *db
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *maxPhase
+      PhaseConfig:
+        Repeat: 1
+
+- Name: MultiplannerWith64IndexesNoResults
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryTemplate
+    Parameters:
+      active: [3]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+      query: &query {
+        Filter: {
+          x1: {$lte: 0},
+          x2: {$lte: 0},
+          x3: {$lte: 0},
+          x4: {$lte: 0},
+          x5: {$lte: 0},
+          x6: {$lte: 0},
+          x7: {$lte: 0},
+          x8: {$lte: 0},
+          x9: {$lte: 0},
+          x10: {$lte: 0},
+          x11: {$lte: 0},
+          x12: {$lte: 0},
+          x13: {$lte: 0},
+          x14: {$lte: 0},
+          x15: {$lte: 0},
+          x16: {$lte: 0},
+          x17: {$lte: 0},
+          x18: {$lte: 0},
+          x19: {$lte: 0},
+          x20: {$lte: 0},
+          x21: {$lte: 0},
+          x22: {$lte: 0},
+          x23: {$lte: 0},
+          x24: {$lte: 0},
+          x25: {$lte: 0},
+          x26: {$lte: 0},
+          x27: {$lte: 0},
+          x28: {$lte: 0},
+          x29: {$lte: 0},
+          x30: {$lte: 0},
+          x31: {$lte: 0},
+          x32: {$lte: 0},
+          x33: {$lte: 0},
+          x34: {$lte: 0},
+          x35: {$lte: 0},
+          x36: {$lte: 0},
+          x37: {$lte: 0},
+          x38: {$lte: 0},
+          x39: {$lte: 0},
+          x40: {$lte: 0},
+          x41: {$lte: 0},
+          x42: {$lte: 0},
+          x43: {$lte: 0},
+          x44: {$lte: 0},
+          x45: {$lte: 0},
+          x46: {$lte: 0},
+          x47: {$lte: 0},
+          x48: {$lte: 0},
+          x49: {$lte: 0},
+          x50: {$lte: 0},
+          x51: {$lte: 0},
+          x52: {$lte: 0},
+          x53: {$lte: 0},
+          x54: {$lte: 0},
+          x55: {$lte: 0},
+          x56: {$lte: 0},
+          x57: {$lte: 0},
+          x58: {$lte: 0},
+          x59: {$lte: 0},
+          x60: {$lte: 0},
+          x61: {$lte: 0},
+          x62: {$lte: 0},
+          x63: {$lte: 0}
+        }
+      }
+
+- Name: Hide48Indexes
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: Hide48IndexesTemplate
+    Parameters:
+      active: [4]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+
+- Name: MultiplannerWith16IndexesNoResults
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryTemplate
+    Parameters:
+      active: [5]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+      query: *query
+
+- Name: Hide14Indexes
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: Hide14IndexesTemplate
+    Parameters:
+      active: [6]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+
+- Name: MultiplannerWith2IndexesNoResults
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryTemplate
+    Parameters:
+      active: [7]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+      query: *query
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-sbe
+      - standalone-all-feature-flags  # At time of writing this will enable PM-3591.
+      - standalone-classic-query-engine
+    branch_name:
+      $gte: v7.3


### PR DESCRIPTION
**Jira Ticket:** PERF-5246

**Whats Changed:**  
Add multiplanner workload where query predicates match no documents

**Patch testing results:**  
https://spruce.mongodb.com/version/65f876e0aaa0f80007c5f141/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC