### PR TITLE
PERF-5522 Fix time_series_lastpoint drop collection actor

### DIFF
--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -100,7 +100,7 @@ LastpointQueryMetaAscTimeAscRepeat100: &LastpointQueryMetaAscTimeAscRepeat100
 
 Actors:
   - Name: DropTimeSeriesCollection
-    Type: RunCommand
+    Type: CrudActor
     Threads: 1
     Phases:
       OnlyActiveInPhases:
@@ -109,9 +109,9 @@ Actors:
         PhaseConfig:
           Repeat: 1
           Database: *db
+          Collection: *coll
           Operation:
-            OperationName: RunCommand
-            OperationCommand: {drop: *coll}
+            OperationName: drop
 
   - Name: CreateTimeSeriesCollection
     Type: RunCommand


### PR DESCRIPTION
**Jira Ticket:** [PERF-5522](https://jira.mongodb.org/browse/PERF-5522)

### Whats Changed

Fix `TimeSeriesLastpoint.yml` drop collection actor so that it does not return an error for non-existing collection on v6.0. This is a fix for BF-33490

### Patch Testing Results

sys-perf patch
https://spruce.mongodb.com/version/6659555749889e0007008b72/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

sys-perf-6.0 patch
https://spruce.mongodb.com/version/665956cfb800a30007b5ad40/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC