### PR TITLE
SERVER-89499: Replacing single-replica auto run flag with replica

### DIFF
--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -4186,7 +4186,7 @@ CrudActor, indexes, Loader, memory, planning, scale, stress
 ### Owner
 @mongodb/query
 ### Description
-The workload tests the server under a "multi-plan storm" situation, by letting many threads execute a query, which triggers a multi-plan. The large number of indexes on the test collection lets the planner generate numerous candidate plans. Normally, plans involving a sorter would quickly loose,  but using a large "skip" attribute with the command delays the end of the best plan contest significantly. This eventually makes the system run out-of-memory, due to each of the plans performing a sort on a  large number of documents.
+The workload tests the server under a "multi-plan storm" situation, by letting many threads execute a query, which triggers a multi-plan. The large number of indexes on the test collection lets the planner generate numerous candidate plans. Normally, plans involving a sorter would quickly loose, but using a large "skip" attribute with the command delays the end of the best plan contest significantly. This eventually makes the system run out-of-memory, due to each of the plans performing a sort on a large number of documents.
 
   
 ### Keywords

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -226,7 +226,7 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - single-replica
+      - replica
       - single-replica-80-feature-flags
       - single-replica-all-feature-flags
     branch_name:

--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -209,7 +209,6 @@ AutoRun:
       - replica
       - replica-80-feature-flags
       - replica-all-feature-flags
-      - single-replica
       - standalone
       - standalone-80-feature-flags
       - standalone-all-feature-flags

--- a/src/workloads/execution/PingCommand.yml
+++ b/src/workloads/execution/PingCommand.yml
@@ -60,5 +60,5 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - single-replica
+      - replica
       - standalone

--- a/src/workloads/issues/ConnectionsBuildup.yml
+++ b/src/workloads/issues/ConnectionsBuildup.yml
@@ -103,5 +103,4 @@ AutoRun:
       - replica
       - replica-80-feature-flags
       - replica-all-feature-flags
-      - single-replica
       - shard-single

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -16,7 +16,6 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
-      - single-replica
       - standalone
       - standalone-80-feature-flags
       - standalone-all-feature-flags

--- a/src/workloads/query/BooleanSimplifierSmallDataset.yml
+++ b/src/workloads/query/BooleanSimplifierSmallDataset.yml
@@ -16,7 +16,6 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
-      - single-replica
       - standalone
       - standalone-80-feature-flags
       - standalone-all-feature-flags

--- a/src/workloads/query/ConstantFoldArithmetic.yml
+++ b/src/workloads/query/ConstantFoldArithmetic.yml
@@ -111,6 +111,5 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
-      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/query/DensifyFillCombo.yml
+++ b/src/workloads/query/DensifyFillCombo.yml
@@ -171,7 +171,7 @@ Actors:
             }
           }
         ]
-        Options: 
+        Options:
           BatchSize:  *limit
           AllowDiskUse: true
   - *Nop
@@ -220,7 +220,7 @@ Actors:
           },
           $limit: *limit
         ]
-        Options: 
+        Options:
           BatchSize:  *limit
           AllowDiskUse: true
   - *Nop
@@ -268,7 +268,7 @@ Actors:
           },
           $limit: *limit
         ]
-        Options: 
+        Options:
           BatchSize:  *limit
           AllowDiskUse: true
   - *Nop
@@ -317,7 +317,7 @@ Actors:
           },
           $limit: *limit
         ]
-        Options: 
+        Options:
           BatchSize:  *limit
           AllowDiskUse: true
   - *Nop
@@ -365,7 +365,7 @@ Actors:
           },
           $limit: *limit
         ]
-        Options: 
+        Options:
           BatchSize:  *limit
           AllowDiskUse: true
 
@@ -375,7 +375,6 @@ AutoRun:
       $eq:
       - standalone
       - replica
-      - single-replica
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/DensifyTimeseriesCollection.yml
+++ b/src/workloads/query/DensifyTimeseriesCollection.yml
@@ -135,7 +135,7 @@ Actors:
         }, {
           $limit: *limit
         }]
-        Options: 
+        Options:
           BatchSize:  *limit
   - *Nop
   - *Nop
@@ -178,7 +178,7 @@ Actors:
         }, {
           $limit: *limit
         }]
