### PR TITLE
SERVER-88846 Fix Streams perf harness system failures due to missing 'options' field

### DIFF
--- a/src/workloads/streams/AddFields.yml
+++ b/src/workloads/streams/AddFields.yml
@@ -110,6 +110,7 @@ Actors:
           { $emit: { connectionName: "__noopSink" }}
         ]
         connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
+        options: {}
   - Phase: 1
     Nop: true
   - Phase: 2

--- a/src/workloads/streams/LargeHoppingWindow.yml
+++ b/src/workloads/streams/LargeHoppingWindow.yml
@@ -101,6 +101,7 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
+        options: {}
   - Phase: 1..2
     Nop: true
   - Phase: 3

--- a/src/workloads/streams/LargeTumblingWindow.yml
+++ b/src/workloads/streams/LargeTumblingWindow.yml
@@ -99,6 +99,7 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
+        options: {}
   - Phase: 1..2
     Nop: true
   - Phase: 3

--- a/src/workloads/streams/LargeWindowMixed.yml
+++ b/src/workloads/streams/LargeWindowMixed.yml
@@ -92,6 +92,7 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
+        options: {}
   - Phase: 1
     Nop: true
   - Phase: 2

--- a/src/workloads/streams/LargeWindowUniqueAndExistingKeys.yml
+++ b/src/workloads/streams/LargeWindowUniqueAndExistingKeys.yml
@@ -97,6 +97,7 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
+        options: {}
   - Phase: 1..2
     Nop: true
   - Phase: 3

--- a/src/workloads/streams/Passthrough.yml
+++ b/src/workloads/streams/Passthrough.yml
@@ -68,6 +68,7 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
+        options: {}
   - Phase: 1
     Nop: true
   - Phase: 2

--- a/src/workloads/streams/Passthrough_ChangeStreamSource.yml
+++ b/src/workloads/streams/Passthrough_ChangeStreamSource.yml
@@ -106,6 +106,7 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "db", type: "atlas", options: { uri: {^ClientURI: { Name: "Default" }}}}]
+        options: {}
   - Phase: 2
     Nop: true
   - Phase: 3

--- a/src/workloads/streams/Passthrough_MongoSink.yml
+++ b/src/workloads/streams/Passthrough_MongoSink.yml
@@ -82,6 +82,7 @@ Actors:
           { name: "__testMemory", type: "in_memory", options: {} },
           { name: "db", type: "atlas", options: { uri: {^ClientURI: { Name: "Default" }} }}
         ]
+        options: {}
   - Phase: 1
     Nop: true
   - Phase: 2

--- a/src/workloads/streams/Search.yml
+++ b/src/workloads/streams/Search.yml
@@ -74,6 +74,7 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
+        options: {}
   - Phase: 1
     Nop: true
   - Phase: 2

--- a/src/workloads/streams/StreamsLookup.yml
+++ b/src/workloads/streams/StreamsLookup.yml
@@ -140,6 +140,7 @@ Actors:
           { name: "__testMemory", type: "in_memory", options: {} },
           { name: "db", type: "atlas", options: { uri: {^ClientURI: { Name: "Default" }} }}
         ]
+        options: {}
   - Phase: 2
     Nop: true
   - Phase: 3

--- a/src/workloads/streams/TopKPerWindow.yml
+++ b/src/workloads/streams/TopKPerWindow.yml
@@ -88,6 +88,7 @@ Actors:
           { $emit: { connectionName: "__noopSink" } }
         ]
         connections: [{ name: "__testMemory", type: "in_memory", options: {} }]
+        options: {}
   - Phase: 1
     Nop: true
   - Phase: 2


### PR DESCRIPTION
Jira Ticket: SERVER-88846

Whats Changed:  
The start_StreamProcessor command has an options field which is not an optional field anymore. That is causing the workloads to fail. This change is to fix the broken stream workloads. Adding an empty options field in the phase which starts a stream processor.

https://spruce.mongodb.com/version/660b8c6b1f4649000769fdd7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC