### PR TITLE
PERF-5282 reduce runtime to prevent OOM on client mixed_workloads_genny_stress

### DIFF
--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -29,7 +29,7 @@ Keywords:
 dbname: &dbname mix
 DocumentCount: &NumDocs 1024
 CollectionCount: &NumColls 512
-PhaseDuration: &PhaseDuration 45 minutes
+PhaseDuration: &PhaseDuration 15 minutes
 StringLength: &StringLength 950
 Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
 Document: &doc

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -29,7 +29,7 @@ Keywords:
 dbname: &dbname mix
 DocumentCount: &NumDocs 1024
 CollectionCount: &NumColls 512
-PhaseDuration: &PhaseDuration 30 minutes
+PhaseDuration: &PhaseDuration 25 minutes
 StringLength: &StringLength 950
 Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
 Document: &doc

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -29,7 +29,7 @@ Keywords:
 dbname: &dbname mix
 DocumentCount: &NumDocs 1024
 CollectionCount: &NumColls 512
-PhaseDuration: &PhaseDuration 25 minutes
+PhaseDuration: &PhaseDuration 20 minutes
 StringLength: &StringLength 950
 Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
 Document: &doc

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -29,7 +29,7 @@ Keywords:
 dbname: &dbname mix
 DocumentCount: &NumDocs 1024
 CollectionCount: &NumColls 512
-PhaseDuration: &PhaseDuration 15 minutes
+PhaseDuration: &PhaseDuration 30 minutes
 StringLength: &StringLength 950
 Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
 Document: &doc


### PR DESCRIPTION
**Jira Ticket:** [PERF-5282](https://jira.mongodb.org/browse/PERF-5282)

**Whats Changed:**  
reduce runtime to prevent OOM on client mixed_workloads_genny_stress. The test currently fails because the workload client memory grows beyond the capacity of the system and crashes. Instead of increasing the instance size we are shortening the test to it finishes before it reaches this breaking point. I tested 30 min, 25 min, 20 min, and 15 min. 20 min was the longest time that didn't OOM die. It also had slightly lower noise than 15 min.

test | measurement | 20 min CV | 15 min CV
-- | -- | -- | --
Find_1024.Crud | Latency50thPercentile | 6.5% | 3.5%
Find_1024.Crud | Latency95thPercentile | 1.1% | 1.4%
Find_1024.Crud | OperationThroughput | 1.5% | 1.4%
Find_1024.findOne | Latency50thPercentile | 6.5% | 3.5%
Find_1024.findOne | Latency95thPercentile | 1.1% | 1.4%
Find_1024.findOne | OperationThroughput | 1.5% | 1.4%
Insert_1024.Crud | Latency50thPercentile | 2.5% | 2.7%
Insert_1024.Crud | Latency95thPercentile | 2.1% | 3.0%
Insert_1024.Crud | OperationThroughput | 2.4% | 2.8%
Insert_1024.insertOne | Latency50thPercentile | 2.5% | 2.7%
Insert_1024.insertOne | Latency95thPercentile | 2.1% | 3.0%
Insert_1024.insertOne | OperationThroughput | 2.4% | 2.8%
LogLevel.DatabaseOperation.0.0 | Latency50thPercentile | 10.5% | 24.3%
LogLevel.DatabaseOperation.0.0 | Latency95thPercentile | 10.5% | 24.3%
LogLevel.DatabaseOperation.0.0 | OperationThroughput | 11.1% | 23.4%
Remove_1024.Crud | Latency50thPercentile | 2.4% | 2.7%
Remove_1024.Crud | Latency95thPercentile | 2.1% | 2.9%
Remove_1024.Crud | OperationThroughput | 2.4% | 2.8%
Remove_1024.deleteOne | Latency50thPercentile | 2.4% | 2.7%
Remove_1024.deleteOne | Latency95thPercentile | 2.1% | 2.9%
Remove_1024.deleteOne | OperationThroughput | 2.4% | 2.8%
Update_1024.Crud | Latency50thPercentile | 2.4% | 2.7%
Update_1024.Crud | Latency95thPercentile | 2.1% | 2.9%
Update_1024.Crud | OperationThroughput | 2.4% | 2.8%
Update_1024.updateOne | Latency50thPercentile | 2.4% | 2.7%
Update_1024.updateOne | Latency95thPercentile | 2.1% | 2.9%
Update_1024.updateOne | OperationThroughput | 2.4% | 2.8%



**Patch testing results:**  
[patch](https://spruce.mongodb.com/version/65fb304f965c6d00073122f8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

**Workload Submission form:**  
N/A

**Related PRs:**   
N/A