### PR TITLE
PERF-5527 add replica condition where standalone only is defined

### DIFF
--- a/src/phases/query/RepeatedPathTraversal.yml
+++ b/src/phases/query/RepeatedPathTraversal.yml
@@ -401,6 +401,7 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/phases/query/RepeatedPathTraversal.yml
+++ b/src/phases/query/RepeatedPathTraversal.yml
@@ -400,6 +400,7 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/execution/MultiPlanning.yml
+++ b/src/workloads/execution/MultiPlanning.yml
@@ -110,4 +110,5 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
 

--- a/src/workloads/execution/MultiPlanning.yml
+++ b/src/workloads/execution/MultiPlanning.yml
@@ -109,4 +109,5 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
 

--- a/src/workloads/execution/ValidateCmd.yml
+++ b/src/workloads/execution/ValidateCmd.yml
@@ -18,4 +18,6 @@ LoadConfig:
 AutoRun:
   - When:
       mongodb_setup:
-        $eq: standalone
+        $eq: 
+          - standalone
+          - replica

--- a/src/workloads/execution/ValidateCmd.yml
+++ b/src/workloads/execution/ValidateCmd.yml
@@ -18,6 +18,6 @@ LoadConfig:
 AutoRun:
   - When:
       mongodb_setup:
-        $eq: 
+        $eq:
           - standalone
           - replica

--- a/src/workloads/execution/ValidateCmdFull.yml
+++ b/src/workloads/execution/ValidateCmdFull.yml
@@ -18,4 +18,6 @@ LoadConfig:
 AutoRun:
   - When:
       mongodb_setup:
-        $eq: standalone
+        $eq: 
+          - standalone
+          - replica

--- a/src/workloads/execution/ValidateCmdFull.yml
+++ b/src/workloads/execution/ValidateCmdFull.yml
@@ -18,6 +18,6 @@ LoadConfig:
 AutoRun:
   - When:
       mongodb_setup:
-        $eq: 
+        $eq:
           - standalone
           - replica

--- a/src/workloads/query/AggregateExpressions.yml
+++ b/src/workloads/query/AggregateExpressions.yml
@@ -1471,6 +1471,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/AggregateExpressions.yml
+++ b/src/workloads/query/AggregateExpressions.yml
@@ -1470,6 +1470,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/BooleanSimplifier.yml
+++ b/src/workloads/query/BooleanSimplifier.yml
@@ -16,6 +16,7 @@ AutoRun:
       mongodb_setup:
         $eq:
           - replica
+          - replica-all-feature-flags
           - standalone
           - standalone-80-feature-flags
           - standalone-all-feature-flags

--- a/src/workloads/query/BooleanSimplifierSmallDataset.yml
+++ b/src/workloads/query/BooleanSimplifierSmallDataset.yml
@@ -16,6 +16,7 @@ AutoRun:
       mongodb_setup:
         $eq:
           - replica
+          - replica-all-feature-flags
           - standalone
           - standalone-80-feature-flags
           - standalone-all-feature-flags

