### PR TITLE
PERF-5523 quiesce to remove tombstones for more stability

### DIFF
--- a/src/workloads/scale/MassDeleteRegression.yml
+++ b/src/workloads/scale/MassDeleteRegression.yml
@@ -66,7 +66,7 @@ Actors:
     Phases:
       OnlyActiveInPhases:
         Active: [1, 3]
-        NopInPhasesUpTo: 5
+        NopInPhasesUpTo: 6
         PhaseConfig:
           Repeat: 1
 

--- a/src/workloads/scale/MassDeleteRegression.yml
+++ b/src/workloads/scale/MassDeleteRegression.yml
@@ -22,11 +22,14 @@ Actors:
           f: {^RandomString: {length: 10}}
       - {Nop: true}
       - {Nop: true}
+      - {Nop: true}
+      - {Nop: true}
 
   - Name: Delete
     Type: CrudActor
     Database: massdel
     Phases:
+      - {Nop: true}
       - {Nop: true}
       - Name: DeleteAllDocs
         Repeat: 1
@@ -38,11 +41,14 @@ Actors:
                 - WriteCommand: deleteMany
                   Filter: {_id: {$lte: *docs}}
       - {Nop: true}
+      - {Nop: true}
 
   - Name: Find
     Type: CrudActor
     Database: massdel
     Phases:
+      - {Nop: true}
+      - {Nop: true}
       - {Nop: true}
       - {Nop: true}
       - Name: FindNotThere
@@ -52,6 +58,17 @@ Actors:
           - OperationName: find
             OperationCommand:
               Filter: {_id: {$lte: *docs}}
+
+  - Name: QuiesceActor
+    Type: QuiesceActor
+    Threads: 1
+    Database: *DbName
+    Phases:
+      OnlyActiveInPhases:
+        Active: [1, 3]
+        NopInPhasesUpTo: 5
+        PhaseConfig:
+          Repeat: 1
 
 AutoRun:
   - When:

--- a/src/workloads/scale/MassDeleteRegression.yml
+++ b/src/workloads/scale/MassDeleteRegression.yml
@@ -62,7 +62,7 @@ Actors:
   - Name: QuiesceActor
     Type: QuiesceActor
     Threads: 1
-    Database: *DbName
+    Database: massdel
     Phases:
       OnlyActiveInPhases:
         Active: [1, 3]

--- a/src/workloads/scale/MassDeleteRegression.yml
+++ b/src/workloads/scale/MassDeleteRegression.yml
@@ -64,11 +64,11 @@ Actors:
     Threads: 1
     Database: massdel
     Phases:
-      OnlyActiveInPhases:
-        Active: [1, 3]
-        NopInPhasesUpTo: 6
-        PhaseConfig:
-          Repeat: 1
+      - {Nop: true}
+      - Repeat: 1
+      - {Nop: true}
+      - Repeat: 1
+      - {Nop: true}
 
 AutoRun:
   - When:

--- a/src/workloads/scale/MassDeleteRegression.yml
+++ b/src/workloads/scale/MassDeleteRegression.yml
@@ -52,23 +52,23 @@ Actors:
       - {Nop: true}
       - {Nop: true}
       - Name: FindNotThere
-        Repeat: 10000
+        Repeat: 100000
         Collection: Collection0
         Operations:
           - OperationName: find
             OperationCommand:
               Filter: {_id: {$lte: *docs}}
 
-  # - Name: QuiesceActor
-  #   Type: QuiesceActor
-  #   Threads: 1
-  #   Database: massdel
-  #   Phases:
-  #     - {Nop: true}
-  #     - Repeat: 1
-  #     - {Nop: true}
-  #     - Repeat: 1
-  #     - {Nop: true}
+  - Name: QuiesceActor
+    Type: QuiesceActor
+    Threads: 1
+    Database: massdel
+    Phases:
+      - {Nop: true}
+      - Repeat: 1
+      - {Nop: true}
+      - Repeat: 1
+      - {Nop: true}
 
 AutoRun:
   - When:

--- a/src/workloads/scale/MassDeleteRegression.yml
+++ b/src/workloads/scale/MassDeleteRegression.yml
@@ -52,7 +52,7 @@ Actors:
       - {Nop: true}
       - {Nop: true}
       - Name: FindNotThere
-        Repeat: 1000
+        Repeat: 10000
         Collection: Collection0
         Operations:
           - OperationName: find

--- a/src/workloads/scale/MassDeleteRegression.yml
+++ b/src/workloads/scale/MassDeleteRegression.yml
@@ -59,16 +59,16 @@ Actors:
             OperationCommand:
               Filter: {_id: {$lte: *docs}}
 
-  - Name: QuiesceActor
-    Type: QuiesceActor
-    Threads: 1
-    Database: massdel
-    Phases:
-      - {Nop: true}
-      - Repeat: 1
-      - {Nop: true}
-      - Repeat: 1
-      - {Nop: true}
+  # - Name: QuiesceActor
+  #   Type: QuiesceActor
+  #   Threads: 1
+  #   Database: massdel
+  #   Phases:
+  #     - {Nop: true}
+  #     - Repeat: 1
+  #     - {Nop: true}
+  #     - Repeat: 1
+  #     - {Nop: true}
 
 AutoRun:
   - When:

--- a/src/workloads/scale/MassDeleteRegression.yml
+++ b/src/workloads/scale/MassDeleteRegression.yml
@@ -52,7 +52,7 @@ Actors:
       - {Nop: true}
       - {Nop: true}
       - Name: FindNotThere
-        Repeat: 100
+        Repeat: 1000
         Collection: Collection0
         Operations:
           - OperationName: find


### PR DESCRIPTION
**Jira Ticket:** PERF-5523

### Whats Changed
add a quiesce after deletes to remove tombstones for more stable results. CV goes down from 157% to 2%.

### Patch Testing Results
[multi-patch](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=26ef34f9-a29f-4c3e-92ce-6324d78caea2&selected_tab=data-table&percent_filter=0%7C%7C100&z_filter=0%7C%7C10)