-        Options: 
+        Options:
           BatchSize:  *limit
   - *Nop
   - *Nop
@@ -221,7 +221,7 @@ Actors:
         }, {
           $limit: *limit
         }]
-        Options: 
+        Options:
           BatchSize:  *limit
   - *Nop
   - *Nop
@@ -264,7 +264,7 @@ Actors:
         }, {
           $limit: *limit
         }]
-        Options: 
+        Options:
           BatchSize:  *limit
   - *Nop
   - *Nop
@@ -308,7 +308,7 @@ Actors:
         }, {
           $limit: *limit
         }]
-        Options: 
+        Options:
           BatchSize:  *limit
   - *Nop
   - *Nop
@@ -351,7 +351,7 @@ Actors:
         }, {
           $limit: *limit
         }]
-        Options: 
+        Options:
           BatchSize:  *limit
   - *Nop
   - *Nop
@@ -395,7 +395,7 @@ Actors:
         }, {
           $limit: *limit
         }]
-        Options: 
+        Options:
           BatchSize:  *limit
 
 AutoRun:
@@ -404,7 +404,6 @@ AutoRun:
       $eq:
       - standalone
       - replica
-      - single-replica
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -191,7 +191,6 @@ AutoRun:
       - replica
       - replica-80-feature-flags
       - replica-all-feature-flags
-      - single-replica
       - standalone
       - standalone-classic-query-engine
       - standalone-query-stats

--- a/src/workloads/query/FillTimeseriesCollection.yml
+++ b/src/workloads/query/FillTimeseriesCollection.yml
@@ -300,7 +300,6 @@ AutoRun:
       $eq:
       - standalone
       - replica
-      - single-replica
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
@@ -101,6 +101,5 @@ AutoRun:
       - shard-lite
       - shard-lite-80-feature-flags
       - shard-lite-all-feature-flags
-      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/LookupWithOnlyUnshardedColls.yml
@@ -71,7 +71,7 @@ Actors:
           }, {
           $limit: *NumDocs
           }]
-        Options: 
+        Options:
           BatchSize:  *NumDocs
     - OperationMetricsName: LookupOneToFewUnshardedToUnsharded
       OperationName: aggregate
@@ -89,7 +89,7 @@ Actors:
             }, {
             $limit: *NumDocs
           }]
-        Options: 
+        Options:
           BatchSize:  *NumDocs
     - OperationMetricsName: LookupOneToManyUnshardedToUnsharded
       OperationName: aggregate
@@ -108,7 +108,7 @@ Actors:
             $limit: *NumDocs
             }
           ]
-        Options: 
+        Options:
           BatchSize:  *NumDocs
 
 AutoRun:
@@ -119,6 +119,5 @@ AutoRun:
       - shard-lite
       - shard-lite-80-feature-flags
       - shard-lite-all-feature-flags
-      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -123,7 +123,6 @@ AutoRun:
       - shard-80-feature-flags
       - shard-query-stats
       - shard-lite
-      - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10

--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -218,7 +218,6 @@ AutoRun:
       # - shard
       # - shard-lite
       - shard-single
-      - single-replica
       - replica
       - atlas-like-replica.2022-10
     branch_name:

--- a/src/workloads/query/QueryStatsQueryShapes.yml
+++ b/src/workloads/query/QueryStatsQueryShapes.yml
@@ -138,7 +138,6 @@ AutoRun:
       - standalone-all-feature-flags
       - standalone
       - standalone-query-stats
-      - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -178,7 +178,6 @@ AutoRun:
       - shard-80-feature-flags
       - shard-lite
       - shard-query-stats
-      - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_Agg.yml
@@ -102,7 +102,6 @@ AutoRun:
       - shard-80-feature-flags
       - shard-query-stats
       - shard-lite
-      - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
@@ -114,7 +114,6 @@ AutoRun:
       - shard-80-feature-flags
       - shard-query-stats
       - shard-lite
-      - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
@@ -115,7 +115,6 @@ AutoRun:
       - shard-80-feature-flags
       - shard-query-stats
       - shard-lite
-      - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -102,7 +102,6 @@ AutoRun:
       - shard-80-feature-flags
       - shard-lite
       - shard-query-stats
