### PR TITLE
DEVPROD-6453 Fix MultikeyIndexes.yml indexes so that multi-planning is exercised as intended

### DIFF
--- a/src/workloads/query/multiplanner/MultikeyIndexes.yml
+++ b/src/workloads/query/multiplanner/MultikeyIndexes.yml
@@ -129,131 +129,131 @@ Actors:
         x63: *distribution
       }
       indexes:
-      - keys: {tenantId: 1, x1: 1}
+      - keys: {x1: 1}
         options: {name: index1}
-      - keys: {tenantId: 1, x2: 1}
+      - keys: {x2: 1}
         options: {name: index2}
-      - keys: {tenantId: 1, x3: 1}
+      - keys: {x3: 1}
         options: {name: index3}
-      - keys: {tenantId: 1, x4: 1}
+      - keys: {x4: 1}
         options: {name: index4}
-      - keys: {tenantId: 1, x5: 1}
+      - keys: {x5: 1}
         options: {name: index5}
-      - keys: {tenantId: 1, x6: 1}
+      - keys: {x6: 1}
         options: {name: index6}
-      - keys: {tenantId: 1, x7: 1}
+      - keys: {x7: 1}
         options: {name: index7}
-      - keys: {tenantId: 1, x8: 1}
+      - keys: {x8: 1}
         options: {name: index8}
-      - keys: {tenantId: 1, x9: 1}
+      - keys: {x9: 1}
         options: {name: index9}
-      - keys: {tenantId: 1, x10: 1}
+      - keys: {x10: 1}
         options: {name: index10}
-      - keys: {tenantId: 1, x11: 1}
+      - keys: {x11: 1}
         options: {name: index11}
-      - keys: {tenantId: 1, x12: 1}
+      - keys: {x12: 1}
         options: {name: index12}
-      - keys: {tenantId: 1, x13: 1}
+      - keys: {x13: 1}
         options: {name: index13}
-      - keys: {tenantId: 1, x14: 1}
+      - keys: {x14: 1}
         options: {name: index14}
-      - keys: {tenantId: 1, x15: 1}
+      - keys: {x15: 1}
         options: {name: index15}
-      - keys: {tenantId: 1, x16: 1}
+      - keys: {x16: 1}
         options: {name: index16}
-      - keys: {tenantId: 1, x17: 1}
+      - keys: {x17: 1}
         options: {name: index17}
-      - keys: {tenantId: 1, x18: 1}
+      - keys: {x18: 1}
         options: {name: index18}
-      - keys: {tenantId: 1, x19: 1}
+      - keys: {x19: 1}
         options: {name: index19}
-      - keys: {tenantId: 1, x20: 1}
+      - keys: {x20: 1}
         options: {name: index20}
-      - keys: {tenantId: 1, x21: 1}
+      - keys: {x21: 1}
         options: {name: index21}
-      - keys: {tenantId: 1, x22: 1}
+      - keys: {x22: 1}
         options: {name: index22}
-      - keys: {tenantId: 1, x23: 1}
+      - keys: {x23: 1}
         options: {name: index23}
-      - keys: {tenantId: 1, x24: 1}
+      - keys: {x24: 1}
         options: {name: index24}
-      - keys: {tenantId: 1, x25: 1}
+      - keys: {x25: 1}
         options: {name: index25}
-      - keys: {tenantId: 1, x26: 1}
+      - keys: {x26: 1}
         options: {name: index26}
-      - keys: {tenantId: 1, x27: 1}
+      - keys: {x27: 1}
         options: {name: index27}
-      - keys: {tenantId: 1, x28: 1}
+      - keys: {x28: 1}
         options: {name: index28}
-      - keys: {tenantId: 1, x29: 1}
+      - keys: {x29: 1}
         options: {name: index29}
-      - keys: {tenantId: 1, x30: 1}
+      - keys: {x30: 1}
         options: {name: index30}
-      - keys: {tenantId: 1, x31: 1}
+      - keys: {x31: 1}
         options: {name: index31}
-      - keys: {tenantId: 1, x32: 1}
+      - keys: {x32: 1}
         options: {name: index32}
