### PR TITLE
PERF-5628 Reduce runtime of TimeseriesEnum test

### DIFF
--- a/src/workloads/query/TimeseriesEnum.yml
+++ b/src/workloads/query/TimeseriesEnum.yml
@@ -11,9 +11,9 @@ Keywords:
 GlobalDefaults:
   Database: &database test
   TSCollection: &tsCollection Collection0
-  DocumentCount: &documentCount 1e7
+  DocumentCount: &documentCount 1e6
   EnumCollection: &enumCollection Collection1
-  repeat: &repeat 20
+  repeat: &repeat 5
   MetaCount: &metaCount 10
   MaxPhases: &maxPhases 15
 


### PR DESCRIPTION
**Jira Ticket:** [PERF-5628](https://jira.mongodb.org/browse/PERF-5628)

### Whats Changed

Changing the test to run on a smaller data set. This will help avoid timeouts (some of the queries currently take 6+ minutes). At the same time, this will not make the queries run so quickly that we don't get a good signal on the query's performance.

### Patch Testing Results

Patch build running here:
https://spruce.mongodb.com/version/667c46abea070d00079381c4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
