### PR TITLE
PERF-5120 Add two multiplanner focused clustered collection workloads

### DIFF
--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -275,7 +275,7 @@ Actors:
       PhaseConfig:
         Repeat: 1
 
-- Name: MultiplannerWith64Indexes
+- Name: ClusteredCollectionMultiplannerWith64Indexes
   LoadConfig:
     Path: "../../../phases/query/Multiplanner.yml"
     Key: QueryTemplate
@@ -364,7 +364,7 @@ Actors:
       database: *db
       collection: *coll
 
-- Name: MultiplannerWith16Indexes
+- Name: ClusteredCollectionMultiplannerWith16Indexes
   LoadConfig:
     Path: "../../../phases/query/Multiplanner.yml"
     Key: QueryTemplate
@@ -387,7 +387,7 @@ Actors:
       database: *db
       collection: *coll
 
-- Name: MultiplannerWith2Indexes
+- Name: ClusteredCollectionMultiplannerWith2Indexes
   LoadConfig:
     Path: "../../../phases/query/Multiplanner.yml"
     Key: QueryTemplate

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -1,13 +1,9 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
 Description: |
-  The goal of this test is to exercise multiplanning. We create as many indexes as possible, and run a
-  query that makes all of them eligible, so we get as many competing plans as possible.
-
-  The original goal of this test was to demonstrate weaknesses of the SBE multiplanner when compared to
-  the classic multiplanner. Mainly, the SBE multiplanner can't round-robin between plans, which means it
-  has to run the list of plans sequentially, which means we can't short-circuit when the shortest-running
-  plan finishes.
+ The goal of this test is to exercise multiplanning. We create as many indexes as possible, and run a
+  query that makes all of them eligible, so we get as many competing plans as possible. Here, we do this on a
+  clustered collection that has very large strings as _id.
 
   We expect classic to have better latency and throughput than SBE on this workload,
   and we expect the combination of classic planner + SBE execution (PM-3591) to perform about

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -1,0 +1,410 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  The goal of this test is to exercise multiplanning. We create as many indexes as possible, and run a
+  query that makes all of them eligible, so we get as many competing plans as possible.
+
+  The original goal of this test was to demonstrate weaknesses of the SBE multiplanner when compared to
+  the classic multiplanner. Mainly, the SBE multiplanner can't round-robin between plans, which means it
+  has to run the list of plans sequentially, which means we can't short-circuit when the shortest-running
+  plan finishes.
+
+  We expect classic to have better latency and throughput than SBE on this workload,
+  and we expect the combination of classic planner + SBE execution (PM-3591) to perform about
+  as well as classic.
+
+GlobalDefaults:
+  dbname: &db test
+  # Collection name used for queries.
+  coll: &coll Collection0
+
+  docCount: &docCount 1e5
+  resultCount: &resultCount 101
+  selectivity: &selectivity {^NumExpr: {
+    withExpression: "resultCount / docCount",
+    andValues: {resultCount: *resultCount, docCount: *docCount}}}
+
+  maxPhase: &maxPhase 7
+  queryRepeats: &queryRepeats 1000
+
+Actors:
+- Name: DropCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *maxPhase
+      PhaseConfig:
+        Repeat: 1
+        Database: *db
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            drop: *coll
+        - OperationName: RunCommand
+          OperationCommand:
+            create: *coll
+            clusteredIndex: { "key": { _id: 1 }, "unique": true }
+
+- Name: SetQueryKnobs
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryKnobTemplate
+    Parameters:
+        # It's ok for this to run in parallel with 'DropCollection'.
+        # It has to be a separate actor because they target different DBs.
+      active: [0]
+      nopInPhasesUpTo: *maxPhase
+      collection: *coll
+
+- Name: CreateDataset
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: InsertTemplate
+    Parameters:
+      database: *db
+      threads: 1
+      active: [1]
+      nopInPhasesUpTo: *maxPhase
+      repeat: 1
+      collection: *coll
+      docCount: *docCount
+      document: {
+        _id: {^FastRandomString: {length: 512}},
+        x1: &distribution {^RandomDouble: {distribution: uniform, min: 0.0, max: 1.0}},
+        x2: *distribution,
+        x3: *distribution,
+        x4: *distribution,
+        x5: *distribution,
+        x6: *distribution,
+        x7: *distribution,
+        x8: *distribution,
+        x9: *distribution,
+        x10: *distribution,
+        x11: *distribution,
+        x12: *distribution,
+        x13: *distribution,
+        x14: *distribution,
+        x15: *distribution,
+        x16: *distribution,
+        x17: *distribution,
+        x18: *distribution,
+        x19: *distribution,
+        x20: *distribution,
+        x21: *distribution,
+        x22: *distribution,
+        x23: *distribution,
+        x24: *distribution,
+        x25: *distribution,
+        x26: *distribution,
+        x27: *distribution,
+        x28: *distribution,
+        x29: *distribution,
+        x30: *distribution,
+        x31: *distribution,
+        x32: *distribution,
+        x33: *distribution,
+        x34: *distribution,
+        x35: *distribution,
+        x36: *distribution,
+        x37: *distribution,
+        x38: *distribution,
+        x39: *distribution,
+        x40: *distribution,
+        x41: *distribution,
+        x42: *distribution,
+        x43: *distribution,
+        x44: *distribution,
+        x45: *distribution,
+        x46: *distribution,
+        x47: *distribution,
+        x48: *distribution,
+        x49: *distribution,
+        x50: *distribution,
+        x51: *distribution,
+        x52: *distribution,
+        x53: *distribution,
+        x54: *distribution,
+        x55: *distribution,
+        x56: *distribution,
+        x57: *distribution,
+        x58: *distribution,
+        x59: *distribution,
+        x60: *distribution,
+        x61: *distribution,
+        x62: *distribution,
+        x63: *distribution
+      }
+      indexes:
+      - keys: {x1: 1}
+        options: {name: index1}
+      - keys: {x2: 1}
+        options: {name: index2}
+      - keys: {x3: 1}
+        options: {name: index3}
+      - keys: {x4: 1}
+        options: {name: index4}
+      - keys: {x5: 1}
+        options: {name: index5}
+      - keys: {x6: 1}
+        options: {name: index6}
+      - keys: {x7: 1}
+        options: {name: index7}
+      - keys: {x8: 1}
+        options: {name: index8}
+      - keys: {x9: 1}
+        options: {name: index9}
+      - keys: {x10: 1}
+        options: {name: index10}
+      - keys: {x11: 1}
+        options: {name: index11}
+      - keys: {x12: 1}
+        options: {name: index12}
+      - keys: {x13: 1}
+        options: {name: index13}
+      - keys: {x14: 1}
+        options: {name: index14}
+      - keys: {x15: 1}
+        options: {name: index15}
+      - keys: {x16: 1}
+        options: {name: index16}
+      - keys: {x17: 1}
+        options: {name: index17}
+      - keys: {x18: 1}
+        options: {name: index18}
+      - keys: {x19: 1}
+        options: {name: index19}
+      - keys: {x20: 1}
+        options: {name: index20}
+      - keys: {x21: 1}
+        options: {name: index21}
+      - keys: {x22: 1}
+        options: {name: index22}
+      - keys: {x23: 1}
+        options: {name: index23}
+      - keys: {x24: 1}
+        options: {name: index24}
+      - keys: {x25: 1}
+        options: {name: index25}
+      - keys: {x26: 1}
+        options: {name: index26}
+      - keys: {x27: 1}
+        options: {name: index27}
+      - keys: {x28: 1}
+        options: {name: index28}
+      - keys: {x29: 1}
+        options: {name: index29}
+      - keys: {x30: 1}
+        options: {name: index30}
+      - keys: {x31: 1}
+        options: {name: index31}
+      - keys: {x32: 1}
+        options: {name: index32}
+      - keys: {x33: 1}
+        options: {name: index33}
+      - keys: {x34: 1}
+        options: {name: index34}
+      - keys: {x35: 1}
+        options: {name: index35}
+      - keys: {x36: 1}
+        options: {name: index36}
+      - keys: {x37: 1}
+        options: {name: index37}
+      - keys: {x38: 1}
+        options: {name: index38}
+      - keys: {x39: 1}
+        options: {name: index39}
+      - keys: {x40: 1}
+        options: {name: index40}
+      - keys: {x41: 1}
+        options: {name: index41}
+      - keys: {x42: 1}
+        options: {name: index42}
+      - keys: {x43: 1}
+        options: {name: index43}
+      - keys: {x44: 1}
+        options: {name: index44}
+      - keys: {x45: 1}
+        options: {name: index45}
+      - keys: {x46: 1}
+        options: {name: index46}
+      - keys: {x47: 1}
+        options: {name: index47}
+      - keys: {x48: 1}
+        options: {name: index48}
+      - keys: {x49: 1}
+        options: {name: index49}
+      - keys: {x50: 1}
+        options: {name: index50}
+      - keys: {x51: 1}
+        options: {name: index51}
+      - keys: {x52: 1}
+        options: {name: index52}
+      - keys: {x53: 1}
+        options: {name: index53}
+      - keys: {x54: 1}
+        options: {name: index54}
+      - keys: {x55: 1}
+        options: {name: index55}
+      - keys: {x56: 1}
+        options: {name: index56}
+      - keys: {x57: 1}
+        options: {name: index57}
+      - keys: {x58: 1}
+        options: {name: index58}
+      - keys: {x59: 1}
+        options: {name: index59}
+      - keys: {x60: 1}
+        options: {name: index60}
+      - keys: {x61: 1}
+        options: {name: index61}
+      - keys: {x62: 1}
+        options: {name: index62}
+      - keys: {x63: 1}
+        options: {name: index63}
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *db
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *maxPhase
+      PhaseConfig:
+        Repeat: 1
+
+- Name: MultiplannerWith64Indexes
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryTemplate
+    Parameters:
+      active: [3]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+      query: &query {
+        Filter: {
+          x1: {$lt: *selectivity},
+          x2: {$lte: 1},
+          x3: {$lte: 1},
+          x4: {$lte: 1},
+          x5: {$lte: 1},
+          x6: {$lte: 1},
+          x7: {$lte: 1},
+          x8: {$lte: 1},
+          x9: {$lte: 1},
+          x10: {$lte: 1},
+          x11: {$lte: 1},
+          x12: {$lte: 1},
+          x13: {$lte: 1},
+          x14: {$lte: 1},
+          x15: {$lte: 1},
+          x16: {$lte: 1},
+          x17: {$lte: 1},
+          x18: {$lte: 1},
+          x19: {$lte: 1},
+          x20: {$lte: 1},
+          x21: {$lte: 1},
+          x22: {$lte: 1},
+          x23: {$lte: 1},
+          x24: {$lte: 1},
+          x25: {$lte: 1},
+          x26: {$lte: 1},
+          x27: {$lte: 1},
+          x28: {$lte: 1},
+          x29: {$lte: 1},
+          x30: {$lte: 1},
+          x31: {$lte: 1},
+          x32: {$lte: 1},
+          x33: {$lte: 1},
+          x34: {$lte: 1},
+          x35: {$lte: 1},
+          x36: {$lte: 1},
+          x37: {$lte: 1},
+          x38: {$lte: 1},
+          x39: {$lte: 1},
+          x40: {$lte: 1},
+          x41: {$lte: 1},
+          x42: {$lte: 1},
+          x43: {$lte: 1},
+          x44: {$lte: 1},
+          x45: {$lte: 1},
+          x46: {$lte: 1},
+          x47: {$lte: 1},
+          x48: {$lte: 1},
+          x49: {$lte: 1},
+          x50: {$lte: 1},
+          x51: {$lte: 1},
+          x52: {$lte: 1},
+          x53: {$lte: 1},
+          x54: {$lte: 1},
+          x55: {$lte: 1},
+          x56: {$lte: 1},
+          x57: {$lte: 1},
+          x58: {$lte: 1},
+          x59: {$lte: 1},
+          x60: {$lte: 1},
+          x61: {$lte: 1},
+          x62: {$lte: 1},
+          x63: {$lte: 1}
+        }
+      }
+
+- Name: Hide48Indexes
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: Hide48IndexesTemplate
+    Parameters:
+      active: [4]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+
+- Name: MultiplannerWith16Indexes
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryTemplate
+    Parameters:
+      active: [5]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+      query: *query
+
+- Name: Hide14Indexes
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: Hide14IndexesTemplate
+    Parameters:
+      active: [6]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+
+- Name: MultiplannerWith2Indexes
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryTemplate
+    Parameters:
+      active: [7]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+      query: *query
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone-sbe
+      - standalone-all-feature-flags  # At time of writing this will enable PM-3591.
+      - standalone-classic-query-engine
+    branch_name:
+      $gte: v7.3