-      - keys: {tenantId: 1, x33: 1}
+      - keys: {x33: 1}
         options: {name: index33}
-      - keys: {tenantId: 1, x34: 1}
+      - keys: {x34: 1}
         options: {name: index34}
-      - keys: {tenantId: 1, x35: 1}
+      - keys: {x35: 1}
         options: {name: index35}
-      - keys: {tenantId: 1, x36: 1}
+      - keys: {x36: 1}
         options: {name: index36}
-      - keys: {tenantId: 1, x37: 1}
+      - keys: {x37: 1}
         options: {name: index37}
-      - keys: {tenantId: 1, x38: 1}
+      - keys: {x38: 1}
         options: {name: index38}
-      - keys: {tenantId: 1, x39: 1}
+      - keys: {x39: 1}
         options: {name: index39}
-      - keys: {tenantId: 1, x40: 1}
+      - keys: {x40: 1}
         options: {name: index40}
-      - keys: {tenantId: 1, x41: 1}
+      - keys: {x41: 1}
         options: {name: index41}
-      - keys: {tenantId: 1, x42: 1}
+      - keys: {x42: 1}
         options: {name: index42}
-      - keys: {tenantId: 1, x43: 1}
+      - keys: {x43: 1}
         options: {name: index43}
-      - keys: {tenantId: 1, x44: 1}
+      - keys: {x44: 1}
         options: {name: index44}
-      - keys: {tenantId: 1, x45: 1}
+      - keys: {x45: 1}
         options: {name: index45}
-      - keys: {tenantId: 1, x46: 1}
+      - keys: {x46: 1}
         options: {name: index46}
-      - keys: {tenantId: 1, x47: 1}
+      - keys: {x47: 1}
         options: {name: index47}
-      - keys: {tenantId: 1, x48: 1}
+      - keys: {x48: 1}
         options: {name: index48}
-      - keys: {tenantId: 1, x49: 1}
+      - keys: {x49: 1}
         options: {name: index49}
-      - keys: {tenantId: 1, x50: 1}
+      - keys: {x50: 1}
         options: {name: index50}
-      - keys: {tenantId: 1, x51: 1}
+      - keys: {x51: 1}
         options: {name: index51}
-      - keys: {tenantId: 1, x52: 1}
+      - keys: {x52: 1}
         options: {name: index52}
-      - keys: {tenantId: 1, x53: 1}
+      - keys: {x53: 1}
         options: {name: index53}
-      - keys: {tenantId: 1, x54: 1}
+      - keys: {x54: 1}
         options: {name: index54}
-      - keys: {tenantId: 1, x55: 1}
+      - keys: {x55: 1}
         options: {name: index55}
-      - keys: {tenantId: 1, x56: 1}
+      - keys: {x56: 1}
         options: {name: index56}
-      - keys: {tenantId: 1, x57: 1}
+      - keys: {x57: 1}
         options: {name: index57}
-      - keys: {tenantId: 1, x58: 1}
+      - keys: {x58: 1}
         options: {name: index58}
-      - keys: {tenantId: 1, x59: 1}
+      - keys: {x59: 1}
         options: {name: index59}
-      - keys: {tenantId: 1, x60: 1}
+      - keys: {x60: 1}
         options: {name: index60}
-      - keys: {tenantId: 1, x61: 1}
+      - keys: {x61: 1}
         options: {name: index61}
-      - keys: {tenantId: 1, x62: 1}
+      - keys: {x62: 1}
         options: {name: index62}
-      - keys: {tenantId: 1, x63: 1}
+      - keys: {x63: 1}
         options: {name: index63}
 
 - Name: Quiesce


### PR DESCRIPTION
I noticed that all of the queries were using COLLSCAN plans. I think this helps to explain the current results for this workload presented here: https://github.com/10gen/product-perf-experimentations/blob/master/investigations/PERF-5121-compare-multiplanners/full-results.ipynb. Hopefully the results tell us something more meaningful about the three multi-planning code paths after this fix!

I'm verifying that the workload runs correctly locally, but haven't done any other testing of this change.

I will alert the perf build barons that change points (probably improvements) are expected for this workload as a consequence of this change!