### PR TITLE
PERF-5440 Fix created indices for ascending sort key queries in TimeSeriesLastpoint.yml workload

### DIFF
--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -6,106 +6,76 @@ Description: |
 CreateIndex:
   Repeat: 1
   Database: &db test
-  Operations:
-    - OperationName: RunCommand
-      OperationMetricsName: CreateIndex
-      OperationCommand:
-        createIndexes:
-          { ^Parameter: { Name: "Collection", Default: "Collection0" } }
-        indexes:
-          - {
-            key: { ^Parameter: { Name: "IndexPattern", Default: {} } },
-            name: { ^Parameter: { Name: "IndexName", Default: "" } },
-          }
+  Operation:
+    OperationName: RunCommand
+    OperationMetricsName: CreateIndex
+    OperationCommand:
+      createIndexes: &coll { ^Parameter: { Name: "Collection", Default: "Collection0" } }
+      indexes:
+        - key: { ^Parameter: { Name: "IndexPattern", Default: {} } }
+          name: { ^Parameter: { Name: "IndexName", Default: "" } }
+
+#
+# Queries defined here assumes that the actor is 'CrudActor'.
+#
 
 RunLastPointQuery:
-  Repeat: 10
+  Repeat: { ^Parameter: { Name: "Repeat", Default: "10" } }
   Database: *db
+  Collection: *coll
   Operations:
     - OperationMetricsName: RunLastPointQuery
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate:
-          &coll { ^Parameter: { Name: "IndexPattern", Default: "Collection0" } }
-        pipeline:
+        Pipeline:
           [
-            &sortStage {
-              $sort:
-                &sortPattern {
-                  ^Parameter: { Name: "SortPattern", Default: {} },
-                },
-            },
-            &groupStage {
-              $group: { ^Parameter: { Name: "GroupPattern", Default: {} } },
-            },
+            &sortStage { $sort: &sortPattern { ^Parameter: { Name: "SortPattern", Default: {} } } },
+            &groupStage { $group: { ^Parameter: { Name: "GroupPattern", Default: {} } } },
           ]
-        cursor:
-          &batchSize {
-            batchSize: { ^Parameter: { Name: "BatchSize", Default: 100 } },
-          }
-        # In cases when we cannot optimize for a covered index sort, allow for external sorting.
-        allowDiskUse: true
     # This predicate should select 90% of documents.
     - OperationMetricsName: RunLastPointQueryWithLargePredicate
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline:
+        Pipeline:
           [
             { $match: { "metadata.sensorId": { $gt: 10 } } },
             *sortStage,
             *groupStage,
           ]
-        cursor: *batchSize
-        # In cases when we cannot optimize for a covered index sort, allow for external sorting.
-        allowDiskUse: true
     # This predicate should select 10% of documents.
     - OperationMetricsName: RunLastPointQueryWithSmallPredicate
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline:
+        Pipeline:
           [
             { $match: { "metadata.sensorId": { $lt: 10 } } },
             *sortStage,
             *groupStage,
           ]
-        cursor: *batchSize
-        # In cases when we cannot optimize for a covered index sort, allow for external sorting.
-        allowDiskUse: true
     # Test the lastpoint optimization with $top or $bottom.
     - OperationMetricsName: RunLastPointQueryWithTopOrBottom
-      OperationName: RunCommand
+      OperationName: aggregate
       OperationCommand:
-        aggregate: *coll
-        pipeline:
+        Pipeline:
           [
             {
               $group:
                 {
                   _id: "$metadata.sensorId",
-                  mostRecent:
-                    {
-                      ^Parameter:
-                        { Name: "GroupPatternTopOrBottom", Default: {} },
-                    },
+                  mostRecent: { ^Parameter: { Name: "GroupPatternTopOrBottom", Default: {} } }
                 },
             },
           ]
-        cursor: *batchSize
-        # In cases when we cannot optimize for a covered index sort, allow for external sorting.
-        allowDiskUse: true
 
 DropIndex:
   Repeat: 1
   Database: *db
-  Operations:
-    - OperationMetricsName: DropIndex
-      OperationName: RunCommand
-      OperationCommand:
-        dropIndexes:
-          { ^Parameter: { Name: "Collection", Default: "Collection0" } }
-        index: { ^Parameter: { Name: "IndexName", Default: "" } }
+  Operation:
+    OperationMetricsName: DropIndex
+    OperationName: RunCommand
+    OperationCommand:
+      dropIndexes: { ^Parameter: { Name: "Collection", Default: "Collection0" } }
+      index: { ^Parameter: { Name: "IndexName", Default: "" } }
 
 QuiesceActor:
   Name: { ^Parameter: { Name: "Name", Default: "QuiesceActor" } }
