### PR TITLE
PERF-5711 remove quiesce so we can rolling restart

### DIFF
--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -148,117 +148,6 @@ Actors:
       - *nop
       - *nop
 
-  # Update Actors
-  - ActorFromTemplate:
-      TemplateName: UpdateTemplate
-      TemplateParameters:
-        Name: Update_1
-        Threads: 1
-        OnlyActiveInPhase: 2
-
-  - ActorFromTemplate:
-      TemplateName: UpdateTemplate
-      TemplateParameters:
-        Name: Update_16
-        Threads: 16
-        OnlyActiveInPhase: 4
-
-  - ActorFromTemplate:
-      TemplateName: UpdateTemplate
-      TemplateParameters:
-        Name: Update_32
-        Threads: 32
-        OnlyActiveInPhase: 6
-
-  - ActorFromTemplate:
-      TemplateName: UpdateTemplate
-      TemplateParameters:
-        Name: Update_64
-        Threads: 64
-        OnlyActiveInPhase: 8
-
-  - ActorFromTemplate:
-      TemplateName: UpdateTemplate
-      TemplateParameters:
-        Name: Update_128
-        Threads: 128
-        OnlyActiveInPhase: 10
-
-  #
-  ## Remove Actors
-  #
-  - ActorFromTemplate:
-      TemplateName: RemoveTemplate
-      TemplateParameters:
-        Name: Remove_1
-        Threads: 1
-        OnlyActiveInPhase: 2
-
-  - ActorFromTemplate:
-      TemplateName: RemoveTemplate
-      TemplateParameters:
-        Name: Remove_16
-        Threads: 16
-        OnlyActiveInPhase: 4
-
-  - ActorFromTemplate:
-      TemplateName: RemoveTemplate
-      TemplateParameters:
-        Name: Remove_32
-        Threads: 32
-        OnlyActiveInPhase: 6
-
-  - ActorFromTemplate:
-      TemplateName: RemoveTemplate
-      TemplateParameters:
-        Name: Remove_64
-        Threads: 64
-        OnlyActiveInPhase: 8
-
-  - ActorFromTemplate:
-      TemplateName: RemoveTemplate
-      TemplateParameters:
-        Name: Remove_128
-        Threads: 128
-        OnlyActiveInPhase: 10
-
-  ## Insert Actors
-  #
-  - ActorFromTemplate:
-      TemplateName: InsertTemplate
-      TemplateParameters:
-        Name: Insert_1
-        Threads: 1
-        OnlyActiveInPhase: 2
-
-  - ActorFromTemplate:
-      TemplateName: InsertTemplate
-      TemplateParameters:
-        Name: Insert_16
-        Threads: 16
-        OnlyActiveInPhase: 4
-
-  - ActorFromTemplate:
-      TemplateName: InsertTemplate
-      TemplateParameters:
-        Name: Insert_32
-        Threads: 32
-        OnlyActiveInPhase: 6
-
-  - ActorFromTemplate:
-      TemplateName: InsertTemplate
-      TemplateParameters:
-        Name: Insert_64
-        Threads: 64
-        OnlyActiveInPhase: 8
-
-  - ActorFromTemplate:
-      TemplateName: InsertTemplate
-      TemplateParameters:
-        Name: Insert_128
-        Threads: 128
-        OnlyActiveInPhase: 10
-
   ## Find Actors
 
   - ActorFromTemplate:
@@ -272,28 +161,28 @@ Actors:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_16
-        Threads: 16
+        Threads: 1
         OnlyActiveInPhase: 4
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_32
-        Threads: 32
+        Threads: 1
         OnlyActiveInPhase: 6
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_64
-        Threads: 64
+        Threads: 1
         OnlyActiveInPhase: 8
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_128
-        Threads: 128
+        Threads: 1
         OnlyActiveInPhase: 10
 
 AutoRun:

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -167,9 +167,7 @@ Actors:
         Threads: 128
         OnlyActiveInPhase: 5
 
-  #
-  ## Remove Actors
-  #
+  # Remove Actors
   - ActorFromTemplate:
       TemplateName: RemoveTemplate
       TemplateParameters:
@@ -205,8 +203,7 @@ Actors:
         Threads: 128
         OnlyActiveInPhase: 5
 
