### PR TITLE
DEVPROD-988: Docs changes for Genny switch to Merge Queue.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,18 +28,6 @@ form is [here].
 
 ### Merging and Linting
 
-Once (1) your PR is approved by a CODEOWNER and (2) all your CI tests
-pass, you can initiate a merge by entering a comment on your PR with the
-text
-
-    evergreen merge
-
-This kicks your PR into the [evergreen commit queue]. Evergreen will
-automatically squash-merge your commit after checking that you have PR
-approval and that the CI tests all pass.
-
-[evergreen commit queue]: https://github.com/evergreen-ci/evergreen/wiki/Commit-Queue
-
 We currently have a manual linting stage required if you're
 adding/modifying a workload YAML document. Evergreen will verify that
 this has been run.
@@ -47,4 +35,13 @@ this has been run.
 ```bash
 ./run-genny generate-docs
 ```
+
+Once (1) your PR is approved by a CODEOWNER and (2) all your CI tests
+pass, you can initiate a merge by clicking "Add to merge queue".
+This kicks your PR into the [Github Merge Queue]. Github will
+automatically squash-merge your commit after checking that Evergreen's
+CI tasks have returned a successful status.
+
+[Github Merge Queue]: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Merge-Queue
+
 --->

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -3,13 +3,13 @@
 This page describes the details of developing in Genny: How to run tests, debug, sanitizers, etc.
 For information on how to write actors and workloads, see [Using Genny](./using.md).
 
-## Commit Queue
+## Merge Queue Queue
 
-Genny uses the [Evergreen Commit-Queue][cq]. When you have received approval
-for your PR, simply comment `evergreen merge` and your PR will automatically
+Genny uses the [Github Merge Queue][merge queue]. When you have received approval
+for your PR, simply click `Add to Merge Queue` and your PR will automatically
 be tested and merged.
 
-[cq]: https://github.com/evergreen-ci/evergreen/wiki/Commit-Queue
+[merge queue]: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Merge-Queue
 
 
 ## Running Genny Self-Tests


### PR DESCRIPTION
Updates any references to the Evergreen Commit Queue to refer to the Github Merge Queue instead.

**Jira Ticket:** [DEVPROD-988](https://jira.mongodb.org/browse/DEVPROD-988)

### Whats Changed

Updates any references to the Evergreen Commit Queue to refer to the Github Merge Queue instead.

I will merge this after approval and after the Merge Queue changes are enabled.