@@ -114,12 +84,8 @@ QuiesceActor:
   Database: { ^Parameter: { Name: "Database", Default: admin } }
   Phases:
     OnlyActiveInPhases:
-      Active:
-        {
-          ^Parameter:
-            { Name: "Active", Default: [2, 5, 8, 11, 14, 17, 18, 21] },
-        }
-      NopInPhasesUpTo: { ^Parameter: { Name: "MaxPhases", Default: 23 } }
+      Active: { ^Parameter: { Name: "Active", Default: [3, 6, 9, 12, 15, 18, 21, 24] } }
+      NopInPhasesUpTo: { ^Parameter: { Name: "MaxPhases", Default: -1 } }
       PhaseConfig:
         SleepBefore: 1 seconds
         SleepAfter: 1 seconds

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -380,22 +380,15 @@ Actors:
       Path: *phasePath
       Key: QuiesceActor
       Parameters:
+        Active: [3, 6, 9, 12, 15, 18, 21, 24]
         MaxPhases: *MaxPhases
 
 AutoRun:
   - When:
       branch_name:
-        $neq:
-          - v4.0
-          - v4.2
-          - v4.4
-          - v5.0
-          - v5.1
+        $gte: v5.3
       mongodb_setup:
         $eq:
-          - standalone
-          - standalone-80-feature-flags
-          - standalone-all-feature-flags
           - replica
           - replica-80-feature-flags
           - replica-all-feature-flags

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -13,6 +13,7 @@ Description: |
 db: &db test
 coll: &coll Collection0
 phasePath: &phasePath ../../phases/query/TimeSeriesLastpoint.yml
+MaxPhases: &MaxPhases 26
 
 # Operations reused in multiple Phases.
 Nop: &Nop {Nop: true}
@@ -24,7 +25,10 @@ LastpointQueryMetaAscTimeDesc: &LastpointQueryMetaAscTimeDesc
       Collection: *coll
       SortPattern: &sortPatternMetaAscTimeDesc {"metadata.sensorId": 1, timestamp: -1}
       GroupPattern: {_id: "$metadata.sensorId", timestamp: {$first: "$timestamp"}, temp: {$first: "$temp"}}
-      GroupPatternTopOrBottom: {$top: {sortBy: *sortPatternMetaAscTimeDesc, output: &output {timestamp: "$timestamp", temp: "$temp"}}}
+      GroupPatternTopOrBottom:
+        $top:
+          sortBy: *sortPatternMetaAscTimeDesc
+          output: &output {timestamp: "$timestamp", temp: "$temp"}
 LastpointQueryMetaDescTimeDesc: &LastpointQueryMetaDescTimeDesc
   LoadConfig:
     Path: *phasePath
@@ -53,369 +57,330 @@ LastpointQueryMetaAscTimeAsc: &LastpointQueryMetaAscTimeAsc
       GroupPattern: {_id: "$metadata.sensorId", timestamp: {$last: "$timestamp"}, temp: {$last: "$temp"}}
       GroupPatternTopOrBottom: {$bottom: {sortBy: *sortPatternMetaAscTimeAsc, output: *output}}
 
