### PR TITLE
Perf 5459  compare disable sbe plan cache

### DIFF
--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -4504,6 +4504,56 @@ as well as classic.
 
 
 
+## [EmptyGroup](https://www.github.com/mongodb/genny/blob/master/src/workloads/query/plan_cache/EmptyGroup.yml)
+### Owner 
+@mongodb/query 
+
+
+
+### Description
+This test was created to compare using the Classic vs SBE plan caches, for an SBE query,
+by testing a worst case.
+
+The test uses a $group query to ensure the query is SBE-eligible, but uses an empty collection
+to minimize the query execution time--to make the query planning time a higher proportion of
+the overall request latency.
+
+The sources of overhead are:
+
+  1. The Classic plan cache does not store an SBE plan, so we have to run stage-builders
+     even after retrieving from it.
+
+  2. (Until SERVER-13341) When the access-path is obvious (no indexes -> collection scan), we don't insert
+     any entry to the Classic plan cache. So there may be some overhead from query
+     plan enumeration--although we'd expect this to be very small if there are no indexes.
+     After SERVER-13341 the Classic plan cache creates cache entries even for single-solution plans,
+     removing this difference between Classic and SBE plan caches.
+
+  
+
+### Keywords
+query, plan_cache, group 
+
+
+## [MatchEqVaryingArray](https://www.github.com/mongodb/genny/blob/master/src/workloads/query/plan_cache/MatchEqVaryingArray.yml)
+### Owner 
+@mongodb/query 
+
+
+
+### Description
+This test was created to demonstrate a problem with the hit rate of the SBE plan cache.
+
+It runs a query like {$match: {a: {$eq: [1]}}} where the number varies. The Classic plan
+cache is able to reuse the same plan even as the parameter varies, but the SBE plan cache
+treats each one separately, resulting in much more planning.
+
+  
+
+### Keywords
+query, plan_cache, array 
+
+
 ## [dbcheck_40GB](https://www.github.com/mongodb/genny/blob/master/src/workloads/replication/dbcheck/dbcheck_40GB.yml)
 ### Owner 
 Replication 

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -26,7 +26,7 @@ GlobalDefaults:
   coll: &coll Collection0
 
   maxPhase: &maxPhase 7
-  queryRepeats: &queryRepeats 1
+  queryRepeats: &queryRepeats 1000
 
 Actors:
   - Name: Setup
@@ -55,17 +55,17 @@ Actors:
     Database: *db
     Phases:
       OnlyActiveInPhases:
-        Active: [2]
+        Active: [1,3]
         NopInPhasesUpTo: *maxPhase
         PhaseConfig:
           Repeat: 1
 
-  - Name: GroupQuery
+  - Name: GroupQuery01Accum
     Type: CrudActor
     Threads: 1
     Phases:
       OnlyActiveInPhases:
-        Active: [3]
+        Active: [2]
         NopInPhasesUpTo: *maxPhase
         PhaseConfig:
           Repeat: *queryRepeats
@@ -78,6 +78,106 @@ Actors:
                   # Include at least one accumulator, and not $count, just to ensure we really execute
                   # a query rather than checking some collection metadata.
                   {$group: {_id: null, avg: {$avg: "$x"}}},