-      - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -115,7 +115,6 @@ AutoRun:
       - shard-80-feature-flags
       - shard-lite
       - shard-query-stats
-      - single-replica
       - replica
       - replica-query-stats-rate-limit
       - atlas-like-replica.2022-10

--- a/src/workloads/scale/BigUpdate.yml
+++ b/src/workloads/scale/BigUpdate.yml
@@ -135,7 +135,6 @@ AutoRun:
       - replica-all-feature-flags
       - replica-disable-execution-control
       - replica-noflowcontrol
-      - single-replica
       - standalone
       - standalone-classic-query-engine
       - standalone-query-stats

--- a/src/workloads/scale/ContentionTTLDeletions.yml
+++ b/src/workloads/scale/ContentionTTLDeletions.yml
@@ -197,7 +197,7 @@ AutoRun:
 - When:
     mongodb_setup:
       $eq:
-      - single-replica
+      - replica
       - single-replica-80-feature-flags
       - single-replica-all-feature-flags
     branch_name:

--- a/src/workloads/scale/InsertBigDocs.yml
+++ b/src/workloads/scale/InsertBigDocs.yml
@@ -30,7 +30,6 @@ AutoRun:
       - replica
       - replica-80-feature-flags
       - replica-all-feature-flags
-      - single-replica
     atlas_setup:
       $neq:
       - M30-repl

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -29,7 +29,6 @@ AutoRun:
       - atlas
       - atlas-like-replica.2022-10
       - replica
-      - single-replica
       - standalone
       - shard
       - shard-80-feature-flags

--- a/src/workloads/scale/LargeIndexedIns.yml
+++ b/src/workloads/scale/LargeIndexedIns.yml
@@ -66,6 +66,5 @@ AutoRun:
       - replica
       - replica-80-feature-flags
       - replica-all-feature-flags
-      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/LargeIndexedInsMatchingDocuments.yml
+++ b/src/workloads/scale/LargeIndexedInsMatchingDocuments.yml
@@ -128,6 +128,5 @@ AutoRun:
         $eq:
           - replica
           - replica-all-feature-flags
-          - single-replica
           - single-replica-classic-query-engine
           - single-replica-sbe

--- a/src/workloads/scale/LargeScaleLongLived.yml
+++ b/src/workloads/scale/LargeScaleLongLived.yml
@@ -96,7 +96,6 @@ AutoRun:
       - replica-all-feature-flags
       - shard
       - shard-80-feature-flags
-      - single-replica
       - single-replica-15gbwtcache
       - standalone
       - standalone-classic-query-engine

--- a/src/workloads/scale/MajorityReads10KThreads.yml
+++ b/src/workloads/scale/MajorityReads10KThreads.yml
@@ -23,6 +23,5 @@ AutoRun:
       - replica
       - replica-80-feature-flags
       - replica-all-feature-flags
-      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -82,7 +82,6 @@ AutoRun:
       - replica-1dayhistory-15gbwtcache
       - replica-80-feature-flags
       - replica-all-feature-flags
-      - single-replica
       - standalone
     atlas_setup:
       $neq:

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -310,7 +310,6 @@ AutoRun:
       - replica-maintenance-events
       - replica-noflowcontrol
       - replica-query-stats-rate-limit
-      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe
       - standalone

--- a/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+++ b/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
@@ -191,7 +191,6 @@ AutoRun:
       - replica-all-feature-flags
       - replica-maintenance-events
       - replica-noflowcontrol
-      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe
       - standalone

--- a/src/workloads/scale/MultiPlanStormRecordIdDedupIdxScan.yml
+++ b/src/workloads/scale/MultiPlanStormRecordIdDedupIdxScan.yml
@@ -99,5 +99,5 @@ Actors:
 # - When:
 #     mongodb_setup:
 #       $eq:
-#       - single-replica
+#       - replica
 

--- a/src/workloads/scale/MultiPlanStormSortSkip.yml
+++ b/src/workloads/scale/MultiPlanStormSortSkip.yml
@@ -3,9 +3,9 @@ Owner: "@mongodb/query"
 Description: >
   The workload tests the server under a "multi-plan storm" situation, by letting many threads execute a
   query, which triggers a multi-plan. The large number of indexes on the test collection lets the planner