+LastpointQueryMetaAscTimeDescRepeat100: &LastpointQueryMetaAscTimeDescRepeat100
+  LoadConfig:
+    Path: *phasePath
+    Key: RunLastPointQuery
+    Parameters:
+      Repeat: 100
+      Collection: *coll
+      SortPattern: *sortPatternMetaAscTimeDesc
+      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$first: "$timestamp"}, temp: {$first: "$temp"}}
+      GroupPatternTopOrBottom: {$top: {sortBy: *sortPatternMetaAscTimeDesc, output: *output}}
+LastpointQueryMetaDescTimeDescRepeat100: &LastpointQueryMetaDescTimeDescRepeat100
+  LoadConfig:
+    Path: *phasePath
+    Key: RunLastPointQuery
+    Parameters:
+      Repeat: 100
+      Collection: *coll
+      SortPattern: *sortPatternMetaDescTimeDesc
+      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$first: "$timestamp"}, temp: {$first: "$temp"}}
+      GroupPatternTopOrBottom: {$top: {sortBy: *sortPatternMetaDescTimeDesc, output: *output}}
+LastpointQueryMetaDescTimeAscRepeat100: &LastpointQueryMetaDescTimeAscRepeat100
+  LoadConfig:
+    Path: *phasePath
+    Key: RunLastPointQuery
+    Parameters:
+      Repeat: 100
+      Collection: *coll
+      SortPattern: *sortPatternMetaDescTimeAsc
+      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$last: "$timestamp"}, temp: {$last: "$temp"}}
+      GroupPatternTopOrBottom: {$bottom: {sortBy: *sortPatternMetaDescTimeAsc, output: *output}}
+LastpointQueryMetaAscTimeAscRepeat100: &LastpointQueryMetaAscTimeAscRepeat100
+  LoadConfig:
+    Path: *phasePath
+    Key: RunLastPointQuery
+    Parameters:
+      Repeat: 100
+      Collection: *coll
+      SortPattern: *sortPatternMetaAscTimeAsc
+      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$last: "$timestamp"}, temp: {$last: "$temp"}}
+      GroupPatternTopOrBottom: {$bottom: {sortBy: *sortPatternMetaAscTimeAsc, output: *output}}
+
 Actors:
+  - Name: DropTimeSeriesCollection
+    Type: RunCommand
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [0]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Repeat: 1
+          Database: *db
+          Operation:
+            OperationName: RunCommand
+            OperationCommand: {drop: *coll}
+
   - Name: CreateTimeSeriesCollection
     Type: RunCommand
     Threads: 1
     Phases:
-      - Repeat: 1
-        Database: *db
-        Operation:
-          OperationMetricsName: CreateTimeSeriesCollection
-          OperationName: RunCommand
-          OperationCommand: {create: *coll, timeseries: {timeField: "timestamp", metaField: "metadata"}}
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      OnlyActiveInPhases:
+        Active: [1]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Repeat: 1
+          Database: *db
+          Operation:
+            OperationMetricsName: CreateTimeSeriesCollection
+            OperationName: RunCommand
+            OperationCommand: {create: *coll, timeseries: {timeField: "timestamp", metaField: "metadata"}}
 
   - Name: InsertData
     Type: Loader
     Threads: 1
     Phases:
-      - *Nop
-      - Repeat: 1
-        Database: *db
-        Collection: *coll
-        Threads: 1
-        CollectionCount: 1
-        DocumentCount: 1000000
-        BatchSize: 100
-        Document:
-          timestamp: {^RandomDate: {min: "2022-01-01", max: "2022-03-01"}}
-          metadata: {sensorId: {^RandomInt: {min: 0, max: 100}}, type: "temperature"}
-          temp: {^RandomDouble: {min: -30, max: 120}}
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      OnlyActiveInPhases:
+        Active: [2]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          Repeat: 1
+          Database: *db
+          Collection: *coll
+          Threads: 1
+          CollectionCount: 1
+          DocumentCount: 1_000_000
+          BatchSize: 100
+          Document:
+            timestamp: {^RandomDate: {min: "2022-01-01", max: "2022-03-01"}}
+            metadata: {sensorId: {^RandomInt: {min: 0, max: 100}}, type: "temperature"}
+            temp: {^RandomDouble: {min: -30, max: 120}}
+
+  # QuiesceActor will run in phase 3.
 
   # Lastpoint query with a sort and group with meta subfield descending and time ascending, but no index.
   - Name: RunLastpointQueryWithMetaSubfieldAscendingTimeDescendingNoIndex
+    Type: CrudActor
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [4]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          *LastpointQueryMetaAscTimeDesc
+
+  - Name: CreateIdxForMetaAscTimeDesc
     Type: RunCommand
     Database: *db
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *LastpointQueryMetaAscTimeDesc
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      OnlyActiveInPhases:
+        Active: [5]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          LoadConfig:
+            Path: *phasePath
+            Key: CreateIndex
+            Parameters:
+              Collection: *coll
+              IndexName: &metaAscTimeDesc "MetaSubfieldAscendingTimeDescending"
+              IndexPattern: *sortPatternMetaAscTimeDesc
+
+  # QuiesceActor will run in phase 6.
 
   # Lastpoint query with a sort and group on meta subfield ascending and time descending.
   - Name: RunLastpointQueryWithMetaSubfieldAscendingTimeDescending
