### PR TITLE
BF-32921: shortened from 15 min to 10 min to keep azure from OOM dying

### DIFF
--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -4131,7 +4131,7 @@ starved by writes. The origin of the test was as a reproduction for BF-2385 in w
 starved out by writes.
 
 This more stressful version of the test only runs one test phase, using 1024 threads per operation
-for 45 minutes.
+for 10 minutes.
 
   
 ### Keywords

--- a/src/workloads/scale/MixedWorkloadsGennyStress.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyStress.yml
@@ -11,7 +11,7 @@ Description: |
   starved out by writes.
 
   This more stressful version of the test only runs one test phase, using 1024 threads per operation
-  for 45 minutes.
+  for 10 minutes.
 
 # This workload does not support sharding yet.
 
@@ -29,7 +29,7 @@ Keywords:
 dbname: &dbname mix
 DocumentCount: &NumDocs 1024
 CollectionCount: &NumColls 512
-PhaseDuration: &PhaseDuration 15 minutes
+PhaseDuration: &PhaseDuration 10 minutes
 StringLength: &StringLength 950
 Filter: &filter {id: {^RandomInt: {min: 0, max: *NumDocs}}}
 Document: &doc


### PR DESCRIPTION
**Jira Ticket:**

[BF-32921](https://jira.mongodb.org/browse/BF-32921)

### Whats Changed

shortened the workload from 15 min to 10 min to keep azure from OOM dying

### Patch Testing Results

[tested twice here](https://spruce.mongodb.com/task/sys_perf_perf_atlas_M60_real.intel.azure.2023_11_mixed_workloads_genny_stress_patch_fb988940d1ce9d0ff567a7d4385352237335b4cf_66268158e774ee00077b7176_24_04_22_15_28_21?execution=1&sortBy=STATUS&sortDir=ASC)