--- a/src/workloads/query/CollScanComplexPredicateLarge.yml
+++ b/src/workloads/query/CollScanComplexPredicateLarge.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanComplexPredicateLarge.yml
+++ b/src/workloads/query/CollScanComplexPredicateLarge.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanComplexPredicateMedium.yml
+++ b/src/workloads/query/CollScanComplexPredicateMedium.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanComplexPredicateMedium.yml
+++ b/src/workloads/query/CollScanComplexPredicateMedium.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanComplexPredicateSmall.yml
+++ b/src/workloads/query/CollScanComplexPredicateSmall.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanComplexPredicateSmall.yml
+++ b/src/workloads/query/CollScanComplexPredicateSmall.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
+++ b/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
+++ b/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
+++ b/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
+++ b/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
+++ b/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
+++ b/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanPredicateSelectivityLarge.yml
+++ b/src/workloads/query/CollScanPredicateSelectivityLarge.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanPredicateSelectivityLarge.yml
+++ b/src/workloads/query/CollScanPredicateSelectivityLarge.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanPredicateSelectivityMedium.yml
+++ b/src/workloads/query/CollScanPredicateSelectivityMedium.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanPredicateSelectivityMedium.yml
+++ b/src/workloads/query/CollScanPredicateSelectivityMedium.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanPredicateSelectivitySmall.yml
+++ b/src/workloads/query/CollScanPredicateSelectivitySmall.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanPredicateSelectivitySmall.yml
+++ b/src/workloads/query/CollScanPredicateSelectivitySmall.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanProjectionLarge.yml
+++ b/src/workloads/query/CollScanProjectionLarge.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanProjectionLarge.yml
+++ b/src/workloads/query/CollScanProjectionLarge.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanProjectionMedium.yml
+++ b/src/workloads/query/CollScanProjectionMedium.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanProjectionMedium.yml
+++ b/src/workloads/query/CollScanProjectionMedium.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanProjectionSmall.yml
+++ b/src/workloads/query/CollScanProjectionSmall.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanProjectionSmall.yml
+++ b/src/workloads/query/CollScanProjectionSmall.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/CsiFragmentedInsertsFlat.yml
+++ b/src/workloads/query/CsiFragmentedInsertsFlat.yml
@@ -20,6 +20,7 @@ AutoRun:
           - standalone-80-feature-flags
           - standalone-all-feature-flags
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/CsiFragmentedInsertsFlat.yml
+++ b/src/workloads/query/CsiFragmentedInsertsFlat.yml
@@ -19,7 +19,6 @@ AutoRun:
         $eq:
           - standalone-80-feature-flags
           - standalone-all-feature-flags
-          - replica
           - replica-all-feature-flags
       branch_name:
         $neq:

--- a/src/workloads/query/CsiFragmentedInsertsFlat.yml
+++ b/src/workloads/query/CsiFragmentedInsertsFlat.yml
@@ -19,6 +19,7 @@ AutoRun:
         $eq:
           - standalone-80-feature-flags
           - standalone-all-feature-flags
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/CsiFragmentedInsertsNested.yml
+++ b/src/workloads/query/CsiFragmentedInsertsNested.yml
@@ -20,6 +20,7 @@ AutoRun:
           - standalone-80-feature-flags
           - standalone-all-feature-flags
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/CsiFragmentedInsertsNested.yml
+++ b/src/workloads/query/CsiFragmentedInsertsNested.yml
@@ -19,7 +19,6 @@ AutoRun:
         $eq:
           - standalone-80-feature-flags
           - standalone-all-feature-flags
-          - replica
           - replica-all-feature-flags
       branch_name:
         $neq:

--- a/src/workloads/query/CsiFragmentedInsertsNested.yml
+++ b/src/workloads/query/CsiFragmentedInsertsNested.yml
@@ -19,6 +19,7 @@ AutoRun:
         $eq:
           - standalone-80-feature-flags
           - standalone-all-feature-flags
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/ExternalSort.yml
+++ b/src/workloads/query/ExternalSort.yml
@@ -104,6 +104,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/ExternalSort.yml
+++ b/src/workloads/query/ExternalSort.yml
@@ -105,6 +105,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -135,6 +135,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -134,6 +134,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/InWithVariedArraySize.yml
+++ b/src/workloads/query/InWithVariedArraySize.yml
@@ -240,5 +240,6 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/InWithVariedArraySize.yml
+++ b/src/workloads/query/InWithVariedArraySize.yml
@@ -239,5 +239,6 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/LimitSkip.yml
+++ b/src/workloads/query/LimitSkip.yml
@@ -218,5 +218,6 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/LimitSkip.yml
+++ b/src/workloads/query/LimitSkip.yml
@@ -217,5 +217,6 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/LookupNLJ.yml
+++ b/src/workloads/query/LookupNLJ.yml
@@ -339,6 +339,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/LookupNLJ.yml
+++ b/src/workloads/query/LookupNLJ.yml
@@ -340,6 +340,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/LookupOnly.yml
+++ b/src/workloads/query/LookupOnly.yml
@@ -501,6 +501,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/LookupOnly.yml
+++ b/src/workloads/query/LookupOnly.yml
@@ -502,6 +502,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/LookupSBEPushdown.yml
+++ b/src/workloads/query/LookupSBEPushdown.yml
@@ -440,6 +440,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/LookupSBEPushdown.yml
+++ b/src/workloads/query/LookupSBEPushdown.yml
@@ -439,6 +439,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/query/LookupSBEPushdownINLJMisc.yml
@@ -389,6 +389,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/query/LookupSBEPushdownINLJMisc.yml
@@ -388,6 +388,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/LookupUnwind.yml
+++ b/src/workloads/query/LookupUnwind.yml
@@ -505,6 +505,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/LookupUnwind.yml
+++ b/src/workloads/query/LookupUnwind.yml
@@ -504,6 +504,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/MatchFilters.yml
+++ b/src/workloads/query/MatchFilters.yml
@@ -23,6 +23,7 @@ AutoRun:
         $eq:
           - atlas
           - replica