+                ]
+
+  - Name: GroupQuery04Accum
+    Type: CrudActor
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [4]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: *queryRepeats
+          Database: *db
+          Collection: *coll
+          Operations:
+            - OperationName: aggregate
+              OperationCommand:
+                Pipeline: [
+                  # Include many accumulators in an attempt to increase the cost of stage-builders.
+                  {$group: {
+                    _id: null,
+
+                    avg00: {$avg: "$x"},
+                    avg01: {$avg: "$x"},
+                    avg02: {$avg: "$x"},
+                    avg03: {$avg: "$x"},
+                  }},
+                ]
+
+  - Name: GroupQuery08Accum
+    Type: CrudActor
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [4]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: *queryRepeats
+          Database: *db
+          Collection: *coll
+          Operations:
+            - OperationName: aggregate
+              OperationCommand:
+                Pipeline: [
+                  # Include many accumulators in an attempt to increase the cost of stage-builders.
+                  {$group: {
+                    _id: null,
+
+                    avg00: {$avg: "$x"},
+                    avg01: {$avg: "$x"},
+                    avg02: {$avg: "$x"},
+                    avg03: {$avg: "$x"},
+
+                    avg04: {$avg: "$x"},
+                    avg05: {$avg: "$x"},
+                    avg06: {$avg: "$x"},
+                    avg07: {$avg: "$x"},
+
+                  }},
+                ]
+
+  - Name: GroupQuery16Accum
+    Type: CrudActor
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [4]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: *queryRepeats
+          Database: *db
+          Collection: *coll
+          Operations:
+            - OperationName: aggregate
+              OperationCommand:
+                Pipeline: [
+                  # Include many accumulators in an attempt to increase the cost of stage-builders.
+                  {$group: {
+                    _id: null,
+
+                    avg00: {$avg: "$x"},
+                    avg01: {$avg: "$x"},
+                    avg02: {$avg: "$x"},
+                    avg03: {$avg: "$x"},
+
+                    avg04: {$avg: "$x"},
+                    avg05: {$avg: "$x"},
+                    avg06: {$avg: "$x"},
+                    avg07: {$avg: "$x"},
+
+                    avg08: {$avg: "$x"},
+                    avg09: {$avg: "$x"},
+                    avg10: {$avg: "$x"},
+                    avg11: {$avg: "$x"},
+
+                    avg12: {$avg: "$x"},
+                    avg13: {$avg: "$x"},
+                    avg14: {$avg: "$x"},
+                    avg15: {$avg: "$x"},
+
+                  }},
                 ]
 
 AutoRun:

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -5,7 +5,8 @@ Description: |
   by testing a worst case.
   
   The test uses a $group query to ensure the query is SBE-eligible, but uses an empty collection
-  to minimize the execution time.
+  to minimize the query execution time--to make the query planning time a higher proportion of
+  the overall request latency.
 
   The sources of overhead are:
 

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -8,13 +8,16 @@ Description: |
   to minimize the execution time.
 
   The sources of overhead are:
+
     - The Classic plan cache does not store an SBE plan, so we have to run stage-builders
       even after retrieving from it.
-    - When the access-path is obvious (no indexes -> collection scan), we don't insert
+
+    - (Until SERVER-13341) When the access-path is obvious (no indexes -> collection scan), we don't insert
       any entry to the Classic plan cache. So there may be some overhead from query
       plan enumeration--although we'd expect this to be very small if there are no indexes.
 
-        TODO except Matt says Jess changed or will change this
+      After SERVER-13341 the Classic plan cache creates cache entries even for single-solution plans,
+      removing this difference between Classic and SBE plan caches.
 
 
 GlobalDefaults:

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -14,15 +14,14 @@ Description: |
 
   The sources of overhead are:
 
-    - The Classic plan cache does not store an SBE plan, so we have to run stage-builders
-      even after retrieving from it.
+    1. The Classic plan cache does not store an SBE plan, so we have to run stage-builders
+       even after retrieving from it.
 
-    - (Until SERVER-13341) When the access-path is obvious (no indexes -> collection scan), we don't insert
-      any entry to the Classic plan cache. So there may be some overhead from query
-      plan enumeration--although we'd expect this to be very small if there are no indexes.
-
-      After SERVER-13341 the Classic plan cache creates cache entries even for single-solution plans,
-      removing this difference between Classic and SBE plan caches.
+    2. (Until SERVER-13341) When the access-path is obvious (no indexes -> collection scan), we don't insert
+       any entry to the Classic plan cache. So there may be some overhead from query
+       plan enumeration--although we'd expect this to be very small if there are no indexes.
+       After SERVER-13341 the Classic plan cache creates cache entries even for single-solution plans,
+       removing this difference between Classic and SBE plan caches.
 
 
 GlobalDefaults:

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -1,5 +1,9 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
+Keywords:
+  - query
+  - plan_cache
+  - group
 Description: |
   This test was created to compare using the Classic vs SBE plan caches, for an SBE query,
   by testing a worst case.
@@ -56,7 +60,7 @@ Actors:
     Database: *db
     Phases:
       OnlyActiveInPhases:
-        Active: [1,3,5,7,9]
+        Active: [1, 3, 5, 7, 9]
         NopInPhasesUpTo: *maxPhase
         PhaseConfig:
           Repeat: 1

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -25,7 +25,7 @@ GlobalDefaults:
   # This name is not actually something we choose: the Loader actor chooses it.
   coll: &coll Collection0
 