-  ## Insert Actors
-  #
+  # Insert Actors
   - ActorFromTemplate:
       TemplateName: InsertTemplate
       TemplateParameters:
@@ -242,8 +239,7 @@ Actors:
         Threads: 128
         OnlyActiveInPhase: 5
 
-  ## Find Actors
-
+  # Find Actors
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -137,15 +137,15 @@ Actors:
     Database: admin
     Phases:
       - &nop {Nop: true}
-      - Repeat: 1
       - *nop
-      - Repeat: 1
       - *nop
-      - Repeat: 1
       - *nop
-      - Repeat: 1
       - *nop
-      - Repeat: 1
+      - *nop
+      - *nop
+      - *nop
+      - *nop
+      - *nop
       - *nop
 
   # Update Actors

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -54,7 +54,7 @@ ActorTemplates:
       Phases:
         OnlyActiveInPhases:
           Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-          NopInPhasesUpTo: 6
+          NopInPhasesUpTo: 5
           PhaseConfig:
             LoadConfig:
               Path: ../../phases/scale/MixPhases.yml
@@ -70,7 +70,7 @@ ActorTemplates:
       Phases:
         OnlyActiveInPhases:
           Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-          NopInPhasesUpTo: 6
+          NopInPhasesUpTo: 5
           PhaseConfig:
             LoadConfig:
               Path: ../../phases/scale/MixPhases.yml
@@ -86,7 +86,7 @@ ActorTemplates:
       Phases:
         OnlyActiveInPhases:
           Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-          NopInPhasesUpTo: 6
+          NopInPhasesUpTo: 5
           PhaseConfig:
             LoadConfig:
               Path: ../../phases/scale/MixPhases.yml
@@ -102,7 +102,7 @@ ActorTemplates:
       Phases:
         OnlyActiveInPhases:
           Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-          NopInPhasesUpTo: 6
+          NopInPhasesUpTo: 5
           PhaseConfig:
             LoadConfig:
               Path: ../../phases/scale/MixPhases.yml
@@ -128,7 +128,7 @@ Actors:
         Indexes:
           - keys: {id: 1}
           - keys: {a: 1}
-      - Phase: 1..6
+      - Phase: 1..5
         Nop: true
 
   # Update Actors

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -148,6 +148,117 @@ Actors:
       - *nop
       - *nop
 
+  # Update Actors
+  - ActorFromTemplate:
+      TemplateName: UpdateTemplate
+      TemplateParameters:
+        Name: Update_1
+        Threads: 1
+        OnlyActiveInPhase: 2
+
+  - ActorFromTemplate:
+      TemplateName: UpdateTemplate
+      TemplateParameters:
+        Name: Update_16
+        Threads: 16
+        OnlyActiveInPhase: 4
+
+  - ActorFromTemplate:
+      TemplateName: UpdateTemplate
+      TemplateParameters:
+        Name: Update_32
+        Threads: 32
+        OnlyActiveInPhase: 6
+
+  - ActorFromTemplate:
+      TemplateName: UpdateTemplate
+      TemplateParameters:
+        Name: Update_64
+        Threads: 64
+        OnlyActiveInPhase: 8
+
+  - ActorFromTemplate:
+      TemplateName: UpdateTemplate
+      TemplateParameters:
+        Name: Update_128
+        Threads: 128
+        OnlyActiveInPhase: 10
+
+  #
+  ## Remove Actors
+  #
+  - ActorFromTemplate:
+      TemplateName: RemoveTemplate
+      TemplateParameters:
+        Name: Remove_1
+        Threads: 1
+        OnlyActiveInPhase: 2
+
+  - ActorFromTemplate:
+      TemplateName: RemoveTemplate
+      TemplateParameters:
+        Name: Remove_16
+        Threads: 16
+        OnlyActiveInPhase: 4
+
+  - ActorFromTemplate:
+      TemplateName: RemoveTemplate
+      TemplateParameters:
+        Name: Remove_32
+        Threads: 32
+        OnlyActiveInPhase: 6
+
+  - ActorFromTemplate:
+      TemplateName: RemoveTemplate
+      TemplateParameters:
+        Name: Remove_64
+        Threads: 64
+        OnlyActiveInPhase: 8
+
+  - ActorFromTemplate:
+      TemplateName: RemoveTemplate
+      TemplateParameters:
+        Name: Remove_128
+        Threads: 128
+        OnlyActiveInPhase: 10
+
+  ## Insert Actors
+  #
+  - ActorFromTemplate:
+      TemplateName: InsertTemplate
+      TemplateParameters:
+        Name: Insert_1
+        Threads: 1
+        OnlyActiveInPhase: 2
+
+  - ActorFromTemplate:
+      TemplateName: InsertTemplate
+      TemplateParameters:
+        Name: Insert_16
+        Threads: 16
+        OnlyActiveInPhase: 4
+
+  - ActorFromTemplate:
+      TemplateName: InsertTemplate
+      TemplateParameters:
+        Name: Insert_32
+        Threads: 32
+        OnlyActiveInPhase: 6
+
+  - ActorFromTemplate:
+      TemplateName: InsertTemplate
+      TemplateParameters:
+        Name: Insert_64
+        Threads: 64
+        OnlyActiveInPhase: 8
+
+  - ActorFromTemplate:
+      TemplateName: InsertTemplate
+      TemplateParameters:
+        Name: Insert_128
+        Threads: 128
+        OnlyActiveInPhase: 10
+
   ## Find Actors
 
   - ActorFromTemplate:
