### PR TITLE
PERF-5310 shorten connection_pool_stress to prevent OOM kill

### DIFF
--- a/src/workloads/issues/ConnectionPoolStress.yml
+++ b/src/workloads/issues/ConnectionPoolStress.yml
@@ -30,7 +30,7 @@ Keywords:
 
 Parameters:
 - ConnectionThreads: &GlobalConnectionThreads 8000
-- ConnectionDuration: &GlobalConnectionDuration 600 seconds
+- ConnectionDuration: &GlobalConnectionDuration 300 seconds
 - ReadMode: &GlobalReadMode secondaryPreferred
 - MaxPoolSize: &GlobalMaxPoolSize 15000
 


### PR DESCRIPTION
**Jira Ticket:** [PERF-5310](https://jira.mongodb.org/browse/PERF-5310)

**Whats Changed:**  
shorten test from 10 min to 5 min to prevent OOM kill in 5.0. Does change performance numbers

test | measurement | 5 min | 10 min | percent_diff | z_score
-- | -- | -- | -- | -- | --
ConnectionPoolStress.Crud | Latency50thPercentile | 1031834 | 3313119.909 | -68.86% | -0.172901736
ConnectionPoolStress.Crud | Latency95thPercentile | 134613776 | 10857745.81 | 1139.79% | 53.65504642
ConnectionPoolStress.Crud | OperationThroughput | 99114.6887 | 48844.0739 | 102.92% | 4.665846322
ConnectionPoolStress.find | Latency50thPercentile | 997415 | 3175574.727 | -68.59% | -0.171927816
ConnectionPoolStress.find | Latency95thPercentile | 133955072 | 9849012.331 | 1260.09% | 53.40898504
ConnectionPoolStress.find | OperationThroughput | 99115.73693 | 48845.66529 | 102.92% | 4.665667082
InsertData.Crud | Latency50thPercentile | 53935476 | 72407829.36 | -25.51% | -2.104451709
InsertData.Crud | Latency95thPercentile | 53935476 | 72407829.36 | -25.51% | -2.104451709
InsertData.Crud | OperationThroughput | 18.54067256 | 13.48883417 | 37.45% | 9.477276833
InsertData.updateOne | Latency50thPercentile | 53390555 | 72063987.45 | -25.91% | -2.135352168
InsertData.updateOne | Latency95thPercentile | 53390555 | 72063987.45 | -25.91% | -2.135352168
InsertData.updateOne | OperationThroughput | 18.72990457 | 13.55546537 | 38.17% | 9.447266006




**Patch testing results:**  
[patch](https://spruce.mongodb.com/version/66047a0c25e5ef0007e20f3c/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=connection_pool_stress)

**Workload Submission form:**  
N/A

**Related PRs:**   
https://github.com/mongodb/genny/pull/1173 https://github.com/mongodb/genny/pull/1163