+    Type: CrudActor
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [7]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          *LastpointQueryMetaAscTimeDescRepeat100
+
+  - Name: DropIdxForMetaAscTimeDesc
     Type: RunCommand
     Database: *db
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - LoadConfig:
-          Path: *phasePath
-          Key: CreateIndex
-          Parameters:
-            Collection: *coll
-            IndexName: &metaAscTimeDesc "MetaSubfieldAscendingTimeDescending"
-            IndexPattern: *sortPatternMetaAscTimeDesc
-      - *Nop
-      - *LastpointQueryMetaAscTimeDesc
-      - LoadConfig:
-          Path: *phasePath
-          Key: DropIndex
-          Parameters:
-            Collection: *coll
-            IndexName: *metaAscTimeDesc
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      OnlyActiveInPhases:
+        Active: [8]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          LoadConfig:
+            Path: *phasePath
+            Key: DropIndex
+            Parameters:
+              Collection: *coll
+              IndexName: *metaAscTimeDesc
+
+  # QuiesceActor will run in phase 9.
 
   # Lastpoint query with a sort and group with meta subfield descending and time ascending, but no index.
   - Name: RunLastpointQueryWithMetaSubfieldDescendingTimeDescendingNoIndex
+    Type: CrudActor
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [10]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          *LastpointQueryMetaDescTimeDesc
+
+  - Name: CreateIndexForMetaDescTimeDesc
     Type: RunCommand
     Database: *db
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *LastpointQueryMetaDescTimeDesc
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      OnlyActiveInPhases:
+        Active: [11]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          LoadConfig:
+            Path: *phasePath
+            Key: CreateIndex
+            Parameters:
+              Collection: *coll
+              IndexName: &metaDescTimeDesc "MetaSubfieldDescendingTimeDescending"
+              IndexPattern: *sortPatternMetaDescTimeDesc
+
+  # QuiesceActor will run in phase 12.
 
   # Lastpoint query with a compound index with meta subfield descending and time descending.
   - Name: RunLastpointQueryWithMetaSubfieldDescendingTimeDescending
+    Type: CrudActor
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [13]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          *LastpointQueryMetaDescTimeDescRepeat100
+
+  - Name: DropIndexForMetaDescTimeDesc
     Type: RunCommand
     Database: *db
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - LoadConfig:
-          Path: *phasePath
-          Key: CreateIndex
-          Parameters:
-            Collection: *coll
-            IndexName: &metaDescTimeDesc "MetaSubfieldDescendingTimeDescending"
-            IndexPattern: *sortPatternMetaDescTimeDesc
-      - *Nop
-      - *LastpointQueryMetaDescTimeDesc
-      - LoadConfig:
-          Path: *phasePath
-          Key: DropIndex
-          Parameters:
-            Collection: *coll
-            IndexName: *metaDescTimeDesc
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      OnlyActiveInPhases:
+        Active: [14]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          LoadConfig:
+            Path: *phasePath
+            Key: DropIndex
+            Parameters:
+              Collection: *coll
+              IndexName: *metaDescTimeDesc
+
+  # QuiesceActor will run in phase 15.
 
   # Lastpoint query with a sort and group with meta subfield descending and time ascending, but no index.
   - Name: RunLastpointQueryWithMetaSubfieldDescendingTimeAscendingNoIndex
+    Type: CrudActor
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [16]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          *LastpointQueryMetaDescTimeAsc
+
+  - Name: CreateIndexForMetaDescTimeAsc
     Type: RunCommand
     Database: *db
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *LastpointQueryMetaDescTimeAsc
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      OnlyActiveInPhases:
+        Active: [17]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          LoadConfig:
+            Path: *phasePath
+            Key: CreateIndex
+            Parameters:
+              Collection: *coll
+              IndexName: *metaAscTimeDesc   # We need to flip the direction for the lastpoint query
+              IndexPattern: *sortPatternMetaAscTimeDesc
+
+  # QuiesceActor will run in phase 18.
 
   # Lastpoint query with a compound index with meta subfield descending and time ascending.
   - Name: RunLastpointQueryWithMetaSubfieldDescendingTimeAscending