-  maxPhase: &maxPhase 7
+  maxPhase: &maxPhase 11
   queryRepeats: &queryRepeats 1000
 
 Actors:
@@ -55,7 +55,7 @@ Actors:
     Database: *db
     Phases:
       OnlyActiveInPhases:
-        Active: [1,3]
+        Active: [1,3,5,7,9]
         NopInPhasesUpTo: *maxPhase
         PhaseConfig:
           Repeat: 1
@@ -111,7 +111,7 @@ Actors:
     Threads: 1
     Phases:
       OnlyActiveInPhases:
-        Active: [4]
+        Active: [6]
         NopInPhasesUpTo: *maxPhase
         PhaseConfig:
           Repeat: *queryRepeats
@@ -143,7 +143,7 @@ Actors:
     Threads: 1
     Phases:
       OnlyActiveInPhases:
-        Active: [4]
+        Active: [8]
         NopInPhasesUpTo: *maxPhase
         PhaseConfig:
           Repeat: *queryRepeats
@@ -176,6 +176,64 @@ Actors:
                     avg13: {$avg: "$x"},
                     avg14: {$avg: "$x"},
                     avg15: {$avg: "$x"},
+
+                  }},
+                ]
+
+  - Name: GroupQuery32Accum
+    Type: CrudActor
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [10]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: *queryRepeats
+          Database: *db
+          Collection: *coll
+          Operations:
+            - OperationName: aggregate
+              OperationCommand:
+                Pipeline: [
+                  # Include many accumulators in an attempt to increase the cost of stage-builders.
+                  {$group: {
+                    _id: null,
+
+                    avg00: {$avg: "$x"},
+                    avg01: {$avg: "$x"},
+                    avg02: {$avg: "$x"},
+                    avg03: {$avg: "$x"},
+                    avg04: {$avg: "$x"},
+                    avg05: {$avg: "$x"},
+                    avg06: {$avg: "$x"},
+                    avg07: {$avg: "$x"},
+
+                    avg08: {$avg: "$x"},
+                    avg09: {$avg: "$x"},
+                    avg10: {$avg: "$x"},
+                    avg11: {$avg: "$x"},
+                    avg12: {$avg: "$x"},
+                    avg13: {$avg: "$x"},
+                    avg14: {$avg: "$x"},
+                    avg15: {$avg: "$x"},
+
+                    avg16: {$avg: "$x"},
+                    avg17: {$avg: "$x"},
+                    avg18: {$avg: "$x"},
+                    avg19: {$avg: "$x"},
+                    avg20: {$avg: "$x"},
+                    avg21: {$avg: "$x"},
+                    avg22: {$avg: "$x"},
+                    avg23: {$avg: "$x"},
+
+                    avg24: {$avg: "$x"},
+                    avg25: {$avg: "$x"},
+                    avg26: {$avg: "$x"},
+                    avg27: {$avg: "$x"},
+                    avg28: {$avg: "$x"},
+                    avg29: {$avg: "$x"},
+                    avg30: {$avg: "$x"},
+                    avg31: {$avg: "$x"},
 
                   }},
                 ]

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -246,7 +246,6 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
-          - standalone-80-feature-flags
+          - replica
       branch_name:
         $gte: v8.0

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -1,0 +1,87 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test was created to compare using the Classic vs SBE plan caches, for an SBE query,
+  by testing a worst case.
+  
+  The test uses a $group query to ensure the query is SBE-eligible, but uses an empty collection
+  to minimize the execution time.
+
+  The sources of overhead are:
+    - The Classic plan cache does not store an SBE plan, so we have to run stage-builders
+      even after retrieving from it.
+    - When the access-path is obvious (no indexes -> collection scan), we don't insert
+      any entry to the Classic plan cache. So there may be some overhead from query
+      plan enumeration--although we'd expect this to be very small if there are no indexes.
+
+        TODO except Matt says Jess changed or will change this
+
+
+GlobalDefaults:
+  dbname: &db test
+  # This name is not actually something we choose: the Loader actor chooses it.
+  coll: &coll Collection0
+
+  maxPhase: &maxPhase 7
+  queryRepeats: &queryRepeats 1
+
+Actors:
+  - Name: Setup
+    Type: RunCommand
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [0]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: 1
+          Database: *db
+          Operations:
+            - OperationName: RunCommand
+              OperationCommand:
+                drop: *coll
+            # Explicitly create the collection, to avoid a special case where empty collections
+            # give you an EOF plan.
+            - OperationName: RunCommand
+              OperationCommand:
+                create: *coll
+
+  - Name: Quiesce
+    Type: QuiesceActor
+    Threads: 1
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [2]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: 1
+
+  - Name: GroupQuery
+    Type: CrudActor
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [3]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: *queryRepeats
+          Database: *db
+          Collection: *coll
+          Operations:
+            - OperationName: aggregate
+              OperationCommand:
+                Pipeline: [
+                  # Include at least one accumulator, and not $count, just to ensure we really execute
+                  # a query rather than checking some collection metadata.
+                  {$group: {_id: null, avg: {$avg: "$x"}}},
+                ]
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - standalone-sbe
+          - standalone-80-feature-flags
+      branch_name:
+        $gte: v8.0

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -7,7 +7,7 @@ Keywords:
 Description: |
   This test was created to compare using the Classic vs SBE plan caches, for an SBE query,
   by testing a worst case.
