### PR TITLE
BF-33222 set `binSize` to null instead of "" (empty string)

### DIFF
--- a/src/workloads/query/GroupStagesOnComputedFields.yml
+++ b/src/workloads/query/GroupStagesOnComputedFields.yml
@@ -148,7 +148,7 @@ GroupStageAfterSortAndAddFields: &GroupStageAfterSortAndAddFields
               {
                 "t":
                   {
-                    $dateTrunc: { date: "$time", unit: "second", binSize: "" },
+                    $dateTrunc: { date: "$time", unit: "second", binSize: null },
                   },
               },
           },


### PR DESCRIPTION
**Jira Ticket:** [BF-33222](https://jira.mongodb.org/browse/BF-33222)

**Whats Changed:**

Set a "binSize" value to null. Originally it lacked a value. During YAML linting and formatting, we set its value to an empty string. Now, change it to `null` as the corresponding test failed with the value being an empty string.

**Patch testing results:**

[patch](https://spruce.mongodb.com/version/664154a8cd210900071d3a14/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

**Related PRs:**

If applicable, link related PRs