### PR TITLE
PERF-5094 Update toolchain version for libmongocrypt Range V2 support

### DIFF
--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -199,7 +199,7 @@ class ToolchainDownloader(Downloader):
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
     #
 
-    TOOLCHAIN_BUILD_ID = "1789759fb0f6fdd2ac08241872376ce56fb7f3b8_24_01_09_06_35_10"
+    TOOLCHAIN_BUILD_ID = "patch_1789759fb0f6fdd2ac08241872376ce56fb7f3b8_660c6f74a645a00007795ba2_24_04_02_20_49_58"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 
     def __init__(

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -199,7 +199,7 @@ class ToolchainDownloader(Downloader):
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
     #
 
-    TOOLCHAIN_BUILD_ID = "patch_1789759fb0f6fdd2ac08241872376ce56fb7f3b8_660c6f74a645a00007795ba2_24_04_02_20_49_58"
+    TOOLCHAIN_BUILD_ID = "cf5743e0a96212cb7fae298399b1759489723cdb_24_04_16_17_45_56"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 
     def __init__(


### PR DESCRIPTION
**Jira Ticket:** PERF-5094

**Whats Changed:**  
Updates the dependency for libmongocrypt to a recent version for Range V2 support. This is necessary for running the performance tests described in the linked ticket. When the next version of libmongocrypt releases, we plan to do another update to the toolchain version so that we don't have a git-hash version in the toolchain; see https://jira.mongodb.org/browse/PERF-5064

**Related PRs:**   
PR for toolchain change: https://github.com/10gen/vcpkg/pull/41