--- a/src/workloads/query/multiplanner/UseClusteredIndex.yml
+++ b/src/workloads/query/multiplanner/UseClusteredIndex.yml
@@ -1,0 +1,410 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  The goal of this test is to exercise multiplanning. We create as many indexes as possible, and run a
+  query that makes all of them eligible, so we get as many competing plans as possible.
+
+  The original goal of this test was to demonstrate weaknesses of the SBE multiplanner when compared to
+  the classic multiplanner. Mainly, the SBE multiplanner can't round-robin between plans, which means it
+  has to run the list of plans sequentially, which means we can't short-circuit when the shortest-running
+  plan finishes.
+
+  We expect classic to have better latency and throughput than SBE on this workload,
+  and we expect the combination of classic planner + SBE execution (PM-3591) to perform about
+  as well as classic.
+
+GlobalDefaults:
+  dbname: &db test
+  # Collection name used for queries.
+  coll: &coll Collection0
+
+  docCount: &docCount 1e5
+  resultCount: &resultCount 101
+  selectivity: &selectivity {^NumExpr: {
+    withExpression: "resultCount / docCount",
+    andValues: {resultCount: *resultCount, docCount: *docCount}}}
+
+  maxPhase: &maxPhase 7
+  queryRepeats: &queryRepeats 1000
+
+Actors:
+- Name: DropCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *maxPhase
+      PhaseConfig:
+        Repeat: 1
+        Database: *db
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand:
+            drop: *coll
+        - OperationName: RunCommand
+          OperationCommand:
+            create: *coll
+            clusteredIndex: { "key": { _id: 1 }, "unique": true }
+
+- Name: SetQueryKnobs
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryKnobTemplate
+    Parameters:
+        # It's ok for this to run in parallel with 'DropCollection'.
+        # It has to be a separate actor because they target different DBs.
+      active: [0]
+      nopInPhasesUpTo: *maxPhase
+      collection: *coll
+
+- Name: CreateDataset
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: InsertTemplate
+    Parameters:
+      database: *db
+      threads: 1
+      active: [1]
+      nopInPhasesUpTo: *maxPhase
+      repeat: 1
+      collection: *coll
+      docCount: *docCount
+      document: {
+        x1: &distribution {^RandomDouble: {distribution: uniform, min: 0.0, max: 1.0}},
+        x2: *distribution,
+        x3: *distribution,
+        x4: *distribution,
+        x5: *distribution,
+        x6: *distribution,
+        x7: *distribution,
+        x8: *distribution,
+        x9: *distribution,
+        x10: *distribution,
+        x11: *distribution,
+        x12: *distribution,
+        x13: *distribution,
+        x14: *distribution,
+        x15: *distribution,
+        x16: *distribution,
+        x17: *distribution,
+        x18: *distribution,
+        x19: *distribution,
+        x20: *distribution,
+        x21: *distribution,
+        x22: *distribution,
+        x23: *distribution,
+        x24: *distribution,
+        x25: *distribution,
+        x26: *distribution,
+        x27: *distribution,
+        x28: *distribution,
+        x29: *distribution,
+        x30: *distribution,
+        x31: *distribution,
+        x32: *distribution,
+        x33: *distribution,
+        x34: *distribution,
+        x35: *distribution,
+        x36: *distribution,
+        x37: *distribution,
+        x38: *distribution,
+        x39: *distribution,
+        x40: *distribution,
+        x41: *distribution,
+        x42: *distribution,
+        x43: *distribution,
+        x44: *distribution,
+        x45: *distribution,
+        x46: *distribution,
+        x47: *distribution,
+        x48: *distribution,
+        x49: *distribution,
+        x50: *distribution,
+        x51: *distribution,
+        x52: *distribution,
+        x53: *distribution,
+        x54: *distribution,
+        x55: *distribution,
+        x56: *distribution,
+        x57: *distribution,
+        x58: *distribution,
+        x59: *distribution,
+        x60: *distribution,
+        x61: *distribution,
+        x62: *distribution,
+        x63: *distribution
+      }
+      indexes:
+      - keys: {x1: 1}
+        options: {name: index1}
+      - keys: {x2: 1}
+        options: {name: index2}
+      - keys: {x3: 1}
+        options: {name: index3}
+      - keys: {x4: 1}
+        options: {name: index4}
+      - keys: {x5: 1}
+        options: {name: index5}
+      - keys: {x6: 1}
+        options: {name: index6}
+      - keys: {x7: 1}
+        options: {name: index7}
+      - keys: {x8: 1}
+        options: {name: index8}
+      - keys: {x9: 1}
+        options: {name: index9}
+      - keys: {x10: 1}
+        options: {name: index10}
+      - keys: {x11: 1}
+        options: {name: index11}
+      - keys: {x12: 1}
+        options: {name: index12}
+      - keys: {x13: 1}
+        options: {name: index13}
+      - keys: {x14: 1}
+        options: {name: index14}
+      - keys: {x15: 1}
+        options: {name: index15}
+      - keys: {x16: 1}
+        options: {name: index16}
+      - keys: {x17: 1}
+        options: {name: index17}
+      - keys: {x18: 1}
+        options: {name: index18}
+      - keys: {x19: 1}
+        options: {name: index19}
+      - keys: {x20: 1}
+        options: {name: index20}
+      - keys: {x21: 1}
+        options: {name: index21}
+      - keys: {x22: 1}
+        options: {name: index22}
+      - keys: {x23: 1}
+        options: {name: index23}
+      - keys: {x24: 1}
+        options: {name: index24}
+      - keys: {x25: 1}
+        options: {name: index25}
+      - keys: {x26: 1}
+        options: {name: index26}
+      - keys: {x27: 1}
+        options: {name: index27}
+      - keys: {x28: 1}
+        options: {name: index28}
+      - keys: {x29: 1}
+        options: {name: index29}
+      - keys: {x30: 1}
+        options: {name: index30}
+      - keys: {x31: 1}
+        options: {name: index31}
+      - keys: {x32: 1}
+        options: {name: index32}
+      - keys: {x33: 1}
+        options: {name: index33}
+      - keys: {x34: 1}
+        options: {name: index34}
+      - keys: {x35: 1}
+        options: {name: index35}
+      - keys: {x36: 1}
+        options: {name: index36}
+      - keys: {x37: 1}
+        options: {name: index37}
+      - keys: {x38: 1}
+        options: {name: index38}
+      - keys: {x39: 1}
+        options: {name: index39}
+      - keys: {x40: 1}
+        options: {name: index40}
+      - keys: {x41: 1}
+        options: {name: index41}
+      - keys: {x42: 1}
+        options: {name: index42}
+      - keys: {x43: 1}
+        options: {name: index43}
+      - keys: {x44: 1}
+        options: {name: index44}
+      - keys: {x45: 1}
+        options: {name: index45}
+      - keys: {x46: 1}
+        options: {name: index46}
+      - keys: {x47: 1}
+        options: {name: index47}
+      - keys: {x48: 1}
+        options: {name: index48}
+      - keys: {x49: 1}
+        options: {name: index49}
+      - keys: {x50: 1}
+        options: {name: index50}
+      - keys: {x51: 1}
+        options: {name: index51}
+      - keys: {x52: 1}
+        options: {name: index52}
+      - keys: {x53: 1}
+        options: {name: index53}
+      - keys: {x54: 1}
+        options: {name: index54}
+      - keys: {x55: 1}
+        options: {name: index55}
+      - keys: {x56: 1}
+        options: {name: index56}
+      - keys: {x57: 1}
+        options: {name: index57}
+      - keys: {x58: 1}
+        options: {name: index58}
+      - keys: {x59: 1}
+        options: {name: index59}
+      - keys: {x60: 1}
+        options: {name: index60}
+      - keys: {x61: 1}
+        options: {name: index61}
+      - keys: {x62: 1}
+        options: {name: index62}
+      - keys: {x63: 1}
+        options: {name: index63}
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *db
+  Phases:
+    OnlyActiveInPhases:
+      Active: [2]
+      NopInPhasesUpTo: *maxPhase
+      PhaseConfig:
+        Repeat: 1
+
+- Name: MultiplannerWith64IndexesAndClusteredIndex
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryTemplate
+    Parameters:
+      active: [3]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+      query: &query {
+        Filter: {
+          _id: {$lt: *resultCount},
+          x1: {$lt: *selectivity},
+          x2: {$lte: 1},
+          x3: {$lte: 1},
+          x4: {$lte: 1},
+          x5: {$lte: 1},
+          x6: {$lte: 1},
+          x7: {$lte: 1},
+          x8: {$lte: 1},
+          x9: {$lte: 1},
+          x10: {$lte: 1},
+          x11: {$lte: 1},
+          x12: {$lte: 1},
+          x13: {$lte: 1},
+          x14: {$lte: 1},
+          x15: {$lte: 1},
+          x16: {$lte: 1},
+          x17: {$lte: 1},
+          x18: {$lte: 1},
+          x19: {$lte: 1},
+          x20: {$lte: 1},
+          x21: {$lte: 1},
+          x22: {$lte: 1},
+          x23: {$lte: 1},
+          x24: {$lte: 1},
+          x25: {$lte: 1},
+          x26: {$lte: 1},
+          x27: {$lte: 1},
+          x28: {$lte: 1},
+          x29: {$lte: 1},
+          x30: {$lte: 1},
+          x31: {$lte: 1},
+          x32: {$lte: 1},
+          x33: {$lte: 1},
+          x34: {$lte: 1},
+          x35: {$lte: 1},
+          x36: {$lte: 1},
+          x37: {$lte: 1},
+          x38: {$lte: 1},
+          x39: {$lte: 1},
+          x40: {$lte: 1},
+          x41: {$lte: 1},
+          x42: {$lte: 1},
+          x43: {$lte: 1},
+          x44: {$lte: 1},
+          x45: {$lte: 1},
+          x46: {$lte: 1},
+          x47: {$lte: 1},
+          x48: {$lte: 1},
+          x49: {$lte: 1},
+          x50: {$lte: 1},
+          x51: {$lte: 1},
+          x52: {$lte: 1},
+          x53: {$lte: 1},
+          x54: {$lte: 1},
+          x55: {$lte: 1},
+          x56: {$lte: 1},
+          x57: {$lte: 1},
+          x58: {$lte: 1},
+          x59: {$lte: 1},
+          x60: {$lte: 1},
+          x61: {$lte: 1},
+          x62: {$lte: 1},
+          x63: {$lte: 1}
+        }
+      }
+
+- Name: Hide48Indexes
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: Hide48IndexesTemplate
+    Parameters:
+      active: [4]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+
+- Name: MultiplannerWith16IndexesAndClusteredIndex
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryTemplate
+    Parameters:
+      active: [5]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+      query: *query
+
+- Name: Hide14Indexes
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: Hide14IndexesTemplate
+    Parameters:
+      active: [6]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+
+- Name: MultiplannerWith2IndexesAndClusteredIndex
+  LoadConfig:
+    Path: "../../../phases/query/Multiplanner.yml"
+    Key: QueryTemplate
+    Parameters:
+      active: [7]
+      nopInPhasesUpTo: *maxPhase
+      repeat: *queryRepeats
+      database: *db
+      collection: *coll
+      query: *query
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone-sbe
+      - standalone-all-feature-flags  # At time of writing this will enable PM-3591.
+      - standalone-classic-query-engine
+    branch_name:
+      $gte: v7.3

