### PR TITLE
SERVER-90382 Fix issues with phase + metadata in QE Range workloads

### DIFF
--- a/src/workloads/contrib/qe_range_testing/templates/rc.yml.j2
+++ b/src/workloads/contrib/qe_range_testing/templates/rc.yml.j2
@@ -154,8 +154,7 @@ Actors: {% if not encrypt %}
     Type: LoggingActor
     Threads: 1
     Phases:
-      - *nop
-      - Phase: 1..2
+      - Phase: 0..1
         LogEvery: 5 minutes
         Blocking: None
 

--- a/src/workloads/contrib/qe_range_testing/templates/rc.yml.j2
+++ b/src/workloads/contrib/qe_range_testing/templates/rc.yml.j2
@@ -165,4 +165,4 @@ AutoRun:
       - single-replica-fle
       - shard-lite-fle
     branch_name:
-      $gte: v7.0
+      $gte: v8.0

--- a/src/workloads/encrypted/qe-range-age-100-0.yml
+++ b/src/workloads/encrypted/qe-range-age-100-0.yml
@@ -452,8 +452,7 @@ Actors:
     Type: LoggingActor
     Threads: 1
     Phases:
-      - *nop
-      - Phase: 1..2
+      - Phase: 0..1
         LogEvery: 5 minutes
         Blocking: None
 

--- a/src/workloads/encrypted/qe-range-age-100-0.yml
+++ b/src/workloads/encrypted/qe-range-age-100-0.yml
@@ -463,4 +463,4 @@ AutoRun:
           - single-replica-fle
           - shard-lite-fle
       branch_name:
-        $gte: v7.0
+        $gte: v8.0

--- a/src/workloads/encrypted/qe-range-age-50-50.yml
+++ b/src/workloads/encrypted/qe-range-age-50-50.yml
@@ -452,8 +452,7 @@ Actors:
     Type: LoggingActor
     Threads: 1
     Phases:
-      - *nop
-      - Phase: 1..2
+      - Phase: 0..1
         LogEvery: 5 minutes
         Blocking: None
 

--- a/src/workloads/encrypted/qe-range-age-50-50.yml
+++ b/src/workloads/encrypted/qe-range-age-50-50.yml
@@ -463,4 +463,4 @@ AutoRun:
           - single-replica-fle
           - shard-lite-fle
       branch_name:
-        $gte: v7.0
+        $gte: v8.0

--- a/src/workloads/encrypted/qe-range-balance-100-0.yml
+++ b/src/workloads/encrypted/qe-range-balance-100-0.yml
@@ -452,8 +452,7 @@ Actors:
     Type: LoggingActor
     Threads: 1
     Phases:
-      - *nop
-      - Phase: 1..2
+      - Phase: 0..1
         LogEvery: 5 minutes
         Blocking: None
 

--- a/src/workloads/encrypted/qe-range-balance-100-0.yml
+++ b/src/workloads/encrypted/qe-range-balance-100-0.yml
@@ -463,4 +463,4 @@ AutoRun:
           - single-replica-fle
           - shard-lite-fle
       branch_name:
-        $gte: v7.0
+        $gte: v8.0

--- a/src/workloads/encrypted/qe-range-balance-50-50.yml
+++ b/src/workloads/encrypted/qe-range-balance-50-50.yml
@@ -452,8 +452,7 @@ Actors:
     Type: LoggingActor
     Threads: 1
     Phases:
-      - *nop
-      - Phase: 1..2
+      - Phase: 0..1
         LogEvery: 5 minutes
         Blocking: None
 

--- a/src/workloads/encrypted/qe-range-balance-50-50.yml
+++ b/src/workloads/encrypted/qe-range-balance-50-50.yml
@@ -463,4 +463,4 @@ AutoRun:
           - single-replica-fle
           - shard-lite-fle
       branch_name:
-        $gte: v7.0
+        $gte: v8.0

--- a/src/workloads/encrypted/qe-range-timestamp-100-0.yml
+++ b/src/workloads/encrypted/qe-range-timestamp-100-0.yml
@@ -452,8 +452,7 @@ Actors:
     Type: LoggingActor
     Threads: 1
     Phases:
-      - *nop
-      - Phase: 1..2
+      - Phase: 0..1
         LogEvery: 5 minutes
         Blocking: None
 

--- a/src/workloads/encrypted/qe-range-timestamp-100-0.yml
+++ b/src/workloads/encrypted/qe-range-timestamp-100-0.yml
@@ -463,4 +463,4 @@ AutoRun:
           - single-replica-fle
           - shard-lite-fle
       branch_name:
-        $gte: v7.0
+        $gte: v8.0

--- a/src/workloads/encrypted/qe-range-timestamp-50-50.yml
+++ b/src/workloads/encrypted/qe-range-timestamp-50-50.yml
@@ -452,8 +452,7 @@ Actors:
     Type: LoggingActor
     Threads: 1
     Phases:
-      - *nop
-      - Phase: 1..2
+      - Phase: 0..1
         LogEvery: 5 minutes
         Blocking: None
 

--- a/src/workloads/encrypted/qe-range-timestamp-50-50.yml
+++ b/src/workloads/encrypted/qe-range-timestamp-50-50.yml
@@ -463,4 +463,4 @@ AutoRun:
           - single-replica-fle
           - shard-lite-fle
       branch_name:
-        $gte: v7.0
+        $gte: v8.0


### PR DESCRIPTION
**Jira Ticket:** [SERVER-90382](https://jira.mongodb.org/browse/SERVER-90382)

Followup to PERF-5094, fixing a bug I accidentally introduced in the workloads.

sys-perf: https://spruce.mongodb.com/version/663d20c77d13b100070fb410/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC