### PR TITLE
DEVPROD-7330 Don't use toolchain with intermediate build and debug artifacts

### DIFF
--- a/src/lamplib/src/genny/tasks/compile.py
+++ b/src/lamplib/src/genny/tasks/compile.py
@@ -169,20 +169,20 @@ def cmake(
     cmake_prefix_paths = [
         os.path.join(
             toolchain_info.toolchain_dir,
-            f"installed/{toolchain_info.triplet_arch}-{toolchain_info.triplet_os}-dynamic",
+            f"installed/{toolchain_info.triplet_arch}-{toolchain_info.triplet_os}-release",
         ),
         os.path.join(
             toolchain_info.toolchain_dir,
-            f"installed/{toolchain_info.triplet_arch}-{toolchain_info.triplet_os}",
+            f"installed/{toolchain_info.triplet_arch}-{toolchain_info.triplet_os}-dynamic",
         ),
     ]
 
     cmake_cmd += [
         "-DGENNY_WORKSPACE_ROOT={}".format(workspace_root),
         "-DGENNY_TOOLCHAIN_DIR={}".format(toolchain_info.toolchain_dir),
-        "-DCMAKE_PREFIX_PATH={}".format(";".join(cmake_prefix_paths)),
+        "-DCMAKE_PREFIX_PATH='{}'".format(";".join(cmake_prefix_paths)),
         "-DCMAKE_EXPORT_COMPILE_COMMANDS=1",
-        f"-DVCPKG_TARGET_TRIPLET={toolchain_info.triplet_arch}-{toolchain_info.triplet_os}",
+        f"-DVCPKG_TARGET_TRIPLET={toolchain_info.triplet_arch}-{toolchain_info.triplet_os}-release",
     ]
 
     cmake_cmd += _sanitizer_flags(sanitizer, genny_repo_root)

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -27,34 +27,10 @@ def _create_compile_environment(
 
     # For mongodbtoolchain compiler (if there).
     paths.insert(0, "/opt/mongodbtoolchain/v4/bin")
-
-    if triplet_arch == "arm64" and triplet_os == "linux":
-        paths.insert(
-            0,
-            os.path.join(
-                toolchain_dir, "installed/arm64-linux/tools/cmake-3.25.0-rc4-linux-aarch64/bin"
-            ),
-        )
-        paths.insert(0, os.path.join(toolchain_dir, "installed/arm64-linux/tools/ninja"))
-
-    else:
-        # For cmake and ctest
-        if triplet_os == "linux":
-            # Only use bundled cmake on Linux because bundled cmake doesn't work on OS X due to integrity checks.
-            # It's easier just to ask users to "brew install cmake"
-            paths.insert(
-                0,
-                os.path.join(
-                    toolchain_dir,
-                    "downloads/tools/cmake-3.24.0-linux/cmake-3.24.0-linux-x86_64/bin",
-                ),
-            )
-
-        # For ninja
-        ninja_bin_dir = os.path.join(
-            toolchain_dir, "downloads/tools/ninja/1.10.2-{}:".format(triplet_os)
-        )
-        paths.insert(0, ninja_bin_dir)
+    # But use our toolchain's ninja
+    paths.insert(
+        0, os.path.join(toolchain_dir, f"installed/{triplet_arch}-{triplet_os}-release/tools/ninja")
+    )
 
     out["PATH"] = ":".join(paths)
     out["NINJA_STATUS"] = "[%f/%t (%p) %es] "  # make the ninja output even nicer
@@ -199,7 +175,9 @@ class ToolchainDownloader(Downloader):
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
     #
 
-    TOOLCHAIN_BUILD_ID = "cf5743e0a96212cb7fae298399b1759489723cdb_24_04_16_17_45_56"
+    TOOLCHAIN_BUILD_ID = (
+        "patch_cf5743e0a96212cb7fae298399b1759489723cdb_664d957bd979e30007b58a69_24_05_22_06_49_32"
+    )
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 
     def __init__(

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -176,7 +176,7 @@ class ToolchainDownloader(Downloader):
     #
 
     TOOLCHAIN_BUILD_ID = (
-        "patch_cf5743e0a96212cb7fae298399b1759489723cdb_664d957bd979e30007b58a69_24_05_22_06_49_32"
+        "e5a0c94080f72e00a20ba8fd6ca6a3082e0873a6_24_05_30_06_59_47"
     )
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-7330](https://jira.mongodb.org/browse/DEVPROD-7330)

**This PR reduces the download and decompress stage of the genny install from 1.25 minutes to 5 seconds**. This reduces the total genny setup time from 6.8 minutes to 5.5 minutes, and reduces the genny compile time from 4.5 minutes to ~3.1 minutes.

The [PR in vcpkg](https://github.com/10gen/vcpkg/pull/42) must be approved and merged in first, to get a real build ID to use in this PR.

In a standard Genny setup on an average configuration (`infrastructure_provisioning = replica`) (metrics [here](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/dsi/result/Cx6TVokULBr)) takes 6.8 minutes. The steps are:

- 2.3 minutes on `workload_setup.genny.1.on_workload_client`, (bash script [here](https://github.com/10gen/dsi/blob/94e56115bc2aa0edd794e356745f333d07a476c6/configurations/workload_setup/workload_setup.2022-11.yml#L53)). This is downloading and installing the mongodbtoolchain and installing Development Tools
- 4.5 minutes on `workload_setup.genny.2.on_workload_client`, (bash script [here](https://github.com/10gen/dsi/blob/94e56115bc2aa0edd794e356745f333d07a476c6/configurations/workload_setup/workload_setup.2022-11.yml#L87)). This is the "Genny Compile"
  - 1.25 minutes, downloading and installing gennytoolchain. **This is what this PR reduces to ~5 seconds**
  - 2.07 minutes, compiling and installing Genny.

It takes 1.25 minutes to download and install the gennytoolchain because the gennytoolchain is 2.98 GiB zipped (8.8 GiB uncompressed). Much of this is intermediate build files (4.9 GiB), duplicates of packages (1.8 GiB), downloads (319.2 MiB) and debug symbols (1.2 GiB).

An example of the different toolchain archives on Amazon 2 arm64 is [before](https://mciuploads.s3.amazonaws.com/genny-toolchain/genny_toolchain_amazon2_arm64_cf5743e0a96212cb7fae298399b1759489723cdb_24_04_16_17_45_56/gennytoolchain.tgz)/[after](https://mciuploads.s3.amazonaws.com/genny-toolchain/genny_toolchain_amazon2_arm64_patch_cf5743e0a96212cb7fae298399b1759489723cdb_664d957bd979e30007b58a69_24_05_22_06_49_32/gennytoolchain.tgz).

This PR strips as much as possible from the built image to end up with a gennytoolchain that is ~250 MiB (~600 MiB uncompressed). This makes it significantly quicker to install Genny on workload clients. The following has been removed:

- Copies of downloaded packages
- Intermediate build files
- Debug symbols for vcpkg libraries

It slightly re-works the vcpkg integration, pointing at the explicit `release` and `host` target rather than the default (with no suffix). This should result in the same built Genny, but we are being explicit about using the `release` install which does not also come with debug symbols (and has a cmake config stating this).

Patch test with some Genny workloads is [here](https://spruce.mongodb.com/version/663db6a9cc20b80007dcc160/tasks), with timing info [here](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/dsi/result/y3SGzTUVXE8) (compare with mainline [here](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/dsi/result/4g9e3f8wDAZ)). Note that this seems to download and install the Gennytoolchain several times, because Genny does not recognise a toolchain that comes from a patch as "Valid". This will be retested once the vcpkg commit builds.

### Testing that compile is unchanged

The following is comparing a `CMakeCache.txt` and `compile_commands.json` to make sure nothing is changing from statically to dynamically linked (or vise-versa). `arm64-osx` is equivalent to `arm64-osx-release`, except `arm64-osx` includes debug symbols under `debug/lib`. The libraries in both are static.

`vcpkg` does not seem to do repeatable builds, but `installed/arm64-linux{,-release}/lib/libgrpc.a` (e.g., the old non-release grpc library and the new release one) are both exactly 19,649,542 bytes. They seem identical but have different hashes.

<details>

<summary>`CmakeCache.txt`</summary>

``` diff
diff --git a/CMakeCache.old.txt b/CMakeCache.txt
index ccc43476e..74a34a46a 100644
--- a/CMakeCache.old.txt
+++ b/CMakeCache.txt
@@ -18 +18 @@
-Boost_ATOMIC_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_atomic.a
+Boost_ATOMIC_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_atomic.a
@@ -21 +21 @@ Boost_ATOMIC_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64
-Boost_ATOMIC_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_atomic.a
+Boost_ATOMIC_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_atomic.a
@@ -24 +24 @@ Boost_ATOMIC_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm
-Boost_CHRONO_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_chrono.a
+Boost_CHRONO_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_chrono.a
@@ -27 +27 @@ Boost_CHRONO_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64
-Boost_CHRONO_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_chrono.a
+Boost_CHRONO_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_chrono.a
@@ -30 +30 @@ Boost_CHRONO_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm
-Boost_FILESYSTEM_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_filesystem.a
+Boost_FILESYSTEM_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_filesystem.a
@@ -33 +33 @@ Boost_FILESYSTEM_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/a
-Boost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_filesystem.a
+Boost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_filesystem.a
@@ -36 +36 @@ Boost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed
-Boost_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/include
+Boost_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/include
@@ -39 +39 @@ Boost_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/include
-Boost_LIBRARY_DIR_DEBUG:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib
+Boost_LIBRARY_DIR_DEBUG:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib
@@ -42 +42 @@ Boost_LIBRARY_DIR_DEBUG:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/li
-Boost_LIBRARY_DIR_RELEASE:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib
+Boost_LIBRARY_DIR_RELEASE:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib
@@ -45 +45 @@ Boost_LIBRARY_DIR_RELEASE:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/
-Boost_LOG_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_log.a
+Boost_LOG_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_log.a
@@ -48 +48 @@ Boost_LOG_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-os
-Boost_LOG_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_log.a
+Boost_LOG_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_log.a
@@ -51 +51 @@ Boost_LOG_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-
-Boost_LOG_SETUP_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_log_setup.a
+Boost_LOG_SETUP_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_log_setup.a
@@ -54 +54 @@ Boost_LOG_SETUP_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/ar
-Boost_LOG_SETUP_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_log_setup.a
+Boost_LOG_SETUP_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_log_setup.a
@@ -57 +57 @@ Boost_LOG_SETUP_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/
-Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_program_options.a
+Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_program_options.a
@@ -60 +60 @@ Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/instal
-Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_program_options.a
+Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_program_options.a
@@ -63 +63 @@ Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/inst
-Boost_REGEX_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_regex.a
+Boost_REGEX_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_regex.a
@@ -66 +66 @@ Boost_REGEX_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-
-Boost_REGEX_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_regex.a
+Boost_REGEX_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_regex.a
@@ -69 +69 @@ Boost_REGEX_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm6
-Boost_THREAD_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_thread.a
+Boost_THREAD_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_thread.a
@@ -72 +72 @@ Boost_THREAD_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64
-Boost_THREAD_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libboost_thread.a
+Boost_THREAD_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libboost_thread.a
@@ -86 +86 @@ CMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=false
-CMAKE_CXX_COMPILER:FILEPATH=/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++
+CMAKE_CXX_COMPILER:STRING=/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++
@@ -245 +245 @@ CMAKE_OSX_SYSROOT:PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk
-CMAKE_PREFIX_PATH:UNINITIALIZED=/opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic;/opt/data/mci/gennytoolchain/installed/arm64-osx
+CMAKE_PREFIX_PATH:UNINITIALIZED=/opt/data/mci/gennytoolchain/installed/arm64-osx-release;/opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic
@@ -339 +339 @@ CMAKE_VERBOSE_MAKEFILE:BOOL=FALSE
-Catch2_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/Catch2
+Catch2_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/share/Catch2
@@ -362 +362 @@ LIBMONGOCXX_LIBRARY_PATH:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-o
-OPENSSL_CRYPTO_LIBRARY:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libcrypto.a
+OPENSSL_CRYPTO_LIBRARY:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libcrypto.a
@@ -364 +364 @@ OPENSSL_CRYPTO_LIBRARY:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx
-OPENSSL_CRYPTO_LIBRARY_REALPATH:STRING=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libcrypto.a
+OPENSSL_CRYPTO_LIBRARY_REALPATH:STRING=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libcrypto.a
@@ -367 +367 @@ OPENSSL_CRYPTO_LIBRARY_REALPATH:STRING=/opt/data/mci/gennytoolchain/installed/ar
-OPENSSL_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/include
+OPENSSL_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/include
@@ -370 +370 @@ OPENSSL_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/includ
-OPENSSL_SSL_LIBRARY:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libssl.a
+OPENSSL_SSL_LIBRARY:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libssl.a
@@ -372 +372 @@ OPENSSL_SSL_LIBRARY:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/li
-OPENSSL_SSL_LIBRARY_REALPATH:STRING=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libssl.a
+OPENSSL_SSL_LIBRARY_REALPATH:STRING=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libssl.a
@@ -396 +396 @@ PKG_CONFIG_EXECUTABLE:FILEPATH=/nix/store/s33ia4rw83qw13825vc89k25cr9nxy0f-pkg-c
-Protobuf_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/protobuf
+Protobuf_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/share/protobuf
@@ -399 +399 @@ Protobuf_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/protobu
-Protobuf_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/include
+Protobuf_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/include
@@ -401,2 +401,2 @@ Protobuf_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/inclu
-//Path to a program.
-Protobuf_PROTOC_EXECUTABLE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/tools/protobuf/protoc
+//The Google Protocol Buffers Compiler
+Protobuf_PROTOC_EXECUTABLE:FILEPATH=/opt/homebrew/bin/protoc
@@ -427 +427 @@ VCPKG_SETUP_CMAKE_PROGRAM_PATH:BOOL=ON
-VCPKG_TARGET_TRIPLET:STRING=arm64-osx
+VCPKG_TARGET_TRIPLET:STRING=arm64-osx-release
@@ -444 +444 @@ X_VCPKG_APPLOCAL_DEPS_SERIALIZED:BOOL=OFF
-ZLIB_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/include
+ZLIB_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/include
@@ -447 +447 @@ ZLIB_INCLUDE_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/include
-ZLIB_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/debug/lib/libz.a
+ZLIB_LIBRARY_DEBUG:FILEPATH=ZLIB_LIBRARY_DEBUG-NOTFOUND
@@ -450 +450 @@ ZLIB_LIBRARY_DEBUG:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/deb
-ZLIB_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libz.a
+ZLIB_LIBRARY_RELEASE:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libz.a
@@ -457 +457 @@ _VCPKG_INSTALLED_DIR:PATH=/opt/data/mci/gennytoolchain/installed
-absl_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/absl
+absl_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/share/absl
@@ -460 +460 @@ absl_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/absl
-c-ares_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/c-ares
+c-ares_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/share/c-ares
@@ -490 +490 @@ driver_SOURCE_DIR:STATIC=/Users/james/Projects/MongoDB/genny/src/driver
-gRPC_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/grpc
+gRPC_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/share/grpc
@@ -526 +526 @@ metrics_SOURCE_DIR:STATIC=/Users/james/Projects/MongoDB/genny/src/metrics
-pkgcfg_lib__OPENSSL_crypto:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libcrypto.a
+pkgcfg_lib__OPENSSL_crypto:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libcrypto.a
@@ -529 +529 @@ pkgcfg_lib__OPENSSL_crypto:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64
-pkgcfg_lib__OPENSSL_ssl:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libssl.a
+pkgcfg_lib__OPENSSL_ssl:FILEPATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libssl.a
@@ -547 +547 @@ protobuf_VERBOSE:BOOL=OFF
-re2_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/re2
+re2_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/share/re2
@@ -559 +559 @@ testlib_SOURCE_DIR:STATIC=/Users/james/Projects/MongoDB/genny/src/testlib
-upb_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/upb
+upb_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/share/upb
@@ -571 +571 @@ value_generators_SOURCE_DIR:STATIC=/Users/james/Projects/MongoDB/genny/src/value
-yaml-cpp_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx/share/yaml-cpp
+yaml-cpp_DIR:PATH=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/share/yaml-cpp
@@ -778 +778 @@ CMAKE_VERBOSE_MAKEFILE-ADVANCED:INTERNAL=1
-FIND_PACKAGE_MESSAGE_DETAILS_Boost:INTERNAL=[/opt/data/mci/gennytoolchain/installed/arm64-osx/include][cfound components: filesystem log_setup log program_options thread regex chrono atomic ][v1.83.0(1.75)]
+FIND_PACKAGE_MESSAGE_DETAILS_Boost:INTERNAL=[/opt/data/mci/gennytoolchain/installed/arm64-osx-release/include][cfound components: filesystem log_setup log program_options thread regex chrono atomic ][v1.83.0(1.75)]
@@ -780 +780 @@ FIND_PACKAGE_MESSAGE_DETAILS_Boost:INTERNAL=[/opt/data/mci/gennytoolchain/instal
-FIND_PACKAGE_MESSAGE_DETAILS_OpenSSL:INTERNAL=[/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libcrypto.a][/opt/data/mci/gennytoolchain/installed/arm64-osx/include][c ][v3.1.4(1.1)]
+FIND_PACKAGE_MESSAGE_DETAILS_OpenSSL:INTERNAL=[/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libcrypto.a][/opt/data/mci/gennytoolchain/installed/arm64-osx-release/include][c ][v3.1.4(1.1)]
@@ -782 +782 @@ FIND_PACKAGE_MESSAGE_DETAILS_OpenSSL:INTERNAL=[/opt/data/mci/gennytoolchain/inst
-FIND_PACKAGE_MESSAGE_DETAILS_Protobuf:INTERNAL=[optimized;/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libprotobuf.a;debug;/opt/data/mci/gennytoolchain/installed/arm64-osx/debug/lib/libprotobufd.a][/opt/data/mci/gennytoolchain/installed/arm64-osx/include][v3.21.12()]
+FIND_PACKAGE_MESSAGE_DETAILS_Protobuf:INTERNAL=[/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libprotobuf.a][/opt/data/mci/gennytoolchain/installed/arm64-osx-release/include][v3.21.12()]
@@ -786 +786 @@ FIND_PACKAGE_MESSAGE_DETAILS_Threads:INTERNAL=[TRUE][v()]
-FIND_PACKAGE_MESSAGE_DETAILS_ZLIB:INTERNAL=[optimized;/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/libz.a;debug;/opt/data/mci/gennytoolchain/installed/arm64-osx/debug/lib/libz.a][/opt/data/mci/gennytoolchain/installed/arm64-osx/include][c ][v1.3.0()]
+FIND_PACKAGE_MESSAGE_DETAILS_ZLIB:INTERNAL=[/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/libz.a][/opt/data/mci/gennytoolchain/installed/arm64-osx-release/include][c ][v1.3.0()]
@@ -788 +788 @@ FIND_PACKAGE_MESSAGE_DETAILS_ZLIB:INTERNAL=[optimized;/opt/data/mci/gennytoolcha
-FIND_PACKAGE_MESSAGE_DETAILS_c-ares:INTERNAL=[/opt/data/mci/gennytoolchain/installed/arm64-osx/share/c-ares/c-ares-config.cmake][v1.19.1()]
+FIND_PACKAGE_MESSAGE_DETAILS_c-ares:INTERNAL=[/opt/data/mci/gennytoolchain/installed/arm64-osx-release/share/c-ares/c-ares-config.cmake][v1.19.1()]
@@ -820 +820 @@ _Boost_COMPONENTS_SEARCHED:INTERNAL=atomic;chrono;filesystem;log;log_setup;progr
-_Boost_INCLUDE_DIR_LAST:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/include
+_Boost_INCLUDE_DIR_LAST:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/include
@@ -822 +822 @@ _Boost_INCLUDE_DIR_LAST:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-os
-_Boost_LIBRARY_DIR_DEBUG_LAST:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib
+_Boost_LIBRARY_DIR_DEBUG_LAST:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib
@@ -824 +824 @@ _Boost_LIBRARY_DIR_DEBUG_LAST:INTERNAL=/opt/data/mci/gennytoolchain/installed/ar
-_Boost_LIBRARY_DIR_RELEASE_LAST:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib
+_Boost_LIBRARY_DIR_RELEASE_LAST:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib
@@ -833 +833 @@ _GNUInstallDirs_LAST_CMAKE_INSTALL_PREFIX:INTERNAL=/Users/james/Projects/MongoDB
-_OPENSSL_CFLAGS:INTERNAL=-I/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../include
+_OPENSSL_CFLAGS:INTERNAL=-I/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../include
@@ -837,3 +837,3 @@ _OPENSSL_FOUND:INTERNAL=1
-_OPENSSL_INCLUDEDIR:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../include
-_OPENSSL_INCLUDE_DIRS:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../include
-_OPENSSL_LDFLAGS:INTERNAL=-L/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../lib;-lssl;-lcrypto
+_OPENSSL_INCLUDEDIR:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../include
+_OPENSSL_INCLUDE_DIRS:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../include
+_OPENSSL_LDFLAGS:INTERNAL=-L/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../lib;-lssl;-lcrypto
@@ -841 +841 @@ _OPENSSL_LDFLAGS_OTHER:INTERNAL=
-_OPENSSL_LIBDIR:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../lib
+_OPENSSL_LIBDIR:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../lib
@@ -843 +843 @@ _OPENSSL_LIBRARIES:INTERNAL=ssl;crypto
-_OPENSSL_LIBRARY_DIRS:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../lib
+_OPENSSL_LIBRARY_DIRS:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../lib
@@ -849,2 +849,2 @@ _OPENSSL_MODULE_NAME:INTERNAL=openssl
-_OPENSSL_PREFIX:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../..
-_OPENSSL_STATIC_CFLAGS:INTERNAL=-I/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../include
+_OPENSSL_PREFIX:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../..
+_OPENSSL_STATIC_CFLAGS:INTERNAL=-I/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../include
@@ -853,2 +853,2 @@ _OPENSSL_STATIC_CFLAGS_OTHER:INTERNAL=
-_OPENSSL_STATIC_INCLUDE_DIRS:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../include
-_OPENSSL_STATIC_LDFLAGS:INTERNAL=-L/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../lib;-lssl;-lcrypto
+_OPENSSL_STATIC_INCLUDE_DIRS:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../include
+_OPENSSL_STATIC_LDFLAGS:INTERNAL=-L/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../lib;-lssl;-lcrypto
@@ -858 +858 @@ _OPENSSL_STATIC_LIBRARIES:INTERNAL=ssl;crypto
-_OPENSSL_STATIC_LIBRARY_DIRS:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../lib
+_OPENSSL_STATIC_LIBRARY_DIRS:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../lib
@@ -874 +874 @@ pkgcfg_lib__OPENSSL_ssl-ADVANCED:INTERNAL=1
-prefix_result:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx/lib/pkgconfig/../../lib
+prefix_result:INTERNAL=/opt/data/mci/gennytoolchain/installed/arm64-osx-release/lib/pkgconfig/../../lib
```

</details>

<details>

<summary>`compile_commands.json`</summary>

``` diff
diff --git a/compile_commands.old.json b/compile_commands.json
index 15ffb51d7..dfcaeda2d 100644
--- a/compile_commands.old.json
+++ b/compile_commands.json
@@ -4 +4 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/collector.grpc.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/collector.grpc.pb.cc",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/collector.grpc.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/collector.grpc.pb.cc",
@@ -10 +10 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/collector.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/collector.pb.cc",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/collector.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/collector.pb.cc",
@@ -16 +16 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/metrics.grpc.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/metrics.grpc.pb.cc",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/metrics.grpc.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/metrics.grpc.pb.cc",
@@ -22 +22 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/metrics.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/metrics.pb.cc",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/metrics.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/metrics.pb.cc",
@@ -28 +28 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/poplar.grpc.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/poplar.grpc.pb.cc",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/poplar.grpc.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/poplar.grpc.pb.cc",
@@ -34 +34 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/poplar.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/poplar.pb.cc",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/poplar.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/poplar.pb.cc",
@@ -40 +40 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/recorder.grpc.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/recorder.grpc.pb.cc",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/recorder.grpc.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/recorder.grpc.pb.cc",
@@ -46 +46 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/recorder.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/recorder.pb.cc",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/third_party/poplar/CMakeFiles/poplarlib.dir/poplarlib/recorder.pb.cc.o -c /Users/james/Projects/MongoDB/genny/src/third_party/poplar/poplarlib/recorder.pb.cc",
@@ -52 +52 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/canaries/include -I/Users/james/Projects/MongoDB/genny/src/canaries/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/canaries/CMakeFiles/canaries.dir/src/Loops.cpp.o -c /Users/james/Projects/MongoDB/genny/src/canaries/src/Loops.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/canaries/include -I/Users/james/Projects/MongoDB/genny/src/canaries/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/canaries/CMakeFiles/canaries.dir/src/Loops.cpp.o -c /Users/james/Projects/MongoDB/genny/src/canaries/src/Loops.cpp",
@@ -58 +58 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/canaries/include -I/Users/james/Projects/MongoDB/genny/src/canaries/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/canaries/CMakeFiles/canaries.dir/src/tasks.cpp.o -c /Users/james/Projects/MongoDB/genny/src/canaries/src/tasks.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/canaries/include -I/Users/james/Projects/MongoDB/genny/src/canaries/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/canaries/CMakeFiles/canaries.dir/src/tasks.cpp.o -c /Users/james/Projects/MongoDB/genny/src/canaries/src/tasks.cpp",
@@ -64 +64 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/canaries/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/canaries/CMakeFiles/genny-canaries.dir/src/main.cpp.o -c /Users/james/Projects/MongoDB/genny/src/canaries/src/main.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/canaries/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/canaries/CMakeFiles/genny-canaries.dir/src/main.cpp.o -c /Users/james/Projects/MongoDB/genny/src/canaries/src/main.cpp",
@@ -70 +70 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/canaries/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/canaries/CMakeFiles/canaries_benchmark.dir/benchmark/canaries_benchmark.cpp.o -c /Users/james/Projects/MongoDB/genny/src/canaries/benchmark/canaries_benchmark.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/canaries/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/canaries/CMakeFiles/canaries_benchmark.dir/benchmark/canaries_benchmark.cpp.o -c /Users/james/Projects/MongoDB/genny/src/canaries/benchmark/canaries_benchmark.cpp",
@@ -76 +76 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/AssertiveActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/AssertiveActor.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/AssertiveActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/AssertiveActor.cpp",
@@ -82 +82 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/CollectionScanner.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/CollectionScanner.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/CollectionScanner.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/CollectionScanner.cpp",
@@ -88 +88 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/CommitLatency.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/CommitLatency.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/CommitLatency.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/CommitLatency.cpp",
@@ -94 +94 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/CrudActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/CrudActor.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/CrudActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/CrudActor.cpp",
@@ -100 +100 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/DbCheckActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/DbCheckActor.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/DbCheckActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/DbCheckActor.cpp",
@@ -106 +106 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/Deleter.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/Deleter.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/Deleter.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/Deleter.cpp",
@@ -112 +112 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/ExternalScriptRunner.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/ExternalScriptRunner.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/ExternalScriptRunner.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/ExternalScriptRunner.cpp",
@@ -118 +118 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/HelloWorld.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/HelloWorld.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/HelloWorld.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/HelloWorld.cpp",
@@ -124 +124 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/Insert.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/Insert.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/Insert.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/Insert.cpp",
@@ -130 +130 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/InsertRemove.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/InsertRemove.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/InsertRemove.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/InsertRemove.cpp",
@@ -136 +136 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/Loader.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/Loader.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/Loader.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/Loader.cpp",
@@ -142 +142 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/LoggingActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/LoggingActor.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/LoggingActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/LoggingActor.cpp",
@@ -148 +148 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MonotonicLoader.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MonotonicLoader.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MonotonicLoader.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MonotonicLoader.cpp",
@@ -154 +154 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MonotonicSingleLoader.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MonotonicSingleLoader.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MonotonicSingleLoader.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MonotonicSingleLoader.cpp",
@@ -160 +160 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MoveRandomChunkToRandomShard.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MoveRandomChunkToRandomShard.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MoveRandomChunkToRandomShard.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MoveRandomChunkToRandomShard.cpp",
@@ -166 +166 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MultiCollectionQuery.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MultiCollectionQuery.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MultiCollectionQuery.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MultiCollectionQuery.cpp",
@@ -172 +172 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MultiCollectionUpdate.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MultiCollectionUpdate.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/MultiCollectionUpdate.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/MultiCollectionUpdate.cpp",
@@ -178 +178 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/NopMetrics.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/NopMetrics.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/NopMetrics.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/NopMetrics.cpp",
@@ -184 +184 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/PhaseTimingRecorder.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/PhaseTimingRecorder.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/PhaseTimingRecorder.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/PhaseTimingRecorder.cpp",
@@ -190 +190 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/QuiesceActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/QuiesceActor.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/QuiesceActor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/QuiesceActor.cpp",
@@ -196 +196 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/RandomSampler.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/RandomSampler.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/RandomSampler.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/RandomSampler.cpp",
@@ -202 +202 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/RollingCollections.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/RollingCollections.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/RollingCollections.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/RollingCollections.cpp",
@@ -208 +208 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/RunCommand.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/RunCommand.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/RunCommand.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/RunCommand.cpp",
@@ -214 +214 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/SamplingLoader.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/SamplingLoader.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/SamplingLoader.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/SamplingLoader.cpp",
@@ -220 +220 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/StreamStatsReporter.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/StreamStatsReporter.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/StreamStatsReporter.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/StreamStatsReporter.cpp",
@@ -226 +226 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/pipeline_helpers.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/pipeline_helpers.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -Dcast_core_EXPORTS -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/cast_core/CMakeFiles/cast_core.dir/src/pipeline_helpers.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/src/pipeline_helpers.cpp",
@@ -232 +232 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/AssertiveActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/AssertiveActor_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/AssertiveActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/AssertiveActor_test.cpp",
@@ -238 +238 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/CollectionScanner_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/CollectionScanner_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/CollectionScanner_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/CollectionScanner_test.cpp",
@@ -244 +244 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/CommitLatency_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/CommitLatency_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/CommitLatency_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/CommitLatency_test.cpp",
@@ -250 +250 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/CrudActorYamlTestRunner.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/CrudActorYamlTestRunner.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/CrudActorYamlTestRunner.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/CrudActorYamlTestRunner.cpp",
@@ -256 +256 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/DbCheckActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/DbCheckActor_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/DbCheckActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/DbCheckActor_test.cpp",
@@ -262 +262 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/ExternalScriptRunnerTest.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/ExternalScriptRunnerTest.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/ExternalScriptRunnerTest.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/ExternalScriptRunnerTest.cpp",
@@ -268 +268 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/Loader_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/Loader_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/Loader_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/Loader_test.cpp",
@@ -274 +274 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/LoggingActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/LoggingActor_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/LoggingActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/LoggingActor_test.cpp",
@@ -280 +280 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/MonotonicLoader_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/MonotonicLoader_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/MonotonicLoader_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/MonotonicLoader_test.cpp",
@@ -286 +286 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/MonotonicSingleLoader_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/MonotonicSingleLoader_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/MonotonicSingleLoader_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/MonotonicSingleLoader_test.cpp",
@@ -292 +292 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/MoveRandomChunkToRandomShard_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/MoveRandomChunkToRandomShard_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/MoveRandomChunkToRandomShard_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/MoveRandomChunkToRandomShard_test.cpp",
@@ -298 +298 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/MultiCollectionQuery_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/MultiCollectionQuery_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/MultiCollectionQuery_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/MultiCollectionQuery_test.cpp",
@@ -304 +304 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/QuiesceActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/QuiesceActor_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/QuiesceActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/QuiesceActor_test.cpp",
@@ -310 +310 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/RunCommandActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/RunCommandActor_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/RunCommandActor_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/RunCommandActor_test.cpp",
@@ -316 +316 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/SamplingLoader_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/SamplingLoader_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/SamplingLoader_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/SamplingLoader_test.cpp",
@@ -322 +322 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/StreamStatsReporter_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/StreamStatsReporter_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/StreamStatsReporter_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/StreamStatsReporter_test.cpp",
@@ -328 +328 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/actors_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/actors_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/cast_core/CMakeFiles/cast_core_test.dir/test/actors_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/cast_core/test/actors_test.cpp",
@@ -334 +334 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -D_GNU_SOURCE -I/Users/james/Projects/MongoDB/genny/src/driver/include -I/Users/james/Projects/MongoDB/genny/src/driver/src -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/driver/CMakeFiles/driver.dir/src/DefaultDriver.cpp.o -c /Users/james/Projects/MongoDB/genny/src/driver/src/DefaultDriver.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -D_GNU_SOURCE -I/Users/james/Projects/MongoDB/genny/src/driver/include -I/Users/james/Projects/MongoDB/genny/src/driver/src -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/driver/CMakeFiles/driver.dir/src/DefaultDriver.cpp.o -c /Users/james/Projects/MongoDB/genny/src/driver/src/DefaultDriver.cpp",
@@ -340 +340 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -D_GNU_SOURCE -I/Users/james/Projects/MongoDB/genny/src/driver/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/driver/CMakeFiles/genny_core.dir/src/main.cpp.o -c /Users/james/Projects/MongoDB/genny/src/driver/src/main.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -D_GNU_SOURCE -I/Users/james/Projects/MongoDB/genny/src/driver/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/driver/CMakeFiles/genny_core.dir/src/main.cpp.o -c /Users/james/Projects/MongoDB/genny/src/driver/src/main.cpp",
@@ -346 +346 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -D_GNU_SOURCE -I/Users/james/Projects/MongoDB/genny/src/driver/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/driver/CMakeFiles/driver_test.dir/test/Driver_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/driver/test/Driver_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -D_GNU_SOURCE -I/Users/james/Projects/MongoDB/genny/src/driver/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/driver/CMakeFiles/driver_test.dir/test/Driver_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/driver/test/Driver_test.cpp",
@@ -352 +352 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -D_GNU_SOURCE -I/Users/james/Projects/MongoDB/genny/src/driver/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/driver/CMakeFiles/driver_test.dir/test/ProgramOptions_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/driver/test/ProgramOptions_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -D_GNU_SOURCE -I/Users/james/Projects/MongoDB/genny/src/driver/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/driver/CMakeFiles/driver_test.dir/test/ProgramOptions_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/driver/test/ProgramOptions_test.cpp",
@@ -358 +358 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/Actor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/Actor.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/Actor.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/Actor.cpp",
@@ -364 +364 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/ActorProducer.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/ActorProducer.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/ActorProducer.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/ActorProducer.cpp",
@@ -370 +370 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/Cast.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/Cast.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/Cast.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/Cast.cpp",
@@ -376 +376 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/Node.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/Node.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/Node.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/Node.cpp",
@@ -382 +382 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/Orchestrator.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/Orchestrator.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/Orchestrator.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/Orchestrator.cpp",
@@ -388 +388 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/PoolFactory.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/PoolFactory.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/PoolFactory.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/PoolFactory.cpp",
@@ -394 +394 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/PoolManager.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/PoolManager.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/PoolManager.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/PoolManager.cpp",
@@ -400 +400 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/context.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/context.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/context.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/context.cpp",
@@ -406 +406 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/encryption.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/encryption.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/encryption.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/encryption.cpp",
@@ -412 +412 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/quiesce.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/quiesce.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/quiesce.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/quiesce.cpp",
@@ -418 +418 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/topology.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/topology.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/topology.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/topology.cpp",
@@ -424 +424 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/version.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/version.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/src -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/gennylib/CMakeFiles/gennylib.dir/src/version.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/src/version.cpp",
@@ -430 +430 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/Cast_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/Cast_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/Cast_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/Cast_test.cpp",
@@ -436 +436 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/GlobalRateLimiter_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/GlobalRateLimiter_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/GlobalRateLimiter_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/GlobalRateLimiter_test.cpp",
@@ -442 +442 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/Node_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/Node_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/Node_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/Node_test.cpp",
@@ -448 +448 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/PhaseLoop_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/PhaseLoop_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/PhaseLoop_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/PhaseLoop_test.cpp",
@@ -454 +454 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/PoolFactory_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/PoolFactory_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/PoolFactory_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/PoolFactory_test.cpp",
@@ -460 +460 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/context_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/context_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/context_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/context_test.cpp",
@@ -466 +466 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/conventions_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/conventions_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/conventions_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/conventions_test.cpp",
@@ -472 +472 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/encryption_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/encryption_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/encryption_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/encryption_test.cpp",
@@ -478 +478 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/orchestrator_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/orchestrator_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/orchestrator_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/orchestrator_test.cpp",
@@ -484 +484 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/parallel_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/parallel_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/parallel_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/parallel_test.cpp",
@@ -490 +490 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/topology_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/topology_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/topology_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/topology_test.cpp",
@@ -496 +496 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/version_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/version_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_test.dir/test/version_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/test/version_test.cpp",
@@ -502 +502 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_benchmark.dir/benchmark/GlobalRateLimiter_benchmark.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/benchmark/GlobalRateLimiter_benchmark.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_benchmark.dir/benchmark/GlobalRateLimiter_benchmark.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/benchmark/GlobalRateLimiter_benchmark.cpp",
@@ -508 +508 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_benchmark.dir/benchmark/PhaseLoop_benchmark.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/benchmark/PhaseLoop_benchmark.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/gennylib/CMakeFiles/gennylib_benchmark.dir/benchmark/PhaseLoop_benchmark.cpp.o -c /Users/james/Projects/MongoDB/genny/src/gennylib/benchmark/PhaseLoop_benchmark.cpp",
@@ -514 +514 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/metrics/CMakeFiles/metrics_test.dir/test/metrics_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/metrics/test/metrics_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/metrics/CMakeFiles/metrics_test.dir/test/metrics_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/metrics/test/metrics_test.cpp",
@@ -520 +520 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/ActorHelper.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/ActorHelper.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/ActorHelper.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/ActorHelper.cpp",
@@ -526 +526 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/MongoTestFixture.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/MongoTestFixture.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/MongoTestFixture.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/MongoTestFixture.cpp",
@@ -532 +532 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/clocks.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/clocks.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/clocks.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/clocks.cpp",
@@ -538 +538 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/findRepoRoot.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/findRepoRoot.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/findRepoRoot.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/findRepoRoot.cpp",
@@ -544 +544 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/yamlToBson.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/yamlToBson.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/testlib/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/testlib/CMakeFiles/testlib.dir/src/yamlToBson.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/src/yamlToBson.cpp",
@@ -550 +550 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/testlib/CMakeFiles/testlib_test.dir/test/ActorHelper_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/test/ActorHelper_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/testlib/CMakeFiles/testlib_test.dir/test/ActorHelper_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/test/ActorHelper_test.cpp",
@@ -556 +556 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/testlib/CMakeFiles/testlib_test.dir/test/helpers_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/test/helpers_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/testlib/CMakeFiles/testlib_test.dir/test/helpers_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/test/helpers_test.cpp",
@@ -562 +562 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/testlib/CMakeFiles/testlib_test.dir/test/yamlToBson_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/test/yamlToBson_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/testlib/CMakeFiles/testlib_test.dir/test/yamlToBson_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/testlib/test/yamlToBson_test.cpp",
@@ -568 +568 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/value_generators/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/value_generators/CMakeFiles/value_generators.dir/src/DocumentGenerator.cpp.o -c /Users/james/Projects/MongoDB/genny/src/value_generators/src/DocumentGenerator.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/value_generators/src -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIC -o src/value_generators/CMakeFiles/value_generators.dir/src/DocumentGenerator.cpp.o -c /Users/james/Projects/MongoDB/genny/src/value_generators/src/DocumentGenerator.cpp",
@@ -574 +574 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/value_generators/CMakeFiles/value_generators_test.dir/test/DefaultRandom_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/value_generators/test/DefaultRandom_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/value_generators/CMakeFiles/value_generators_test.dir/test/DefaultRandom_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/value_generators/test/DefaultRandom_test.cpp",
@@ -580 +580 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/value_generators/CMakeFiles/value_generators_test.dir/test/DocGenYamlTestCaseRunner.cpp.o -c /Users/james/Projects/MongoDB/genny/src/value_generators/test/DocGenYamlTestCaseRunner.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/value_generators/CMakeFiles/value_generators_test.dir/test/DocGenYamlTestCaseRunner.cpp.o -c /Users/james/Projects/MongoDB/genny/src/value_generators/test/DocGenYamlTestCaseRunner.cpp",
@@ -586 +586 @@
-    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/value_generators/CMakeFiles/value_generators_test.dir/test/FrequencyMap_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/value_generators/test/FrequencyMap_test.cpp",
+    "command": "/nix/store/qw1k8cijsmff5pjb7bmj27v5m9k2hzl0-clang-wrapper-16.0.6/bin/clang++ -DBOOST_ALL_DYN_LINK -DCARES_STATICLIB -DYAML_CPP_STATIC_DEFINE -I/Users/james/Projects/MongoDB/genny/src/value_generators/include -I/Users/james/Projects/MongoDB/genny/src/gennylib/include -I/Users/james/Projects/MongoDB/genny/src/third_party/loki/include -I/Users/james/Projects/MongoDB/genny/src/metrics/include -I/Users/james/Projects/MongoDB/genny/src/third_party/poplar -I/Users/james/Projects/MongoDB/genny/src/testlib/include -I/Users/james/Projects/MongoDB/genny/src/cast_core/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-release/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/bsoncxx/v_noabi -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include -isystem /opt/data/mci/gennytoolchain/installed/arm64-osx-dynamic/include/mongocxx/v_noabi -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -mmacosx-version-min=11.0 -fPIE -o src/value_generators/CMakeFiles/value_generators_test.dir/test/FrequencyMap_test.cpp.o -c /Users/james/Projects/MongoDB/genny/src/value_generators/test/FrequencyMap_test.cpp",
```

</details>
