### PR TITLE
DEVPROD-6937 Pass hint correctly to TimeSeriesSortCompound aggregation

### DIFF
--- a/src/workloads/query/TimeSeriesSortCompound.yml
+++ b/src/workloads/query/TimeSeriesSortCompound.yml
@@ -87,7 +87,8 @@ Actors:
           {$_internalInhibitOptimization: {}},
           {$skip: 1e10},
         ]
-        Hint: {m: 1, t: 1}
+        Options:
+          Hint: "m_1_t_1"
   - *Nop
 
 AutoRun:


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-6937](https://jira.mongodb.org/browse/DEVPROD-6937)

### What Changed
Passed in the hint correctly to the pipeline options, so we change from using a blocking sort to BoundedSorter. This should improve performance and remove a regression. See https://jira.mongodb.org/browse/BF-32682 for more details.

From local testing the throughput without the hint is below:
                ops       : 50.0    
                seconds   : 1378.591
                ops per second: 0.0363 

The throughput with my change is:
        throughput:
                ops       : 50.0    
                seconds   : 425.903 
                ops per second: 0.1174 

There is a huge improvement locally. I'm running a sys-perf patch now to see the improvement on evergreen.

### Patch Testing Results
[patch link](https://spruce.mongodb.com/version/663105334e149a0007f16090/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

Results from the evergreen patch ([link](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=546e3833-f7e3-4f07-9d16-9cdc60ecb5a6)). Operation throughput improved around 300%!

