### PR TITLE
PERF-5308: shorten genny stressy workloads to 15 min to prevent OOM on all major releases of mongo

### DIFF
--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -29,7 +29,7 @@ Keywords:
 dbname: &dbname mix
 DocumentCount: &NumDocs 1024
 CollectionCount: &NumColls 512
-PhaseDuration: &PhaseDuration 20 minutes
+PhaseDuration: &PhaseDuration 15 minutes
 StringLength: &StringLength 950
 Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
 Document: &doc

--- a/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
@@ -32,7 +32,7 @@ Keywords:
 dbname: &dbname mix
 DocumentCount: &NumDocs 1024
 CollectionCount: &NumColls 512
-PhaseDuration: &PhaseDuration 45 minutes
+PhaseDuration: &PhaseDuration 15 minutes
 StringLength: &StringLength 950
 Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
 Document: &doc

--- a/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+++ b/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
@@ -17,7 +17,7 @@ GlobalDefaults:
   Collection: &Collection Collection0
   Namespace: &Namespace test.Collection0
 
-  DocumentCount: &DocumentCount 10~000  # Number of documents to insert and modify.
+  DocumentCount: &DocumentCount 10000  # Number of documents to insert and modify.
 
 Actors:
 - Name: CreateShardedCollection

--- a/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+++ b/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
@@ -17,7 +17,7 @@ GlobalDefaults:
   Collection: &Collection Collection0
   Namespace: &Namespace test.Collection0
 
-  DocumentCount: &DocumentCount 10000  # Number of documents to insert and modify.
+  DocumentCount: &DocumentCount 10~000  # Number of documents to insert and modify.
 
 Actors:
 - Name: CreateShardedCollection


### PR DESCRIPTION
**Jira Ticket:** PERF-5308

**Whats Changed:**  
shorten genny stressy workloads to 15 min to prevent OOM on all major releases of mongo

**Patch testing results:**  
https://spruce.mongodb.com/version/66033c11ca19fe0007f985c7/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=mixed_workloads_genny_stress

**Workload Submission form:**  
N/A

**Related PRs:**   
https://github.com/mongodb/genny/pull/1163