### PR TITLE
PERF-5359 use one selective predicate in MultiplannerWithGroup.yml workload

### DIFF
--- a/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+++ b/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
@@ -15,7 +15,13 @@ GlobalDefaults:
   dbname: &db test
   # Collection name used for queries.
   coll: &coll Collection0
+
   docCount: &docCount 1e5
+  resultCount: &resultCount 101
+  selectivity: &selectivity {^NumExpr: {
+    withExpression: "resultCount / docCount",
+    andValues: {resultCount: *resultCount, docCount: *docCount}}}
+
   maxPhase: &maxPhase 7
   queryRepeats: &queryRepeats 1000
 
@@ -272,7 +278,7 @@ Actors:
       repeat: *queryRepeats
       collection: *coll
       pipeline: &pipeline [{$match: {
-            x1: {$lte: 1},
+            x1: {$lt: *selectivity},
             x2: {$lte: 1},
             x3: {$lte: 1},
             x4: {$lte: 1},


### PR DESCRIPTION
**Jira Ticket:** [PERF-5359](https://jira.mongodb.org/browse/PERF-5359)

### Whats Changed

This corrects an error with the original implementation of the workload. Before the change, the $match stage had no selective predicates. As a result, all of the documents in the collection matched, which in turn caused the workload to be dominated by query execution time. Since this is a multi-planning benchmark, we instead want the time required to select a plan to be significant relative to the overall query runtime.

This change also has the nice side effect of making the workload run much more quickly overall.

### Patch Testing Results

The workload seems to work as expected when I run it locally. I have this patch build created, but I'm figuring out how to take advantage of [DEVPROD-2159](https://jira.mongodb.org/browse/DEVPROD-2159) in order to only schedule the affected workload: https://spruce.mongodb.com/version/663a408fc899ea00071eed28/tasks