### PR TITLE
DEVPROD-5102: Generating all auto_tasks should skip some variants.

### DIFF
--- a/src/lamplib/src/genny/tasks/auto_tasks_all.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_all.py
@@ -28,7 +28,8 @@ def get_all_builds(
     variants = project["buildvariants"]
     all_builds = []
     for variant in variants:
-        if "expansions" in variant and "mongodb_setup" in variant["expansions"]:
+        contains_auto_task = any(task["name"] == "schedule_variant_auto_tasks" for task in variant["tasks"])
+        if "expansions" in variant and "mongodb_setup" in variant["expansions"] and contains_auto_task:
             build_info_dict = {}
             build_info_dict.update(global_expansions)
             build_info_dict.update(variant["expansions"])

--- a/src/lamplib/src/tests/test_auto_tasks_all.py
+++ b/src/lamplib/src/tests/test_auto_tasks_all.py
@@ -363,6 +363,8 @@ buildvariants:
       - "rhel70-perf-single"
     tasks:
       - name: bestbuy_agg_merge_target_hashed
+      - name: schedule_patch_auto_tasks
+      - name: schedule_variant_auto_tasks
 
   - name: linux-standalone-all-feature-flags.2022-11
     display_name: Linux Standalone (all feature flags) 2022-11
@@ -382,6 +384,26 @@ buildvariants:
       - "rhel70-perf-single"
     tasks:
       - name: schedule_patch_auto_tasks
+      - name: schedule_variant_auto_tasks
+
+  - name: do-not-schedule-no-autotasks.2022-11
+    display_name: Linux Standalone (all feature flags) 2022-11
+    cron: "0 0 * * 2,4,6"  # Tuesday, Thursday and Saturday at 00:00
+    expansions:
+      mongodb_setup_release: 2022-11
+      mongodb_setup: standalone-all-feature-flags
+      infrastructure_provisioning_release: 2022-11
+      infrastructure_provisioning: single
+      workload_setup: 2022-11
+      platform: linux
+      project_dir: dsi
+      authentication: enabled
+      storageEngine: wiredTiger
+      compile_variant: "-arm64"
+    run_on:
+      - "rhel70-perf-single"
+    tasks:
+      - name: some-specific-task
         """
 
         m = mock_open(read_data=YAML_INPUT)


### PR DESCRIPTION
Variants that don't have a schedule_variant_auto_tasks task should not have tasks generated for them, since several of them don't work with task generation and none of them have been tested to work with task generation.

<!---
Thanks for submitting a PR to the Genny repo. Please include the
following fields (if relevant) prior to submitting your PR.
--->

**Jira Ticket:** [DEVPROD-5102](https://jira.mongodb.org/browse/DEVPROD-5102)

### Whats Changed

This modifies auto_tasks_all so that it avoids generating tasks for variants that don't already have a schedule_variant_auto_tasks task. This fixes BF-31453

### Patch Testing Results

https://spruce.mongodb.com/version/665fa75cc5864900075c7a8d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

This should show that generate_all_variant_auto_tasks works.
