### PR TITLE
SERVER-87143 Skip WouldChangeOwningShardBatchWrite workload on versions < 6.0

### DIFF
--- a/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+++ b/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
@@ -92,6 +92,6 @@ AutoRun:
           - shard-all-feature-flags
           - shard-lite-80-feature-flags
       branch_name:
-        $neq:
-          - v4.4
-          - v5.0
+        # Version prior to 6.0 are affected by SERVER-87143 that would cause routers
+        # to return WouldChangeOwningShard to the driver.
+        $gte: v6.0

--- a/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+++ b/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
@@ -93,4 +93,5 @@ AutoRun:
           - shard-lite-80-feature-flags
       branch_name:
         $neq:
-          - v4.0
+          - v4.4
+          - v5.0


### PR DESCRIPTION
**Jira Ticket:** [SERVER-87143](https://jira.mongodb.org/browse/SERVER-87143)

### Whats Changed

Skip  WouldChangeOwningShardBatchWrite workload on versions < 6.0.

[🌲 EVG](https://spruce.mongodb.com/version/66961fda4521620007b5f050/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)