### PR TITLE
PERF-5302: Properly process port number environment variables captured by Poplar

### DIFF
--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -150,6 +150,7 @@ def poplar_grpc(cleanup_metrics: bool, workspace_root: str, genny_repo_root: str
             poplar = subprocess.Popen(
                 args, stdout=log_file_obj, stderr=subprocess.STDOUT, text=True
             )
+            poplar_port = int(os.environ.get("POPLAR_RPC_PORT", 2288))
             if poplar.poll() is not None:
                 raise OSError("Failed to start Poplar.")
             try:
@@ -159,7 +160,7 @@ def poplar_grpc(cleanup_metrics: bool, workspace_root: str, genny_repo_root: str
                     time.sleep(0.2)  # sleep to let curator get started. This is a heuristic.
                     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     try:
-                        sock.connect(("127.0.0.1", 2288))
+                        sock.connect(("127.0.0.1", poplar_port))
                         # If we didn't throw an exception, then we successfully connected
                         connected = True
                         break
@@ -171,7 +172,7 @@ def poplar_grpc(cleanup_metrics: bool, workspace_root: str, genny_repo_root: str
                     finally:
                         sock.close()
                 if not connected:
-                    raise OSError(f"Poplar not listening on port 2288")
+                    raise OSError(f"Poplar not listening on port {poplar_port}.")
                 yield poplar
             finally:
                 try:

--- a/src/metrics/include/metrics/v2/event.hpp
+++ b/src/metrics/include/metrics/v2/event.hpp
@@ -104,10 +104,19 @@ private:
         // Maximum buffer size grpc will allow.
         args.SetInt(GRPC_ARG_HTTP2_WRITE_BUFFER_SIZE, GRPC_BUFFER_SIZE);
         // Local subchannels prohibit global sharing and forces multiple TCP connections.
+
+        auto channelUriBuilder = std::stringstream{} << "localhost:";
+        if (auto channelPortString = std::getenv("POPLAR_RPC_PORT")) {
+          channelUriBuilder << channelPortString;
+        } else {
+          channelUriBuilder << 2288;
+        }
+        const auto channelUri = channelUriBuilder.str();
+
         args.SetInt(GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL, 1);
         for (int i = 0; i < NUM_CHANNELS; i++) {
             _channels.push_back(grpc::CreateCustomChannel(
-                "localhost:2288", grpc::InsecureChannelCredentials(), args));
+                channelUri, grpc::InsecureChannelCredentials(), args));
         }
 
         return _channels;


### PR DESCRIPTION
This fixes a potential bug with the Genny hook via Curator into Poplar. [Poplar](https://github.com/mongodb/curator/blob/a1293258b30e04ea503e6b91b6b1628789e90093/operations/poplar.go#L21C34-L21C49) accepts the `POPLAR_RPC_HOST` and the `POPLAR_RPC_PORT` environment variables and defaults to `localhost` and `2288` if those environment variables are not set.

This change properly handles the `POPLAR_RPC_PORT` environment variable when setting up Genny to connect to Poplar. Prior to this change, Genny would attempt to connect to port `2288`, regardless of where the Poplar service was actually listening.