### PR TITLE
DEVPROD-6718 - Create documentation page for TPCH and Streams workload

### DIFF
--- a/docs/TPCH.md
+++ b/docs/TPCH.md
@@ -2,7 +2,7 @@
 
 The [TPC-H](https://www.tpc.org/tpch/) is a decision support benchmark. It consists of a suite of business oriented ad-hoc queries and concurrent data modifications. The queries and the data populating the database have been chosen to have broad industry-wide relevance. This benchmark illustrates decision support systems that examine large volumes of data, execute queries with a high degree of complexity, and give answers to critical business questions.
 
-We support several setups of the TPC-H benchmark by varying the schema type and scale.
+We support several setups of the TPC-H benchmark by varying the schema type and scale. You also have the option to [run the TPC-H benchmark locally](https://docs.google.com/document/d/1joTjH9yKuPLifuQIL1QxaBl59WyvYvNmNCaSoMnyDYM/edit?usp=sharing).
 
 ## Denormalized
 ### Scale 1

--- a/docs/TPCH.md
+++ b/docs/TPCH.md
@@ -29,3 +29,5 @@ We support several setups of the TPC-H benchmark by varying the schema type and 
 [Q10](./generated/workloads.md#q10-3), [Q11](./generated/workloads.md#q11-3), [Q12](./generated/workloads.md#q12-3), [Q13](./generated/workloads.md#q13-3), [Q14](./generated/workloads.md#q14-3), [Q15](./generated/workloads.md#q15-3), [Q16](./generated/workloads.md#q16-3), [Q17](./generated/workloads.md#q17-3), [Q18](./generated/workloads.md#q18-3), [Q19](./generated/workloads.md#q19-3)
 [Q20](./generated/workloads.md#q20-3), [Q21](./generated/workloads.md#q21-3), [Q22](./generated/workloads.md#q22-3),
 [validate](./generated/workloads.md#validate-3)
+
+* Note that the linked docs are auto-generated and these links may break

--- a/docs/TPCH.md
+++ b/docs/TPCH.md
@@ -30,4 +30,4 @@ We support several setups of the TPC-H benchmark by varying the schema type and 
 [Q20](./generated/workloads.md#q20-3), [Q21](./generated/workloads.md#q21-3), [Q22](./generated/workloads.md#q22-3),
 [validate](./generated/workloads.md#validate-3)
 
-Note that the linked docs are auto-generated and these links may break
+_Note that the linked docs are auto-generated and these links may break_

--- a/docs/TPCH.md
+++ b/docs/TPCH.md
@@ -1,0 +1,31 @@
+# TPCH Workload Documentation
+
+The [TPC-H](https://www.tpc.org/tpch/) is a decision support benchmark. It consists of a suite of business oriented ad-hoc queries and concurrent data modifications. The queries and the data populating the database have been chosen to have broad industry-wide relevance. This benchmark illustrates decision support systems that examine large volumes of data, execute queries with a high degree of complexity, and give answers to critical business questions.
+
+We support several setups of the TPC-H benchmark by varying the schema type and scale.
+
+## Denormalized
+### Scale 1
+[Q1](./generated/workloads.md#q1), [Q2](./generated/workloads.md#q2), [Q3](./generated/workloads.md#q3), [Q4](./generated/workloads.md#q4), [Q5](./generated/workloads.md#q5), [Q6](./generated/workloads.md#q6), [Q7](./generated/workloads.md#q7), [Q8](./generated/workloads.md#q8), [Q9](./generated/workloads.md#q9)
+[Q10](./generated/workloads.md#q10), [Q11](./generated/workloads.md#q11), [Q12](./generated/workloads.md#q12), [Q13](./generated/workloads.md#q13), [Q14](./generated/workloads.md#q14), [Q15](./generated/workloads.md#q15), [Q16](./generated/workloads.md#q16), [Q17](./generated/workloads.md#q17), [Q18](./generated/workloads.md#q18), [Q19](./generated/workloads.md#q19)
+[Q20](./generated/workloads.md#q20), [Q21](./generated/workloads.md#q21), [Q22](./generated/workloads.md#q22),
+[validate](./generated/workloads.md#validate)
+
+### Scale 10
+[Q1](./generated/workloads.md#q1-1), [Q2](./generated/workloads.md#q2-1), [Q3](./generated/workloads.md#q3-1), [Q4](./generated/workloads.md#q4-1), [Q5](./generated/workloads.md#q5-1), [Q6](./generated/workloads.md#q6-1), [Q7](./generated/workloads.md#q7-1), [Q8](./generated/workloads.md#q8-1), [Q9](./generated/workloads.md#q9-1)
+[Q10](./generated/workloads.md#q10-1), [Q11](./generated/workloads.md#q11-1), [Q12](./generated/workloads.md#q12-1), [Q13](./generated/workloads.md#q13-1), [Q14](./generated/workloads.md#q14-1), [Q15](./generated/workloads.md#q15-1), [Q16](./generated/workloads.md#q16-1), [Q17](./generated/workloads.md#q17-1), [Q18](./generated/workloads.md#q18-1), [Q19](./generated/workloads.md#q19-1)
+[Q20](./generated/workloads.md#q20-1), [Q21](./generated/workloads.md#q21-1), [Q22](./generated/workloads.md#q22-1),
+[validate](./generated/workloads.md#validate-1)
+
+## Normalized
+### Scale 1
+[Q1](./generated/workloads.md#q1-2), [Q2](./generated/workloads.md#q2-2), [Q3](./generated/workloads.md#q3-2), [Q4](./generated/workloads.md#q4-2), [Q5](./generated/workloads.md#q5-2), [Q6](./generated/workloads.md#q6-2), [Q7](./generated/workloads.md#q7-2), [Q8](./generated/workloads.md#q8-2), [Q9](./generated/workloads.md#q9-2)
+[Q10](./generated/workloads.md#q10-2), [Q11](./generated/workloads.md#q11-2), [Q12](./generated/workloads.md#q12-2), [Q13](./generated/workloads.md#q13-2), [Q14](./generated/workloads.md#q14-2), [Q15](./generated/workloads.md#q15-2), [Q16](./generated/workloads.md#q16-2), [Q17](./generated/workloads.md#q17-2), [Q18](./generated/workloads.md#q18-2), [Q19](./generated/workloads.md#q19-2)
+[Q20](./generated/workloads.md#q20-2), [Q21](./generated/workloads.md#q21-2), [Q22](./generated/workloads.md#q22-2),
+[validate](./generated/workloads.md#validate-2)
+
+### Scale 10
+[Q1](./generated/workloads.md#q1-3), [Q2](./generated/workloads.md#q2-3), [Q3](./generated/workloads.md#q3-3), [Q4](./generated/workloads.md#q4-3), [Q5](./generated/workloads.md#q5-3), [Q6](./generated/workloads.md#q6-3), [Q7](./generated/workloads.md#q7-3), [Q8](./generated/workloads.md#q8-3), [Q9](./generated/workloads.md#q9-3)
+[Q10](./generated/workloads.md#q10-3), [Q11](./generated/workloads.md#q11-3), [Q12](./generated/workloads.md#q12-3), [Q13](./generated/workloads.md#q13-3), [Q14](./generated/workloads.md#q14-3), [Q15](./generated/workloads.md#q15-3), [Q16](./generated/workloads.md#q16-3), [Q17](./generated/workloads.md#q17-3), [Q18](./generated/workloads.md#q18-3), [Q19](./generated/workloads.md#q19-3)
+[Q20](./generated/workloads.md#q20-3), [Q21](./generated/workloads.md#q21-3), [Q22](./generated/workloads.md#q22-3),
+[validate](./generated/workloads.md#validate-3)

--- a/docs/TPCH.md
+++ b/docs/TPCH.md
@@ -30,4 +30,4 @@ We support several setups of the TPC-H benchmark by varying the schema type and 
 [Q20](./generated/workloads.md#q20-3), [Q21](./generated/workloads.md#q21-3), [Q22](./generated/workloads.md#q22-3),
 [validate](./generated/workloads.md#validate-3)
 
-* Note that the linked docs are auto-generated and these links may break
+Note that the linked docs are auto-generated and these links may break

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -14,4 +14,4 @@ The Streams workload consists of several Genny workloads that run in waterfall f
 - [Large Hopping Window](./generated/workloads.md#largehoppingwindow)
 - [Add Fields](./generated/workloads.md#addfields)
 
-Note that the linked docs are auto-generated and these links may break
+_Note that the linked docs are auto-generated and these links may break_

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -1,0 +1,15 @@
+# Streams Workload Documentation
+
+The Streams workload consists of several Genny workloads that run in waterfall fashion. Please find more information about each workload below:
+
+- [Passthrough](./generated/workloads.md#passthrough)
+- [Passthrough Change Stream Source](./generated/workloads.md#passthrough_changestreamsource)
+- [Passthrough Mongo Sink](./generated/workloads.md#passthrough_mongosink)
+- [Search](./generated/workloads.md#search)
+- [Streams Lookup](./generated/workloads.md#streamslookup)
+- [Top K per View](./generated/workloads.md#topkperwindow)
+- [Large Window Mixed](./generated/workloads.md#largewindowmixed)
+- [Large Window Unique and Existing Keys](./generated/workloads.md#largewindowuniqueandexistingkeys)
+- [Large Tumbling Window](./generated/workloads.md#largetumblingwindow)
+- [Large Hopping Window](./generated/workloads.md#largehoppingwindow)
+- [Add Fields](./generated/workloads.md#addfields)

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -14,4 +14,4 @@ The Streams workload consists of several Genny workloads that run in waterfall f
 - [Large Hopping Window](./generated/workloads.md#largehoppingwindow)
 - [Add Fields](./generated/workloads.md#addfields)
 
-* Note that the linked docs are auto-generated and these links may break
+Note that the linked docs are auto-generated and these links may break

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -13,3 +13,5 @@ The Streams workload consists of several Genny workloads that run in waterfall f
 - [Large Tumbling Window](./generated/workloads.md#largetumblingwindow)
 - [Large Hopping Window](./generated/workloads.md#largehoppingwindow)
 - [Add Fields](./generated/workloads.md#addfields)
+
+* Note that the linked docs are auto-generated and these links may break


### PR DESCRIPTION
JIRA Ticket: https://jira.mongodb.org/browse/DEVPROD-6718

Whats Changed:
We have added new documentation pages for the TPCH and Streams workloads. These workloads are run through test control files in DSI and call several Genny workloads within them. We will use these pages to link via the test control files.
