### PR TITLE
PERF-5064 Update toolchain version in order to use libmongocrypt 1.11.0

### DIFF
--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -176,7 +176,7 @@ class ToolchainDownloader(Downloader):
     #
 
     TOOLCHAIN_BUILD_ID = (
-        "patch_e5a0c94080f72e00a20ba8fd6ca6a3082e0873a6_66be486227900e00073aece6_24_08_15_18_26_44"
+        "fd7e48a1ad502b2ee383583a099e1207f04c67fc_24_08_16_15_36_08"
     )
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -176,7 +176,7 @@ class ToolchainDownloader(Downloader):
     #
 
     TOOLCHAIN_BUILD_ID = (
-        "e5a0c94080f72e00a20ba8fd6ca6a3082e0873a6_24_05_30_06_59_47"
+        "patch_e5a0c94080f72e00a20ba8fd6ca6a3082e0873a6_66be486227900e00073aece6_24_08_15_18_26_44"
     )
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 


### PR DESCRIPTION
<!---
Thanks for submitting a PR to the Genny repo. Please include the
following fields (if relevant) prior to submitting your PR.
--->

**Jira Ticket:** [PERF-5064](https://jira.mongodb.org/browse/PERF-5064)

Related vcpkg (toolchain) ticket: https://github.com/10gen/vcpkg/pull/43

### Whats Changed

Update toolchain version to latest.

### Patch Testing Results

<!---
Linting YAML files

If you update/add any YAML files under the workload and/or resmoke directory or
the evergreen file, please lint them first: src/lamplib/src/genny/tasks/

cd <genny_repo_root>        # replace `<genny_repo_root>` with the actual directory
./run-genny -v lint-yaml --format

Note: it will report 'invalid config: no such rule: "anchors"' if the yamllint
in the genny venv is too old. To fix this issue, please `rm -r genny_venv` and
then re-run the aforementioned lint command.

--->

<!---
If applicable, link a patch test showing code changes running
successfully
--->

sys-perf: https://spruce.mongodb.com/version/66be672a839af200074950d1/

<!---
### Workload Submission form

If applicable, only required if there is a new workload being added. The
form is [here].

[here]: https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform

### Merging and Linting

We currently have a manual linting stage required if you're
adding/modifying a workload YAML document. Evergreen will verify that
this has been run.

```bash
./run-genny generate-docs
```

Once (1) your PR is approved by a CODEOWNER and (2) all your CI tests
pass, you can initiate a merge by clicking "Add to merge queue".
This kicks your PR into the [Github Merge Queue]. Github will
automatically squash-merge your commit after checking that Evergreen's
CI tasks have returned a successful status.

[Github Merge Queue]: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Merge-Queue

--->

Note: Currently, the toolchain points to a patch version. My plan is to first merge the vcpkg PR, then point the toolchain at the actual version, and rerun testing.