+          - replica-all-feature-flags
           - standalone
           - standalone-80-feature-flags
           - standalone-all-feature-flags

--- a/src/workloads/query/MatchFiltersMedium.yml
+++ b/src/workloads/query/MatchFiltersMedium.yml
@@ -23,6 +23,7 @@ AutoRun:
         $eq:
           - atlas
           - replica
+          - replica-all-feature-flags
           - standalone
           - standalone-80-feature-flags
           - standalone-all-feature-flags

--- a/src/workloads/query/MatchFiltersSmall.yml
+++ b/src/workloads/query/MatchFiltersSmall.yml
@@ -23,6 +23,7 @@ AutoRun:
         $eq:
           - atlas
           - replica
+          - replica-all-feature-flags
           - standalone
           - standalone-80-feature-flags
           - standalone-all-feature-flags

--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -181,5 +181,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.2

--- a/src/workloads/query/MatchWithLargeExpression.yml
+++ b/src/workloads/query/MatchWithLargeExpression.yml
@@ -180,5 +180,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.2

--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -135,4 +135,5 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone
           - replica
+          - replica-all-feature-flags
           - atlas-like-replica.2022-10

--- a/src/workloads/query/PercentilesAgg.yml
+++ b/src/workloads/query/PercentilesAgg.yml
@@ -31,6 +31,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0
 

--- a/src/workloads/query/PercentilesAgg.yml
+++ b/src/workloads/query/PercentilesAgg.yml
@@ -30,6 +30,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0
 

--- a/src/workloads/query/PercentilesExpr.yml
+++ b/src/workloads/query/PercentilesExpr.yml
@@ -17,6 +17,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0
 

--- a/src/workloads/query/PercentilesExpr.yml
+++ b/src/workloads/query/PercentilesExpr.yml
@@ -18,6 +18,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0
 

--- a/src/workloads/query/PercentilesExpr.yml
+++ b/src/workloads/query/PercentilesExpr.yml
@@ -17,7 +17,6 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/PercentilesWindow.yml
+++ b/src/workloads/query/PercentilesWindow.yml
@@ -28,7 +28,6 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/PercentilesWindow.yml
+++ b/src/workloads/query/PercentilesWindow.yml
@@ -28,6 +28,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0
 

--- a/src/workloads/query/PercentilesWindow.yml
+++ b/src/workloads/query/PercentilesWindow.yml
@@ -29,6 +29,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0
 

--- a/src/workloads/query/PercentilesWindowSpillToDisk.yml
+++ b/src/workloads/query/PercentilesWindowSpillToDisk.yml
@@ -25,6 +25,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0
 

--- a/src/workloads/query/PercentilesWindowSpillToDisk.yml
+++ b/src/workloads/query/PercentilesWindowSpillToDisk.yml
@@ -25,7 +25,6 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/PercentilesWindowSpillToDisk.yml
+++ b/src/workloads/query/PercentilesWindowSpillToDisk.yml
@@ -26,6 +26,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0
 

--- a/src/workloads/query/ProjectParse.yml
+++ b/src/workloads/query/ProjectParse.yml
@@ -141,5 +141,6 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/ProjectParse.yml
+++ b/src/workloads/query/ProjectParse.yml
@@ -140,5 +140,6 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v7.0

--- a/src/workloads/query/QueryStatsQueryShapes.yml
+++ b/src/workloads/query/QueryStatsQueryShapes.yml
@@ -124,4 +124,5 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone
           - replica
