### PR TITLE
DEVPROD-7139 Create the default time-series index for timeseries sort compound

### DIFF
--- a/src/workloads/query/TimeSeriesSortCompound.yml
+++ b/src/workloads/query/TimeSeriesSortCompound.yml
@@ -31,6 +31,8 @@ Actors:
   - *Nop
   - *Nop
   - *Nop
+  - *Nop
+  - *Nop
   - Repeat: 1
     Database: test
     Operations:
@@ -38,10 +40,48 @@ Actors:
       OperationCommand:
         drop: *coll
 
+# This index is created by default on versions 7.0.0+, but we must create this index for the
+# aggregation to run on versions 6.X.X correctly.
+- Name: IndexCollection
+  Type: RunCommand
+  Threads: 1
+  Phases:
+  - *Nop
+  - Repeat: 1
+    Database: *db
+    Operations:
+    - OperationMetricsName: CreateDefaultTimeseriesIndex
+      OperationName: RunCommand
+      OperationCommand:
+        createIndexes: *coll
+        indexes:
+        - key: {m: 1, t: 1}
+          name: "m_1_t_1"
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+  - *Nop
+
+- Name: Quiesce
+  Type: QuiesceActor
+  Threads: 1
+  Database: *db
+  Phases:
+  - *Nop
+  - *Nop
+  - Repeat: 1 # phase 2
+  - *Nop
+  - Repeat: 1 # phase 4
+  - *Nop
+  - *Nop
+
 - Name: InsertData
   Type: Loader
   Threads: 1
   Phases:
+  - *Nop
+  - *Nop 
   - *Nop
   - Repeat: 1
     Database: *db
@@ -57,21 +97,12 @@ Actors:
   - *Nop
   - *Nop
 
-- Name: Quiesce
-  Type: QuiesceActor
-  Threads: 1
-  Database: *db
-  Phases:
-  - *Nop
-  - *Nop
-  - Repeat: 1
-  - *Nop
-  - *Nop
-
 - Name: Queries
   Type: CrudActor
   Threads: 1
   Phases:
+  - *Nop
+  - *Nop
   - *Nop
   - *Nop
   - *Nop


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-7139](https://jira.mongodb.org/browse/DEVPROD-7139)

### Whats Changed
We fixed how the hint was passed into this workload to solve a regression BF. However, this workload runs on 6.0, and the index used in the hint is created by default in 7.0.0. So the aggregation now fails, since the index hint can't be applied to the query plan.