### PR TITLE
PERF-5241 Update AutoRun in workloads relevant to the QueryStats 6.0 backport

### DIFF
--- a/src/workloads/query/CollScanComplexPredicateLarge.yml
+++ b/src/workloads/query/CollScanComplexPredicateLarge.yml
@@ -25,4 +25,4 @@ AutoRun:
       - standalone-sbe
     branch_name:
       $gte:
-        v7.0
+        v6.0

--- a/src/workloads/query/CollScanComplexPredicateMedium.yml
+++ b/src/workloads/query/CollScanComplexPredicateMedium.yml
@@ -25,4 +25,4 @@ AutoRun:
       - standalone-sbe
     branch_name:
       $gte:
-        v7.0
+        v6.0

--- a/src/workloads/query/CollScanComplexPredicateSmall.yml
+++ b/src/workloads/query/CollScanComplexPredicateSmall.yml
@@ -25,4 +25,4 @@ AutoRun:
       - standalone-sbe
     branch_name:
       $gte:
-        v7.0
+        v6.0

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -25,4 +25,4 @@ AutoRun:
       - standalone-sbe
     branch_name:
       $gte:
-        v7.0
+        v6.0

--- a/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
@@ -25,4 +25,4 @@ AutoRun:
       - standalone-sbe
     branch_name:
       $gte:
-        v7.0
+        v6.0

--- a/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
@@ -25,4 +25,4 @@ AutoRun:
       - standalone-sbe
     branch_name:
       $gte:
-        v7.0
+        v6.0

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -105,6 +105,7 @@ AutoRun:
       - replica
       - replica-80-feature-flags
       - replica-all-feature-flags
+      - replica-query-stats-rate-limit
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/ProjectParse.yml
+++ b/src/workloads/query/ProjectParse.yml
@@ -108,4 +108,4 @@ AutoRun:
       - standalone-sbe
     branch_name:
       $gte:
-        v7.0
+        v6.0

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -230,4 +230,4 @@ AutoRun:
       - atlas-like-replica-query-stats.2023-09
     branch_name:
       $gte:
-        v7.0
+        v6.0

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -228,6 +228,8 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas-like-replica-query-stats.2023-09
+      # Note: this is just using the configuration used for all of our 3-node repl query stats variants.
+      # The workload will still override the rate limit regardless of what the base configuration is.
       - replica-query-stats-rate-limit
     branch_name:
       $gte:

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -228,6 +228,7 @@ AutoRun:
     mongodb_setup:
       $eq:
       - atlas-like-replica-query-stats.2023-09
+      - replica-query-stats-rate-limit
     branch_name:
       $gte:
         v6.0


### PR DESCRIPTION
### What's Changed
Updating the auto-run branches on tasks that we added query stats auto-run configs for in PERF-5152 to include 6.0. Also, adding a query stats variant to the MetricSecondaryIndexTimeseriesCollection.yml auto-run because we'd like to get data from it on both backport branches. 

SERVER-87943 is adding the query stats variants that these will be run under to v6.0.

### Patch Testing Results
https://spruce.mongodb.com/version/6617fa2e8ce8480007b1695c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