+          - replica-all-feature-flags
           - atlas-like-replica.2022-10

--- a/src/workloads/query/RepeatedPathTraversal.yml
+++ b/src/workloads/query/RepeatedPathTraversal.yml
@@ -23,6 +23,7 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/RepeatedPathTraversal.yml
+++ b/src/workloads/query/RepeatedPathTraversal.yml
@@ -22,6 +22,7 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/RepeatedPathTraversalMedium.yml
+++ b/src/workloads/query/RepeatedPathTraversalMedium.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v5.0

--- a/src/workloads/query/RepeatedPathTraversalMedium.yml
+++ b/src/workloads/query/RepeatedPathTraversalMedium.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v5.0

--- a/src/workloads/query/RepeatedPathTraversalSmall.yml
+++ b/src/workloads/query/RepeatedPathTraversalSmall.yml
@@ -22,5 +22,6 @@ AutoRun:
           - standalone-heuristic-bonsai
           - standalone-sampling-bonsai
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v5.0

--- a/src/workloads/query/RepeatedPathTraversalSmall.yml
+++ b/src/workloads/query/RepeatedPathTraversalSmall.yml
@@ -23,5 +23,6 @@ AutoRun:
           - standalone-sampling-bonsai
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v5.0

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -168,4 +168,5 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone
           - replica
+          - replica-all-feature-flags
           - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_Agg.yml
@@ -98,4 +98,5 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone
           - replica
+          - replica-all-feature-flags
           - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
@@ -110,4 +110,5 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone
           - replica
+          - replica-all-feature-flags
           - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
@@ -111,4 +111,5 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone
           - replica
+          - replica-all-feature-flags
           - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -98,4 +98,5 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone
           - replica
+          - replica-all-feature-flags
           - atlas-like-replica.2022-10

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -111,4 +111,5 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone
           - replica
+          - replica-all-feature-flags
           - atlas-like-replica.2022-10

--- a/src/workloads/query/UnwindGroup.yml
+++ b/src/workloads/query/UnwindGroup.yml
@@ -88,6 +88,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/UnwindGroup.yml
+++ b/src/workloads/query/UnwindGroup.yml
@@ -89,6 +89,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/VariadicAggregateExpressions.yml
+++ b/src/workloads/query/VariadicAggregateExpressions.yml
@@ -1044,6 +1044,7 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/VariadicAggregateExpressions.yml
+++ b/src/workloads/query/VariadicAggregateExpressions.yml
@@ -1043,6 +1043,7 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $neq:
           - v4.0

--- a/src/workloads/query/multiplanner/BlockingSort.yml
+++ b/src/workloads/query/multiplanner/BlockingSort.yml
@@ -399,5 +399,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/BlockingSort.yml
+++ b/src/workloads/query/multiplanner/BlockingSort.yml
@@ -399,7 +399,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/BlockingSort.yml
+++ b/src/workloads/query/multiplanner/BlockingSort.yml
@@ -400,5 +400,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -417,7 +417,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -418,5 +418,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -417,5 +417,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/CompoundIndexes.yml
+++ b/src/workloads/query/multiplanner/CompoundIndexes.yml
@@ -409,5 +409,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/CompoundIndexes.yml
+++ b/src/workloads/query/multiplanner/CompoundIndexes.yml
@@ -410,5 +410,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/CompoundIndexes.yml
+++ b/src/workloads/query/multiplanner/CompoundIndexes.yml
@@ -409,7 +409,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+++ b/src/workloads/query/multiplanner/ManyIndexSeeks.yml
@@ -409,5 +409,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+++ b/src/workloads/query/multiplanner/ManyIndexSeeks.yml
@@ -410,5 +410,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+++ b/src/workloads/query/multiplanner/ManyIndexSeeks.yml
@@ -409,7 +409,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+++ b/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
@@ -160,5 +160,6 @@ AutoRun:
           - standalone-all-feature-flags
           - standalone-classic-query-engine
           - standalone-sbe
+          - replica
       branch_name:
         $gte: v8.0

--- a/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+++ b/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
@@ -161,5 +161,6 @@ AutoRun:
           - standalone-classic-query-engine
           - standalone-sbe
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v8.0

