### PR TITLE
PERF-5358 Improve CompoundIndexes.yml workload

### DIFF
--- a/src/workloads/query/multiplanner/CompoundIndexes.yml
+++ b/src/workloads/query/multiplanner/CompoundIndexes.yml
@@ -14,14 +14,20 @@ GlobalDefaults:
   # Collection name used for queries.
   coll: &coll Collection0
 
-  docCount: &docCount 1e5
+  # We will create 300,000 documents split uniformly amongst three tenants.
+  docsPerTenant: &docsPerTenant 1e5
+  tenantCount: &tenantCount 3
+  docCount: &docCount {^NumExpr: {
+    withExpression: "docsPerTenant * tenantCount",
+    andValues: {docsPerTenant: *docsPerTenant, tenantCount: *tenantCount}}}
+
   resultCount: &resultCount 101
   selectivity: &selectivity {^NumExpr: {
-    withExpression: "resultCount / docCount",
-    andValues: {resultCount: *resultCount, docCount: *docCount}}}
+    withExpression: "resultCount / docsPerTenant",
+    andValues: {resultCount: *resultCount, docsPerTenant: *docsPerTenant}}}
 
   maxPhase: &maxPhase 7
-  queryRepeats: &queryRepeats 1000
+  queryRepeats: &queryRepeats 500
 
 Actors:
 - Name: DropCollection
@@ -62,7 +68,7 @@ Actors:
       collection: *coll
       docCount: *docCount
       document: {
-        tenantId: {^RandomInt: {distribution: uniform, min: 0, max: 100}},
+        tenantId: {^RandomInt: {distribution: uniform, min: 1, max: *tenantCount}},
         x1: &distribution {^RandomDouble: {distribution: uniform, min: 0.0, max: 1.0}},
         x2: *distribution,
         x3: *distribution,
@@ -278,10 +284,70 @@ Actors:
       collection: *coll
       query: &query {
         Filter: {
-          tenantId: {$eq : 0},
+          tenantId: {$eq : 1},
           x1: {$lt: *selectivity},
           x2: {$lte: 1},
-          x3: {$lte: 1}
+          x3: {$lte: 1},
+          x4: {$lte: 1},
+          x5: {$lte: 1},
+          x6: {$lte: 1},
+          x7: {$lte: 1},
+          x8: {$lte: 1},
+          x9: {$lte: 1},
+          x10: {$lte: 1},
+          x11: {$lte: 1},
+          x12: {$lte: 1},
+          x13: {$lte: 1},
+          x14: {$lte: 1},
+          x15: {$lte: 1},
+          x16: {$lte: 1},
+          x17: {$lte: 1},
+          x18: {$lte: 1},
+          x19: {$lte: 1},
+          x20: {$lte: 1},
+          x21: {$lte: 1},
+          x22: {$lte: 1},
+          x23: {$lte: 1},
+          x24: {$lte: 1},
+          x25: {$lte: 1},
+          x26: {$lte: 1},
+          x27: {$lte: 1},
+          x28: {$lte: 1},
+          x29: {$lte: 1},
+          x30: {$lte: 1},
+          x31: {$lte: 1},
+          x32: {$lte: 1},
+          x33: {$lte: 1},
+          x34: {$lte: 1},
+          x35: {$lte: 1},
+          x36: {$lte: 1},
+          x37: {$lte: 1},
+          x38: {$lte: 1},
+          x39: {$lte: 1},
+          x40: {$lte: 1},
+          x41: {$lte: 1},
+          x42: {$lte: 1},
+          x43: {$lte: 1},
+          x44: {$lte: 1},
+          x45: {$lte: 1},
+          x46: {$lte: 1},
+          x47: {$lte: 1},
+          x48: {$lte: 1},
+          x49: {$lte: 1},
+          x50: {$lte: 1},
+          x51: {$lte: 1},
+          x52: {$lte: 1},
+          x53: {$lte: 1},
+          x54: {$lte: 1},
+          x55: {$lte: 1},
+          x56: {$lte: 1},
+          x57: {$lte: 1},
+          x58: {$lte: 1},
+          x59: {$lte: 1},
+          x60: {$lte: 1},
+          x61: {$lte: 1},
+          x62: {$lte: 1},
+          x63: {$lte: 1}
         }
       }
 


### PR DESCRIPTION

**Jira Ticket:** [PERF-5358](https://jira.mongodb.org/browse/PERF-5358)

### Whats Changed

There are three related changes:

1. Change the data so that there are 300,000 with approximately 100,000 associated with each of three tenants. Then change how the "selectivity" value is calculated so that the query returns ~101 results. I did confirm by looking at the mongod logs that beforehand the query was returning 0 results and now it returns 87 (which is much closer to the expected 101).
2. Change the predicate to have a conjunct for each indexed field. This makes the test much more similar to "Simple.yml", and it's not clear to me why it wasn't written this way in the first place.
3. Reduce the number of repetitions of each query from 1000 to 500. I did this because adding the additional conjuncts made multi-planning run for significantly longer, so I wanted to avoid making the workload run for longer than necessary.

### Patch Testing Results

https://spruce.mongodb.com/version/663bb9ac889ffa0007942ecb/tasks

--->
