### PR TITLE
DEVPROD-8018: Give Genny the ability to output JSON rollups

### DIFF
--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -367,6 +367,14 @@ def benchmark_test(ctx: click.Context) -> None:
     help=("Run with every phase of every actor having repeat: 1."),
 )
 @click.option(
+    "-r",
+    "--calculate-rollups",
+    required=False,
+    default=False,
+    is_flag=True,
+    help=("Whether to automatically calculate rollups from all created FTDC files. "),
+)
+@click.option(
     "-b",
     "--debug",
     required=False,
@@ -387,6 +395,7 @@ def workload(
     override: str,
     dry_run: bool,
     smoke_test: bool,
+    calculate_rollups: bool,
     debug: bool,
 ):
     from genny.tasks import genny_runner
@@ -405,6 +414,7 @@ def workload(
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
         cleanup_metrics=True,
         hang=debug,
+        should_calculate_rollups=calculate_rollups
     )
 
 

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -414,7 +414,7 @@ def workload(
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
         cleanup_metrics=True,
         hang=debug,
-        should_calculate_rollups=calculate_rollups
+        should_calculate_rollups=calculate_rollups,
     )
 
 

--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -133,6 +133,7 @@ def translate(
     )
     subprocess.run(args, check=True)
 
+
 # Calculate rollups from all the FTDC outputs that are not from canaries.
 def calculate_rollups(output_dir: str, workspace_root: str, genny_repo_root: str) -> None:
     curator = _find_curator(workspace_root, genny_repo_root)
@@ -150,10 +151,9 @@ def calculate_rollups(output_dir: str, workspace_root: str, genny_repo_root: str
                         "--inputFile",
                         ftdc_file_name,
                         "--outputFile",
-                        rollup_file_name
+                        rollup_file_name,
                     ]
                     subprocess.run(args, stderr=subprocess.STDOUT, text=True)
-
 
 
 @contextmanager

--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -145,6 +145,11 @@ def calculate_rollups(output_dir: str, workspace_root: str, genny_repo_root: str
                 if file.endswith(".ftdc") and "canary" not in file:
                     ftdc_file_name = os.path.join(root, file)
                     rollup_file_name = ftdc_file_name.replace(".ftdc", ".json")
+                    SLOG.info(
+                        "Creating perf rollup from FTDC file.",
+                        ftdc_file=ftdc_file_name,
+                        output=rollup_file_name,
+                    )
                     args = [
                         curator,
                         "calculate-rollups",

--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -133,6 +133,28 @@ def translate(
     )
     subprocess.run(args, check=True)
 
+# Calculate rollups from all the FTDC outputs that are not from canaries.
+def calculate_rollups(output_dir: str, workspace_root: str, genny_repo_root: str) -> None:
+    curator = _find_curator(workspace_root, genny_repo_root)
+    if not curator:
+        raise OSError("Could not find Curator.")
+    for root, dirs, files in os.walk(output_dir):
+        if "internal" not in root:
+            for file in files:
+                if file.endswith(".ftdc") and "canary" not in file:
+                    ftdc_file_name = os.path.join(root, file)
+                    rollup_file_name = ftdc_file_name.replace(".ftdc", ".json")
+                    args = [
+                        curator,
+                        "calculate-rollups",
+                        "--inputFile",
+                        ftdc_file_name,
+                        "--outputFile",
+                        rollup_file_name
+                    ]
+                    subprocess.run(args, stderr=subprocess.STDOUT, text=True)
+
+
 
 @contextmanager
 def poplar_grpc(cleanup_metrics: bool, workspace_root: str, genny_repo_root: str):
@@ -244,7 +266,7 @@ class CuratorDownloader(Downloader):
     # These build IDs are from the Curator Evergreen task.
     # https://evergreen.mongodb.com/waterfall/curator
 
-    CURATOR_VERSION = "a1293258b30e04ea503e6b91b6b1628789e90093"
+    CURATOR_VERSION = "fa0dfec710dfbe2fb47c15d5800e978717f23614"
 
     DISTRO_MAPPING = {
         "archlinux": "linux-amd64",

--- a/src/lamplib/src/genny/tasks/dry_run.py
+++ b/src/lamplib/src/genny/tasks/dry_run.py
@@ -66,7 +66,7 @@ def dry_run_workload(
         genny_repo_root=genny_repo_root,
         workspace_root=workspace_root,
         cleanup_metrics=True,
-        should_calculate_rollups=False
+        should_calculate_rollups=False,
     )
 
 

--- a/src/lamplib/src/genny/tasks/dry_run.py
+++ b/src/lamplib/src/genny/tasks/dry_run.py
@@ -66,6 +66,7 @@ def dry_run_workload(
         genny_repo_root=genny_repo_root,
         workspace_root=workspace_root,
         cleanup_metrics=True,
+        should_calculate_rollups=False
     )
 
 

--- a/src/lamplib/src/genny/tasks/genny_runner.py
+++ b/src/lamplib/src/genny/tasks/genny_runner.py
@@ -87,4 +87,6 @@ def main_genny_runner(
             cwd=workspace_root,
         )
     if should_calculate_rollups:
-        calculate_rollups(output_dir=output_dir, workspace_root=workspace_root, genny_repo_root=genny_repo_root)
+        calculate_rollups(
+            output_dir=output_dir, workspace_root=workspace_root, genny_repo_root=genny_repo_root
+        )

--- a/src/lamplib/src/genny/tasks/genny_runner.py
+++ b/src/lamplib/src/genny/tasks/genny_runner.py
@@ -6,7 +6,7 @@ import shutil
 import os
 
 from genny.cmd_runner import run_command
-from genny.curator import poplar_grpc
+from genny.curator import poplar_grpc, calculate_rollups
 from genny.tasks import preprocess
 
 SLOG = structlog.get_logger(__name__)
@@ -22,6 +22,7 @@ def main_genny_runner(
     genny_repo_root: str,
     cleanup_metrics: bool,
     workspace_root: str,
+    should_calculate_rollups: bool,
     hang: bool = False,
     mongostream_uri: Optional[str] = None,
 ):
@@ -47,7 +48,8 @@ def main_genny_runner(
         cmd.append("--verbosity")
         cmd.append(verbosity)
 
-        preprocessed_dir = os.path.join(workspace_root, "build/WorkloadOutput/workload")
+        output_dir = os.path.join(workspace_root, "build/WorkloadOutput")
+        preprocessed_dir = os.path.join(output_dir, "workload")
         os.makedirs(preprocessed_dir, exist_ok=True)
 
         processed_workload = os.path.join(preprocessed_dir, os.path.basename(workload_yaml_path))
@@ -84,3 +86,5 @@ def main_genny_runner(
             check=True,
             cwd=workspace_root,
         )
+    if should_calculate_rollups:
+        calculate_rollups(output_dir=output_dir, workspace_root=workspace_root, genny_repo_root=genny_repo_root)


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-8018](https://jira.mongodb.org/browse/DEVPROD-8018)

### Whats Changed

This adds a new flag to Genny that allows for generating JSON rollups from the FTDC files output from workloads. It does so by iterating over the output data folder and calling out to Curator using a CLI. 

I gave it a default of "Off" to preserve the current default behavior. When testing locally, I did not see a significant amount of time added to the runtime of Genny when doing these rollups. 

### Patch Testing Results

[Sys-perf](https://spruce.mongodb.com/version/666a071466c328000796b15c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[Sys-perf with flag](https://spruce.mongodb.com/version/666a071466c328000796b15c/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=mixed)