--- a/src/workloads/query/multiplanner/MultikeyIndexes.yml
+++ b/src/workloads/query/multiplanner/MultikeyIndexes.yml
@@ -413,5 +413,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultikeyIndexes.yml
+++ b/src/workloads/query/multiplanner/MultikeyIndexes.yml
@@ -412,7 +412,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultikeyIndexes.yml
+++ b/src/workloads/query/multiplanner/MultikeyIndexes.yml
@@ -412,5 +412,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+++ b/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
@@ -405,5 +405,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+++ b/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
@@ -404,5 +404,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NoResults.yml
+++ b/src/workloads/query/multiplanner/NoResults.yml
@@ -395,5 +395,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NoResults.yml
+++ b/src/workloads/query/multiplanner/NoResults.yml
@@ -396,5 +396,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NoSuchField.yml
+++ b/src/workloads/query/multiplanner/NoSuchField.yml
@@ -408,5 +408,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NoSuchField.yml
+++ b/src/workloads/query/multiplanner/NoSuchField.yml
@@ -408,6 +408,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+++ b/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
@@ -222,7 +222,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+++ b/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
@@ -223,5 +223,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+++ b/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
@@ -222,5 +222,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/Simple.yml
+++ b/src/workloads/query/multiplanner/Simple.yml
@@ -408,5 +408,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/Simple.yml
+++ b/src/workloads/query/multiplanner/Simple.yml
@@ -409,5 +409,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/Simple.yml
+++ b/src/workloads/query/multiplanner/Simple.yml
@@ -408,7 +408,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/Subplanning.yml
+++ b/src/workloads/query/multiplanner/Subplanning.yml
@@ -356,7 +356,6 @@ AutoRun:
           - standalone-sbe
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/Subplanning.yml
+++ b/src/workloads/query/multiplanner/Subplanning.yml
@@ -357,5 +357,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/Subplanning.yml
+++ b/src/workloads/query/multiplanner/Subplanning.yml
@@ -356,5 +356,6 @@ AutoRun:
           - standalone-sbe
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/UseClusteredIndex.yml
+++ b/src/workloads/query/multiplanner/UseClusteredIndex.yml
@@ -414,5 +414,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/UseClusteredIndex.yml
+++ b/src/workloads/query/multiplanner/UseClusteredIndex.yml
@@ -414,7 +414,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/UseClusteredIndex.yml
+++ b/src/workloads/query/multiplanner/UseClusteredIndex.yml
@@ -415,5 +415,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/VariedSelectivity.yml
+++ b/src/workloads/query/multiplanner/VariedSelectivity.yml
@@ -254,7 +254,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
-          - replica
           - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/VariedSelectivity.yml
+++ b/src/workloads/query/multiplanner/VariedSelectivity.yml
@@ -255,5 +255,6 @@ AutoRun:
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
           - replica
+          - replica-all-feature-flags
       branch_name:
         $gte: v7.3

--- a/src/workloads/query/multiplanner/VariedSelectivity.yml
+++ b/src/workloads/query/multiplanner/VariedSelectivity.yml
@@ -254,5 +254,6 @@ AutoRun:
           - standalone-80-feature-flags # At time of writing this will enable PM-3591.
           - standalone-all-feature-flags # At time of writing this will enable PM-3591.
           - standalone-classic-query-engine
+          - replica
       branch_name:
         $gte: v7.3

--- a/src/workloads/selftests/GennyOverhead.yml
+++ b/src/workloads/selftests/GennyOverhead.yml
@@ -70,6 +70,6 @@ Actors:
 AutoRun:
   - When:
       mongodb_setup:
-        $eq: 
+        $eq:
           - standalone
           - replica

--- a/src/workloads/selftests/GennyOverhead.yml
+++ b/src/workloads/selftests/GennyOverhead.yml
@@ -70,4 +70,6 @@ Actors:
 AutoRun:
   - When:
       mongodb_setup:
-        $eq: standalone
+        $eq: 
+          - standalone
+          - replica


### PR DESCRIPTION
Standalone variants are being removed. 
For genny tasks that have a standalone conditions and would otherwise not run, we add in a replica condition. 