### PR TITLE
PERF-5738: Add missing Nop phases to ProjectParse

### DIFF
--- a/src/workloads/query/ProjectParse.yml
+++ b/src/workloads/query/ProjectParse.yml
@@ -34,6 +34,7 @@ Actors:
       - *Nop
       - *Nop
       - *Nop
+      - *Nop
 
   - Name: Quiesce
     Type: QuiesceActor
@@ -42,6 +43,7 @@ Actors:
     Phases:
       - *Nop
       - Repeat: 1
+      - *Nop
       - *Nop
       - *Nop
       - *Nop


### PR DESCRIPTION
**Jira Ticket:** [PERF-5738](https://jira.mongodb.org/browse/PERF-5738)

### Whats Changed

A pair of `Nop` phases didn't make it into the previous patch (my mistake). Adding them in for certain now.

### Patch Testing Results

[Patch](https://spruce.mongodb.com/version/66abab00e751700007781f74).