### PR TITLE
SERVER-88684: Mixed10KThreads find operations limited to 10

### DIFF
--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -4944,7 +4944,8 @@ PERF-2075 to find the cause of SERVER-48522
 ### Description
 This workload consists of a situation where the server is being contacted by 10k different
 clients to simulate an extreme case of overload in the server. Both reads and writes happen
-at the same time in balanced fashion.
+at the same time in balanced fashion. Find operations are limited to return 10 documents to
+avoid slow decline in performance as more documents are inserted
 
 The metrics to monitor are:
   * ErrorsTotal / ErrorRate: The total number of errors and rate of errors encountered by the workload. Networking

--- a/src/workloads/scale/Mixed10KThreads.yml
+++ b/src/workloads/scale/Mixed10KThreads.yml
@@ -23,8 +23,6 @@ Keywords:
 dbname: &dbname mixed_10k
 DocumentCount: &NumDocs 10000
 CollectionCount: &NumColls 1
-Limit: &limit 100
-
 NumPhases: &NumPhases 2
 Document: &doc
   a: {^RandomInt: {min: 0, max: *NumDocs}}

--- a/src/workloads/scale/Mixed10KThreads.yml
+++ b/src/workloads/scale/Mixed10KThreads.yml
@@ -22,6 +22,7 @@ Keywords:
 dbname: &dbname mixed_10k
 DocumentCount: &NumDocs 10000
 CollectionCount: &NumColls 1
+Limit: &limit 100
 
 NumPhases: &NumPhases 2
 Document: &doc
@@ -68,9 +69,11 @@ ActorTemplates:
           RecordFailure: true
           CollectionCount: *NumColls
           Operations:
-          - OperationName: find
+          - OperationName: findOne
             OperationCommand:
               Filter: { a: { ^RandomInt: { min: 0, max: *NumDocs } } }
+              Options:
+                Limit: 1
             OperationMetricsName: ReadDocs
             ThrowOnFailure: false
 Actors:

--- a/src/workloads/scale/Mixed10KThreads.yml
+++ b/src/workloads/scale/Mixed10KThreads.yml
@@ -3,7 +3,8 @@ Owner: "@mongodb/server-execution"
 Description: |
   This workload consists of a situation where the server is being contacted by 10k different
   clients to simulate an extreme case of overload in the server. Both reads and writes happen
-  at the same time in balanced fashion.
+  at the same time in balanced fashion. Find operations are limited to return 10 documents to
+  avoid slow decline in performance as more documents are inserted
 
   The metrics to monitor are:
     * ErrorsTotal / ErrorRate: The total number of errors and rate of errors encountered by the workload. Networking
@@ -69,11 +70,11 @@ ActorTemplates:
           RecordFailure: true
           CollectionCount: *NumColls
           Operations:
-          - OperationName: findOne
+          - OperationName: find
             OperationCommand:
               Filter: { a: { ^RandomInt: { min: 0, max: *NumDocs } } }
               Options:
-                Limit: 1
+                Limit: 10
             OperationMetricsName: ReadDocs
             ThrowOnFailure: false
 Actors:


### PR DESCRIPTION
The read queries match on an increasing set of documents over time because we insert more data that matches the query predicate over time. Read throughput is directly influenced by write throughput. To reduce that influence, the find query will only return 10 documents per query.