### PR TITLE
PERF-5868 Edit comment in TenMDocCollection_IntId about {_id: {$eq: <val>}}

### DIFF
--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -111,9 +111,9 @@ Actors:
   - ActorFromTemplate:
       TemplateName: CrudTemplate
       TemplateParameters:
-        Name: IDFieldPointProject128Threads
+        Name: IDHackEqPointProject128Threads
         Find:
-          # Using $eq turns this from an IDHACK find into a scan find.
+          # Queries of the shape {_id: {$eq: <value>}} are eligible for IDHACK.
           Filter: {_id: {$eq: {^RandomInt: {min: 0, max: 9999999}}}}
           Options:
             Projection: {_id: 1}


### PR DESCRIPTION
**Jira Ticket:** [PERF-5868](https://jira.mongodb.org/browse/PERF-5868)

### Whats Changed

Needed to change a comment, and maybe a test name, now that we use IDHACK for a query of the shape `{_id: {$eq: <value>}}`. And maybe we should add another query that doesn't use IDHACK to replace the one we lost here.