### PR TITLE
DEVPROD-7308: Run multiplanning Genny workloads on single-node all-feature-flags variants

### DIFF
--- a/src/workloads/query/multiplanner/BlockingSort.yml
+++ b/src/workloads/query/multiplanner/BlockingSort.yml
@@ -395,11 +395,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/BlockingSort.yml
+++ b/src/workloads/query/multiplanner/BlockingSort.yml
@@ -399,6 +399,6 @@ AutoRun:
           - replica-all-feature-flags
           - replica-query-engine-sbe
           - replica-query-engine-classic
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/BlockingSort.yml
+++ b/src/workloads/query/multiplanner/BlockingSort.yml
@@ -395,10 +395,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -413,10 +413,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -417,6 +417,6 @@ AutoRun:
           - replica-all-feature-flags
           - replica-query-engine-sbe
           - replica-query-engine-classic
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -413,11 +413,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/CompoundIndexes.yml
+++ b/src/workloads/query/multiplanner/CompoundIndexes.yml
@@ -405,10 +405,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/CompoundIndexes.yml
+++ b/src/workloads/query/multiplanner/CompoundIndexes.yml
@@ -405,11 +405,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/CompoundIndexes.yml
+++ b/src/workloads/query/multiplanner/CompoundIndexes.yml
@@ -409,6 +409,6 @@ AutoRun:
           - replica-all-feature-flags
           - replica-query-engine-sbe
           - replica-query-engine-classic
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+++ b/src/workloads/query/multiplanner/ManyIndexSeeks.yml
@@ -405,10 +405,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+++ b/src/workloads/query/multiplanner/ManyIndexSeeks.yml
@@ -405,11 +405,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+++ b/src/workloads/query/multiplanner/ManyIndexSeeks.yml
@@ -409,6 +409,6 @@ AutoRun:
           - replica-all-feature-flags
           - replica-query-engine-sbe
           - replica-query-engine-classic
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+++ b/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
@@ -155,11 +155,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags
-          - standalone-all-feature-flags
-          - standalone-classic-query-engine
-          - standalone-sbe
           - replica
           - replica-all-feature-flags
       branch_name:

--- a/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+++ b/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
@@ -155,12 +155,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags
           - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags
       branch_name:
         $gte: v8.0

--- a/src/workloads/query/multiplanner/MultikeyIndexes.yml
+++ b/src/workloads/query/multiplanner/MultikeyIndexes.yml
@@ -408,10 +408,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultikeyIndexes.yml
+++ b/src/workloads/query/multiplanner/MultikeyIndexes.yml
@@ -412,6 +412,6 @@ AutoRun:
           - replica-all-feature-flags
           - replica-query-engine-sbe
           - replica-query-engine-classic
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultikeyIndexes.yml
+++ b/src/workloads/query/multiplanner/MultikeyIndexes.yml
@@ -408,11 +408,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+++ b/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
@@ -399,11 +399,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone
-          - standalone-sbe
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
           - replica
           - replica-all-feature-flags
       branch_name:

--- a/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+++ b/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
@@ -403,6 +403,6 @@ AutoRun:
           - replica-all-feature-flags
           - replica-query-engine-sbe
           - replica-query-engine-classic
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+++ b/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
@@ -399,12 +399,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NoResults.yml
+++ b/src/workloads/query/multiplanner/NoResults.yml
@@ -390,11 +390,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone
-          - standalone-sbe
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
           - replica
           - replica-all-feature-flags
       branch_name:

--- a/src/workloads/query/multiplanner/NoResults.yml
+++ b/src/workloads/query/multiplanner/NoResults.yml
@@ -394,6 +394,6 @@ AutoRun:
           - replica-all-feature-flags
           - replica-query-engine-sbe
           - replica-query-engine-classic
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NoResults.yml
+++ b/src/workloads/query/multiplanner/NoResults.yml
@@ -390,12 +390,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NoSuchField.yml
+++ b/src/workloads/query/multiplanner/NoSuchField.yml
@@ -404,11 +404,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NoSuchField.yml
+++ b/src/workloads/query/multiplanner/NoSuchField.yml
@@ -404,10 +404,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NoSuchField.yml
+++ b/src/workloads/query/multiplanner/NoSuchField.yml
@@ -408,6 +408,6 @@ AutoRun:
           - replica-all-feature-flags
           - replica-query-engine-sbe
           - replica-query-engine-classic
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+++ b/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
@@ -222,6 +222,6 @@ AutoRun:
           - replica-all-feature-flags
           - replica-query-engine-sbe
           - replica-query-engine-classic
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+++ b/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
@@ -218,10 +218,11 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
+          - single-replica
+          - single-replica-all-feature-flags
+          - single-replica-sbe
+          - single-replica-classic-query-engine
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+++ b/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
@@ -218,11 +218,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - single-replica
-          - single-replica-all-feature-flags
-          - single-replica-sbe
-          - single-replica-classic-query-engine
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/Simple.yml
+++ b/src/workloads/query/multiplanner/Simple.yml
@@ -404,10 +404,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/Subplanning.yml
+++ b/src/workloads/query/multiplanner/Subplanning.yml
@@ -353,9 +353,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/UseClusteredIndex.yml
+++ b/src/workloads/query/multiplanner/UseClusteredIndex.yml
@@ -410,10 +410,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/VariedSelectivity.yml
+++ b/src/workloads/query/multiplanner/VariedSelectivity.yml
@@ -250,10 +250,10 @@ AutoRun:
   - When:
       mongodb_setup:
         $eq:
-          - standalone-sbe
-          - standalone-80-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-all-feature-flags # At time of writing this will enable PM-3591.
-          - standalone-classic-query-engine
+          - replica
           - replica-all-feature-flags
+          - replica-query-engine-sbe
+          - replica-query-engine-classic
+          - standalone-80-feature-flags
       branch_name:
         $gte: v7.3


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-7308](https://jira.mongodb.org/browse/DEVPROD-7308)

### Whats Changed

Add single replica all feature flags variants to multiplanner Genny workloads.

### Patch Testing Results

[Patch](https://spruce.mongodb.com/version/66a2b4eab87fd00007bc4d87).