-  generate numerous candidate plans. Normally, plans involving a sorter would quickly loose, 
+  generate numerous candidate plans. Normally, plans involving a sorter would quickly loose,
   but using a large "skip" attribute with the command delays the end of the best plan contest significantly.
-  This eventually makes the system run out-of-memory, due to each of the plans performing a sort on a 
+  This eventually makes the system run out-of-memory, due to each of the plans performing a sort on a
   large number of documents.
 
 Keywords:
@@ -119,5 +119,5 @@ Actors:
 # - When:
 #     mongodb_setup:
 #       $eq:
-#       - single-replica
+#       - replica
 

--- a/src/workloads/scale/ScanWithLongLived.yml
+++ b/src/workloads/scale/ScanWithLongLived.yml
@@ -102,6 +102,6 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica-noflowcontrol
-      - single-replica
+      - replica
       - single-replica-classic-query-engine
       - single-replica-sbe

--- a/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
+++ b/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
@@ -74,5 +74,5 @@ Actors:
 # - When:
 #     mongodb_setup:
 #       $eq:
-#       - single-replica
+#       - replica
 

--- a/src/workloads/sharding/WriteOneReplicaSet.yml
+++ b/src/workloads/sharding/WriteOneReplicaSet.yml
@@ -71,5 +71,4 @@ AutoRun:
     mongodb_setup:
       $eq:
       - replica
-      - single-replica
       - standalone

--- a/src/workloads/transactions/LLTAnalytics.yml
+++ b/src/workloads/transactions/LLTAnalytics.yml
@@ -294,4 +294,3 @@ Actors:
 #       - atlas
 #       - replica
 #       - replica-all-feature-flags
-#       - single-replica

--- a/src/workloads/transactions/LLTMixed.yml
+++ b/src/workloads/transactions/LLTMixed.yml
@@ -610,7 +610,6 @@ AutoRun:
       - replica
       - replica-80-feature-flags
       - replica-all-feature-flags
-      - single-replica
       - single-replica-classic-query-engine
       - single-replica-sbe
     branch_name:

--- a/src/workloads/transactions/LLTMixedSmall.yml
+++ b/src/workloads/transactions/LLTMixedSmall.yml
@@ -35,7 +35,6 @@ AutoRun:
       - replica
       - replica-80-feature-flags
       - replica-all-feature-flags
-      - single-replica
     branch_name:
       $neq:
       - v4.0

--- a/src/workloads/transactions/templates/LLTInsertLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTInsertLowLtc.tmpl
@@ -281,7 +281,6 @@ AutoRun:
           - replica
           - replica-80-feature-flags
           - replica-all-feature-flags
-          - single-replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/transactions/templates/LLTMixedLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTMixedLowLtc.tmpl
@@ -569,7 +569,6 @@ AutoRun:
           - replica
           - replica-80-feature-flags
           - replica-all-feature-flags
-          - single-replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/transactions/templates/LLTQueryLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTQueryLowLtc.tmpl
@@ -300,7 +300,6 @@ AutoRun:
           - replica
           - replica-80-feature-flags
           - replica-all-feature-flags
-          - single-replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/transactions/templates/LLTRemoveLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTRemoveLowLtc.tmpl
@@ -296,7 +296,6 @@ AutoRun:
           - replica
           - replica-80-feature-flags
           - replica-all-feature-flags
-          - single-replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/transactions/templates/LLTUpdateLowLtc.tmpl
+++ b/src/workloads/transactions/templates/LLTUpdateLowLtc.tmpl
@@ -318,7 +318,6 @@ AutoRun:
           - replica
           - replica-80-feature-flags
           - replica-all-feature-flags
-          - single-replica
       branch_name:
         $neq:
           - v4.0


### PR DESCRIPTION
[SERVER-89499](https://jira.mongodb.org/browse/SERVER-89499): Remove shard-lite, standalone, 1-node replica set and m60-like variants

Removing the 1 Node Replica set variants, so modifying the single-replica autoRun tags. 

Waiting on [this patch](https://spruce.mongodb.com/version/662a62114b395a000762ef0a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

Related [Mongo PR](https://github.com/10gen/mongo/pull/21499)