### PR TITLE
PERF-1885 unique index benchmark

### DIFF
--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -1558,6 +1558,27 @@ application deletes data within some time ranges.
 
 
 
+## [UniqueIndexes](https://www.github.com/mongodb/genny/blob/master/src/workloads/execution/UniqueIndexes.yml)
+### Owner 
+Storage Execution 
+
+
+### Support Channel
+[#server-storage-execution](https://mongodb.enterprise.slack.com/archives/C2RCHGB2L)
+
+
+### Description
+This workload tests concurrent insert/update/delete performance with unique indexes,
+a v2 unique index on 'a' and a v1 unique index on 'b'. The documents being inserted have
+duplicate keys across threads, and the uniqueness of indexes allows only one insertion
+to succeed. It first performs the operations with 8 threads, then 32, up to 128.
+
+  
+
+### Keywords
+insert, update, delete, unique indexes 
+
+
 ## [UpdateWithSecondaryIndexes](https://www.github.com/mongodb/genny/blob/master/src/workloads/execution/UpdateWithSecondaryIndexes.yml)
 ### Owner 
 Storage Execution 

--- a/docs/using.md
+++ b/docs/using.md
@@ -226,7 +226,7 @@ Actors:
 
 This example has an additional `InsertRemove` Actor with 100 threads, where each thread inserts and removes a document as fast as possible. A user observing the database contents might notice a document appearing and disappearing rapidly. This Actor will output `InsertRemoveExample.Insert.ftdc` and `InsertRemoveExample.Remove.ftdc` time series outputs, showing the insertions and removals happening for 10 milliseconds at the phase start. (See [here](#orgec88ad4) for more details on outputs.)
 
-Note that even though the Actors are listed sequentially, all Actors are concurrent. [Example](../src/workloads/HelloWorld-MultiplePhases.yml).
+Note that even though the Actors are listed sequentially, all Actors are concurrent. [Example](../src/workloads/docs/HelloWorld-MultiplePhases.yml).
 
 Actor configurations expect the following keys:
 
@@ -506,7 +506,7 @@ This would set up the workload and print it as a list of Phases with the Actors 
 
     *Note:* [Skipping the compile step in sys-perf projects](https://github.com/10gen/performance-tooling-docs/blob/main/patch_testing.md#skipping-compilation-on-sys-perf-projects) can save some time when testing a genny workload.
 
-For more details on workload development, please check out our general docs on [Developing and Modifying Workloads](https://github.com/10gen/performance-tooling-docs/blob/main/new_workloads.md) and on [Basic Performance Patch Testing](https://github.com/10gen/performance-tooling-docs/blob/main/patch_testing.md).
+For more details on workload development, please check out our general docs on [Developing and Modifying Workloads](https://github.com/10gen/performance-tooling-docs/blob/main/workloads/new_workloads.md) and on [Basic Performance Patch Testing](https://github.com/10gen/performance-tooling-docs/blob/main/patch_testing.md).
 
 Users who would like a second look at their workloads can ask product performance. Users who have questions about their Genny usage can ask DEVPROD in #ask-devprod-performance.
 

--- a/src/workloads/execution/UniqueIndexes.yml
+++ b/src/workloads/execution/UniqueIndexes.yml
@@ -1,0 +1,214 @@
+SchemaVersion: 2018-07-01
+Owner: Storage Execution
+Description: |
+  This workload tests concurrent insert/update/delete performance with unique indexes,
+  a v2 unique index on 'a' and a v1 unique index on 'b'. The documents being inserted have
+  duplicate keys across threads, and the uniqueness of indexes allows only one insertion
+  to succeed. It first performs the operations with 8 threads, then 32, up to 128.
+
+Keywords:
+- insert
+- update
+- delete
+- unique indexes
+
+string_length: &string_length 10
+max_phases: &max_phases 9
+db: &db test
+coll: &coll test
+iterations: &iterations 12800
+
+Clients:
+  Default:
+    QueryOptions:
+      maxPoolSize: 1000
+
+ActorTemplates:
+- TemplateName: UniqueIndexesInsertTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: ""}}
+    Type: CrudActor
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: {^Parameter: {Name: "ActivePhases", Default: []}}
+        NopInPhasesUpTo: *max_phases
+        PhaseConfig:
+          Collection: *coll
+          Repeat: *iterations
+          ThrowOnFailure: false
+          Operations:
+          - &InsertOp
+            OperationName: insertMany
+            OperationCommand:
+              Documents:
+                # Documents with duplicate keys are being inserted concurrently
+                # by the threads, and only one of them will succeed.
+              - a: {^Inc: {start: 0}}
+                b: {^FastRandomString: {length: *string_length}}
+              - a: {^FastRandomString: {length: *string_length}}
+                b: {^Inc: {start: 0}}
+
+- TemplateName: UniqueIndexesUpdateTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: ""}}
+    Type: CrudActor
+    Threads: {^Parameter: {Name: "Threads", Default: 1}}
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: {^Parameter: {Name: "ActivePhases", Default: []}}
+        NopInPhasesUpTo: *max_phases
+        PhaseConfig:
+          Collection: *coll
+          Repeat: *iterations
+          Operations:
+          - &UpdateOpA
+            OperationName: updateOne
+            OperationCommand:
+              Filter: { a: {^Inc: {start: 0}} }
+              Update: { $set: { b: {^Inc: {start: *iterations}} } }
+          - &UpdateOpB
+            OperationName: updateOne
+            OperationCommand:
+              Filter: { b: {^Inc: {start: 0}} }
+              Update: { $set: { a: {^Inc: {start: *iterations}} } }
+
+- TemplateName: UniqueIndexesDeleteTemplate
+  Config:
+    Name: {^Parameter: {Name: "Name", Default: ""}}
+    Type: CrudActor
+    Threads: &threads {^Parameter: {Name: "Threads", Default: 1}}
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: {^Parameter: {Name: "ActivePhases", Default: []}}
+        NopInPhasesUpTo: *max_phases
+        PhaseConfig:
+          Collection: *coll
+          Repeat: {^NumExpr: {
+            withExpression: "iterations / threads",
+            andValues: {iterations: *iterations, threads: *threads}}}
+          Operations:
+          - &DeleteOpA
+            OperationName: deleteOne
+            OperationCommand:
+              Filter: { a: {^Inc: {start: 0, multiplier: 1, step: *threads}} }
+          - &DeleteOpB
+            OperationName: deleteOne
+            OperationCommand:
+              Filter: { b: {^Inc: {start: 0, multiplier: 1, step: *threads}} }
+
+Actors:
+- Name: Setup
+  Type: RunCommand
+  Threads: 1
+  Phases:
+    OnlyActiveInPhases:
+      Active: [0]
+      NopInPhasesUpTo: *max_phases
+      PhaseConfig:
+        Repeat: 1
+        Database: *db
+        Collection: *coll
+        Operations:
+        - OperationName: RunCommand
+          OperationCommand: {dropDatabase: 1}
+        - OperationName: RunCommand
+          OperationCommand:
+            createIndexes: *coll
+            indexes:
+            - key: {a: 1}
+              name: a
+              unique: true
+            - key: {b: 1}
+              name: b
+              unique: true
+              v: 1
+
+- ActorFromTemplate:
+    TemplateName: UniqueIndexesInsertTemplate
+    TemplateParameters:
+      Name: Insert8Threads
+      Threads: 8
+      ActivePhases: [1]
+
+- ActorFromTemplate:
+    TemplateName: UniqueIndexesUpdateTemplate
+    TemplateParameters:
+      Name: Update8Threads
+      Threads: 8
+      ActivePhases: [2]
+
+- ActorFromTemplate:
+    TemplateName: UniqueIndexesDeleteTemplate
+    TemplateParameters:
+      Name: Delete8Threads
+      Threads: 8
+      ActivePhases: [3]
+
+- ActorFromTemplate:
+    TemplateName: UniqueIndexesInsertTemplate
+    TemplateParameters:
+      Name: Insert32Threads
+      Threads: 32
+      ActivePhases: [4]
+
+- ActorFromTemplate:
+    TemplateName: UniqueIndexesUpdateTemplate
+    TemplateParameters:
+      Name: Update32Threads
+      Threads: 32
+      ActivePhases: [5]
+
+- ActorFromTemplate:
+    TemplateName: UniqueIndexesDeleteTemplate
+    TemplateParameters:
+      Name: Delete32Threads
+      Threads: 32
+      ActivePhases: [6]
+
+- ActorFromTemplate:
+    TemplateName: UniqueIndexesInsertTemplate
+    TemplateParameters:
+      Name: Insert128Threads
+      Threads: 128
+      ActivePhases: [7]
+
+- ActorFromTemplate:
+    TemplateName: UniqueIndexesUpdateTemplate
+    TemplateParameters:
+      Name: Update128Threads
+      Threads: 128
+      ActivePhases: [8]
+
+- ActorFromTemplate:
+    TemplateName: UniqueIndexesDeleteTemplate
+    TemplateParameters:
+      Name: Delete128Threads
+      Threads: 128
+      ActivePhases: [9]
+
+AutoRun:
+- When:
+    mongodb_setup:
+      $eq:
+      - standalone
+      - standalone-80-feature-flags
+      - standalone-all-feature-flags
+      - standalone-query-stats
+      - replica
+      - replica-80-feature-flags
+      - replica-all-feature-flags
+      - replica-query-stats-rate-limit
+      - atlas-like-replica.2022-10
+      - atlas-like-replica.2023-09
+      - atlas-like-replica-query-stats.2023-09
+      - shard
+      - shard-80-feature-flags
+      - shard-lite-80-feature-flags
+      - shard-lite-all-feature-flags
+      - shard-query-stats
+    branch_name:
+      $gte:  v7.0


### PR DESCRIPTION
<!---
Thanks for submitting a PR to the Genny repo. Please include the
following fields (if relevant) prior to submitting your PR.
--->

**Jira Ticket:** [PERF-1885](https://jira.mongodb.org/browse/PERF-1885)

### Whats Changed

A new workload that tests performance of unique indexes, in particular concurrent insertion of duplicate keys. It also tests concurrent update and deletion of documents using the indexes, starting from 8 threads up to 128 threads.

### Patch Testing Results

https://spruce.mongodb.com/version/662d950c48f968000712eaf6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

<!---
### Workload Submission form

If applicable, only required if there is a new workload being added. The
form is [here].

[here]: https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform

### Merging and Linting

We currently have a manual linting stage required if you're
adding/modifying a workload YAML document. Evergreen will verify that
this has been run.

```bash
./run-genny generate-docs
```

Once (1) your PR is approved by a CODEOWNER and (2) all your CI tests
pass, you can initiate a merge by clicking "Add to merge queue".
This kicks your PR into the [Github Merge Queue]. Github will
automatically squash-merge your commit after checking that Evergreen's
CI tasks have returned a successful status.

[Github Merge Queue]: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Merge-Queue

--->