+    Type: CrudActor
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [19]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          *LastpointQueryMetaDescTimeAscRepeat100
+
+  - Name: DropIndexForMetaDescTimeAsc
     Type: RunCommand
     Database: *db
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - LoadConfig:
-          Path: *phasePath
-          Key: CreateIndex
-          Parameters:
-            Collection: *coll
-            IndexName: &metaDescTimeAsc "MetaSubfieldDescendingTimeAscending"
-            IndexPattern: *sortPatternMetaDescTimeAsc
-      - *Nop
-      - *LastpointQueryMetaDescTimeAsc
-      - LoadConfig:
-          Path: *phasePath
-          Key: DropIndex
-          Parameters:
-            Collection: *coll
-            IndexName: *metaDescTimeAsc
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      OnlyActiveInPhases:
+        Active: [20]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          LoadConfig:
+            Path: *phasePath
+            Key: DropIndex
+            Parameters:
+              Collection: *coll
+              IndexName: *metaAscTimeDesc
+
+  # QuiesceActor will run in phase 21.
 
   # Lastpoint query with a sort and group with meta subfield ascending and time ascending, but no index.
   - Name: RunLastpointQueryWithMetaSubfieldAscendingTimeAscendingNoIndex
+    Type: CrudActor
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [22]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          *LastpointQueryMetaAscTimeAsc
+
+  - Name: CreateIndexForMetaAscTimeAsc
     Type: RunCommand
     Database: *db
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *LastpointQueryMetaAscTimeAsc
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
+      OnlyActiveInPhases:
+        Active: [23]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          LoadConfig:
+            Path: *phasePath
+            Key: CreateIndex
+            Parameters:
+              Collection: *coll
+              IndexName: *metaDescTimeDesc   # We need to flip the direction for the lastpoint query
+              IndexPattern: *sortPatternMetaDescTimeDesc
+
+  # QuiesceActor will run in phase 24.
 
   # Lastpoint query with a compound index with meta subfield ascending and time ascending.
   - Name: RunLastpointQueryWithMetaSubfieldAscendingTimeAscending
+    Type: CrudActor
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [25]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          *LastpointQueryMetaAscTimeAscRepeat100
+
+  - Name: DropIndexForMetaAscTimeAsc
     Type: RunCommand
     Database: *db
     Phases:
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - *Nop
-      - LoadConfig:
-          Path: *phasePath
-          Key: CreateIndex
-          Parameters:
-            Collection: *coll
-            IndexName: &metaAscTimeAsc "MetaSubfieldAscendingTimeAscending"
-            IndexPattern: *sortPatternMetaAscTimeAsc
-      - *Nop
-      - *LastpointQueryMetaAscTimeAsc
-      - LoadConfig:
-          Path: *phasePath
-          Key: DropIndex
-          Parameters:
-            Collection: *coll
-            IndexName: *metaAscTimeAsc
+      OnlyActiveInPhases:
+        Active: [26]
+        NopInPhasesUpTo: *MaxPhases
+        PhaseConfig:
+          LoadConfig:
+            Path: *phasePath
+            Key: DropIndex
+            Parameters:
+              Collection: *coll
+              IndexName: *metaDescTimeDesc
 
   - LoadConfig:
       Path: *phasePath
       Key: QuiesceActor
       Parameters:
-        MaxPhases: 23
+        MaxPhases: *MaxPhases
 
 AutoRun:
   - When:


### PR DESCRIPTION
**Jira Ticket:** [PERF-5440](https://jira.mongodb.org/browse/PERF-5440)

### Whats Changed

- Fix wrong index creation for ascending time sort key queries
- Repeat optimized last point queries100 times instead of 10 to be able to collect on-cpu profiling
- Use `CrudActor` instead of `RunCommand` to execute the aggregates
- Use `OnlyActiveInPhases`

### Patch Testing Results

https://spruce.mongodb.com/version/663feee5e0ec0400072fd1cb/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

<!---
Linting YAML files

If you update/add any YAML files under the workload and/or resmoke directory or
the evergreen file, please lint them first: src/lamplib/src/genny/tasks/

cd <genny_repo_root>        # replace `<genny_repo_root>` with the actual directory
./run-genny -v lint-yaml --format
--->

<!---
If applicable, link a patch test showing code changes running
successfully
--->

<!---
### Workload Submission form

If applicable, only required if there is a new workload being added. The
form is [here].

[here]: https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform

### Merging and Linting

We currently have a manual linting stage required if you're
adding/modifying a workload YAML document. Evergreen will verify that
this has been run.

```bash
./run-genny generate-docs
```

Once (1) your PR is approved by a CODEOWNER and (2) all your CI tests
pass, you can initiate a merge by clicking "Add to merge queue".
This kicks your PR into the [Github Merge Queue]. Github will
automatically squash-merge your commit after checking that Evergreen's
CI tasks have returned a successful status.

[Github Merge Queue]: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Merge-Queue

--->