-  
+
   The test uses a $group query to ensure the query is SBE-eligible, but uses an empty collection
   to minimize the query execution time--to make the query planning time a higher proportion of
   the overall request latency.

--- a/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+++ b/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
@@ -203,7 +203,6 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
-          - standalone-80-feature-flags
+          - replica
       branch_name:
         $gte: v8.0

--- a/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+++ b/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
@@ -1,5 +1,9 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
+Keywords:
+  - query
+  - plan_cache
+  - array
 Description: |
   This test was created to demonstrate a problem with the hit rate of the SBE plan cache.
 
@@ -99,7 +103,7 @@ Actors:
                 Pipeline: [
                   {$match: {
                     # The main predicate which we vary to show the problem with auto-parameterization.
-                    a: {$eq: [ {^Inc: {}}, ]},
+                    a: {$eq: [{^Inc: {}}]},
 
                     # Other indexed but nonselective predicates which we include only to increase the cost of planning.
                     # Multiplanning only happens if there are at least two indexed predicates.
@@ -134,7 +138,7 @@ Actors:
                 Pipeline: [
                   {$match: {
                     # The main predicate which we vary to show the problem with auto-parameterization.
-                    a: {$eq: [ {^Inc: {}}, ]},
+                    a: {$eq: [{^Inc: {}}]},
 
                     # Other indexed but nonselective predicates which we include only to increase the cost of planning.
                     # Multiplanning only happens if there are at least two indexed predicates.
@@ -171,7 +175,7 @@ Actors:
                 Pipeline: [
                   {$match: {
                     # The main predicate which we vary to show the problem with auto-parameterization.
-                    a: {$eq: [ {^Inc: {}}, ]},
+                    a: {$eq: [{^Inc: {}}]},
 
                     # Other indexed but nonselective predicates which we include only to increase the cost of planning.
                     # Multiplanning only happens if there are at least two indexed predicates.

--- a/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+++ b/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
@@ -12,7 +12,7 @@ GlobalDefaults:
   # This name is not actually something we choose: the Loader actor chooses it.
   coll: &coll Collection0
 
-  docCount: &docCount 1e5
+  docCount: &docCount 1e4
   maxPhase: &maxPhase 7
   queryRepeats: &queryRepeats 100
 

--- a/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+++ b/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
@@ -7,18 +7,14 @@ Description: |
   cache is able to reuse the same plan even as the parameter varies, but the SBE plan cache
   treats each one separately, resulting in much more planning.
 
-  TODO more nonselective indexed predicates to increase planning time?
-  TODO more docs to increase planning time?
-
-
 GlobalDefaults:
   dbname: &db test
   # This name is not actually something we choose: the Loader actor chooses it.
   coll: &coll Collection0
 
-  docCount: &docCount 1000
+  docCount: &docCount 1e5
   maxPhase: &maxPhase 7
-  queryRepeats: &queryRepeats 1000
+  queryRepeats: &queryRepeats 100
 
 Actors:
   - Name: Drop
@@ -60,10 +56,22 @@ Actors:
           Document: {
             x00: {^Inc: {}},
             x01: {^Inc: {}},
+            x02: {^Inc: {}},
+            x03: {^Inc: {}},
+            x04: {^Inc: {}},
+            x05: {^Inc: {}},
+            x06: {^Inc: {}},
+            x07: {^Inc: {}},
           }
           Indexes:
             - keys: {x00: 1}
             - keys: {x01: 1}
+            - keys: {x02: 1}
+            - keys: {x03: 1}
+            - keys: {x04: 1}
+            - keys: {x05: 1}
+            - keys: {x06: 1}
+            - keys: {x07: 1}
 
   - Name: Quiesce
     Type: QuiesceActor
@@ -95,10 +103,89 @@ Actors:
                     # The main predicate which we vary to show the problem with auto-parameterization.
                     a: {$eq: [ {^Inc: {}}, ]},
 
-                    # Other unindexed predicates which we include only to increase the cost of planning.
+                    # Other indexed but nonselective predicates which we include only to increase the cost of planning.
                     # Multiplanning only happens if there are at least two indexed predicates.
                     x00: {$gte: 0},
                     x01: {$gte: 0},
+
+                  }},
+
+                  # Add a group stage to make the query eligible for SBE.
+                  {$group: {
+                    _id: null,
+
+                    # Include a non-count accumulator to avoid any kind of specialized plan for counting.
+                    avg: {$avg: "$x"},
+                  }},
+                ]
+
+  - Name: MatchQuery04Indexes
+    Type: CrudActor
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [5]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: *queryRepeats
+          Database: *db
+          Collection: *coll
+          Operations:
+            - OperationName: aggregate
+              OperationCommand:
+                Pipeline: [
+                  {$match: {
+                    # The main predicate which we vary to show the problem with auto-parameterization.
+                    a: {$eq: [ {^Inc: {}}, ]},
+
+                    # Other indexed but nonselective predicates which we include only to increase the cost of planning.
+                    # Multiplanning only happens if there are at least two indexed predicates.
+                    x00: {$gte: 0},
+                    x01: {$gte: 0},
+                    x02: {$gte: 0},
+                    x03: {$gte: 0},
+
+                  }},
+
+                  # Add a group stage to make the query eligible for SBE.
+                  {$group: {
+                    _id: null,
+
+                    # Include a non-count accumulator to avoid any kind of specialized plan for counting.
+                    avg: {$avg: "$x"},
+                  }},
+                ]
+
+  - Name: MatchQuery08Indexes
+    Type: CrudActor
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [7]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: *queryRepeats
+          Database: *db
+          Collection: *coll
+          Operations:
+            - OperationName: aggregate
+              OperationCommand:
+                Pipeline: [
+                  {$match: {
+                    # The main predicate which we vary to show the problem with auto-parameterization.
+                    a: {$eq: [ {^Inc: {}}, ]},
+
+                    # Other indexed but nonselective predicates which we include only to increase the cost of planning.
+                    # Multiplanning only happens if there are at least two indexed predicates.
+                    x00: {$gte: 0},
+                    x01: {$gte: 0},
+                    x02: {$gte: 0},
+                    x03: {$gte: 0},
+                    x04: {$gte: 0},
+                    x05: {$gte: 0},
+                    x06: {$gte: 0},
+                    x07: {$gte: 0},
+
                   }},
 
                   # Add a group stage to make the query eligible for SBE.

--- a/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+++ b/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
@@ -40,7 +40,6 @@ Actors:
   - Name: CreateDataset
     Type: Loader
     Threads: 1
-    Database: *db  # TODO unused?
     Phases:
       OnlyActiveInPhases:
         Active: [1]
@@ -48,8 +47,7 @@ Actors:
         PhaseConfig:
           Threads: 1
           Repeat: 1
-          Database: *db  # TODO unused?
-          Collection: *coll  # TODO unused?
+          Database: *db
           CollectionCount: 1
           DocumentCount: *docCount
           BatchSize: 1000

--- a/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+++ b/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
@@ -1,0 +1,120 @@
+SchemaVersion: 2018-07-01
+Owner: "@mongodb/query"
+Description: |
+  This test was created to demonstrate a problem with the hit rate of the SBE plan cache.
+
+  It runs a query like {$match: {a: {$eq: [1]}}} where the number varies. The Classic plan
+  cache is able to reuse the same plan even as the parameter varies, but the SBE plan cache
+  treats each one separately, resulting in much more planning.
+
+  TODO more nonselective indexed predicates to increase planning time?
+  TODO more docs to increase planning time?
+
+
+GlobalDefaults:
+  dbname: &db test
+  # This name is not actually something we choose: the Loader actor chooses it.
+  coll: &coll Collection0
+
+  docCount: &docCount 1000
+  maxPhase: &maxPhase 7
+  queryRepeats: &queryRepeats 1000
+
+Actors:
+  - Name: Drop
+    Type: RunCommand
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [0]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: 1
+          Database: *db
+          Operations:
+            - OperationName: RunCommand
+              OperationCommand:
+                drop: *coll
+            # Explicitly create the collection, to avoid a special case where empty collections
+            # give you an EOF plan.
+            - OperationName: RunCommand
+              OperationCommand:
+                create: *coll
+
+  - Name: CreateDataset
+    Type: Loader
+    Threads: 1
+    Database: *db  # TODO unused?
+    Phases:
+      OnlyActiveInPhases:
+        Active: [1]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Threads: 1
+          Repeat: 1
+          Database: *db  # TODO unused?
+          Collection: *coll  # TODO unused?
+          CollectionCount: 1
+          DocumentCount: *docCount
+          BatchSize: 1000
+          Document: {
+            x00: {^Inc: {}},
+            x01: {^Inc: {}},
+          }
+          Indexes:
+            - keys: {x00: 1}
+            - keys: {x01: 1}
+
+  - Name: Quiesce
+    Type: QuiesceActor
+    Threads: 1
+    Database: *db
+    Phases:
+      OnlyActiveInPhases:
+        Active: [2]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: 1
+
+  - Name: MatchQuery02Indexes
+    Type: CrudActor
+    Threads: 1
+    Phases:
+      OnlyActiveInPhases:
+        Active: [3]
+        NopInPhasesUpTo: *maxPhase
+        PhaseConfig:
+          Repeat: *queryRepeats
+          Database: *db
+          Collection: *coll
+          Operations:
+            - OperationName: aggregate
+              OperationCommand:
+                Pipeline: [
+                  {$match: {
+                    # The main predicate which we vary to show the problem with auto-parameterization.
+                    a: {$eq: [ {^Inc: {}}, ]},
+
+                    # Other unindexed predicates which we include only to increase the cost of planning.
+                    # Multiplanning only happens if there are at least two indexed predicates.
+                    x00: {$gte: 0},
+                    x01: {$gte: 0},
+                  }},
+
+                  # Add a group stage to make the query eligible for SBE.
+                  {$group: {
+                    _id: null,
+
+                    # Include a non-count accumulator to avoid any kind of specialized plan for counting.
+                    avg: {$avg: "$x"},
+                  }},
+                ]
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - standalone-sbe
+          - standalone-80-feature-flags
+      branch_name:
+        $gte: v8.0


### PR DESCRIPTION
<!---
Thanks for submitting a PR to the Genny repo. Please include the
following fields (if relevant) prior to submitting your PR.
--->

**Jira Ticket:** [PERF-5459](https://jira.mongodb.org/browse/PERF-5459)

### Whats Changed

I've added two new Genny benchmarks:
* $group on an empty collection, intended to show a case where the time taken by stage-builders matters.
* $eq with a varying array, intended to show a case where the Classic plan cache has a much better hit rate than the SBE plan cache.

I've spot checked it locally to make sure it does what we want.  I checked the number of plan cache entries in each scenario:
* empty $group
    * master: 5 cache entries (one per query shape -- there are no parameters varying here)
    * draft PR: 0 cache entries (because there are no indexes)
* $eq array
    * master: 1000 cache entries (one per parameter value)
    * draft PR: 1 cache entry (showing Classic's auto-parameterization working well)

I also looked at the histograms locally, just to spot check.  (Don't believe the actual numbers, because I didn't build with `--release`.)  Things I noticed are:
* empty $group
    * master
        * The median latency is negative in many cases??
        * There's consistently one outlier per query shape.  (Maybe this is the first request, which does the query planning?)
        * Despite the SBE plan cache, the average latency does increase with the size of the query text.
    * draft PR
        * For each query shape the average latency is higher than on master.
        * There's still consistently one outlier.  (It can't be that only the first request did query planning, because there are 0 cache entries.)
* $eq array
    * master
        * There's still one outlier. (It can't be due to planning, because there are 1000 cache entries. It must be some other kind of warm-up.)
        * Very roughly, one query took 7ms and the rest took 5ms.
    * draft PR
        * Now there are two "outliers": 7ms and 5ms, while the rest took 2ms.
        * (We know there's only one cache entry, and IIRC it would require planning twice to become active.  So the 7ms and 5ms must be the two requests that did the planning, which makes sense because the 5ms matches the typical value on master, which is planning every time.)

The histograms are all generated with `genny_venv/bin/python src/workloads/contrib/analysis/test_result_summary.py -m timers.dur -a ".*agg.*"`.


<!---
High level explanation of changes
--->

### Patch Testing Results

I've started two individual patch builds:
* new benchmark on draft pr: https://spruce.mongodb.com/version/66452b0162b06200078e3f27/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
* new benchmarks on base commit: https://spruce.mongodb.com/version/66452b3ae0a31d00071c6ea4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Just to make sure it basically works, and that I've selected the right tasks.  If that works I'll do a multipatch to get more trustworthy numbers, or I'll address any PR feedback first.


<!---
Linting YAML files

If you update/add any YAML files under the workload and/or resmoke directory or
the evergreen file, please lint them first: src/lamplib/src/genny/tasks/

cd <genny_repo_root>        # replace `<genny_repo_root>` with the actual directory
./run-genny -v lint-yaml --format

Note: it will report 'invalid config: no such rule: "anchors"' if the yamllint
in the genny venv is too old. To fix this issue, please `rm -r genny_venv` and
then re-run the aforementioned lint command.

--->


### Histograms I ran locally


empty $group, master:
```
GroupQuery01Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 0.3135  
                median    : -0.1903 
                mode      : 0.3056  
                stddev    : 0.02719 
                [min, max]: ['0.3024', '1.108']
                histogram:
                        [0,0): ************************************************************...  (992)
                        [0,0): ******   (6)
                        [0,0):  (0)
                        [0,1): *        (1)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1]: *        (1)


GroupQuery04Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 0.3363  
                median    : 0.3329  
                mode      : 0.3317  
                stddev    : 0.02574 
                [min, max]: ['0.3265', '1.079']
                histogram:
                        [0,0): ************************************************************...  (993)
                        [0,0): ****     (4)
                        [0,0): *        (1)
                        [0,1): *        (1)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1]: *        (1)


GroupQuery08Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 0.3856  
                median    : -0.118  
                mode      : 0.3832  
                stddev    : 0.02769 
                [min, max]: ['0.3747', '1.215']
                histogram:
                        [0,0): ************************************************************...  (995)
                        [0,0): ***      (3)
                        [0,1): *        (1)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1]: *        (1)


GroupQuery16Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 0.4898  
                median    : -0.01565
                mode      : 0.4814  
                stddev    : 0.04695 
                [min, max]: ['0.4755', '1.899']
                histogram:
                        [0,1): ************************************************************...  (995)
                        [1,1): ***      (3)
                        [1,1):  (0)
                        [1,1): *        (1)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,2):  (0)
                        [2,2):  (0)
                        [2,2):  (0)
                        [2,2):  (0)
                        [2,2]: *        (1)


GroupQuery32Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 0.6548  
                median    : 0.1489  
                mode      : 0.6443  
                stddev    : 0.05987 
                [min, max]: ['0.6386', '2.507']
                histogram:
                        [1,1): ************************************************************...  (997)
                        [1,1): **       (2)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,2):  (0)
                        [2,2):  (0)
                        [2,2):  (0)
                        [2,2):  (0)
                        [2,2):  (0)
                        [2,2):  (0)
                        [2,2):  (0)
                        [2,2):  (0)
                        [2,3]: *        (1)
```

empty $group, draft PR:
```
GroupQuery01Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 0.4015  
                median    : -0.1025 
                mode      : 0.3966  
                stddev    : 0.01979 
                [min, max]: ['0.3888', '0.8884']
                histogram:
                        [0,0): ************************************************************...  (966)
                        [0,0): **************************       (26)
                        [0,0): ****     (4)
                        [0,1): *        (1)
                        [1,1): *        (1)
                        [1,1): *        (1)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1]: *        (1)


GroupQuery04Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 0.5456  
                median    : 0.04166 
                mode      : 0.5391  
                stddev    : 0.01639 
                [min, max]: ['0.5319', '0.9104']
                histogram:
                        [1,1): ************************************************************...  (878)
                        [1,1): ************************************************************...  (114)
                        [1,1): ****     (4)
                        [1,1): *        (1)
                        [1,1):  (0)
                        [1,1): *        (1)
                        [1,1):  (0)
                        [1,1): *        (1)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1]: *        (1)


GroupQuery08Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 0.7421  
                median    : 0.2377  
                mode      : 0.7292  
                stddev    : 0.01712 
                [min, max]: ['0.7244', '1.074']
                histogram:
                        [1,1): ************************************************************...  (741)
                        [1,1): ************************************************************...  (235)
                        [1,1): **************   (14)
                        [1,1): ******   (6)
                        [1,1):  (0)
                        [1,1): ***      (3)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1]: *        (1)


GroupQuery16Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 1.130   
                median    : 0.6253  
                mode      : 1.128   
                stddev    : 0.02557 
                [min, max]: ['1.097', '1.510']
                histogram:
                        [1,1): ************************************************************...  (485)
                        [1,1): ************************************************************...  (397)
                        [1,1): ************************************************************...  (84)
                        [1,1): **************************       (26)
                        [1,1): **       (2)
                        [1,1): ***      (3)
                        [1,1):  (0)
                        [1,1): *        (1)
                        [1,1):  (0)
                        [1,1): *        (1)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,1):  (0)
                        [1,2]: *        (1)


GroupQuery32Accum.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 1.917   
                median    : 1.406   
                mode      : 1.927   
                stddev    : 0.06044 
                [min, max]: ['1.828', '2.360']
                histogram:
                        [2,2): ************************************************************...  (155)
                        [2,2): ************************************************************...  (289)
                        [2,2): ************************************************************...  (266)
                        [2,2): ************************************************************...  (158)
                        [2,2): *******************************************************  (55)
                        [2,2): *************************************    (37)
                        [2,2): **************** (16)
                        [2,2): *****    (5)
                        [2,2): ******** (8)
                        [2,2): ******   (6)
                        [2,2): ***      (3)
                        [2,2): *        (1)
                        [2,2):  (0)
                        [2,2):  (0)
                        [2,2]: *        (1)
```

$eq array, master:
```
MatchQuery02Indexes.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 5.116   
                median    : 4.616   
                mode      : 5.101   
                stddev    : 0.09576 
                [min, max]: ['4.913', '7.244']
                histogram:
                        [5,5): ************************************************************...  (234)
                        [5,5): ************************************************************...  (719)
                        [5,5): *********************************************    (45)
                        [5,6): *        (1)
                        [6,6):  (0)
                        [6,6):  (0)
                        [6,6):  (0)
                        [6,6):  (0)
                        [6,6):  (0)
                        [6,6):  (0)
                        [6,7):  (0)
                        [7,7):  (0)
                        [7,7):  (0)
                        [7,7):  (0)
                        [7,7]: *        (1)
```

$eq array, draft PR:
```
MatchQuery02Indexes.aggregate summary:
        timers.dur (measured in nanoseconds, displayed in milliseconds):
                count     : 1000    
                average   : 1.771   
                median    : 1.751   
                mode      : 1.817   
                stddev    : 0.2151  
                [min, max]: ['1.648', '7.319']
                histogram:
                        [2,2): ************************************************************...  (997)
                        [2,2): *        (1)
                        [2,3):  (0)
                        [3,3):  (0)
                        [3,4):  (0)
                        [4,4):  (0)
                        [4,4):  (0)
                        [4,5):  (0)
                        [5,5):  (0)
                        [5,5): *        (1)
                        [5,6):  (0)
                        [6,6):  (0)
                        [6,7):  (0)
                        [7,7):  (0)
                        [7,7]: *        (1)
```


<!---
If applicable, link a patch test showing code changes running
successfully
--->

<!---
### Workload Submission form

If applicable, only required if there is a new workload being added. The
form is [here].

[here]: https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform

### Merging and Linting

We currently have a manual linting stage required if you're
adding/modifying a workload YAML document. Evergreen will verify that
this has been run.

```bash
./run-genny generate-docs
```

Once (1) your PR is approved by a CODEOWNER and (2) all your CI tests
pass, you can initiate a merge by clicking "Add to merge queue".
This kicks your PR into the [Github Merge Queue]. Github will
automatically squash-merge your commit after checking that Evergreen's
CI tasks have returned a successful status.

[Github Merge Queue]: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Merge-Queue

--->
