### PR TITLE
DEVPROD-7874: Update Genny to use the latest version of Curator

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -107,14 +107,6 @@ buildvariants:
     tasks:
       - name: tg_compile
 
-  - name: ubuntu1804
-    display_name: Ubuntu 18.04
-    modules: [mongo]
-    run_on:
-      - ubuntu1804-build
-    tasks:
-      - name: tg_compile
-
   - name: macos-1100
     display_name: macOS Big Sur x64
     modules: [mongo]

--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -245,11 +245,6 @@ class CuratorDownloader(Downloader):
     # https://evergreen.mongodb.com/waterfall/curator
 
     CURATOR_VERSION = "a1293258b30e04ea503e6b91b6b1628789e90093"
-    ARM_CURATOR_VERSION = "a1293258b30e04ea503e6b91b6b1628789e90093"
-
-    SPECIAL_CURATOR_VERSIONS = {
-        "arm": ARM_CURATOR_VERSION,
-    }
 
     DISTRO_MAPPING = {
         "archlinux": "linux-amd64",
@@ -295,11 +290,7 @@ class CuratorDownloader(Downloader):
         )
 
     def _get_url(self):
-        # Check if we need a special curator version for the distro. Otherwise use the default
-        # CURATOR_VERSION
-        version = CuratorDownloader.SPECIAL_CURATOR_VERSIONS.get(
-            self._curator_distro, CuratorDownloader.CURATOR_VERSION
-        )
+        version = CuratorDownloader.CURATOR_VERSION
         return (
             "https://s3.amazonaws.com/boxes.10gen.com/build/curator/"
             "curator-dist-{distro}-{build}.tar.gz".format(

--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -244,8 +244,8 @@ class CuratorDownloader(Downloader):
     # These build IDs are from the Curator Evergreen task.
     # https://evergreen.mongodb.com/waterfall/curator
 
-    CURATOR_VERSION = "3df28d2514d4c4de7c903d027e43f3ee48bf8ec1"
-    ARM_CURATOR_VERSION = "965d53845fd1987ddbf04a937ff625f3c243dee3"
+    CURATOR_VERSION = "a1293258b30e04ea503e6b91b6b1628789e90093"
+    ARM_CURATOR_VERSION = "a1293258b30e04ea503e6b91b6b1628789e90093"
 
     SPECIAL_CURATOR_VERSIONS = {
         "arm": ARM_CURATOR_VERSION,


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-7874](https://jira.mongodb.org/browse/DEVPROD-7874)

### Whats Changed

Removed the special casing for Curator versions. Now, Genny always just grabs the version of Curator pinned below. Also, removed the testing for Ubuntu 1804 - it's EOL and as far as I can tell, we don't run any tests on that os anymore. Please correct me if I'm wrong on that though.

### Patch Testing Results

[Genny](https://spruce.mongodb.com/version/6661cdaf7f45dc0007653b7e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

[Sys-perf
](https://spruce.mongodb.com/version/6661dc545f5be30007113ef2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)