@@ -161,28 +272,28 @@ Actors:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_16
-        Threads: 1
+        Threads: 16
         OnlyActiveInPhase: 4
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_32
-        Threads: 1
+        Threads: 32
         OnlyActiveInPhase: 6
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_64
-        Threads: 1
+        Threads: 64
         OnlyActiveInPhase: 8
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_128
-        Threads: 1
+        Threads: 128
         OnlyActiveInPhase: 10
 
 AutoRun:

--- a/src/workloads/scale/MixedWorkloadsGenny.yml
+++ b/src/workloads/scale/MixedWorkloadsGenny.yml
@@ -54,7 +54,7 @@ ActorTemplates:
       Phases:
         OnlyActiveInPhases:
           Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-          NopInPhasesUpTo: 10
+          NopInPhasesUpTo: 6
           PhaseConfig:
             LoadConfig:
               Path: ../../phases/scale/MixPhases.yml
@@ -70,7 +70,7 @@ ActorTemplates:
       Phases:
         OnlyActiveInPhases:
           Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-          NopInPhasesUpTo: 10
+          NopInPhasesUpTo: 6
           PhaseConfig:
             LoadConfig:
               Path: ../../phases/scale/MixPhases.yml
@@ -86,7 +86,7 @@ ActorTemplates:
       Phases:
         OnlyActiveInPhases:
           Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-          NopInPhasesUpTo: 10
+          NopInPhasesUpTo: 6
           PhaseConfig:
             LoadConfig:
               Path: ../../phases/scale/MixPhases.yml
@@ -102,7 +102,7 @@ ActorTemplates:
       Phases:
         OnlyActiveInPhases:
           Active: [{^Parameter: {Name: "OnlyActiveInPhase", Default: 1}}]
-          NopInPhasesUpTo: 10
+          NopInPhasesUpTo: 6
           PhaseConfig:
             LoadConfig:
               Path: ../../phases/scale/MixPhases.yml
@@ -128,25 +128,8 @@ Actors:
         Indexes:
           - keys: {id: 1}
           - keys: {a: 1}
-      - Phase: 1..10
+      - Phase: 1..6
         Nop: true
-
-  - Name: QuiesceBetweenLevels
-    Type: QuiesceActor
-    Threads: 1
-    Database: admin
-    Phases:
-      - &nop {Nop: true}
-      - *nop
-      - *nop
-      - *nop
-      - *nop
-      - *nop
-      - *nop
-      - *nop
-      - *nop
-      - *nop
-      - *nop
 
   # Update Actors
   - ActorFromTemplate:
@@ -154,35 +137,35 @@ Actors:
       TemplateParameters:
         Name: Update_1
         Threads: 1
-        OnlyActiveInPhase: 2
+        OnlyActiveInPhase: 1
 
   - ActorFromTemplate:
       TemplateName: UpdateTemplate
       TemplateParameters:
         Name: Update_16
         Threads: 16
-        OnlyActiveInPhase: 4
+        OnlyActiveInPhase: 2
 
   - ActorFromTemplate:
       TemplateName: UpdateTemplate
       TemplateParameters:
         Name: Update_32
         Threads: 32
