### PR TITLE
PERF-5539 Enable QueryStats workload auto-run on v6.0

### DIFF
--- a/src/workloads/query/QueryStats.yml
+++ b/src/workloads/query/QueryStats.yml
@@ -217,5 +217,4 @@ AutoRun:
           - replica
           - atlas-like-replica.2022-10
       branch_name:
-        # TODO PERF-5539 Change the version to v6.0
-        $gte: v7.0
+        $gte: v6.0


### PR DESCRIPTION
**Jira Ticket:** PERF-5539

### Whats Changed

Enabling the `QueryStats` workload to auto-run on v6.0 now that the query stats feature flag is enabled there.

### Patch Testing Results

[Evergreen](https://spruce.mongodb.com/version/66845e3a5faa1b0007ef9a5c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)