--- a/src/workloads/query/multiplanner/UseClusteredIndex.yml
+++ b/src/workloads/query/multiplanner/UseClusteredIndex.yml
@@ -1,13 +1,9 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
 Description: |
-  The goal of this test is to exercise multiplanning. We create as many indexes as possible, and run a
-  query that makes all of them eligible, so we get as many competing plans as possible.
-
-  The original goal of this test was to demonstrate weaknesses of the SBE multiplanner when compared to
-  the classic multiplanner. Mainly, the SBE multiplanner can't round-robin between plans, which means it
-  has to run the list of plans sequentially, which means we can't short-circuit when the shortest-running
-  plan finishes.
+ The goal of this test is to exercise multiplanning. We create as many indexes as possible, and run a
+  query that makes all of them eligible, so we get as many competing plans as possible. Here, we do this on a
+  clustered collection and add a selective predicate on _id, so that the clustered index is a viable candidate plan.
 
   We expect classic to have better latency and throughput than SBE on this workload,
   and we expect the combination of classic planner + SBE execution (PM-3591) to perform about


### PR DESCRIPTION
**Jira Ticket:** PERF-5120

**Whats Changed:**  
ClusteredCollection workload that has huge _id.
UseClusteredIndex workload that has predicate on _id as selective as predicate on x1, making clustered index tied with x1 index.

**Patch testing results:**  
https://spruce.mongodb.com/version/65fc278f3a0f5b000781f94d/tasks

Note: it depends on the monotonic loader PR #1155