### PR TITLE
PERF-5373 Fix NoSuchField.yml so that it hits 'max works' as intended

### DIFF
--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -4396,13 +4396,19 @@ as well as classic.
 
 
 ### Description
-The goal of this test is to exercise multiplanning. We create as many indexes as possible, and run a
-query that makes all of them eligible, so we get as many competing plans as possible. Here, we add
-an additional predicate: {no_such_field: "none"} to guarantee that we hit getTrialPeriodMaxWorks().
+The goal of this test is to exercise the "max works" case of multi-planning. The test is similar
+to 'Simple.yml' except we add an additional predicate: {no_such_field: "none"}, which is always
+false on this dataset. All of the other predicates match all the data, meaning none of the indexed
+predicates are selective. This guarantees that the query will not be able to finish multi-planning
+by producing enough documents, so instead we will hit getTrialPeriodMaxWorks().
 
-We expect classic to have better latency and throughput than SBE on this workload,
-and we expect the combination of classic planner + SBE execution (PM-3591) to perform about
-as well as classic.
+This also covers the special case in which the trial period hits max works without any of the
+candidate plans producing any documents. This is known to be a troublesome scenario for the
+multi-planner for a few reasons:
+    1) Multi-planning can run for too long and become expensive, especially when there are lots of
+    candidate plans and none of them produce any results.
+    2) When there are zero results, each plan has a productivity ratio of zero. This makes ties
+    likely during plan ranking, which can in turn lead to an incorrect plan choice.
 
 
 

--- a/src/workloads/query/multiplanner/NoSuchField.yml
+++ b/src/workloads/query/multiplanner/NoSuchField.yml
@@ -1,13 +1,19 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
 Description: |
-  The goal of this test is to exercise multiplanning. We create as many indexes as possible, and run a
-  query that makes all of them eligible, so we get as many competing plans as possible. Here, we add
-  an additional predicate: {no_such_field: "none"} to guarantee that we hit getTrialPeriodMaxWorks().
+  The goal of this test is to exercise the "max works" case of multi-planning. The test is similar
+  to 'Simple.yml' except we add an additional predicate: {no_such_field: "none"}, which is always
+  false on this dataset. All of the other predicates match all the data, meaning none of the indexed
+  predicates are selective. This guarantees that the query will not be able to finish multi-planning
+  by producing enough documents, so instead we will hit getTrialPeriodMaxWorks().
 
-  We expect classic to have better latency and throughput than SBE on this workload,
-  and we expect the combination of classic planner + SBE execution (PM-3591) to perform about
-  as well as classic.
+  This also covers the special case in which the trial period hits max works without any of the
+  candidate plans producing any documents. This is known to be a troublesome scenario for the
+  multi-planner for a few reasons:
+      1) Multi-planning can run for too long and become expensive, especially when there are lots of
+      candidate plans and none of them produce any results.
+      2) When there are zero results, each plan has a productivity ratio of zero. This makes ties
+      likely during plan ranking, which can in turn lead to an incorrect plan choice.
 
 GlobalDefaults:
   dbname: &db test
@@ -16,17 +22,8 @@ GlobalDefaults:
 
   docCount: &docCount 1e5
   resultCount: &resultCount 101
-  selectivity:
-    &selectivity {
-      ^NumExpr:
-        {
-          withExpression: "resultCount / docCount",
-          andValues: { resultCount: *resultCount, docCount: *docCount },
-        },
-    }
-
   maxPhase: &maxPhase 7
-  queryRepeats: &queryRepeats 1000
+  queryRepeats: &queryRepeats 10
 
 Actors:
   - Name: DropCollection
@@ -289,7 +286,7 @@ Actors:
             Filter:
               {
                 no_such_field: "none",
-                x1: { $lt: *selectivity },
+                x1: { $lte: 1 },
                 x2: { $lte: 1 },
                 x3: { $lte: 1 },
                 x4: { $lte: 1 },
@@ -362,7 +359,7 @@ Actors:
       Parameters:
         active: [4]
         nopInPhasesUpTo: *maxPhase
-        repeat: *queryRepeats
+        repeat: 1
         database: *db
         collection: *coll
 
@@ -385,7 +382,7 @@ Actors:
       Parameters:
         active: [6]
         nopInPhasesUpTo: *maxPhase
-        repeat: *queryRepeats
+        repeat: 1
         database: *db
         collection: *coll
 


### PR DESCRIPTION
**Jira Ticket:** [PERF-5373](https://jira.mongodb.org/browse/PERF-5373)

### Whats Changed

I confirmed that as originally implemented, the multi-planning trial period would end after the plan using index `{x1: 1}` hit EOF. By changing this predicate from `{x: {$lt: *selectivity}}` to `{x1: { $lte: 1}}`, I've made it so that all of the indexed plans need to perform a large index scan. After this change, I've confirmed that none of the plans will hit EOF, and the trial period will instead terminate by hitting the "max works" condition.

In addition, I noticed that we were unnecessarily repeating the `collMod` command to hide indexes 1000 times, so I fixed this to just hide indexes once.

### Patch Testing Results

I've confirmed that this lints locally by running `./run-genny -v lint-yaml --format`.

Kicked off a patch build: https://spruce.mongodb.com/version/6658beef88b0fc0007615e39/tasks. As of this writing, I'm letting it auto-generate tasks first and will need to come back and schedule the generated Genny task for this workload later.