-        OnlyActiveInPhase: 6
+        OnlyActiveInPhase: 3
 
   - ActorFromTemplate:
       TemplateName: UpdateTemplate
       TemplateParameters:
         Name: Update_64
         Threads: 64
-        OnlyActiveInPhase: 8
+        OnlyActiveInPhase: 4
 
   - ActorFromTemplate:
       TemplateName: UpdateTemplate
       TemplateParameters:
         Name: Update_128
         Threads: 128
-        OnlyActiveInPhase: 10
+        OnlyActiveInPhase: 5
 
   #
   ## Remove Actors
@@ -192,35 +175,35 @@ Actors:
       TemplateParameters:
         Name: Remove_1
         Threads: 1
-        OnlyActiveInPhase: 2
+        OnlyActiveInPhase: 1
 
   - ActorFromTemplate:
       TemplateName: RemoveTemplate
       TemplateParameters:
         Name: Remove_16
         Threads: 16
-        OnlyActiveInPhase: 4
+        OnlyActiveInPhase: 2
 
   - ActorFromTemplate:
       TemplateName: RemoveTemplate
       TemplateParameters:
         Name: Remove_32
         Threads: 32
-        OnlyActiveInPhase: 6
+        OnlyActiveInPhase: 3
 
   - ActorFromTemplate:
       TemplateName: RemoveTemplate
       TemplateParameters:
         Name: Remove_64
         Threads: 64
-        OnlyActiveInPhase: 8
+        OnlyActiveInPhase: 4
 
   - ActorFromTemplate:
       TemplateName: RemoveTemplate
       TemplateParameters:
         Name: Remove_128
         Threads: 128
-        OnlyActiveInPhase: 10
+        OnlyActiveInPhase: 5
 
   ## Insert Actors
   #
@@ -229,35 +212,35 @@ Actors:
       TemplateParameters:
         Name: Insert_1
         Threads: 1
-        OnlyActiveInPhase: 2
+        OnlyActiveInPhase: 1
 
   - ActorFromTemplate:
       TemplateName: InsertTemplate
       TemplateParameters:
         Name: Insert_16
         Threads: 16
-        OnlyActiveInPhase: 4
+        OnlyActiveInPhase: 2
 
   - ActorFromTemplate:
       TemplateName: InsertTemplate
       TemplateParameters:
         Name: Insert_32
         Threads: 32
-        OnlyActiveInPhase: 6
+        OnlyActiveInPhase: 3
 
   - ActorFromTemplate:
       TemplateName: InsertTemplate
       TemplateParameters:
         Name: Insert_64
         Threads: 64
-        OnlyActiveInPhase: 8
+        OnlyActiveInPhase: 4
 
   - ActorFromTemplate:
       TemplateName: InsertTemplate
       TemplateParameters:
         Name: Insert_128
         Threads: 128
-        OnlyActiveInPhase: 10
+        OnlyActiveInPhase: 5
 
   ## Find Actors
 
@@ -266,35 +249,35 @@ Actors:
       TemplateParameters:
         Name: Find_1
         Threads: 1
-        OnlyActiveInPhase: 2
+        OnlyActiveInPhase: 1
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_16
         Threads: 16
-        OnlyActiveInPhase: 4
+        OnlyActiveInPhase: 2
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_32
         Threads: 32
-        OnlyActiveInPhase: 6
+        OnlyActiveInPhase: 3
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_64
         Threads: 64
-        OnlyActiveInPhase: 8
+        OnlyActiveInPhase: 4
 
   - ActorFromTemplate:
       TemplateName: FindTemplate
       TemplateParameters:
         Name: Find_128
         Threads: 128
-        OnlyActiveInPhase: 10
+        OnlyActiveInPhase: 5
 
 AutoRun:
   - When:


### PR DESCRIPTION
**Jira Ticket:** PERF-5711

### Whats Changed
Replace quiesce with noop which appears to not impact the results in this test thankfully. This lets us then use this genny test to test rolling restarts. Instead of making genny quiesce handle a rolling restart we should keep this in mind for Locust

### Patch Testing Results
[patch](https://spruce.mongodb.com/version/66a9417b7f65a40007ac9e15/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)