### PR TITLE
DEVPROD-10486 Move to local task generation

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,9 @@
 
 extends: default
 
+ignore:
+  - evergreen
+
 rules:
   anchors:
     forbid-undeclared-aliases: true

--- a/docs/using.md
+++ b/docs/using.md
@@ -1,47 +1,47 @@
 # Using Genny
+
 [go/using-genny](http://go/using-genny)
 
 ## Table of Contents
 
-1.  [Introduction](#orgf1f92f6)
-2.  [Getting Started and Building](#org35e6dff)
-3.  [Core Concepts](#org1140a6b)
-    1.  [What is load generation?](#orgdcd1898)
-	2.  [What other load generation tools are there?](#orgc7988ae)
-    3.  [What is the system under test?](#orgc7904ae)
-    4.  [What is a workload?](#org3610c67)
-        1.  [How are workloads configured?](#orgdecc7ae)
-        2.  [What is an Actor?](#org51d4d33)
-        3.  [What is a phase?](#orgb655d69)
-        4.  [How do I run a workload?](#org32b8ad3)
-    5.  [Outputs](#orgec88ad4)
-        1.  [Analyzing workload output locally](#analyzing-workload-output-locally)
-    6.  [Workload Development](#org0e7c476)
-4.  [Further Concepts](#org61c719c)
-    1.  [Common Actors](#org78b250a)
-    2.  [AutoRun](#org2b04b49)
-        1.  [What is AutoRun?](#orgd0067d1)
-        2.  [Configuring AutoRun](#orgbfb0d8e)
-    3.  [Value Generators](#orgd89f221)
-    4.  [Preprocessor](#org2078b23)
-        1.  [LoadConfig](#orga6d35c7)
-        2.  [ActorTemplate](#orga45b1d8)
-        3.  [OnlyActiveInPhases](#orgf9c328f)
-        4.  [FlattenOnce](#preprocessorflattenonce)
-        5.  [PreprocessorFormatString](#preprocessorformatstring)
-        6.  [NumExpr](#preprocessornumexpr)
-        7.  [Defaults and Overrides](#org22b7a0f)
-    5.  [Connecting to the Server](#orgd6b0450)
-        1.  [Connection Strings and Pools](#orgd2659db)
-        2.  [Multiple Connection Strings](#orga591018)
-        3.  [Default](#org65830c2)
-    6.  [Creating an Actor](#org7e6c6bd)
-    7.  [Enabling Client-Side Field Level Encryption](#org627591d)
-5.  [Pitfalls](#org3aaae9e)
-    1.  [pipe creation failed (24): Too many open files](#orga7ab911)
-    2.  [Actor integration tests fail locally](#orgb084b49)
-    3.  [The Loader agent requires thread count set on both Actor and phase level](#org97681a9)
-
+1. [Introduction](#orgf1f92f6)
+2. [Getting Started and Building](#org35e6dff)
+3. [Core Concepts](#org1140a6b)
+    1. [What is load generation?](#orgdcd1898)
+    2. [What other load generation tools are there?](#orgc7988ae)
+    3. [What is the system under test?](#orgc7904ae)
+    4. [What is a workload?](#org3610c67)
+        1. [How are workloads configured?](#orgdecc7ae)
+        2. [What is an Actor?](#org51d4d33)
+        3. [What is a phase?](#orgb655d69)
+        4. [How do I run a workload?](#org32b8ad3)
+    5. [Outputs](#orgec88ad4)
+        1. [Analyzing workload output locally](#analyzing-workload-output-locally)
+    6. [Workload Development](#org0e7c476)
+4. [Further Concepts](#org61c719c)
+    1. [Common Actors](#org78b250a)
+    2. [AutoRun](#org2b04b49)
+        1. [What is AutoRun?](#orgd0067d1)
+        2. [Configuring AutoRun](#orgbfb0d8e)
+    3. [Value Generators](#orgd89f221)
+    4. [Preprocessor](#org2078b23)
+        1. [LoadConfig](#orga6d35c7)
+        2. [ActorTemplate](#orga45b1d8)
+        3. [OnlyActiveInPhases](#orgf9c328f)
+        4. [FlattenOnce](#preprocessorflattenonce)
+        5. [PreprocessorFormatString](#preprocessorformatstring)
+        6. [NumExpr](#preprocessornumexpr)
+        7. [Defaults and Overrides](#org22b7a0f)
+    5. [Connecting to the Server](#orgd6b0450)
+        1. [Connection Strings and Pools](#orgd2659db)
+        2. [Multiple Connection Strings](#orga591018)
+        3. [Default](#org65830c2)
+    6. [Creating an Actor](#org7e6c6bd)
+    7. [Enabling Client-Side Field Level Encryption](#org627591d)
+5. [Pitfalls](#org3aaae9e)
+    1. [pipe creation failed (24): Too many open files](#orga7ab911)
+    2. [Actor integration tests fail locally](#orgb084b49)
+    3. [The Loader agent requires thread count set on both Actor and phase level](#org97681a9)
 
 <a id="orgf1f92f6"></a>
 
@@ -51,19 +51,18 @@ Hello! These are the docs for Genny specifically. Genny is a workload-generator 
 
 If you have any questions, please reach out to the DEVPROD team in our dedicated slack channel: [#ask-devprod-performance](https://mongodb.slack.com/archives/C01VD0LQZED). If you feel like these docs can be improved in any way, feel free to open a PR and assign someone from DEVPROD. No ticket necessary. This document is intended to be readable straight-through, in addition to serving as a reference on an as-needed basis. If there are any difficulties in flow or discoverability, please let us know.
 
-
 <a id="org35e6dff"></a>
 
 # Getting Started and Building
 
 For build instructions, see the installation guide [here](setup.md).
 
-To try launching Genny, navigate to the root of the Genny repo and run the following: 
+To try launching Genny, navigate to the root of the Genny repo and run the following:
 
 ```bash
 ./run-genny workload src/workloads/docs/HelloWorld.yml
 ```
-	
+
 You should see output similar to the following:
 
 ```
@@ -85,7 +84,6 @@ You should see output similar to the following:
 [curator] 2022/03/24 10:44:58 [p=info]: poplar rpc service terminated
 ```
 
-
 Note that the above test workload does not connect to a remote server, while most do. For more details, see [What is the System Under Test?](#orgc7904ae)
 
 Whenever you have questions about the Genny CLI, you can always use the `-h` option for the top-level Genny CLI or any subcommands:
@@ -95,13 +93,11 @@ Whenever you have questions about the Genny CLI, you can always use the `-h` opt
 ./run-genny workload -h # See args and options for the workload subcommand
 ```
 
-
 <a id="org1140a6b"></a>
 
 # Core Concepts
 
 This section introduces the core concepts used by Genny, the minimal required syntax for its inputs, and builds up a basic example.
-
 
 <a id="orgdcd1898"></a>
 
@@ -114,6 +110,7 @@ Results of a load test can inform developers as to the performance of the test s
 <a id="orgc7988ae"></a>
 
 ### What other load generation tools are there?
+
 At MongoDB, we've historically used [benchrun-based](https://github.com/10gen/workloads) workloads. This legacy tooling was deprecated in favor of Genny in order to provide:
 
 - A standardized [interface](#org3610c67) for workload authoring in yaml.
@@ -136,13 +133,11 @@ By default, Genny will try to connect to a MongoDB server at `localhost:27017`. 
 
 For more details on how Genny handles connections, see [Connecting to the Server](#orgd6b0450).
 
-
 <a id="org3610c67"></a>
 
 ## What is a workload?
 
 A **workload** is a repeatable procedure that Genny uses to generate load against a system under test. Genny workloads are written in yaml configs that describe how **Actors** move through **phases**. This section describes each of these.
-
 
 <a id="orgdecc7ae"></a>
 
@@ -174,13 +169,12 @@ Actors:
 
 Everything under the `Actor` key (where the magic happens) will be explained in the next section. First let's look at the other **required** keys:
 
--   `SchemaVersion` - This is a basic versioning system used for Genny workload syntax. For the moment, any new workloads should have the value `2018-07-01` for this key.
--   `Owner` - This should have an identifier for the team that owns the workload, ideally an @-mentionable GitHub team.
--   `Description` - This should contain a written description of the workload. It's recommended to go into as much detail as possible, since understanding the performance issue behind why a workload was written can be difficult months or years later.
--   `Keywords` - These should be searchable keywords associated with your workload. Include keywords for Actors used, operations performed, qualities of the system under test that are expected, etc.
+- `SchemaVersion` - This is a basic versioning system used for Genny workload syntax. For the moment, any new workloads should have the value `2018-07-01` for this key.
+- `Owner` - This should have an identifier for the team that owns the workload, ideally an @-mentionable GitHub team.
+- `Description` - This should contain a written description of the workload. It's recommended to go into as much detail as possible, since understanding the performance issue behind why a workload was written can be difficult months or years later.
+- `Keywords` - These should be searchable keywords associated with your workload. Include keywords for Actors used, operations performed, qualities of the system under test that are expected, etc.
 
 Workload configurations can be found in [./src/workloads](../src/workloads) from the Genny repo root. Organization of this directory is arbitrary as far as Genny is concerned, though example workloads should be in the `docs` subdir.
-
 
 <a id="org51d4d33"></a>
 
@@ -230,10 +224,10 @@ Note that even though the Actors are listed sequentially, all Actors are concurr
 
 Actor configurations expect the following keys:
 
--   `Name` - The human-understandable name of this particular Actor configuration. This should be unique throughout the workload.
--   `Type` - The kind of Actor to create. This determines the Actor's behavior and possible configuration options.
--   `Threads` - How many threads to allocate for this Actor.
--   `Phases` - A list of phase configurations (described in next section).
+- `Name` - The human-understandable name of this particular Actor configuration. This should be unique throughout the workload.
+- `Type` - The kind of Actor to create. This determines the Actor's behavior and possible configuration options.
+- `Threads` - How many threads to allocate for this Actor.
+- `Phases` - A list of phase configurations (described in next section).
 
 In addition to the universal fields above, individual Actors may have their own configuration keys, such as the `Message` key of the `HelloWorld` Actor, used to determine what message is printed.
 
@@ -245,7 +239,6 @@ Some tips for configuring Actors:
 - Consider whether your Actor will have "lingering" effects after a phase transition. If it does, and if that's not desireable for this workload, consider using the Quiesce Actor.
 
 Actors are written in C++, and creating new Actors or extending existing ones is a common and encouraged workflow when using Genny. These Actors are owned by their authors. For more details, see [Creating an Actor](#org7e6c6bd).
-
 
 <a id="orgb655d69"></a>
 
@@ -296,20 +289,20 @@ Therefore, the logged output of this Actor would show many lines of `Hello Phase
 
 Phase configurations accept the following main keys:
 
--   `Duration` - How long to operate in this phase while holding the phase open.
--   `Repeat` - How many times to repeat the operation while holding the phase open.
--   `Blocking` - This key can be specified with the value `None` to cause the Actor to run as a **background Actor** for this phase. This Actor will act as many times as possible during the phase without holding it open, then move on to the next phase when everyone else is ready.
--   `Nop` - This key can be set with the value `true` to cause the Actor to nop for the duration of the phase.
+- `Duration` - How long to operate in this phase while holding the phase open.
+- `Repeat` - How many times to repeat the operation while holding the phase open.
+- `Blocking` - This key can be specified with the value `None` to cause the Actor to run as a **background Actor** for this phase. This Actor will act as many times as possible during the phase without holding it open, then move on to the next phase when everyone else is ready.
+- `Nop` - This key can be set with the value `true` to cause the Actor to nop for the duration of the phase.
 
 A couple of notes about the above:
 
--   You can specify both `Repeat` and `Duration` for a phase. Whichever lasts longer wins.
--   It is undefined behavior if a given phase does not have some Actor specifying `Repeat` or `Duration`.
+- You can specify both `Repeat` and `Duration` for a phase. Whichever lasts longer wins.
+- It is undefined behavior if a given phase does not have some Actor specifying `Repeat` or `Duration`.
 
-1.  Sleeping
+1. Sleeping
 
     In addition to the above keys, Actors can also be configured to sleep during parts of phases. For example:
-    
+
 ```yaml
 Actors:
 - Name: HelloWorldExample
@@ -321,16 +314,16 @@ Actors:
     Duration: 50 milliseconds
     SleepAfter: 15 milliseconds
 ```
-    
-This will sleep for 10 milliseconds at the beginning of *every* Actor iteration and for 15 milliseconds at the end of every iteration. This time is counted as part of the phase duration. Genny accepts the following sleep configurations:
-    
--   `SleepBefore` - duration to sleep at the beginning of each iteration
--   `SleepAfter` - duration to sleep after each iteration
 
-2.  Rate Limiting
+This will sleep for 10 milliseconds at the beginning of _every_ Actor iteration and for 15 milliseconds at the end of every iteration. This time is counted as part of the phase duration. Genny accepts the following sleep configurations:
+
+- `SleepBefore` - duration to sleep at the beginning of each iteration
+- `SleepAfter` - duration to sleep after each iteration
+
+2. Rate Limiting
 
 By default, Actors will repeat their main loop as quickly as possible. Sometimes you want to restrict how quickly an Actor works. This can be done using a rate limiter:
-    
+
 ```yaml
 Actors:
 - Name: HelloWorldExample
@@ -341,11 +334,11 @@ Actors:
     GlobalRate: 5 per 10 milliseconds
     Duration: 50 milliseconds
 ```
-    
+
 Using the `GlobalRate` configuration, the above Actor will only have 5 threads act every 10 milliseconds, despite having 100 threads that could reasonable act at once. If this workload's outputs were to be analyzed and the intrarun time series were graphed, the user would see only 5 operations occurring every 10 milliseconds. (See [here](#orgec88ad4) for more details about outputs.)
-    
+
 In addition to hard-coding how many threads act and when, you can configure Genny to rate-limit the Actor at a percentage of the detected maximum rate:
-    
+
 ```yaml
 Actors:
 - Name: HelloWorldExample
@@ -356,17 +349,16 @@ Actors:
     GlobalRate: 80%
     Duration: 2 minutes
 ```
-    
-    The above workload will run `HelloWorldExample` at maximum throughput for either 1 minutes or 3 iterations of the Actor's loop, whichever is longer. Afterwards, Genny will use the estimated throughput from that time to limit the Actor to 80% of the max throughput.
-    
-Note that the rate limiter uses a [token bucket algorithm](https://en.wikipedia.org/wiki/Token_bucket). This means that bursty behavior is possible. For example, if we configure `GlobalRate: 5 per 10 milliseconds` then we will have 5 threads act all at once, followed by 9 or so milliseconds without any threads acting, then another burst of 5 threads acting, etc. We can smooth the rate by specifying a tighter yet equivalent rate limit: `GlobalRate: 1 per 2 milliseconds`.
-    
-Since the percentage-based limiting treats the entire estimation period as the duration in the rate specification, it is highly prone to bursty behavior.
-    
-Rate limiting accepts the following configurations:
-    
--   `GlobalRate` - specified as either a rate specification (x per y minutes/seconds/milliseconds/etc) or as a percentage
 
+    The above workload will run `HelloWorldExample` at maximum throughput for either 1 minutes or 3 iterations of the Actor's loop, whichever is longer. Afterwards, Genny will use the estimated throughput from that time to limit the Actor to 80% of the max throughput.
+
+Note that the rate limiter uses a [token bucket algorithm](https://en.wikipedia.org/wiki/Token_bucket). This means that bursty behavior is possible. For example, if we configure `GlobalRate: 5 per 10 milliseconds` then we will have 5 threads act all at once, followed by 9 or so milliseconds without any threads acting, then another burst of 5 threads acting, etc. We can smooth the rate by specifying a tighter yet equivalent rate limit: `GlobalRate: 1 per 2 milliseconds`.
+
+Since the percentage-based limiting treats the entire estimation period as the duration in the rate specification, it is highly prone to bursty behavior.
+
+Rate limiting accepts the following configurations:
+
+- `GlobalRate` - specified as either a rate specification (x per y minutes/seconds/milliseconds/etc) or as a percentage
 
 <a id="org32b8ad3"></a>
 
@@ -382,7 +374,6 @@ If your workload requires a MongoDB connection (most do), then you can pass it i
 
 If you'd like to have your results summarized locally in a JSON format, you can pass in the `-r` flag.
 
-
 <a id="orgec88ad4"></a>
 
 ## Outputs
@@ -391,8 +382,8 @@ Genny's primary output is time-series data. Every time an Actor performs an oper
 
 Genny outputs to `./build/WorkloadOutput`. When running Genny for the first time, you should see two outputs in that directory:
 
--   `CedarMetrics` - a directory full of FTDC files, where each file corresponds to a single time-series metric for a single operation. For more details about the format and contents of these FTDC files, see our tool-agnostic documentation [here](https://github.com/10gen/performance-tooling-docs/blob/main/getting_started/intrarun_data_generation.md). NOTE: this FTDC is different from the [MongoDB server Full Time Diagnostic Data Capture](https://www.mongodb.com/docs/manual/administration/analyzing-mongodb-performance/#full-time-diagnostic-data-capture). This file can also contain a JSON summary of these FTDC files if you pass in the `-r` flag when running the `workload` command.
--   `workload` - a directory containing the preprocessed workload. Learn more about the preprocessor [here](#org2078b23).
+- `CedarMetrics` - a directory full of FTDC files, where each file corresponds to a single time-series metric for a single operation. For more details about the format and contents of these FTDC files, see our tool-agnostic documentation [here](https://github.com/10gen/performance-tooling-docs/blob/main/getting_started/intrarun_data_generation.md). NOTE: this FTDC is different from the [MongoDB server Full Time Diagnostic Data Capture](https://www.mongodb.com/docs/manual/administration/analyzing-mongodb-performance/#full-time-diagnostic-data-capture). This file can also contain a JSON summary of these FTDC files if you pass in the `-r` flag when running the `workload` command.
+- `workload` - a directory containing the preprocessed workload. Learn more about the preprocessor [here](#org2078b23).
 
 If you run Genny and the `CedarMetrics` directory already exists, it will be moved to `CedarMetrics-<current_time>` to avoid overwriting results. The preprocessed workload will be deposited into the `workload` directory, possibly overwriting the existing one. (Or you may end up with multiple workloads in the directory, if they have different names. This has no impact on execution.)
 
@@ -418,20 +409,20 @@ After installing the required Python packages, the tool can be run as in the fol
 python src/workloads/contrib/analysis/test_result_summary.py -m throughput timers.dur -a ".*Sleep.*" -b 3
 SleepTest.SleepTest summary:
         timers.dur (measured in nanoseconds, displayed in milliseconds):
-                count     : 160     
-                average   : 1001.3  
-                median    : 1000.9  
-                mode      : 1000.9  
-                stddev    : 0.4     
+                count     : 160
+                average   : 1001.3
+                median    : 1000.9
+                mode      : 1000.9
+                stddev    : 0.4
                 [min, max]: [1000.4, 1002.5]
                 histogram:
                         [1000,1001): ***************************        (27)
                         [1001,1002): ************************************************************...    (128)
                         [1002,1002]: *****      (5)
         throughput:
-                ops       : 160.0   
+                ops       : 160.0
                 seconds   : 160.213370114
-                ops per second: 0.9987  
+                ops per second: 0.9987
 
 ```
 
@@ -441,20 +432,20 @@ Try using `python test_result_summary.py --help` for more options.
 
 ## Workload Development
 
-1.  Create a yaml file in `./src/workloads` in whatever topical subdirectory you deem appropriate and populate it with appropriate configuration. If you have yaml configuration that may need loading, place it in `./src/phases` (and for more details about what that means, see [here](#org2078b23)). Consider whether existing Actors can be repurposed for your workload, or whether a new one is needed. For the latter, see [here](#org7e6c6bd).
-
+1. Create a yaml file in `./src/workloads` in whatever topical subdirectory you deem appropriate and populate it with appropriate configuration. If you have yaml configuration that may need loading, place it in `./src/phases` (and for more details about what that means, see [here](#org2078b23)). Consider whether existing Actors can be repurposed for your workload, or whether a new one is needed. For the latter, see [here](#org7e6c6bd).
 
     ```bash
     vim src/workloads/[workload_dir]/[workload_name.yml]
     vim src/phases/[phase_dir]/[phases_name.yml] # Only necessary if creating external configuration
     ./run-genny create-new-actor  # Only necessary if creating a new Actor
     ```
-    
+
     Note: The `Owner` field in the workload yaml is expected to be a valid team in the [mothra](https://github.com/10gen/mothra/tree/main/mothra/teams) repo. Each team in Mothra that is referenced in Genny is expected to have a `support_slack_channel_name` and `support_slack_channel_id` in Mothra, if these values are not present you will need to add them before merging your workload.
 
-2.  Run the self-tests:
+2. Run the self-tests:
 
     To run `self-test` it is required that the [Mothra repository](https://github.com/10gen/mothra/) exists at the root of the repository.
+
     ```bash
     git clone https://github.com/10gen/mothra.git
     ```
@@ -476,43 +467,45 @@ Try using `python test_result_summary.py --help` for more options.
 
     If changes have been made to the workload name, description, owners, or keywords you need to generate documentation for the workload. Include the generated documentation with your commit.
 
-4.  (Optional) To double-check which Actors run in each Phase, run your workload in dry-run mode with `debug` log level.
+4. (Optional) To double-check which Actors run in each Phase, run your workload in dry-run mode with `debug` log level.
 This would set up the workload and print it as a list of Phases with the Actors that run in each Phase, then quit:
 
     ```bash
     ./run-genny workload --dry-run --verbosity debug src/workloads/[workload_dir/workload_name.yml]
     ```
 
-5.  (Optional) If you can run your system under test locally, you can test against it as a sanity-check:
+5. (Optional) If you can run your system under test locally, you can test against it as a sanity-check:
 
     ```bash
     ./run-genny workload -u [connection_uri] src/workloads/[workload_dir/workload_name.yml]
     ```
 
-6.  (Optional) If you are using DSI, you can run your workload through it by copying or symlinking your Genny directory into your DSI workdir. See [Running DSI Locally](go/running-dsi-locally) for details:
+6. (Optional) If you are using DSI, you can run your workload through it by copying or symlinking your Genny directory into your DSI workdir. See [Running DSI Locally](go/running-dsi-locally) for details:
 
-	```bash
-	./run-dsi onboarding  # introductory DSI command; see link above for details
-	cd WORK
-	rm -rf src/genny
-	ln -s ~/[path_to_genny]/genny src
-	vim bootstrap.yml
-	```
+ ```bash
+ ./run-dsi onboarding  # introductory DSI command; see link above for details
+ cd WORK
+ rm -rf src/genny
+ ln -s ~/[path_to_genny]/genny src
+ vim bootstrap.yml
+ ```
 
-7.  Before merging, you should run your workload in realistic situations in CI and check the resultant metrics. For Genny workloads run through DSI using [AutoRun](#org2b04b49), you can create a patch using the following:
+7. Before merging, you should run your workload in realistic situations in CI and check the resultant metrics. For Genny workloads run through DSI using [AutoRun](#org2b04b49), you can create a patch using the following:
 
-	```bash
-	cd ~/[path_to_evg_project_repo]
-	evergreen patch -p [evg_project]
-	cd ~/[path_to_genny]/genny
-	evergreen patch-set-module -i [patch_id_number] -m genny
-	```
+    ```bash
+    # Regenerate the autotask definitions
+    cd ~/[path_to_genny_repo]
+    ./run-genny auto-tasks-local
 
-	The `evg_project` above should correspond to the Evergreen project being tested. For example, `sys-perf`.
+    # Create the patch
+    cd ~/[path_to_evg_project_repo]
+    evergreen patch -p [evg_project] --include-modules
+    # In the resulting dialog, specify the location of your local genny repository
+    ```
 
-    You can then select `schedule_patch_auto_tasks` on a variant to schedule any modified or new Genny tasks created by AutoRun. Alternatively, you could select `schedule_variant_auto_tasks` to schedule all Genny tasks on that variant.
+   The `evg_project` above should correspond to the Evergreen project being tested. For example, `sys-perf`.
 
-    *Note:* [Skipping the compile step in sys-perf projects](https://github.com/10gen/performance-tooling-docs/blob/main/patch_testing.md#skipping-compilation-on-sys-perf-projects) can save some time when testing a genny workload.
+    _Note:_ [Skipping the compile step in sys-perf projects](https://github.com/10gen/performance-tooling-docs/blob/main/patch_testing.md#skipping-compilation-on-sys-perf-projects) can save some time when testing a genny workload.
 
 For more details on workload development, please check out our general docs on [Developing and Modifying Workloads](https://github.com/10gen/performance-tooling-docs/blob/main/new_workloads.md) and on [Basic Performance Patch Testing](https://github.com/10gen/performance-tooling-docs/blob/main/patch_testing.md).
 
@@ -520,11 +513,9 @@ Users who would like a second look at their workloads can ask product performanc
 
 Users who would like a private workload should consider putting it in the [PrivateWorkloads repo](https://github.com/10gen/PrivateWorkloads).
 
-
 <a id="org61c719c"></a>
 
 # Further Concepts
-
 
 <a id="org78b250a"></a>
 
@@ -532,18 +523,16 @@ Users who would like a private workload should consider putting it in the [Priva
 
 There are several Actors owned by DEVPROD which are intended for widespread use:
 
--   CrudActor - Used to perform CRUD operations, recording client-side metrics.
--   RunCommand - Execute a command against the remote server. Often used for utility purposes, but metrics are collected as well.
--   Loader - Load many documents into the remote database. Often used early in a workload to set the preconditions for testing.
--   QuiesceActor - Quiesce a cluster, making sure common operations are complete. This is often used to reduce noise between phases.
+- CrudActor - Used to perform CRUD operations, recording client-side metrics.
+- RunCommand - Execute a command against the remote server. Often used for utility purposes, but metrics are collected as well.
+- Loader - Load many documents into the remote database. Often used early in a workload to set the preconditions for testing.
+- QuiesceActor - Quiesce a cluster, making sure common operations are complete. This is often used to reduce noise between phases.
 
 Examples with these and other Actors can be found in [./src/workloads/docs](../src/workloads/docs).
-
 
 <a id="org2b04b49"></a>
 
 ## AutoRun
-
 
 <a id="orgd0067d1"></a>
 
@@ -553,17 +542,11 @@ AutoRun is a utility to allow workload authors to determine scheduling of their 
 
 AutoRun searches in `[workspace]/src/*/src/workloads` and assumes that all workload repos, including Genny itself, are checked out in `[workspace]/src`.
 
-After performing the above integration, your Evergreen project should have a `schedule_variant_auto_tasks` task on each variant, which can be used to schedule all Genny workloads that are configured to run on this variant. There will also be the `schedule_patch_auto_tasks` task which will schedule any new or modified Genny workloads. If you want to run an unmodified workload, make a small edit (such as inserting whitespace) to force it to be picked up by that latter task.
-
-Both of the above tasks will have a dependency on `schedule_global_auto_tasks`, which invokes `./run-genny auto-tasks` to create all possible tasks, viewable in the `TaskJson` directory of that task's DSI artifacts. The variant-specific task generator task will then schedule the appropriate task, based on the workload configurations described below. Note that task execution only occurs once per patch, even if a task is re-executed. If testing changes to task generation configuration, creating a new patch will be necessary.
-
-
-
-<a id="orgbfb0d8e"></a>
+Based on these, Genny generates task defintion files that are used by Evergreen. See [Auto-generated Genny Tasks](evergreen/system_perf/README.md) for more information.
 
 ### Configuring AutoRun
 
-The `schedule_variant_auto_tasks` task automatically runs workloads based on the evergreen environment
+Genny automatically runs workloads based on the evergreen environment
 (variables from `bootstrap.yml` and `runtime.yml` in DSI) and an optional AutoRun
 section in any workload. The AutoRun section is a list of `When`/`ThenRun` blocks,
 where if the When condition is met, tasks are scheduled with additional bootstrap
@@ -610,32 +593,31 @@ we schedule `demo_workload` with no additional params.
 
 A few notes on the syntax:
 
--   Supports multiple `When`/`ThenRun` blocks per `AutoRun`. Each are evaluated independently.
--   `When` blocks can evaluate multiple conditions. All conditions must be true to schedule the task.
--   `When` supports `$eq`, `$neq`, `$gte`, `$gt`, `$lte` and `$lt`.
--   `$eq` and `$neq` can accept either a scalar or list of values.
--   `$gte`, `$gt`, `$lte` and `$lt` can accept only scalar values.
--   For a list of values, `$eq` evaluates to true if it is equal to at least one.
--   For a list of values, `$neq` evaluates to true if it is equal to none of the values.
--   `$gte`, `$gt`, `$lte` and `$lt` use either regular comparison or version comparison.
--   Version comparison is used when both arguments are version strings. Version strings have format
+- Supports multiple `When`/`ThenRun` blocks per `AutoRun`. Each are evaluated independently.
+- `When` blocks can evaluate multiple conditions. All conditions must be true to schedule the task.
+- `When` supports `$eq`, `$neq`, `$gte`, `$gt`, `$lte` and `$lt`.
+- `$eq` and `$neq` can accept either a scalar or list of values.
+- `$gte`, `$gt`, `$lte` and `$lt` can accept only scalar values.
+- For a list of values, `$eq` evaluates to true if it is equal to at least one.
+- For a list of values, `$neq` evaluates to true if it is equal to none of the values.
+- `$gte`, `$gt`, `$lte` and `$lt` use either regular comparison or version comparison.
+- Version comparison is used when both arguments are version strings. Version strings have format
     `vA.B` where `A` and `B` are integers. When comparing two version strings, first `A` values are
     compared and only if they are equal, `B` values are compared.
--   Special strings `master` and `main` are also considered version strings which are greater
+- Special strings `master` and `main` are also considered version strings which are greater
     than all other version strings.
--   `ThenRun` blocks are optional.
-    -   ****Most usecases do not need to use ThenRun****
-    -   If you do use `ThenRun`, please be judicious. If you have a task that is scheduled when
+- `ThenRun` blocks are optional.
+  - ****Most usecases do not need to use ThenRun****
+  - If you do use `ThenRun`, please be judicious. If you have a task that is scheduled when
         `mongodb_setup` == `replica`, it would be confusing if `mongodb_setup` was overwritten to `standalone`.
         But it would be ok to overwrite `mongodb_setup` to `replica-delay-mixed`.
--   Each item in the `ThenRun` list can only support one `{bootstrap_key: bootstrap_value}` pair.
--   If using `ThenRun` but you would also like to schedule a task without any bootstrap overrides,
+- Each item in the `ThenRun` list can only support one `{bootstrap_key: bootstrap_value}` pair.
+- If using `ThenRun` but you would also like to schedule a task without any bootstrap overrides,
     Add an extra pair to `ThenRun` with the original key/value.
--   If using `ThenRun`, the new task name becomes `<taskname>_<bootstrap-value>`. In the `ParallelWorkload` example,
+- If using `ThenRun`, the new task name becomes `<taskname>_<bootstrap-value>`. In the `ParallelWorkload` example,
     the task name becomes `parallel_insert_replica_delay_mixed` (name is automatically converted to snake_case).
     The `bootstrap-key` is not included in the name for the purpose of not changing existing names and
     thus deleting history. This may change after PM-2310.
-
 
 <a id="orgd89f221"></a>
 
@@ -656,9 +638,8 @@ For convenience when developing workloads, Genny offers a preprocessing syntax t
 ```bash
 ./run-genny evaluate src/workloads/[workload_dir/workload_name.yml]
 ```
-	
-This command helps find yaml-based mistakes. Note that we don't do schema-checking for this yaml.
 
+This command helps find yaml-based mistakes. Note that we don't do schema-checking for this yaml.
 
 <a id="orga6d35c7"></a>
 
@@ -693,7 +674,7 @@ UseMe:
   Repeat: {^Parameter: {Name: "Repeat", Default: 1}}
 ```
 
-Using `LoadConfig`, the contents of the `UseMe` key will be placed into the location where the `LoadConfig` was evaluated, with parameters substituted, so we end up with the following ouput from evaluation: 
+Using `LoadConfig`, the contents of the `UseMe` key will be placed into the location where the `LoadConfig` was evaluated, with parameters substituted, so we end up with the following ouput from evaluation:
 
 ```yaml
 Actors:
@@ -709,19 +690,17 @@ Actors:
 
 A few notes:
 
--   The parameter `Repeat` was substituted in. A loaded config can have any number of parameters substituted, at any key's value.
--   The loaded config filepath should be relative to the location of the workload containing `LoadConfig`.
--   The contents of the loaded config are shallow-merged into the location where the `LoadConfig` is evaluated. If there are conflicting keys at the location, the existing key-values are kept. There is no deep dict merge at present.
+- The parameter `Repeat` was substituted in. A loaded config can have any number of parameters substituted, at any key's value.
+- The loaded config filepath should be relative to the location of the workload containing `LoadConfig`.
+- The contents of the loaded config are shallow-merged into the location where the `LoadConfig` is evaluated. If there are conflicting keys at the location, the existing key-values are kept. There is no deep dict merge at present.
 
 The `LoadConfig` keyword can be used to substitute and parameterize anything, including entire workloads! For an example of this, see [here](../src/workloads/docs/HelloWorld-LoadConfig.yml).
-
 
 <a id="orga45b1d8"></a>
 
 ### ActorTemplate
 
 Genny also offers a syntax for templatizing Actors. This is useful if there are many Actors that share common configuration, which need to differ in specific ways. An example of this can be found [here](../src/workloads/docs/HelloWorld-ActorTemplate.yml).
-
 
 <a id="orgf9c328f"></a>
 
@@ -885,12 +864,12 @@ Genny also has an override syntax for configuring workloads. When invoking Genny
 This uses [OmegaConf](https://omegaconf.readthedocs.io/en/2.1_branch/) to merge the override file onto the workload. This functionality
 should only be used to set values that absolutely need to be specified at runtime, such as URIs for systems under test. (See [Connecting to the Server](#orgd6b0450) for details.)
 
-*Warning* - Using overrides and omegaconf syntax and greatly increase workload complexity. Users interested in using overrides files or OmegaConf functionality should come talk to the DEVPROD team.
+_Warning_ - Using overrides and omegaconf syntax and greatly increase workload complexity. Users interested in using overrides files or OmegaConf functionality should come talk to the DEVPROD team.
 
 Furthermore, there is a default Actor that is injected during preprocessing, which has the following configuration:
 
 ```yaml
-Name: PhaseTimingRecorder 
+Name: PhaseTimingRecorder
 Type: PhaseTimingRecorder
 Threads: 1
 ```
@@ -899,20 +878,18 @@ This Actor is used to collect several internal metrics.
 
 When actually evaluating and constructing a workload at runtime, Genny takes the following steps:
 
-1.  Start with the defaults.
-2.  Apply the workload yaml configuration over the defaults, deep merging the yamls and giving priority to the workload yaml.
-3.  Apply the overrides file (if given) over the results of step 2, deep merging the yamls and giving priority to the overrides.
-4.  Use the preprocessor on the resultant config, evaluating all `LoadConfig`, `ActorTemplate`, and other keywords recursively. Injection of the `PhaseTimingRecorder` default Actor occurs while evaluating the `Actors` list.
-5.  Output the result to `./build/WorkloadOutput/workload`.
-6.  Run the workload.
+1. Start with the defaults.
+2. Apply the workload yaml configuration over the defaults, deep merging the yamls and giving priority to the workload yaml.
+3. Apply the overrides file (if given) over the results of step 2, deep merging the yamls and giving priority to the overrides.
+4. Use the preprocessor on the resultant config, evaluating all `LoadConfig`, `ActorTemplate`, and other keywords recursively. Injection of the `PhaseTimingRecorder` default Actor occurs while evaluating the `Actors` list.
+5. Output the result to `./build/WorkloadOutput/workload`.
+6. Run the workload.
 
 Note that the final results of the above can be viewed with `./run-genny evaluate`. This is extremely useful for debugging.
-
 
 <a id="orgd6b0450"></a>
 
 ## Connecting to the Server
-
 
 <a id="orgd2659db"></a>
 
@@ -954,7 +931,6 @@ Clients:
       maxPoolSize: 500
 ```
 
-
 <a id="orga591018"></a>
 
 ### Multiple Connection Strings
@@ -992,7 +968,6 @@ Clients:
 
 Genny's `evaluate` subcommand can always be used to see the result of complex configurations.
 
-
 <a id="org65830c2"></a>
 
 ### Default
@@ -1010,7 +985,6 @@ Clients:
 
 For more information, see [Defaults and Overrides](#org22b7a0f).
 
-
 <a id="org7e6c6bd"></a>
 
 ## Creating an Actor
@@ -1024,7 +998,6 @@ Creating new Actors is a common and encouraged workflow in Genny. To create one,
 This will create new Actor .cpp and .h files, an example workload yaml, as well as Actor integration tests, all with inline comments guiding you through the Actor creation process. You might want to take a look at [Developing Genny](./developing.md) and the [Contribution Guidelines](../CONTRIBUTING.md).
 
 If your configuration wants to use logic, ifs, or anything beyond simple or existing commands in a loop, then consider writing your own Actor. It doesn't need to be super general or even super well-tested or refactored. Genny is open to submissions and you own whatever Actor you write. No need to loop DEVPROD in to your custom actor's PR unless you'd just like a second look.
-
 
 <a id="org627591d"></a>
 
@@ -1067,6 +1040,7 @@ Clients:
       - encrypted_db.fle_encrypted_coll
       - encrypted_db.qe_encrypted_coll
 ```
+
 In the above example, we enable encryption in the `Default` client pool. The `EncryptionOptions` node requires that the namespace of the key vault be specified via the `KeyVaultDatabase` and `KeyVaultCollection` fields. It also requires that the encrypted namespaces that will be operated on through this client be listed under the `EncryptedCollections` field. These namespaces must have a corresponding definition in `Encryption.EncryptedCollections`.
 
 During client pool setup, key vaults in each unique URI are dropped & created once, when the first client pool for that URI is created. Data keys for encrypted namespaces are generated only once, if the associated key vault & URI does not yet contain keys for that namespace. This means that if two client pools have a similar URI and key vault namespace, then the encrypted collections they have in common will be using the same data keys.
@@ -1082,20 +1056,17 @@ For a full example of an encrypted workload, see [here](../src/workloads/docs/Cr
 
 # Pitfalls
 
-
 <a id="orga7ab911"></a>
 
 ## pipe creation failed (24): Too many open files
 
 If you see errors like this locally, try either increasing your ulimit or reducing the number of threads and duration.
 
-
 <a id="orgb084b49"></a>
 
 ## Actor integration tests fail locally
 
 There are currently pathing issues when running integration tests locally. This is tracked in [TIG-3687](https://jira.mongodb.org/browse/TIG-3687). That ticket also lists a workaround for local use.
-
 
 <a id="org97681a9"></a>
 
@@ -1107,5 +1078,5 @@ This is tracked in [TIG-3016](https://jira.mongodb.org/browse/TIG-3016) which wi
 
 ## Two similarly-named workloads are not permitted to coexist
 
-This is tracked in [TIG-3700](https://jira.mongodb.org/browse/TIG-3700) which will correct the issue. 
-Note that the failure symptom when this occurs could be an infractrue provisioning error, even though the issue is unrelated to provisioning. 
+This is tracked in [TIG-3700](https://jira.mongodb.org/browse/TIG-3700) which will correct the issue.
+Note that the failure symptom when this occurs could be an infractrue provisioning error, even though the issue is unrelated to provisioning.

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -123,6 +123,14 @@ buildvariants:
     tasks:
       - name: tg_compile_and_test_with_server_on_macos
 
+  - name: validate-genny-tasks
+    display_name: Validate Genny Tasks
+    modules: [dsi, PrivateWorkloads]
+    run_on:
+      - amazon2-arm64
+    tasks:
+      - name: validate_genny_tasks
+
 ##                ⚡️ Tasks ⚡️
 
 tasks:
@@ -226,6 +234,11 @@ tasks:
             - -v
             - resmoke-test
             - --create-new-actor-test-suite
+
+  - name: validate_genny_tasks
+    commands:
+      - func: f_fetch_source
+      - func: f_validate_genny_tasks
 
 ##                ⚡️ Task Groups ⚡️
 
@@ -492,6 +505,40 @@ functions:
       params:
         file: build/XUnitXML/*.xml
 
+  ##
+  # Validate that the auto-generated genny tasks are up to date.
+  ##
+  f_validate_genny_tasks:
+    - command: shell.exec
+      params:
+        working_dir: src/genny
+        script: |
+          set -eu
+          versions=("master" "8.0" "7.3" "7.0" "6.0" "5.0")
+
+          # Move original files to backup locations
+          for version in $versions; do
+            mv evergreen/system_perf/$version/genny_tasks.yml evergreen/system_perf/$version/genny_tasks.bak.yml
+          done
+
+          # Regenerate the genny task files
+          ./run-genny auto-tasks-local --evergreen
+
+          # Validate that the files are identical
+          for version in $versions; do
+            original="evergreen/system_perf/$version/genny_tasks.bak.yml"
+            new="evergreen/system_perf/$version/genny_tasks.yml"
+            exitCode=0
+            diff $original $new || exitCode=1
+
+            if [ $exitCode -ne 0 ]; then
+              echo -e '\033[31mThe auto-generated genny task files are not up to date!\033[0m'
+              echo -e '\033[31mThis typically happens if you are adding a new genny test, update the AutoRun section of a test, or someone added a new variant in DSI and did not regenerate the files.\033[0m'
+              echo -e '\033[31mTo resolve this issue, please run ./run-genny auto-tasks-local and commit the new files in the evergreen folder.\033[0m'
+              exit 1
+            fi
+          done
+
 ##                ⚡️ Modules ⚡️
 
 modules:
@@ -506,3 +553,11 @@ modules:
     owner: 10gen
     repo: mothra
     branch: main
+  - name: dsi
+    owner: 10gen
+    repo: dsi
+    branch: master
+  - name: PrivateWorkloads
+    owner: 10gen
+    repo: PrivateWorkloads
+    branch: production

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -533,7 +533,8 @@ functions:
 
             if [ $exitCode -ne 0 ]; then
               echo -e '\033[31mThe auto-generated genny task files are not up to date!\033[0m'
-              echo -e '\033[31mThis typically happens if you are adding a new genny test, update the AutoRun section of a test, or someone added a new variant in DSI and did not regenerate the files.\033[0m'
+              echo -e '\033[31mThis typically happens if you are adding a new genny test,\033[0m'
+              echo -e '\033[31mupdate the AutoRun section of a test, or someone added a new variant in DSI and did not regenerate the files.\033[0m'
               echo -e '\033[31mTo resolve this issue, please run ./run-genny auto-tasks-local and commit the new files in the evergreen folder.\033[0m'
               exit 1
             fi

--- a/evergreen/system_perf/5.0/genny_tasks.yml
+++ b/evergreen/system_perf/5.0/genny_tasks.yml
@@ -1,0 +1,2778 @@
+buildvariants:
+- name: perf-atlas-M60-real.arm.aws.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-atlas-M60-real.intel.azure.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-3-shard.arm.aws.2023-11
+  tasks:
+  - name: aggregations_output
+  - name: graph_lookup
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup
+  - name: lookup_colocated_data
+  - name: lookup_with_only_unsharded_colls
+  - name: ten_m_doc_collection__object_id__sharded
+  - name: reshard_collection_mixed
+  - name: reshard_collection_read_heavy
+  - name: multi_updates_multi_updates__shard_collection
+  - name: multi_updates_multi_updates
+- name: perf-3-node-replSet.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+- name: perf-3-node-replSet-intel.intel.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+tasks:
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      test_control: device_monitoring
+  name: device_monitoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      test_control: coinbase_timeseries_group_date_trunc
+  name: coinbase_timeseries_group_date_trunc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      test_control: coinbase_timeseries_group_date_trunc_memory_limit
+  name: coinbase_timeseries_group_date_trunc_memory_limit
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      test_control: coinbase_timeseries_group_date_trunc_sort
+  name: coinbase_timeseries_group_date_trunc_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      test_control: coinbase_timeseries_match
+  name: coinbase_timeseries_match
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      test_control: coinbase_timeseries_match_count
+  name: coinbase_timeseries_match_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      test_control: coinbase_timeseries_query01
+  name: coinbase_timeseries_query01
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      test_control: coinbase_timeseries_query02
+  name: coinbase_timeseries_query02
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      test_control: coinbase_timeseries_query03
+  name: coinbase_timeseries_query03
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/basic/ReadOnlyMultiThreaded.yml
+      test_control: read_only_multi_threaded
+  name: read_only_multi_threaded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica
+      test_control: parallel_insert_replica
+  name: parallel_insert_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: parallel_insert_replica_delay_mixed
+  name: parallel_insert_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/ExponentialCompact.yml
+      test_control: exponential_compact
+  name: exponential_compact
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16.yml
+      test_control: ycsb_like_queryable_encrypt1_cf16
+  name: ycsb_like_queryable_encrypt1_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32.yml
+      test_control: ycsb_like_queryable_encrypt1_cf32
+  name: ycsb_like_queryable_encrypt1_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt1_cfdefault
+  name: ycsb_like_queryable_encrypt1_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16.yml
+      test_control: ycsb_like_queryable_encrypt5_cf16
+  name: ycsb_like_queryable_encrypt5_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32.yml
+      test_control: ycsb_like_queryable_encrypt5_cf32
+  name: ycsb_like_queryable_encrypt5_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt5_cfdefault
+  name: ycsb_like_queryable_encrypt5_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0-unencrypted.yml
+      test_control: medical_workload_diagnosis_100_0_unencrypted
+  name: medical_workload_diagnosis_100_0_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0.yml
+      test_control: medical_workload_diagnosis_100_0
+  name: medical_workload_diagnosis_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50-unencrypted.yml
+      test_control: medical_workload_diagnosis_50_50_unencrypted
+  name: medical_workload_diagnosis_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50.yml
+      test_control: medical_workload_diagnosis_50_50
+  name: medical_workload_diagnosis_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50-unencrypted.yml
+      test_control: medical_workload_guid_50_50_unencrypted
+  name: medical_workload_guid_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50.yml
+      test_control: medical_workload_guid_50_50
+  name: medical_workload_guid_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load-unencrypted.yml
+      test_control: medical_workload_load_unencrypted
+  name: medical_workload_load_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load.yml
+      test_control: medical_workload_load
+  name: medical_workload_load
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-100-0.yml
+      test_control: qe_range_age_100_0
+  name: qe_range_age_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-50-50.yml
+      test_control: qe_range_age_50_50
+  name: qe_range_age_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-100-0.yml
+      test_control: qe_range_balance_100_0
+  name: qe_range_balance_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-50-50.yml
+      test_control: qe_range_balance_50_50
+  name: qe_range_balance_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-100-0.yml
+      test_control: qe_range_timestamp_100_0
+  name: qe_range_timestamp_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-50-50.yml
+      test_control: qe_range_timestamp_50_50
+  name: qe_range_timestamp_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundIndexConstruction.yml
+      test_control: background_index_construction
+  name: background_index_construction
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundTTLDeletions.yml
+      test_control: background_ttl_deletions
+  name: background_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundValidateCmd.yml
+      test_control: background_validate_cmd
+  name: background_validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollection.yml
+      test_control: clustered_collection
+  name: clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+      test_control: clustered_collection_large_record_ids
+  name: clustered_collection_large_record_ids
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/CreateBigIndex.yml
+      test_control: create_big_index
+  name: create_big_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatched.yml
+      test_control: mixed_multi_deletes_batched
+  name: mixed_multi_deletes_batched
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatchedWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_batched_with_secondary_indexes
+  name: mixed_multi_deletes_batched_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDoc.yml
+      test_control: mixed_multi_deletes_doc_by_doc
+  name: mixed_multi_deletes_doc_by_doc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDocWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MultiPlanning.yml
+      test_control: multi_planning
+  name: multi_planning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/PingCommand.yml
+      test_control: ping_command
+  name: ping_command
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SecondaryReadsGenny.yml
+      test_control: secondary_reads_genny
+  name: secondary_reads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SinusoidalReadWrites.yml
+      test_control: sinusoidal_read_writes
+  name: sinusoidal_read_writes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesArbitraryUpdate.yml
+      test_control: time_series_arbitrary_update
+  name: time_series_arbitrary_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesRangeDelete.yml
+      test_control: time_series_range_delete
+  name: time_series_range_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/UpdateWithSecondaryIndexes.yml
+      test_control: update_with_secondary_indexes
+  name: update_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmd.yml
+      test_control: validate_cmd
+  name: validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmdFull.yml
+      test_control: validate_cmd_full
+  name: validate_cmd_full
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/filesystem/Flushing.yml
+      test_control: flushing
+  name: flushing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionPoolStress.yml
+      test_control: connection_pool_stress
+  name: connection_pool_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionsBuildup.yml
+      test_control: connections_buildup
+  name: connections_buildup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/MongosLatency.yml
+      test_control: mongos_latency
+  name: mongos_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatency.yml
+      test_control: commit_latency
+  name: commit_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatencySingleUpdate.yml
+      test_control: commit_latency_single_update
+  name: commit_latency_single_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/ServiceArchitectureWorkloads.yml
+      test_control: service_architecture_workloads
+  name: service_architecture_workloads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/TransportLayerConnectTiming.yml
+      test_control: transport_layer_connect_timing
+  name: transport_layer_connect_timing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregateExpressions.yml
+      test_control: aggregate_expressions
+  name: aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregationsOutput.yml
+      test_control: aggregations_output
+  name: aggregations_output
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ArrayTraversal.yml
+      test_control: array_traversal
+  name: array_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifier.yml
+      test_control: boolean_simplifier
+  name: boolean_simplifier
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifierSmallDataset.yml
+      test_control: boolean_simplifier_small_dataset
+  name: boolean_simplifier_small_dataset
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsDelete.yml
+      test_control: cpu_cycle_metrics_delete
+  name: cpu_cycle_metrics_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsFind.yml
+      test_control: cpu_cycle_metrics_find
+  name: cpu_cycle_metrics_find
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsInsert.yml
+      test_control: cpu_cycle_metrics_insert
+  name: cpu_cycle_metrics_insert
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsUpdate.yml
+      test_control: cpu_cycle_metrics_update
+  name: cpu_cycle_metrics_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateLarge.yml
+      test_control: coll_scan_complex_predicate_large
+  name: coll_scan_complex_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateMedium.yml
+      test_control: coll_scan_complex_predicate_medium
+  name: coll_scan_complex_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateSmall.yml
+      test_control: coll_scan_complex_predicate_small
+  name: coll_scan_complex_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
+      test_control: coll_scan_large_number_of_fields_large
+  name: coll_scan_large_number_of_fields_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
+      test_control: coll_scan_large_number_of_fields_medium
+  name: coll_scan_large_number_of_fields_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+      test_control: coll_scan_large_number_of_fields_small
+  name: coll_scan_large_number_of_fields_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
+      test_control: coll_scan_on_mixed_data_types_large
+  name: coll_scan_on_mixed_data_types_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
+      test_control: coll_scan_on_mixed_data_types_medium
+  name: coll_scan_on_mixed_data_types_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
+      test_control: coll_scan_on_mixed_data_types_small
+  name: coll_scan_on_mixed_data_types_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityLarge.yml
+      test_control: coll_scan_predicate_selectivity_large
+  name: coll_scan_predicate_selectivity_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityMedium.yml
+      test_control: coll_scan_predicate_selectivity_medium
+  name: coll_scan_predicate_selectivity_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivitySmall.yml
+      test_control: coll_scan_predicate_selectivity_small
+  name: coll_scan_predicate_selectivity_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionLarge.yml
+      test_control: coll_scan_projection_large
+  name: coll_scan_projection_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionMedium.yml
+      test_control: coll_scan_projection_medium
+  name: coll_scan_projection_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionSmall.yml
+      test_control: coll_scan_projection_small
+  name: coll_scan_projection_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+      test_control: coll_scan_simplifiable_predicate_large
+  name: coll_scan_simplifiable_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+      test_control: coll_scan_simplifiable_predicate_medium
+  name: coll_scan_simplifiable_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+      test_control: coll_scan_simplifiable_predicate_small
+  name: coll_scan_simplifiable_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollectionLevelDiagnosticCommands.yml
+      test_control: collection_level_diagnostic_commands
+  name: collection_level_diagnostic_commands
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ConstantFoldArithmetic.yml
+      test_control: constant_fold_arithmetic
+  name: constant_fold_arithmetic
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
+      test_control: csi_fragmented_inserts_flat
+  name: csi_fragmented_inserts_flat
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
+      test_control: csi_fragmented_inserts_nested
+  name: csi_fragmented_inserts_nested
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
+      test_control: cumulative_windows
+  name: cumulative_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindowsMultiAccums.yml
+      test_control: cumulative_windows_multi_accums
+  name: cumulative_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyFillCombo.yml
+      test_control: densify_fill_combo
+  name: densify_fill_combo
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyHours.yml
+      test_control: densify_hours
+  name: densify_hours
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMilliseconds.yml
+      test_control: densify_milliseconds
+  name: densify_milliseconds
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMonths.yml
+      test_control: densify_months
+  name: densify_months
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyNumeric.yml
+      test_control: densify_numeric
+  name: densify_numeric
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyTimeseriesCollection.yml
+      test_control: densify_timeseries_collection
+  name: densify_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExpressiveQueries.yml
+      test_control: expressive_queries
+  name: expressive_queries
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExternalSort.yml
+      test_control: external_sort
+  name: external_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FillTimeseriesCollection.yml
+      test_control: fill_timeseries_collection
+  name: fill_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpression.yml
+      test_control: filter_with_complex_logical_expression
+  name: filter_with_complex_logical_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
+      test_control: filter_with_complex_logical_expression_medium
+  name: filter_with_complex_logical_expression_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
+      test_control: filter_with_complex_logical_expression_small
+  name: filter_with_complex_logical_expression_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookup.yml
+      test_control: graph_lookup
+  name: graph_lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+      test_control: graph_lookup_with_only_unsharded_colls
+  name: graph_lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupLikeDistinct.yml
+      test_control: group_like_distinct
+  name: group_like_distinct
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupSpillToDisk.yml
+      test_control: group_spill_to_disk
+  name: group_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupStagesOnComputedFields.yml
+      test_control: group_stages_on_computed_fields
+  name: group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/InWithVariedArraySize.yml
+      test_control: in_with_varied_array_size
+  name: in_with_varied_array_size
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LimitSkip.yml
+      test_control: limit_skip
+  name: limit_skip
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/Lookup.yml
+      test_control: lookup
+  name: lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupColocatedData.yml
+      test_control: lookup_colocated_data
+  name: lookup_colocated_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupNLJ.yml
+      test_control: lookup_nlj
+  name: lookup_nlj
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupOnly.yml
+      test_control: lookup_only
+  name: lookup_only
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdown.yml
+      test_control: lookup_sbe_pushdown
+  name: lookup_sbe_pushdown
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+      test_control: lookup_sbe_pushdown_inlj_misc
+  name: lookup_sbe_pushdown_inlj_misc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupUnwind.yml
+      test_control: lookup_unwind
+  name: lookup_unwind
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+      test_control: lookup_with_only_unsharded_colls
+  name: lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFilters.yml
+      test_control: match_filters
+  name: match_filters
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersMedium.yml
+      test_control: match_filters_medium
+  name: match_filters_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersSmall.yml
+      test_control: match_filters_small
+  name: match_filters_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchWithLargeExpression.yml
+      test_control: match_with_large_expression
+  name: match_with_large_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+      test_control: metric_secondary_index_timeseries_collection
+  name: metric_secondary_index_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/NonSearchHybridScoring.yml
+      test_control: non_search_hybrid_scoring
+  name: non_search_hybrid_scoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+      test_control: one_m_doc_collection__large_doc_int_id
+  name: one_m_doc_collection__large_doc_int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesAgg.yml
+      test_control: percentiles_agg
+  name: percentiles_agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesExpr.yml
+      test_control: percentiles_expr
+  name: percentiles_expr
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindow.yml
+      test_control: percentiles_window
+  name: percentiles_window
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindowSpillToDisk.yml
+      test_control: percentiles_window_spill_to_disk
+  name: percentiles_window_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PipelineUpdate.yml
+      test_control: pipeline_update
+  name: pipeline_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ProjectParse.yml
+      test_control: project_parse
+  name: project_parse
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStats.yml
+      test_control: query_stats
+  name: query_stats
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStatsQueryShapes.yml
+      test_control: query_stats_query_shapes
+  name: query_stats_query_shapes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversal.yml
+      test_control: repeated_path_traversal
+  name: repeated_path_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalMedium.yml
+      test_control: repeated_path_traversal_medium
+  name: repeated_path_traversal_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalSmall.yml
+      test_control: repeated_path_traversal_small
+  name: repeated_path_traversal_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SetWindowFieldsUnbounded.yml
+      test_control: set_window_fields_unbounded
+  name: set_window_fields_unbounded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ShardFilter.yml
+      test_control: shard_filter
+  name: shard_filter
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindows.yml
+      test_control: sliding_windows
+  name: sliding_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindowsMultiAccums.yml
+      test_control: sliding_windows_multi_accums
+  name: sliding_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SortByExpression.yml
+      test_control: sort_by_expression
+  name: sort_by_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId.yml
+      test_control: ten_m_doc_collection__int_id
+  name: ten_m_doc_collection__int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+      test_control: ten_m_doc_collection__int_id__agg
+  name: ten_m_doc_collection__int_id__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+      test_control: ten_m_doc_collection__int_id__identity_view
+  name: ten_m_doc_collection__int_id__identity_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+      test_control: ten_m_doc_collection__int_id__identity_view__agg
+  name: ten_m_doc_collection__int_id__identity_view__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId.yml
+      test_control: ten_m_doc_collection__object_id
+  name: ten_m_doc_collection__object_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+      test_control: ten_m_doc_collection__object_id__sharded
+  name: ten_m_doc_collection__object_id__sharded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_SubDocId.yml
+      test_control: ten_m_doc_collection__sub_doc_id
+  name: ten_m_doc_collection__sub_doc_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeries2dsphere.yml
+      test_control: time_series2dsphere
+  name: time_series2dsphere
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
+      test_control: time_series_group_stages_on_computed_fields
+  name: time_series_group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
+      test_control: time_series_lastpoint
+  name: time_series_lastpoint
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
+      test_control: time_series_sort
+  name: time_series_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortCompound.yml
+      test_control: time_series_sort_compound
+  name: time_series_sort_compound
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
+      test_control: time_series_sort_overlapping_buckets
+  name: time_series_sort_overlapping_buckets
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesTelemetry.yml
+      test_control: time_series_telemetry
+  name: time_series_telemetry
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesBlockProcessing.yml
+      test_control: timeseries_block_processing
+  name: timeseries_block_processing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesCount.yml
+      test_control: timeseries_count
+  name: timeseries_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesEnum.yml
+      test_control: timeseries_enum
+  name: timeseries_enum
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesStressUnpacking.yml
+      test_control: timeseries_stress_unpacking
+  name: timeseries_stress_unpacking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnionWith.yml
+      test_control: union_with
+  name: union_with
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnwindGroup.yml
+      test_control: unwind_group
+  name: unwind_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UpdateLargeDocuments.yml
+      test_control: update_large_documents
+  name: update_large_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/VariadicAggregateExpressions.yml
+      test_control: variadic_aggregate_expressions
+  name: variadic_aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithComplexPartitionExpression.yml
+      test_control: window_with_complex_partition_expression
+  name: window_with_complex_partition_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithNestedFieldProjection.yml
+      test_control: window_with_nested_field_projection
+  name: window_with_nested_field_projection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/linearFill.yml
+      test_control: linear_fill
+  name: linear_fill
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/locf.yml
+      test_control: locf
+  name: locf
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/BlockingSort.yml
+      test_control: multiplanner_blocking_sort
+  name: multiplanner_blocking_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ClusteredCollection.yml
+      test_control: multiplanner_clustered_collection
+  name: multiplanner_clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/CompoundIndexes.yml
+      test_control: multiplanner_compound_indexes
+  name: multiplanner_compound_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+      test_control: multiplanner_many_index_seeks
+  name: multiplanner_many_index_seeks
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+      test_control: multiplanner_multi_planning_reads_a_lot_of_data
+  name: multiplanner_multi_planning_reads_a_lot_of_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultikeyIndexes.yml
+      test_control: multiplanner_multikey_indexes
+  name: multiplanner_multikey_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+      test_control: multiplanner_multiplanner_with_group
+  name: multiplanner_multiplanner_with_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoResults.yml
+      test_control: multiplanner_no_results
+  name: multiplanner_no_results
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoSuchField.yml
+      test_control: multiplanner_no_such_field
+  name: multiplanner_no_such_field
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+      test_control: multiplanner_non_blocking_vs_blocking
+  name: multiplanner_non_blocking_vs_blocking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Simple.yml
+      test_control: multiplanner_simple
+  name: multiplanner_simple
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Subplanning.yml
+      test_control: multiplanner_subplanning
+  name: multiplanner_subplanning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/UseClusteredIndex.yml
+      test_control: multiplanner_use_clustered_index
+  name: multiplanner_use_clustered_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/VariedSelectivity.yml
+      test_control: multiplanner_varied_selectivity
+  name: multiplanner_varied_selectivity
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/EmptyGroup.yml
+      test_control: plan_cache_empty_group
+  name: plan_cache_empty_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+      test_control: plan_cache_match_eq_varying_array
+  name: plan_cache_match_eq_varying_array
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BigUpdate.yml
+      test_control: big_update
+  name: big_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BulkLoading.yml
+      test_control: bulk_loading
+  name: bulk_loading
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ContentionTTLDeletions.yml
+      test_control: contention_ttl_deletions
+  name: contention_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/CreateDropView.yml
+      test_control: create_drop_view
+  name: create_drop_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InCacheSnapshotReads.yml
+      test_control: in_cache_snapshot_reads
+  name: in_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertBigDocs.yml
+      test_control: insert_big_docs
+  name: insert_big_docs
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertRemove.yml
+      test_control: insert_remove
+  name: insert_remove
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedIns.yml
+      test_control: large_indexed_ins
+  name: large_indexed_ins
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedInsMatchingDocuments.yml
+      test_control: large_indexed_ins_matching_documents
+  name: large_indexed_ins_matching_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeScaleLongLived.yml
+      test_control: large_scale_long_lived
+  name: large_scale_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LoadTest.yml
+      test_control: load_test
+  name: load_test
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MajorityWrites10KThreads.yml
+      test_control: majority_writes10_k_threads
+  name: majority_writes10_k_threads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ManyUpdate.yml
+      test_control: many_update
+  name: many_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MassDeleteRegression.yml
+      test_control: mass_delete_regression
+  name: mass_delete_regression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGenny.yml
+      test_control: mixed_workloads_genny
+  name: mixed_workloads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+      test_control: mixed_workloads_genny_rate_limited
+  name: mixed_workloads_genny_rate_limited
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStress.yml
+      test_control: mixed_workloads_genny_stress
+  name: mixed_workloads_genny_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
+      test_control: mixed_workloads_genny_stress_with_scans
+  name: mixed_workloads_genny_stress_with_scans
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica
+      test_control: mixed_writes_replica
+  name: mixed_writes_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: mixed_writes_replica_delay_mixed
+  name: mixed_writes_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheScanner.yml
+      test_control: out_of_cache_scanner
+  name: out_of_cache_scanner
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheSnapshotReads.yml
+      test_control: out_of_cache_snapshot_reads
+  name: out_of_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ScanWithLongLived.yml
+      test_control: scan_with_long_lived
+  name: scan_with_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/TimeSeriesSortScale.yml
+      test_control: time_series_sort_scale
+  name: time_series_sort_scale
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/selftests/GennyOverhead.yml
+      test_control: genny_overhead
+  name: genny_overhead
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: batched_update_one_without_shard_key_with_id
+  name: batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: bulk_write_batched_update_one_without_shard_key_with_id
+  name: bulk_write_batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactions.yml
+      test_control: multi_shard_transactions
+  name: multi_shard_transactions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactionsWithManyNamespaces.yml
+      test_control: multi_shard_transactions_with_many_namespaces
+  name: multi_shard_transactions_with_many_namespaces
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollection.yml
+      test_control: reshard_collection
+  name: reshard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionMixed.yml
+      test_control: reshard_collection_mixed
+  name: reshard_collection_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+      test_control: reshard_collection_read_heavy
+  name: reshard_collection_read_heavy
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+      test_control: would_change_owning_shard_batch_write
+  name: would_change_owning_shard_batch_write
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneReplicaSet.yml
+      test_control: write_one_replica_set
+  name: write_one_replica_set
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyShardedCollection.yml
+      test_control: write_one_without_shard_key_sharded_collection
+  name: write_one_without_shard_key_sharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyUnshardedCollection.yml
+      test_control: write_one_without_shard_key_unsharded_collection
+  name: write_one_without_shard_key_unsharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations-ShardCollection.yml
+      test_control: multi_updates_multi_updates__pause_migrations__shard_collection
+  name: multi_updates_multi_updates__pause_migrations__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations.yml
+      test_control: multi_updates_multi_updates__pause_migrations
+  name: multi_updates_multi_updates__pause_migrations
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-ShardCollection.yml
+      test_control: multi_updates_multi_updates__shard_collection
+  name: multi_updates_multi_updates__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates.yml
+      test_control: multi_updates_multi_updates
+  name: multi_updates_multi_updates
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixed.yml
+      test_control: llt_mixed
+  name: llt_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixedSmall.yml
+      test_control: llt_mixed_small
+  name: llt_mixed_small
+  priority: 5

--- a/evergreen/system_perf/5.0/genny_tasks.yml
+++ b/evergreen/system_perf/5.0/genny_tasks.yml
@@ -1263,28 +1263,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
-      test_control: csi_fragmented_inserts_flat
-  name: csi_fragmented_inserts_flat
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
-      test_control: csi_fragmented_inserts_nested
-  name: csi_fragmented_inserts_nested
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
       test_control: cumulative_windows
   name: cumulative_windows

--- a/evergreen/system_perf/5.0/genny_tasks.yml
+++ b/evergreen/system_perf/5.0/genny_tasks.yml
@@ -282,7 +282,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
       test_control: device_monitoring
   name: device_monitoring
   priority: 5
@@ -293,7 +293,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
       test_control: coinbase_timeseries_group_date_trunc
   name: coinbase_timeseries_group_date_trunc
   priority: 5
@@ -304,7 +304,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
       test_control: coinbase_timeseries_group_date_trunc_memory_limit
   name: coinbase_timeseries_group_date_trunc_memory_limit
   priority: 5
@@ -315,7 +315,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
       test_control: coinbase_timeseries_group_date_trunc_sort
   name: coinbase_timeseries_group_date_trunc_sort
   priority: 5
@@ -326,7 +326,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
       test_control: coinbase_timeseries_match
   name: coinbase_timeseries_match
   priority: 5
@@ -337,7 +337,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
       test_control: coinbase_timeseries_match_count
   name: coinbase_timeseries_match_count
   priority: 5
@@ -348,7 +348,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
       test_control: coinbase_timeseries_query01
   name: coinbase_timeseries_query01
   priority: 5
@@ -359,7 +359,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
       test_control: coinbase_timeseries_query02
   name: coinbase_timeseries_query02
   priority: 5
@@ -370,7 +370,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
       test_control: coinbase_timeseries_query03
   name: coinbase_timeseries_query03
   priority: 5

--- a/evergreen/system_perf/6.0/genny_tasks.yml
+++ b/evergreen/system_perf/6.0/genny_tasks.yml
@@ -1,0 +1,2778 @@
+buildvariants:
+- name: perf-atlas-M60-real.arm.aws.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-atlas-M60-real.intel.azure.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-3-shard.arm.aws.2023-11
+  tasks:
+  - name: aggregations_output
+  - name: graph_lookup
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup
+  - name: lookup_colocated_data
+  - name: lookup_with_only_unsharded_colls
+  - name: ten_m_doc_collection__object_id__sharded
+  - name: reshard_collection_mixed
+  - name: reshard_collection_read_heavy
+  - name: multi_updates_multi_updates__shard_collection
+  - name: multi_updates_multi_updates
+- name: perf-3-node-replSet.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+- name: perf-3-node-replSet-intel.intel.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+tasks:
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      test_control: device_monitoring
+  name: device_monitoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      test_control: coinbase_timeseries_group_date_trunc
+  name: coinbase_timeseries_group_date_trunc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      test_control: coinbase_timeseries_group_date_trunc_memory_limit
+  name: coinbase_timeseries_group_date_trunc_memory_limit
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      test_control: coinbase_timeseries_group_date_trunc_sort
+  name: coinbase_timeseries_group_date_trunc_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      test_control: coinbase_timeseries_match
+  name: coinbase_timeseries_match
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      test_control: coinbase_timeseries_match_count
+  name: coinbase_timeseries_match_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      test_control: coinbase_timeseries_query01
+  name: coinbase_timeseries_query01
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      test_control: coinbase_timeseries_query02
+  name: coinbase_timeseries_query02
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      test_control: coinbase_timeseries_query03
+  name: coinbase_timeseries_query03
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/basic/ReadOnlyMultiThreaded.yml
+      test_control: read_only_multi_threaded
+  name: read_only_multi_threaded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica
+      test_control: parallel_insert_replica
+  name: parallel_insert_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: parallel_insert_replica_delay_mixed
+  name: parallel_insert_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/ExponentialCompact.yml
+      test_control: exponential_compact
+  name: exponential_compact
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16.yml
+      test_control: ycsb_like_queryable_encrypt1_cf16
+  name: ycsb_like_queryable_encrypt1_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32.yml
+      test_control: ycsb_like_queryable_encrypt1_cf32
+  name: ycsb_like_queryable_encrypt1_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt1_cfdefault
+  name: ycsb_like_queryable_encrypt1_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16.yml
+      test_control: ycsb_like_queryable_encrypt5_cf16
+  name: ycsb_like_queryable_encrypt5_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32.yml
+      test_control: ycsb_like_queryable_encrypt5_cf32
+  name: ycsb_like_queryable_encrypt5_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt5_cfdefault
+  name: ycsb_like_queryable_encrypt5_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0-unencrypted.yml
+      test_control: medical_workload_diagnosis_100_0_unencrypted
+  name: medical_workload_diagnosis_100_0_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0.yml
+      test_control: medical_workload_diagnosis_100_0
+  name: medical_workload_diagnosis_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50-unencrypted.yml
+      test_control: medical_workload_diagnosis_50_50_unencrypted
+  name: medical_workload_diagnosis_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50.yml
+      test_control: medical_workload_diagnosis_50_50
+  name: medical_workload_diagnosis_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50-unencrypted.yml
+      test_control: medical_workload_guid_50_50_unencrypted
+  name: medical_workload_guid_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50.yml
+      test_control: medical_workload_guid_50_50
+  name: medical_workload_guid_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load-unencrypted.yml
+      test_control: medical_workload_load_unencrypted
+  name: medical_workload_load_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load.yml
+      test_control: medical_workload_load
+  name: medical_workload_load
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-100-0.yml
+      test_control: qe_range_age_100_0
+  name: qe_range_age_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-50-50.yml
+      test_control: qe_range_age_50_50
+  name: qe_range_age_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-100-0.yml
+      test_control: qe_range_balance_100_0
+  name: qe_range_balance_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-50-50.yml
+      test_control: qe_range_balance_50_50
+  name: qe_range_balance_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-100-0.yml
+      test_control: qe_range_timestamp_100_0
+  name: qe_range_timestamp_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-50-50.yml
+      test_control: qe_range_timestamp_50_50
+  name: qe_range_timestamp_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundIndexConstruction.yml
+      test_control: background_index_construction
+  name: background_index_construction
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundTTLDeletions.yml
+      test_control: background_ttl_deletions
+  name: background_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundValidateCmd.yml
+      test_control: background_validate_cmd
+  name: background_validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollection.yml
+      test_control: clustered_collection
+  name: clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+      test_control: clustered_collection_large_record_ids
+  name: clustered_collection_large_record_ids
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/CreateBigIndex.yml
+      test_control: create_big_index
+  name: create_big_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatched.yml
+      test_control: mixed_multi_deletes_batched
+  name: mixed_multi_deletes_batched
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatchedWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_batched_with_secondary_indexes
+  name: mixed_multi_deletes_batched_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDoc.yml
+      test_control: mixed_multi_deletes_doc_by_doc
+  name: mixed_multi_deletes_doc_by_doc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDocWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MultiPlanning.yml
+      test_control: multi_planning
+  name: multi_planning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/PingCommand.yml
+      test_control: ping_command
+  name: ping_command
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SecondaryReadsGenny.yml
+      test_control: secondary_reads_genny
+  name: secondary_reads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SinusoidalReadWrites.yml
+      test_control: sinusoidal_read_writes
+  name: sinusoidal_read_writes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesArbitraryUpdate.yml
+      test_control: time_series_arbitrary_update
+  name: time_series_arbitrary_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesRangeDelete.yml
+      test_control: time_series_range_delete
+  name: time_series_range_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/UpdateWithSecondaryIndexes.yml
+      test_control: update_with_secondary_indexes
+  name: update_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmd.yml
+      test_control: validate_cmd
+  name: validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmdFull.yml
+      test_control: validate_cmd_full
+  name: validate_cmd_full
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/filesystem/Flushing.yml
+      test_control: flushing
+  name: flushing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionPoolStress.yml
+      test_control: connection_pool_stress
+  name: connection_pool_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionsBuildup.yml
+      test_control: connections_buildup
+  name: connections_buildup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/MongosLatency.yml
+      test_control: mongos_latency
+  name: mongos_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatency.yml
+      test_control: commit_latency
+  name: commit_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatencySingleUpdate.yml
+      test_control: commit_latency_single_update
+  name: commit_latency_single_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/ServiceArchitectureWorkloads.yml
+      test_control: service_architecture_workloads
+  name: service_architecture_workloads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/TransportLayerConnectTiming.yml
+      test_control: transport_layer_connect_timing
+  name: transport_layer_connect_timing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregateExpressions.yml
+      test_control: aggregate_expressions
+  name: aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregationsOutput.yml
+      test_control: aggregations_output
+  name: aggregations_output
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ArrayTraversal.yml
+      test_control: array_traversal
+  name: array_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifier.yml
+      test_control: boolean_simplifier
+  name: boolean_simplifier
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifierSmallDataset.yml
+      test_control: boolean_simplifier_small_dataset
+  name: boolean_simplifier_small_dataset
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsDelete.yml
+      test_control: cpu_cycle_metrics_delete
+  name: cpu_cycle_metrics_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsFind.yml
+      test_control: cpu_cycle_metrics_find
+  name: cpu_cycle_metrics_find
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsInsert.yml
+      test_control: cpu_cycle_metrics_insert
+  name: cpu_cycle_metrics_insert
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsUpdate.yml
+      test_control: cpu_cycle_metrics_update
+  name: cpu_cycle_metrics_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateLarge.yml
+      test_control: coll_scan_complex_predicate_large
+  name: coll_scan_complex_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateMedium.yml
+      test_control: coll_scan_complex_predicate_medium
+  name: coll_scan_complex_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateSmall.yml
+      test_control: coll_scan_complex_predicate_small
+  name: coll_scan_complex_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
+      test_control: coll_scan_large_number_of_fields_large
+  name: coll_scan_large_number_of_fields_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
+      test_control: coll_scan_large_number_of_fields_medium
+  name: coll_scan_large_number_of_fields_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+      test_control: coll_scan_large_number_of_fields_small
+  name: coll_scan_large_number_of_fields_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
+      test_control: coll_scan_on_mixed_data_types_large
+  name: coll_scan_on_mixed_data_types_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
+      test_control: coll_scan_on_mixed_data_types_medium
+  name: coll_scan_on_mixed_data_types_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
+      test_control: coll_scan_on_mixed_data_types_small
+  name: coll_scan_on_mixed_data_types_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityLarge.yml
+      test_control: coll_scan_predicate_selectivity_large
+  name: coll_scan_predicate_selectivity_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityMedium.yml
+      test_control: coll_scan_predicate_selectivity_medium
+  name: coll_scan_predicate_selectivity_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivitySmall.yml
+      test_control: coll_scan_predicate_selectivity_small
+  name: coll_scan_predicate_selectivity_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionLarge.yml
+      test_control: coll_scan_projection_large
+  name: coll_scan_projection_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionMedium.yml
+      test_control: coll_scan_projection_medium
+  name: coll_scan_projection_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionSmall.yml
+      test_control: coll_scan_projection_small
+  name: coll_scan_projection_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+      test_control: coll_scan_simplifiable_predicate_large
+  name: coll_scan_simplifiable_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+      test_control: coll_scan_simplifiable_predicate_medium
+  name: coll_scan_simplifiable_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+      test_control: coll_scan_simplifiable_predicate_small
+  name: coll_scan_simplifiable_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollectionLevelDiagnosticCommands.yml
+      test_control: collection_level_diagnostic_commands
+  name: collection_level_diagnostic_commands
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ConstantFoldArithmetic.yml
+      test_control: constant_fold_arithmetic
+  name: constant_fold_arithmetic
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
+      test_control: csi_fragmented_inserts_flat
+  name: csi_fragmented_inserts_flat
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
+      test_control: csi_fragmented_inserts_nested
+  name: csi_fragmented_inserts_nested
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
+      test_control: cumulative_windows
+  name: cumulative_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindowsMultiAccums.yml
+      test_control: cumulative_windows_multi_accums
+  name: cumulative_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyFillCombo.yml
+      test_control: densify_fill_combo
+  name: densify_fill_combo
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyHours.yml
+      test_control: densify_hours
+  name: densify_hours
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMilliseconds.yml
+      test_control: densify_milliseconds
+  name: densify_milliseconds
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMonths.yml
+      test_control: densify_months
+  name: densify_months
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyNumeric.yml
+      test_control: densify_numeric
+  name: densify_numeric
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyTimeseriesCollection.yml
+      test_control: densify_timeseries_collection
+  name: densify_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExpressiveQueries.yml
+      test_control: expressive_queries
+  name: expressive_queries
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExternalSort.yml
+      test_control: external_sort
+  name: external_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FillTimeseriesCollection.yml
+      test_control: fill_timeseries_collection
+  name: fill_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpression.yml
+      test_control: filter_with_complex_logical_expression
+  name: filter_with_complex_logical_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
+      test_control: filter_with_complex_logical_expression_medium
+  name: filter_with_complex_logical_expression_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
+      test_control: filter_with_complex_logical_expression_small
+  name: filter_with_complex_logical_expression_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookup.yml
+      test_control: graph_lookup
+  name: graph_lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+      test_control: graph_lookup_with_only_unsharded_colls
+  name: graph_lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupLikeDistinct.yml
+      test_control: group_like_distinct
+  name: group_like_distinct
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupSpillToDisk.yml
+      test_control: group_spill_to_disk
+  name: group_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupStagesOnComputedFields.yml
+      test_control: group_stages_on_computed_fields
+  name: group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/InWithVariedArraySize.yml
+      test_control: in_with_varied_array_size
+  name: in_with_varied_array_size
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LimitSkip.yml
+      test_control: limit_skip
+  name: limit_skip
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/Lookup.yml
+      test_control: lookup
+  name: lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupColocatedData.yml
+      test_control: lookup_colocated_data
+  name: lookup_colocated_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupNLJ.yml
+      test_control: lookup_nlj
+  name: lookup_nlj
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupOnly.yml
+      test_control: lookup_only
+  name: lookup_only
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdown.yml
+      test_control: lookup_sbe_pushdown
+  name: lookup_sbe_pushdown
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+      test_control: lookup_sbe_pushdown_inlj_misc
+  name: lookup_sbe_pushdown_inlj_misc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupUnwind.yml
+      test_control: lookup_unwind
+  name: lookup_unwind
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+      test_control: lookup_with_only_unsharded_colls
+  name: lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFilters.yml
+      test_control: match_filters
+  name: match_filters
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersMedium.yml
+      test_control: match_filters_medium
+  name: match_filters_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersSmall.yml
+      test_control: match_filters_small
+  name: match_filters_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchWithLargeExpression.yml
+      test_control: match_with_large_expression
+  name: match_with_large_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+      test_control: metric_secondary_index_timeseries_collection
+  name: metric_secondary_index_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/NonSearchHybridScoring.yml
+      test_control: non_search_hybrid_scoring
+  name: non_search_hybrid_scoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+      test_control: one_m_doc_collection__large_doc_int_id
+  name: one_m_doc_collection__large_doc_int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesAgg.yml
+      test_control: percentiles_agg
+  name: percentiles_agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesExpr.yml
+      test_control: percentiles_expr
+  name: percentiles_expr
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindow.yml
+      test_control: percentiles_window
+  name: percentiles_window
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindowSpillToDisk.yml
+      test_control: percentiles_window_spill_to_disk
+  name: percentiles_window_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PipelineUpdate.yml
+      test_control: pipeline_update
+  name: pipeline_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ProjectParse.yml
+      test_control: project_parse
+  name: project_parse
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStats.yml
+      test_control: query_stats
+  name: query_stats
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStatsQueryShapes.yml
+      test_control: query_stats_query_shapes
+  name: query_stats_query_shapes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversal.yml
+      test_control: repeated_path_traversal
+  name: repeated_path_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalMedium.yml
+      test_control: repeated_path_traversal_medium
+  name: repeated_path_traversal_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalSmall.yml
+      test_control: repeated_path_traversal_small
+  name: repeated_path_traversal_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SetWindowFieldsUnbounded.yml
+      test_control: set_window_fields_unbounded
+  name: set_window_fields_unbounded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ShardFilter.yml
+      test_control: shard_filter
+  name: shard_filter
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindows.yml
+      test_control: sliding_windows
+  name: sliding_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindowsMultiAccums.yml
+      test_control: sliding_windows_multi_accums
+  name: sliding_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SortByExpression.yml
+      test_control: sort_by_expression
+  name: sort_by_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId.yml
+      test_control: ten_m_doc_collection__int_id
+  name: ten_m_doc_collection__int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+      test_control: ten_m_doc_collection__int_id__agg
+  name: ten_m_doc_collection__int_id__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+      test_control: ten_m_doc_collection__int_id__identity_view
+  name: ten_m_doc_collection__int_id__identity_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+      test_control: ten_m_doc_collection__int_id__identity_view__agg
+  name: ten_m_doc_collection__int_id__identity_view__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId.yml
+      test_control: ten_m_doc_collection__object_id
+  name: ten_m_doc_collection__object_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+      test_control: ten_m_doc_collection__object_id__sharded
+  name: ten_m_doc_collection__object_id__sharded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_SubDocId.yml
+      test_control: ten_m_doc_collection__sub_doc_id
+  name: ten_m_doc_collection__sub_doc_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeries2dsphere.yml
+      test_control: time_series2dsphere
+  name: time_series2dsphere
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
+      test_control: time_series_group_stages_on_computed_fields
+  name: time_series_group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
+      test_control: time_series_lastpoint
+  name: time_series_lastpoint
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
+      test_control: time_series_sort
+  name: time_series_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortCompound.yml
+      test_control: time_series_sort_compound
+  name: time_series_sort_compound
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
+      test_control: time_series_sort_overlapping_buckets
+  name: time_series_sort_overlapping_buckets
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesTelemetry.yml
+      test_control: time_series_telemetry
+  name: time_series_telemetry
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesBlockProcessing.yml
+      test_control: timeseries_block_processing
+  name: timeseries_block_processing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesCount.yml
+      test_control: timeseries_count
+  name: timeseries_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesEnum.yml
+      test_control: timeseries_enum
+  name: timeseries_enum
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesStressUnpacking.yml
+      test_control: timeseries_stress_unpacking
+  name: timeseries_stress_unpacking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnionWith.yml
+      test_control: union_with
+  name: union_with
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnwindGroup.yml
+      test_control: unwind_group
+  name: unwind_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UpdateLargeDocuments.yml
+      test_control: update_large_documents
+  name: update_large_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/VariadicAggregateExpressions.yml
+      test_control: variadic_aggregate_expressions
+  name: variadic_aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithComplexPartitionExpression.yml
+      test_control: window_with_complex_partition_expression
+  name: window_with_complex_partition_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithNestedFieldProjection.yml
+      test_control: window_with_nested_field_projection
+  name: window_with_nested_field_projection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/linearFill.yml
+      test_control: linear_fill
+  name: linear_fill
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/locf.yml
+      test_control: locf
+  name: locf
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/BlockingSort.yml
+      test_control: multiplanner_blocking_sort
+  name: multiplanner_blocking_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ClusteredCollection.yml
+      test_control: multiplanner_clustered_collection
+  name: multiplanner_clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/CompoundIndexes.yml
+      test_control: multiplanner_compound_indexes
+  name: multiplanner_compound_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+      test_control: multiplanner_many_index_seeks
+  name: multiplanner_many_index_seeks
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+      test_control: multiplanner_multi_planning_reads_a_lot_of_data
+  name: multiplanner_multi_planning_reads_a_lot_of_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultikeyIndexes.yml
+      test_control: multiplanner_multikey_indexes
+  name: multiplanner_multikey_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+      test_control: multiplanner_multiplanner_with_group
+  name: multiplanner_multiplanner_with_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoResults.yml
+      test_control: multiplanner_no_results
+  name: multiplanner_no_results
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoSuchField.yml
+      test_control: multiplanner_no_such_field
+  name: multiplanner_no_such_field
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+      test_control: multiplanner_non_blocking_vs_blocking
+  name: multiplanner_non_blocking_vs_blocking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Simple.yml
+      test_control: multiplanner_simple
+  name: multiplanner_simple
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Subplanning.yml
+      test_control: multiplanner_subplanning
+  name: multiplanner_subplanning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/UseClusteredIndex.yml
+      test_control: multiplanner_use_clustered_index
+  name: multiplanner_use_clustered_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/VariedSelectivity.yml
+      test_control: multiplanner_varied_selectivity
+  name: multiplanner_varied_selectivity
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/EmptyGroup.yml
+      test_control: plan_cache_empty_group
+  name: plan_cache_empty_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+      test_control: plan_cache_match_eq_varying_array
+  name: plan_cache_match_eq_varying_array
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BigUpdate.yml
+      test_control: big_update
+  name: big_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BulkLoading.yml
+      test_control: bulk_loading
+  name: bulk_loading
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ContentionTTLDeletions.yml
+      test_control: contention_ttl_deletions
+  name: contention_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/CreateDropView.yml
+      test_control: create_drop_view
+  name: create_drop_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InCacheSnapshotReads.yml
+      test_control: in_cache_snapshot_reads
+  name: in_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertBigDocs.yml
+      test_control: insert_big_docs
+  name: insert_big_docs
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertRemove.yml
+      test_control: insert_remove
+  name: insert_remove
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedIns.yml
+      test_control: large_indexed_ins
+  name: large_indexed_ins
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedInsMatchingDocuments.yml
+      test_control: large_indexed_ins_matching_documents
+  name: large_indexed_ins_matching_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeScaleLongLived.yml
+      test_control: large_scale_long_lived
+  name: large_scale_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LoadTest.yml
+      test_control: load_test
+  name: load_test
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MajorityWrites10KThreads.yml
+      test_control: majority_writes10_k_threads
+  name: majority_writes10_k_threads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ManyUpdate.yml
+      test_control: many_update
+  name: many_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MassDeleteRegression.yml
+      test_control: mass_delete_regression
+  name: mass_delete_regression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGenny.yml
+      test_control: mixed_workloads_genny
+  name: mixed_workloads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+      test_control: mixed_workloads_genny_rate_limited
+  name: mixed_workloads_genny_rate_limited
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStress.yml
+      test_control: mixed_workloads_genny_stress
+  name: mixed_workloads_genny_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
+      test_control: mixed_workloads_genny_stress_with_scans
+  name: mixed_workloads_genny_stress_with_scans
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica
+      test_control: mixed_writes_replica
+  name: mixed_writes_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: mixed_writes_replica_delay_mixed
+  name: mixed_writes_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheScanner.yml
+      test_control: out_of_cache_scanner
+  name: out_of_cache_scanner
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheSnapshotReads.yml
+      test_control: out_of_cache_snapshot_reads
+  name: out_of_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ScanWithLongLived.yml
+      test_control: scan_with_long_lived
+  name: scan_with_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/TimeSeriesSortScale.yml
+      test_control: time_series_sort_scale
+  name: time_series_sort_scale
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/selftests/GennyOverhead.yml
+      test_control: genny_overhead
+  name: genny_overhead
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: batched_update_one_without_shard_key_with_id
+  name: batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: bulk_write_batched_update_one_without_shard_key_with_id
+  name: bulk_write_batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactions.yml
+      test_control: multi_shard_transactions
+  name: multi_shard_transactions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactionsWithManyNamespaces.yml
+      test_control: multi_shard_transactions_with_many_namespaces
+  name: multi_shard_transactions_with_many_namespaces
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollection.yml
+      test_control: reshard_collection
+  name: reshard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionMixed.yml
+      test_control: reshard_collection_mixed
+  name: reshard_collection_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+      test_control: reshard_collection_read_heavy
+  name: reshard_collection_read_heavy
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+      test_control: would_change_owning_shard_batch_write
+  name: would_change_owning_shard_batch_write
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneReplicaSet.yml
+      test_control: write_one_replica_set
+  name: write_one_replica_set
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyShardedCollection.yml
+      test_control: write_one_without_shard_key_sharded_collection
+  name: write_one_without_shard_key_sharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyUnshardedCollection.yml
+      test_control: write_one_without_shard_key_unsharded_collection
+  name: write_one_without_shard_key_unsharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations-ShardCollection.yml
+      test_control: multi_updates_multi_updates__pause_migrations__shard_collection
+  name: multi_updates_multi_updates__pause_migrations__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations.yml
+      test_control: multi_updates_multi_updates__pause_migrations
+  name: multi_updates_multi_updates__pause_migrations
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-ShardCollection.yml
+      test_control: multi_updates_multi_updates__shard_collection
+  name: multi_updates_multi_updates__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates.yml
+      test_control: multi_updates_multi_updates
+  name: multi_updates_multi_updates
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixed.yml
+      test_control: llt_mixed
+  name: llt_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixedSmall.yml
+      test_control: llt_mixed_small
+  name: llt_mixed_small
+  priority: 5

--- a/evergreen/system_perf/6.0/genny_tasks.yml
+++ b/evergreen/system_perf/6.0/genny_tasks.yml
@@ -1263,28 +1263,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
-      test_control: csi_fragmented_inserts_flat
-  name: csi_fragmented_inserts_flat
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
-      test_control: csi_fragmented_inserts_nested
-  name: csi_fragmented_inserts_nested
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
       test_control: cumulative_windows
   name: cumulative_windows

--- a/evergreen/system_perf/6.0/genny_tasks.yml
+++ b/evergreen/system_perf/6.0/genny_tasks.yml
@@ -282,7 +282,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
       test_control: device_monitoring
   name: device_monitoring
   priority: 5
@@ -293,7 +293,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
       test_control: coinbase_timeseries_group_date_trunc
   name: coinbase_timeseries_group_date_trunc
   priority: 5
@@ -304,7 +304,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
       test_control: coinbase_timeseries_group_date_trunc_memory_limit
   name: coinbase_timeseries_group_date_trunc_memory_limit
   priority: 5
@@ -315,7 +315,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
       test_control: coinbase_timeseries_group_date_trunc_sort
   name: coinbase_timeseries_group_date_trunc_sort
   priority: 5
@@ -326,7 +326,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
       test_control: coinbase_timeseries_match
   name: coinbase_timeseries_match
   priority: 5
@@ -337,7 +337,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
       test_control: coinbase_timeseries_match_count
   name: coinbase_timeseries_match_count
   priority: 5
@@ -348,7 +348,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
       test_control: coinbase_timeseries_query01
   name: coinbase_timeseries_query01
   priority: 5
@@ -359,7 +359,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
       test_control: coinbase_timeseries_query02
   name: coinbase_timeseries_query02
   priority: 5
@@ -370,7 +370,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
       test_control: coinbase_timeseries_query03
   name: coinbase_timeseries_query03
   priority: 5

--- a/evergreen/system_perf/7.0/genny_tasks.yml
+++ b/evergreen/system_perf/7.0/genny_tasks.yml
@@ -1,0 +1,2778 @@
+buildvariants:
+- name: perf-atlas-M60-real.arm.aws.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-atlas-M60-real.intel.azure.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-3-shard.arm.aws.2023-11
+  tasks:
+  - name: aggregations_output
+  - name: graph_lookup
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup
+  - name: lookup_colocated_data
+  - name: lookup_with_only_unsharded_colls
+  - name: ten_m_doc_collection__object_id__sharded
+  - name: reshard_collection_mixed
+  - name: reshard_collection_read_heavy
+  - name: multi_updates_multi_updates__shard_collection
+  - name: multi_updates_multi_updates
+- name: perf-3-node-replSet.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+- name: perf-3-node-replSet-intel.intel.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+tasks:
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      test_control: device_monitoring
+  name: device_monitoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      test_control: coinbase_timeseries_group_date_trunc
+  name: coinbase_timeseries_group_date_trunc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      test_control: coinbase_timeseries_group_date_trunc_memory_limit
+  name: coinbase_timeseries_group_date_trunc_memory_limit
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      test_control: coinbase_timeseries_group_date_trunc_sort
+  name: coinbase_timeseries_group_date_trunc_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      test_control: coinbase_timeseries_match
+  name: coinbase_timeseries_match
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      test_control: coinbase_timeseries_match_count
+  name: coinbase_timeseries_match_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      test_control: coinbase_timeseries_query01
+  name: coinbase_timeseries_query01
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      test_control: coinbase_timeseries_query02
+  name: coinbase_timeseries_query02
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      test_control: coinbase_timeseries_query03
+  name: coinbase_timeseries_query03
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/basic/ReadOnlyMultiThreaded.yml
+      test_control: read_only_multi_threaded
+  name: read_only_multi_threaded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica
+      test_control: parallel_insert_replica
+  name: parallel_insert_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: parallel_insert_replica_delay_mixed
+  name: parallel_insert_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/ExponentialCompact.yml
+      test_control: exponential_compact
+  name: exponential_compact
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16.yml
+      test_control: ycsb_like_queryable_encrypt1_cf16
+  name: ycsb_like_queryable_encrypt1_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32.yml
+      test_control: ycsb_like_queryable_encrypt1_cf32
+  name: ycsb_like_queryable_encrypt1_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt1_cfdefault
+  name: ycsb_like_queryable_encrypt1_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16.yml
+      test_control: ycsb_like_queryable_encrypt5_cf16
+  name: ycsb_like_queryable_encrypt5_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32.yml
+      test_control: ycsb_like_queryable_encrypt5_cf32
+  name: ycsb_like_queryable_encrypt5_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt5_cfdefault
+  name: ycsb_like_queryable_encrypt5_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0-unencrypted.yml
+      test_control: medical_workload_diagnosis_100_0_unencrypted
+  name: medical_workload_diagnosis_100_0_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0.yml
+      test_control: medical_workload_diagnosis_100_0
+  name: medical_workload_diagnosis_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50-unencrypted.yml
+      test_control: medical_workload_diagnosis_50_50_unencrypted
+  name: medical_workload_diagnosis_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50.yml
+      test_control: medical_workload_diagnosis_50_50
+  name: medical_workload_diagnosis_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50-unencrypted.yml
+      test_control: medical_workload_guid_50_50_unencrypted
+  name: medical_workload_guid_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50.yml
+      test_control: medical_workload_guid_50_50
+  name: medical_workload_guid_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load-unencrypted.yml
+      test_control: medical_workload_load_unencrypted
+  name: medical_workload_load_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load.yml
+      test_control: medical_workload_load
+  name: medical_workload_load
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-100-0.yml
+      test_control: qe_range_age_100_0
+  name: qe_range_age_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-50-50.yml
+      test_control: qe_range_age_50_50
+  name: qe_range_age_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-100-0.yml
+      test_control: qe_range_balance_100_0
+  name: qe_range_balance_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-50-50.yml
+      test_control: qe_range_balance_50_50
+  name: qe_range_balance_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-100-0.yml
+      test_control: qe_range_timestamp_100_0
+  name: qe_range_timestamp_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-50-50.yml
+      test_control: qe_range_timestamp_50_50
+  name: qe_range_timestamp_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundIndexConstruction.yml
+      test_control: background_index_construction
+  name: background_index_construction
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundTTLDeletions.yml
+      test_control: background_ttl_deletions
+  name: background_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundValidateCmd.yml
+      test_control: background_validate_cmd
+  name: background_validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollection.yml
+      test_control: clustered_collection
+  name: clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+      test_control: clustered_collection_large_record_ids
+  name: clustered_collection_large_record_ids
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/CreateBigIndex.yml
+      test_control: create_big_index
+  name: create_big_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatched.yml
+      test_control: mixed_multi_deletes_batched
+  name: mixed_multi_deletes_batched
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatchedWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_batched_with_secondary_indexes
+  name: mixed_multi_deletes_batched_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDoc.yml
+      test_control: mixed_multi_deletes_doc_by_doc
+  name: mixed_multi_deletes_doc_by_doc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDocWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MultiPlanning.yml
+      test_control: multi_planning
+  name: multi_planning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/PingCommand.yml
+      test_control: ping_command
+  name: ping_command
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SecondaryReadsGenny.yml
+      test_control: secondary_reads_genny
+  name: secondary_reads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SinusoidalReadWrites.yml
+      test_control: sinusoidal_read_writes
+  name: sinusoidal_read_writes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesArbitraryUpdate.yml
+      test_control: time_series_arbitrary_update
+  name: time_series_arbitrary_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesRangeDelete.yml
+      test_control: time_series_range_delete
+  name: time_series_range_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/UpdateWithSecondaryIndexes.yml
+      test_control: update_with_secondary_indexes
+  name: update_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmd.yml
+      test_control: validate_cmd
+  name: validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmdFull.yml
+      test_control: validate_cmd_full
+  name: validate_cmd_full
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/filesystem/Flushing.yml
+      test_control: flushing
+  name: flushing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionPoolStress.yml
+      test_control: connection_pool_stress
+  name: connection_pool_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionsBuildup.yml
+      test_control: connections_buildup
+  name: connections_buildup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/MongosLatency.yml
+      test_control: mongos_latency
+  name: mongos_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatency.yml
+      test_control: commit_latency
+  name: commit_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatencySingleUpdate.yml
+      test_control: commit_latency_single_update
+  name: commit_latency_single_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/ServiceArchitectureWorkloads.yml
+      test_control: service_architecture_workloads
+  name: service_architecture_workloads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/TransportLayerConnectTiming.yml
+      test_control: transport_layer_connect_timing
+  name: transport_layer_connect_timing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregateExpressions.yml
+      test_control: aggregate_expressions
+  name: aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregationsOutput.yml
+      test_control: aggregations_output
+  name: aggregations_output
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ArrayTraversal.yml
+      test_control: array_traversal
+  name: array_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifier.yml
+      test_control: boolean_simplifier
+  name: boolean_simplifier
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifierSmallDataset.yml
+      test_control: boolean_simplifier_small_dataset
+  name: boolean_simplifier_small_dataset
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsDelete.yml
+      test_control: cpu_cycle_metrics_delete
+  name: cpu_cycle_metrics_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsFind.yml
+      test_control: cpu_cycle_metrics_find
+  name: cpu_cycle_metrics_find
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsInsert.yml
+      test_control: cpu_cycle_metrics_insert
+  name: cpu_cycle_metrics_insert
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsUpdate.yml
+      test_control: cpu_cycle_metrics_update
+  name: cpu_cycle_metrics_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateLarge.yml
+      test_control: coll_scan_complex_predicate_large
+  name: coll_scan_complex_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateMedium.yml
+      test_control: coll_scan_complex_predicate_medium
+  name: coll_scan_complex_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateSmall.yml
+      test_control: coll_scan_complex_predicate_small
+  name: coll_scan_complex_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
+      test_control: coll_scan_large_number_of_fields_large
+  name: coll_scan_large_number_of_fields_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
+      test_control: coll_scan_large_number_of_fields_medium
+  name: coll_scan_large_number_of_fields_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+      test_control: coll_scan_large_number_of_fields_small
+  name: coll_scan_large_number_of_fields_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
+      test_control: coll_scan_on_mixed_data_types_large
+  name: coll_scan_on_mixed_data_types_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
+      test_control: coll_scan_on_mixed_data_types_medium
+  name: coll_scan_on_mixed_data_types_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
+      test_control: coll_scan_on_mixed_data_types_small
+  name: coll_scan_on_mixed_data_types_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityLarge.yml
+      test_control: coll_scan_predicate_selectivity_large
+  name: coll_scan_predicate_selectivity_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityMedium.yml
+      test_control: coll_scan_predicate_selectivity_medium
+  name: coll_scan_predicate_selectivity_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivitySmall.yml
+      test_control: coll_scan_predicate_selectivity_small
+  name: coll_scan_predicate_selectivity_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionLarge.yml
+      test_control: coll_scan_projection_large
+  name: coll_scan_projection_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionMedium.yml
+      test_control: coll_scan_projection_medium
+  name: coll_scan_projection_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionSmall.yml
+      test_control: coll_scan_projection_small
+  name: coll_scan_projection_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+      test_control: coll_scan_simplifiable_predicate_large
+  name: coll_scan_simplifiable_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+      test_control: coll_scan_simplifiable_predicate_medium
+  name: coll_scan_simplifiable_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+      test_control: coll_scan_simplifiable_predicate_small
+  name: coll_scan_simplifiable_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollectionLevelDiagnosticCommands.yml
+      test_control: collection_level_diagnostic_commands
+  name: collection_level_diagnostic_commands
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ConstantFoldArithmetic.yml
+      test_control: constant_fold_arithmetic
+  name: constant_fold_arithmetic
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
+      test_control: csi_fragmented_inserts_flat
+  name: csi_fragmented_inserts_flat
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
+      test_control: csi_fragmented_inserts_nested
+  name: csi_fragmented_inserts_nested
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
+      test_control: cumulative_windows
+  name: cumulative_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindowsMultiAccums.yml
+      test_control: cumulative_windows_multi_accums
+  name: cumulative_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyFillCombo.yml
+      test_control: densify_fill_combo
+  name: densify_fill_combo
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyHours.yml
+      test_control: densify_hours
+  name: densify_hours
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMilliseconds.yml
+      test_control: densify_milliseconds
+  name: densify_milliseconds
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMonths.yml
+      test_control: densify_months
+  name: densify_months
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyNumeric.yml
+      test_control: densify_numeric
+  name: densify_numeric
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyTimeseriesCollection.yml
+      test_control: densify_timeseries_collection
+  name: densify_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExpressiveQueries.yml
+      test_control: expressive_queries
+  name: expressive_queries
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExternalSort.yml
+      test_control: external_sort
+  name: external_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FillTimeseriesCollection.yml
+      test_control: fill_timeseries_collection
+  name: fill_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpression.yml
+      test_control: filter_with_complex_logical_expression
+  name: filter_with_complex_logical_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
+      test_control: filter_with_complex_logical_expression_medium
+  name: filter_with_complex_logical_expression_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
+      test_control: filter_with_complex_logical_expression_small
+  name: filter_with_complex_logical_expression_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookup.yml
+      test_control: graph_lookup
+  name: graph_lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+      test_control: graph_lookup_with_only_unsharded_colls
+  name: graph_lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupLikeDistinct.yml
+      test_control: group_like_distinct
+  name: group_like_distinct
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupSpillToDisk.yml
+      test_control: group_spill_to_disk
+  name: group_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupStagesOnComputedFields.yml
+      test_control: group_stages_on_computed_fields
+  name: group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/InWithVariedArraySize.yml
+      test_control: in_with_varied_array_size
+  name: in_with_varied_array_size
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LimitSkip.yml
+      test_control: limit_skip
+  name: limit_skip
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/Lookup.yml
+      test_control: lookup
+  name: lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupColocatedData.yml
+      test_control: lookup_colocated_data
+  name: lookup_colocated_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupNLJ.yml
+      test_control: lookup_nlj
+  name: lookup_nlj
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupOnly.yml
+      test_control: lookup_only
+  name: lookup_only
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdown.yml
+      test_control: lookup_sbe_pushdown
+  name: lookup_sbe_pushdown
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+      test_control: lookup_sbe_pushdown_inlj_misc
+  name: lookup_sbe_pushdown_inlj_misc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupUnwind.yml
+      test_control: lookup_unwind
+  name: lookup_unwind
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+      test_control: lookup_with_only_unsharded_colls
+  name: lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFilters.yml
+      test_control: match_filters
+  name: match_filters
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersMedium.yml
+      test_control: match_filters_medium
+  name: match_filters_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersSmall.yml
+      test_control: match_filters_small
+  name: match_filters_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchWithLargeExpression.yml
+      test_control: match_with_large_expression
+  name: match_with_large_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+      test_control: metric_secondary_index_timeseries_collection
+  name: metric_secondary_index_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/NonSearchHybridScoring.yml
+      test_control: non_search_hybrid_scoring
+  name: non_search_hybrid_scoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+      test_control: one_m_doc_collection__large_doc_int_id
+  name: one_m_doc_collection__large_doc_int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesAgg.yml
+      test_control: percentiles_agg
+  name: percentiles_agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesExpr.yml
+      test_control: percentiles_expr
+  name: percentiles_expr
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindow.yml
+      test_control: percentiles_window
+  name: percentiles_window
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindowSpillToDisk.yml
+      test_control: percentiles_window_spill_to_disk
+  name: percentiles_window_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PipelineUpdate.yml
+      test_control: pipeline_update
+  name: pipeline_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ProjectParse.yml
+      test_control: project_parse
+  name: project_parse
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStats.yml
+      test_control: query_stats
+  name: query_stats
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStatsQueryShapes.yml
+      test_control: query_stats_query_shapes
+  name: query_stats_query_shapes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversal.yml
+      test_control: repeated_path_traversal
+  name: repeated_path_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalMedium.yml
+      test_control: repeated_path_traversal_medium
+  name: repeated_path_traversal_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalSmall.yml
+      test_control: repeated_path_traversal_small
+  name: repeated_path_traversal_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SetWindowFieldsUnbounded.yml
+      test_control: set_window_fields_unbounded
+  name: set_window_fields_unbounded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ShardFilter.yml
+      test_control: shard_filter
+  name: shard_filter
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindows.yml
+      test_control: sliding_windows
+  name: sliding_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindowsMultiAccums.yml
+      test_control: sliding_windows_multi_accums
+  name: sliding_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SortByExpression.yml
+      test_control: sort_by_expression
+  name: sort_by_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId.yml
+      test_control: ten_m_doc_collection__int_id
+  name: ten_m_doc_collection__int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+      test_control: ten_m_doc_collection__int_id__agg
+  name: ten_m_doc_collection__int_id__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+      test_control: ten_m_doc_collection__int_id__identity_view
+  name: ten_m_doc_collection__int_id__identity_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+      test_control: ten_m_doc_collection__int_id__identity_view__agg
+  name: ten_m_doc_collection__int_id__identity_view__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId.yml
+      test_control: ten_m_doc_collection__object_id
+  name: ten_m_doc_collection__object_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+      test_control: ten_m_doc_collection__object_id__sharded
+  name: ten_m_doc_collection__object_id__sharded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_SubDocId.yml
+      test_control: ten_m_doc_collection__sub_doc_id
+  name: ten_m_doc_collection__sub_doc_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeries2dsphere.yml
+      test_control: time_series2dsphere
+  name: time_series2dsphere
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
+      test_control: time_series_group_stages_on_computed_fields
+  name: time_series_group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
+      test_control: time_series_lastpoint
+  name: time_series_lastpoint
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
+      test_control: time_series_sort
+  name: time_series_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortCompound.yml
+      test_control: time_series_sort_compound
+  name: time_series_sort_compound
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
+      test_control: time_series_sort_overlapping_buckets
+  name: time_series_sort_overlapping_buckets
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesTelemetry.yml
+      test_control: time_series_telemetry
+  name: time_series_telemetry
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesBlockProcessing.yml
+      test_control: timeseries_block_processing
+  name: timeseries_block_processing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesCount.yml
+      test_control: timeseries_count
+  name: timeseries_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesEnum.yml
+      test_control: timeseries_enum
+  name: timeseries_enum
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesStressUnpacking.yml
+      test_control: timeseries_stress_unpacking
+  name: timeseries_stress_unpacking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnionWith.yml
+      test_control: union_with
+  name: union_with
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnwindGroup.yml
+      test_control: unwind_group
+  name: unwind_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UpdateLargeDocuments.yml
+      test_control: update_large_documents
+  name: update_large_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/VariadicAggregateExpressions.yml
+      test_control: variadic_aggregate_expressions
+  name: variadic_aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithComplexPartitionExpression.yml
+      test_control: window_with_complex_partition_expression
+  name: window_with_complex_partition_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithNestedFieldProjection.yml
+      test_control: window_with_nested_field_projection
+  name: window_with_nested_field_projection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/linearFill.yml
+      test_control: linear_fill
+  name: linear_fill
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/locf.yml
+      test_control: locf
+  name: locf
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/BlockingSort.yml
+      test_control: multiplanner_blocking_sort
+  name: multiplanner_blocking_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ClusteredCollection.yml
+      test_control: multiplanner_clustered_collection
+  name: multiplanner_clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/CompoundIndexes.yml
+      test_control: multiplanner_compound_indexes
+  name: multiplanner_compound_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+      test_control: multiplanner_many_index_seeks
+  name: multiplanner_many_index_seeks
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+      test_control: multiplanner_multi_planning_reads_a_lot_of_data
+  name: multiplanner_multi_planning_reads_a_lot_of_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultikeyIndexes.yml
+      test_control: multiplanner_multikey_indexes
+  name: multiplanner_multikey_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+      test_control: multiplanner_multiplanner_with_group
+  name: multiplanner_multiplanner_with_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoResults.yml
+      test_control: multiplanner_no_results
+  name: multiplanner_no_results
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoSuchField.yml
+      test_control: multiplanner_no_such_field
+  name: multiplanner_no_such_field
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+      test_control: multiplanner_non_blocking_vs_blocking
+  name: multiplanner_non_blocking_vs_blocking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Simple.yml
+      test_control: multiplanner_simple
+  name: multiplanner_simple
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Subplanning.yml
+      test_control: multiplanner_subplanning
+  name: multiplanner_subplanning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/UseClusteredIndex.yml
+      test_control: multiplanner_use_clustered_index
+  name: multiplanner_use_clustered_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/VariedSelectivity.yml
+      test_control: multiplanner_varied_selectivity
+  name: multiplanner_varied_selectivity
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/EmptyGroup.yml
+      test_control: plan_cache_empty_group
+  name: plan_cache_empty_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+      test_control: plan_cache_match_eq_varying_array
+  name: plan_cache_match_eq_varying_array
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BigUpdate.yml
+      test_control: big_update
+  name: big_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BulkLoading.yml
+      test_control: bulk_loading
+  name: bulk_loading
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ContentionTTLDeletions.yml
+      test_control: contention_ttl_deletions
+  name: contention_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/CreateDropView.yml
+      test_control: create_drop_view
+  name: create_drop_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InCacheSnapshotReads.yml
+      test_control: in_cache_snapshot_reads
+  name: in_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertBigDocs.yml
+      test_control: insert_big_docs
+  name: insert_big_docs
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertRemove.yml
+      test_control: insert_remove
+  name: insert_remove
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedIns.yml
+      test_control: large_indexed_ins
+  name: large_indexed_ins
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedInsMatchingDocuments.yml
+      test_control: large_indexed_ins_matching_documents
+  name: large_indexed_ins_matching_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeScaleLongLived.yml
+      test_control: large_scale_long_lived
+  name: large_scale_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LoadTest.yml
+      test_control: load_test
+  name: load_test
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MajorityWrites10KThreads.yml
+      test_control: majority_writes10_k_threads
+  name: majority_writes10_k_threads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ManyUpdate.yml
+      test_control: many_update
+  name: many_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MassDeleteRegression.yml
+      test_control: mass_delete_regression
+  name: mass_delete_regression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGenny.yml
+      test_control: mixed_workloads_genny
+  name: mixed_workloads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+      test_control: mixed_workloads_genny_rate_limited
+  name: mixed_workloads_genny_rate_limited
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStress.yml
+      test_control: mixed_workloads_genny_stress
+  name: mixed_workloads_genny_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
+      test_control: mixed_workloads_genny_stress_with_scans
+  name: mixed_workloads_genny_stress_with_scans
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica
+      test_control: mixed_writes_replica
+  name: mixed_writes_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: mixed_writes_replica_delay_mixed
+  name: mixed_writes_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheScanner.yml
+      test_control: out_of_cache_scanner
+  name: out_of_cache_scanner
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheSnapshotReads.yml
+      test_control: out_of_cache_snapshot_reads
+  name: out_of_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ScanWithLongLived.yml
+      test_control: scan_with_long_lived
+  name: scan_with_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/TimeSeriesSortScale.yml
+      test_control: time_series_sort_scale
+  name: time_series_sort_scale
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/selftests/GennyOverhead.yml
+      test_control: genny_overhead
+  name: genny_overhead
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: batched_update_one_without_shard_key_with_id
+  name: batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: bulk_write_batched_update_one_without_shard_key_with_id
+  name: bulk_write_batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactions.yml
+      test_control: multi_shard_transactions
+  name: multi_shard_transactions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactionsWithManyNamespaces.yml
+      test_control: multi_shard_transactions_with_many_namespaces
+  name: multi_shard_transactions_with_many_namespaces
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollection.yml
+      test_control: reshard_collection
+  name: reshard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionMixed.yml
+      test_control: reshard_collection_mixed
+  name: reshard_collection_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+      test_control: reshard_collection_read_heavy
+  name: reshard_collection_read_heavy
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+      test_control: would_change_owning_shard_batch_write
+  name: would_change_owning_shard_batch_write
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneReplicaSet.yml
+      test_control: write_one_replica_set
+  name: write_one_replica_set
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyShardedCollection.yml
+      test_control: write_one_without_shard_key_sharded_collection
+  name: write_one_without_shard_key_sharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyUnshardedCollection.yml
+      test_control: write_one_without_shard_key_unsharded_collection
+  name: write_one_without_shard_key_unsharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations-ShardCollection.yml
+      test_control: multi_updates_multi_updates__pause_migrations__shard_collection
+  name: multi_updates_multi_updates__pause_migrations__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations.yml
+      test_control: multi_updates_multi_updates__pause_migrations
+  name: multi_updates_multi_updates__pause_migrations
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-ShardCollection.yml
+      test_control: multi_updates_multi_updates__shard_collection
+  name: multi_updates_multi_updates__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates.yml
+      test_control: multi_updates_multi_updates
+  name: multi_updates_multi_updates
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixed.yml
+      test_control: llt_mixed
+  name: llt_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixedSmall.yml
+      test_control: llt_mixed_small
+  name: llt_mixed_small
+  priority: 5

--- a/evergreen/system_perf/7.0/genny_tasks.yml
+++ b/evergreen/system_perf/7.0/genny_tasks.yml
@@ -1263,28 +1263,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
-      test_control: csi_fragmented_inserts_flat
-  name: csi_fragmented_inserts_flat
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
-      test_control: csi_fragmented_inserts_nested
-  name: csi_fragmented_inserts_nested
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
       test_control: cumulative_windows
   name: cumulative_windows

--- a/evergreen/system_perf/7.0/genny_tasks.yml
+++ b/evergreen/system_perf/7.0/genny_tasks.yml
@@ -282,7 +282,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
       test_control: device_monitoring
   name: device_monitoring
   priority: 5
@@ -293,7 +293,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
       test_control: coinbase_timeseries_group_date_trunc
   name: coinbase_timeseries_group_date_trunc
   priority: 5
@@ -304,7 +304,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
       test_control: coinbase_timeseries_group_date_trunc_memory_limit
   name: coinbase_timeseries_group_date_trunc_memory_limit
   priority: 5
@@ -315,7 +315,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
       test_control: coinbase_timeseries_group_date_trunc_sort
   name: coinbase_timeseries_group_date_trunc_sort
   priority: 5
@@ -326,7 +326,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
       test_control: coinbase_timeseries_match
   name: coinbase_timeseries_match
   priority: 5
@@ -337,7 +337,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
       test_control: coinbase_timeseries_match_count
   name: coinbase_timeseries_match_count
   priority: 5
@@ -348,7 +348,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
       test_control: coinbase_timeseries_query01
   name: coinbase_timeseries_query01
   priority: 5
@@ -359,7 +359,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
       test_control: coinbase_timeseries_query02
   name: coinbase_timeseries_query02
   priority: 5
@@ -370,7 +370,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
       test_control: coinbase_timeseries_query03
   name: coinbase_timeseries_query03
   priority: 5

--- a/evergreen/system_perf/7.3/genny_tasks.yml
+++ b/evergreen/system_perf/7.3/genny_tasks.yml
@@ -1,0 +1,2778 @@
+buildvariants:
+- name: perf-atlas-M60-real.arm.aws.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-atlas-M60-real.intel.azure.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-3-shard.arm.aws.2023-11
+  tasks:
+  - name: aggregations_output
+  - name: graph_lookup
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup
+  - name: lookup_colocated_data
+  - name: lookup_with_only_unsharded_colls
+  - name: ten_m_doc_collection__object_id__sharded
+  - name: reshard_collection_mixed
+  - name: reshard_collection_read_heavy
+  - name: multi_updates_multi_updates__shard_collection
+  - name: multi_updates_multi_updates
+- name: perf-3-node-replSet.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+- name: perf-3-node-replSet-intel.intel.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+tasks:
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      test_control: device_monitoring
+  name: device_monitoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      test_control: coinbase_timeseries_group_date_trunc
+  name: coinbase_timeseries_group_date_trunc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      test_control: coinbase_timeseries_group_date_trunc_memory_limit
+  name: coinbase_timeseries_group_date_trunc_memory_limit
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      test_control: coinbase_timeseries_group_date_trunc_sort
+  name: coinbase_timeseries_group_date_trunc_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      test_control: coinbase_timeseries_match
+  name: coinbase_timeseries_match
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      test_control: coinbase_timeseries_match_count
+  name: coinbase_timeseries_match_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      test_control: coinbase_timeseries_query01
+  name: coinbase_timeseries_query01
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      test_control: coinbase_timeseries_query02
+  name: coinbase_timeseries_query02
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      test_control: coinbase_timeseries_query03
+  name: coinbase_timeseries_query03
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/basic/ReadOnlyMultiThreaded.yml
+      test_control: read_only_multi_threaded
+  name: read_only_multi_threaded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica
+      test_control: parallel_insert_replica
+  name: parallel_insert_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: parallel_insert_replica_delay_mixed
+  name: parallel_insert_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/ExponentialCompact.yml
+      test_control: exponential_compact
+  name: exponential_compact
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16.yml
+      test_control: ycsb_like_queryable_encrypt1_cf16
+  name: ycsb_like_queryable_encrypt1_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32.yml
+      test_control: ycsb_like_queryable_encrypt1_cf32
+  name: ycsb_like_queryable_encrypt1_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt1_cfdefault
+  name: ycsb_like_queryable_encrypt1_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16.yml
+      test_control: ycsb_like_queryable_encrypt5_cf16
+  name: ycsb_like_queryable_encrypt5_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32.yml
+      test_control: ycsb_like_queryable_encrypt5_cf32
+  name: ycsb_like_queryable_encrypt5_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt5_cfdefault
+  name: ycsb_like_queryable_encrypt5_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0-unencrypted.yml
+      test_control: medical_workload_diagnosis_100_0_unencrypted
+  name: medical_workload_diagnosis_100_0_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0.yml
+      test_control: medical_workload_diagnosis_100_0
+  name: medical_workload_diagnosis_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50-unencrypted.yml
+      test_control: medical_workload_diagnosis_50_50_unencrypted
+  name: medical_workload_diagnosis_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50.yml
+      test_control: medical_workload_diagnosis_50_50
+  name: medical_workload_diagnosis_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50-unencrypted.yml
+      test_control: medical_workload_guid_50_50_unencrypted
+  name: medical_workload_guid_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50.yml
+      test_control: medical_workload_guid_50_50
+  name: medical_workload_guid_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load-unencrypted.yml
+      test_control: medical_workload_load_unencrypted
+  name: medical_workload_load_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load.yml
+      test_control: medical_workload_load
+  name: medical_workload_load
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-100-0.yml
+      test_control: qe_range_age_100_0
+  name: qe_range_age_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-50-50.yml
+      test_control: qe_range_age_50_50
+  name: qe_range_age_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-100-0.yml
+      test_control: qe_range_balance_100_0
+  name: qe_range_balance_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-50-50.yml
+      test_control: qe_range_balance_50_50
+  name: qe_range_balance_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-100-0.yml
+      test_control: qe_range_timestamp_100_0
+  name: qe_range_timestamp_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-50-50.yml
+      test_control: qe_range_timestamp_50_50
+  name: qe_range_timestamp_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundIndexConstruction.yml
+      test_control: background_index_construction
+  name: background_index_construction
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundTTLDeletions.yml
+      test_control: background_ttl_deletions
+  name: background_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundValidateCmd.yml
+      test_control: background_validate_cmd
+  name: background_validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollection.yml
+      test_control: clustered_collection
+  name: clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+      test_control: clustered_collection_large_record_ids
+  name: clustered_collection_large_record_ids
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/CreateBigIndex.yml
+      test_control: create_big_index
+  name: create_big_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatched.yml
+      test_control: mixed_multi_deletes_batched
+  name: mixed_multi_deletes_batched
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatchedWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_batched_with_secondary_indexes
+  name: mixed_multi_deletes_batched_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDoc.yml
+      test_control: mixed_multi_deletes_doc_by_doc
+  name: mixed_multi_deletes_doc_by_doc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDocWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MultiPlanning.yml
+      test_control: multi_planning
+  name: multi_planning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/PingCommand.yml
+      test_control: ping_command
+  name: ping_command
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SecondaryReadsGenny.yml
+      test_control: secondary_reads_genny
+  name: secondary_reads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SinusoidalReadWrites.yml
+      test_control: sinusoidal_read_writes
+  name: sinusoidal_read_writes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesArbitraryUpdate.yml
+      test_control: time_series_arbitrary_update
+  name: time_series_arbitrary_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesRangeDelete.yml
+      test_control: time_series_range_delete
+  name: time_series_range_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/UpdateWithSecondaryIndexes.yml
+      test_control: update_with_secondary_indexes
+  name: update_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmd.yml
+      test_control: validate_cmd
+  name: validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmdFull.yml
+      test_control: validate_cmd_full
+  name: validate_cmd_full
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/filesystem/Flushing.yml
+      test_control: flushing
+  name: flushing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionPoolStress.yml
+      test_control: connection_pool_stress
+  name: connection_pool_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionsBuildup.yml
+      test_control: connections_buildup
+  name: connections_buildup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/MongosLatency.yml
+      test_control: mongos_latency
+  name: mongos_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatency.yml
+      test_control: commit_latency
+  name: commit_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatencySingleUpdate.yml
+      test_control: commit_latency_single_update
+  name: commit_latency_single_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/ServiceArchitectureWorkloads.yml
+      test_control: service_architecture_workloads
+  name: service_architecture_workloads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/TransportLayerConnectTiming.yml
+      test_control: transport_layer_connect_timing
+  name: transport_layer_connect_timing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregateExpressions.yml
+      test_control: aggregate_expressions
+  name: aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregationsOutput.yml
+      test_control: aggregations_output
+  name: aggregations_output
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ArrayTraversal.yml
+      test_control: array_traversal
+  name: array_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifier.yml
+      test_control: boolean_simplifier
+  name: boolean_simplifier
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifierSmallDataset.yml
+      test_control: boolean_simplifier_small_dataset
+  name: boolean_simplifier_small_dataset
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsDelete.yml
+      test_control: cpu_cycle_metrics_delete
+  name: cpu_cycle_metrics_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsFind.yml
+      test_control: cpu_cycle_metrics_find
+  name: cpu_cycle_metrics_find
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsInsert.yml
+      test_control: cpu_cycle_metrics_insert
+  name: cpu_cycle_metrics_insert
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsUpdate.yml
+      test_control: cpu_cycle_metrics_update
+  name: cpu_cycle_metrics_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateLarge.yml
+      test_control: coll_scan_complex_predicate_large
+  name: coll_scan_complex_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateMedium.yml
+      test_control: coll_scan_complex_predicate_medium
+  name: coll_scan_complex_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateSmall.yml
+      test_control: coll_scan_complex_predicate_small
+  name: coll_scan_complex_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
+      test_control: coll_scan_large_number_of_fields_large
+  name: coll_scan_large_number_of_fields_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
+      test_control: coll_scan_large_number_of_fields_medium
+  name: coll_scan_large_number_of_fields_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+      test_control: coll_scan_large_number_of_fields_small
+  name: coll_scan_large_number_of_fields_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
+      test_control: coll_scan_on_mixed_data_types_large
+  name: coll_scan_on_mixed_data_types_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
+      test_control: coll_scan_on_mixed_data_types_medium
+  name: coll_scan_on_mixed_data_types_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
+      test_control: coll_scan_on_mixed_data_types_small
+  name: coll_scan_on_mixed_data_types_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityLarge.yml
+      test_control: coll_scan_predicate_selectivity_large
+  name: coll_scan_predicate_selectivity_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityMedium.yml
+      test_control: coll_scan_predicate_selectivity_medium
+  name: coll_scan_predicate_selectivity_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivitySmall.yml
+      test_control: coll_scan_predicate_selectivity_small
+  name: coll_scan_predicate_selectivity_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionLarge.yml
+      test_control: coll_scan_projection_large
+  name: coll_scan_projection_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionMedium.yml
+      test_control: coll_scan_projection_medium
+  name: coll_scan_projection_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionSmall.yml
+      test_control: coll_scan_projection_small
+  name: coll_scan_projection_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+      test_control: coll_scan_simplifiable_predicate_large
+  name: coll_scan_simplifiable_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+      test_control: coll_scan_simplifiable_predicate_medium
+  name: coll_scan_simplifiable_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+      test_control: coll_scan_simplifiable_predicate_small
+  name: coll_scan_simplifiable_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollectionLevelDiagnosticCommands.yml
+      test_control: collection_level_diagnostic_commands
+  name: collection_level_diagnostic_commands
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ConstantFoldArithmetic.yml
+      test_control: constant_fold_arithmetic
+  name: constant_fold_arithmetic
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
+      test_control: csi_fragmented_inserts_flat
+  name: csi_fragmented_inserts_flat
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
+      test_control: csi_fragmented_inserts_nested
+  name: csi_fragmented_inserts_nested
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
+      test_control: cumulative_windows
+  name: cumulative_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindowsMultiAccums.yml
+      test_control: cumulative_windows_multi_accums
+  name: cumulative_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyFillCombo.yml
+      test_control: densify_fill_combo
+  name: densify_fill_combo
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyHours.yml
+      test_control: densify_hours
+  name: densify_hours
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMilliseconds.yml
+      test_control: densify_milliseconds
+  name: densify_milliseconds
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMonths.yml
+      test_control: densify_months
+  name: densify_months
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyNumeric.yml
+      test_control: densify_numeric
+  name: densify_numeric
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyTimeseriesCollection.yml
+      test_control: densify_timeseries_collection
+  name: densify_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExpressiveQueries.yml
+      test_control: expressive_queries
+  name: expressive_queries
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExternalSort.yml
+      test_control: external_sort
+  name: external_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FillTimeseriesCollection.yml
+      test_control: fill_timeseries_collection
+  name: fill_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpression.yml
+      test_control: filter_with_complex_logical_expression
+  name: filter_with_complex_logical_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
+      test_control: filter_with_complex_logical_expression_medium
+  name: filter_with_complex_logical_expression_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
+      test_control: filter_with_complex_logical_expression_small
+  name: filter_with_complex_logical_expression_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookup.yml
+      test_control: graph_lookup
+  name: graph_lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+      test_control: graph_lookup_with_only_unsharded_colls
+  name: graph_lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupLikeDistinct.yml
+      test_control: group_like_distinct
+  name: group_like_distinct
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupSpillToDisk.yml
+      test_control: group_spill_to_disk
+  name: group_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupStagesOnComputedFields.yml
+      test_control: group_stages_on_computed_fields
+  name: group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/InWithVariedArraySize.yml
+      test_control: in_with_varied_array_size
+  name: in_with_varied_array_size
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LimitSkip.yml
+      test_control: limit_skip
+  name: limit_skip
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/Lookup.yml
+      test_control: lookup
+  name: lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupColocatedData.yml
+      test_control: lookup_colocated_data
+  name: lookup_colocated_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupNLJ.yml
+      test_control: lookup_nlj
+  name: lookup_nlj
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupOnly.yml
+      test_control: lookup_only
+  name: lookup_only
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdown.yml
+      test_control: lookup_sbe_pushdown
+  name: lookup_sbe_pushdown
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+      test_control: lookup_sbe_pushdown_inlj_misc
+  name: lookup_sbe_pushdown_inlj_misc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupUnwind.yml
+      test_control: lookup_unwind
+  name: lookup_unwind
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+      test_control: lookup_with_only_unsharded_colls
+  name: lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFilters.yml
+      test_control: match_filters
+  name: match_filters
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersMedium.yml
+      test_control: match_filters_medium
+  name: match_filters_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersSmall.yml
+      test_control: match_filters_small
+  name: match_filters_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchWithLargeExpression.yml
+      test_control: match_with_large_expression
+  name: match_with_large_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+      test_control: metric_secondary_index_timeseries_collection
+  name: metric_secondary_index_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/NonSearchHybridScoring.yml
+      test_control: non_search_hybrid_scoring
+  name: non_search_hybrid_scoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+      test_control: one_m_doc_collection__large_doc_int_id
+  name: one_m_doc_collection__large_doc_int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesAgg.yml
+      test_control: percentiles_agg
+  name: percentiles_agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesExpr.yml
+      test_control: percentiles_expr
+  name: percentiles_expr
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindow.yml
+      test_control: percentiles_window
+  name: percentiles_window
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindowSpillToDisk.yml
+      test_control: percentiles_window_spill_to_disk
+  name: percentiles_window_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PipelineUpdate.yml
+      test_control: pipeline_update
+  name: pipeline_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ProjectParse.yml
+      test_control: project_parse
+  name: project_parse
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStats.yml
+      test_control: query_stats
+  name: query_stats
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStatsQueryShapes.yml
+      test_control: query_stats_query_shapes
+  name: query_stats_query_shapes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversal.yml
+      test_control: repeated_path_traversal
+  name: repeated_path_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalMedium.yml
+      test_control: repeated_path_traversal_medium
+  name: repeated_path_traversal_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalSmall.yml
+      test_control: repeated_path_traversal_small
+  name: repeated_path_traversal_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SetWindowFieldsUnbounded.yml
+      test_control: set_window_fields_unbounded
+  name: set_window_fields_unbounded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ShardFilter.yml
+      test_control: shard_filter
+  name: shard_filter
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindows.yml
+      test_control: sliding_windows
+  name: sliding_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindowsMultiAccums.yml
+      test_control: sliding_windows_multi_accums
+  name: sliding_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SortByExpression.yml
+      test_control: sort_by_expression
+  name: sort_by_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId.yml
+      test_control: ten_m_doc_collection__int_id
+  name: ten_m_doc_collection__int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+      test_control: ten_m_doc_collection__int_id__agg
+  name: ten_m_doc_collection__int_id__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+      test_control: ten_m_doc_collection__int_id__identity_view
+  name: ten_m_doc_collection__int_id__identity_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+      test_control: ten_m_doc_collection__int_id__identity_view__agg
+  name: ten_m_doc_collection__int_id__identity_view__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId.yml
+      test_control: ten_m_doc_collection__object_id
+  name: ten_m_doc_collection__object_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+      test_control: ten_m_doc_collection__object_id__sharded
+  name: ten_m_doc_collection__object_id__sharded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_SubDocId.yml
+      test_control: ten_m_doc_collection__sub_doc_id
+  name: ten_m_doc_collection__sub_doc_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeries2dsphere.yml
+      test_control: time_series2dsphere
+  name: time_series2dsphere
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
+      test_control: time_series_group_stages_on_computed_fields
+  name: time_series_group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
+      test_control: time_series_lastpoint
+  name: time_series_lastpoint
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
+      test_control: time_series_sort
+  name: time_series_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortCompound.yml
+      test_control: time_series_sort_compound
+  name: time_series_sort_compound
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
+      test_control: time_series_sort_overlapping_buckets
+  name: time_series_sort_overlapping_buckets
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesTelemetry.yml
+      test_control: time_series_telemetry
+  name: time_series_telemetry
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesBlockProcessing.yml
+      test_control: timeseries_block_processing
+  name: timeseries_block_processing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesCount.yml
+      test_control: timeseries_count
+  name: timeseries_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesEnum.yml
+      test_control: timeseries_enum
+  name: timeseries_enum
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesStressUnpacking.yml
+      test_control: timeseries_stress_unpacking
+  name: timeseries_stress_unpacking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnionWith.yml
+      test_control: union_with
+  name: union_with
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnwindGroup.yml
+      test_control: unwind_group
+  name: unwind_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UpdateLargeDocuments.yml
+      test_control: update_large_documents
+  name: update_large_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/VariadicAggregateExpressions.yml
+      test_control: variadic_aggregate_expressions
+  name: variadic_aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithComplexPartitionExpression.yml
+      test_control: window_with_complex_partition_expression
+  name: window_with_complex_partition_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithNestedFieldProjection.yml
+      test_control: window_with_nested_field_projection
+  name: window_with_nested_field_projection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/linearFill.yml
+      test_control: linear_fill
+  name: linear_fill
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/locf.yml
+      test_control: locf
+  name: locf
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/BlockingSort.yml
+      test_control: multiplanner_blocking_sort
+  name: multiplanner_blocking_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ClusteredCollection.yml
+      test_control: multiplanner_clustered_collection
+  name: multiplanner_clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/CompoundIndexes.yml
+      test_control: multiplanner_compound_indexes
+  name: multiplanner_compound_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+      test_control: multiplanner_many_index_seeks
+  name: multiplanner_many_index_seeks
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+      test_control: multiplanner_multi_planning_reads_a_lot_of_data
+  name: multiplanner_multi_planning_reads_a_lot_of_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultikeyIndexes.yml
+      test_control: multiplanner_multikey_indexes
+  name: multiplanner_multikey_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+      test_control: multiplanner_multiplanner_with_group
+  name: multiplanner_multiplanner_with_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoResults.yml
+      test_control: multiplanner_no_results
+  name: multiplanner_no_results
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoSuchField.yml
+      test_control: multiplanner_no_such_field
+  name: multiplanner_no_such_field
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+      test_control: multiplanner_non_blocking_vs_blocking
+  name: multiplanner_non_blocking_vs_blocking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Simple.yml
+      test_control: multiplanner_simple
+  name: multiplanner_simple
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Subplanning.yml
+      test_control: multiplanner_subplanning
+  name: multiplanner_subplanning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/UseClusteredIndex.yml
+      test_control: multiplanner_use_clustered_index
+  name: multiplanner_use_clustered_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/VariedSelectivity.yml
+      test_control: multiplanner_varied_selectivity
+  name: multiplanner_varied_selectivity
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/EmptyGroup.yml
+      test_control: plan_cache_empty_group
+  name: plan_cache_empty_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+      test_control: plan_cache_match_eq_varying_array
+  name: plan_cache_match_eq_varying_array
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BigUpdate.yml
+      test_control: big_update
+  name: big_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BulkLoading.yml
+      test_control: bulk_loading
+  name: bulk_loading
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ContentionTTLDeletions.yml
+      test_control: contention_ttl_deletions
+  name: contention_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/CreateDropView.yml
+      test_control: create_drop_view
+  name: create_drop_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InCacheSnapshotReads.yml
+      test_control: in_cache_snapshot_reads
+  name: in_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertBigDocs.yml
+      test_control: insert_big_docs
+  name: insert_big_docs
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertRemove.yml
+      test_control: insert_remove
+  name: insert_remove
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedIns.yml
+      test_control: large_indexed_ins
+  name: large_indexed_ins
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedInsMatchingDocuments.yml
+      test_control: large_indexed_ins_matching_documents
+  name: large_indexed_ins_matching_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeScaleLongLived.yml
+      test_control: large_scale_long_lived
+  name: large_scale_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LoadTest.yml
+      test_control: load_test
+  name: load_test
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MajorityWrites10KThreads.yml
+      test_control: majority_writes10_k_threads
+  name: majority_writes10_k_threads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ManyUpdate.yml
+      test_control: many_update
+  name: many_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MassDeleteRegression.yml
+      test_control: mass_delete_regression
+  name: mass_delete_regression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGenny.yml
+      test_control: mixed_workloads_genny
+  name: mixed_workloads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+      test_control: mixed_workloads_genny_rate_limited
+  name: mixed_workloads_genny_rate_limited
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStress.yml
+      test_control: mixed_workloads_genny_stress
+  name: mixed_workloads_genny_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
+      test_control: mixed_workloads_genny_stress_with_scans
+  name: mixed_workloads_genny_stress_with_scans
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica
+      test_control: mixed_writes_replica
+  name: mixed_writes_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: mixed_writes_replica_delay_mixed
+  name: mixed_writes_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheScanner.yml
+      test_control: out_of_cache_scanner
+  name: out_of_cache_scanner
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheSnapshotReads.yml
+      test_control: out_of_cache_snapshot_reads
+  name: out_of_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ScanWithLongLived.yml
+      test_control: scan_with_long_lived
+  name: scan_with_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/TimeSeriesSortScale.yml
+      test_control: time_series_sort_scale
+  name: time_series_sort_scale
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/selftests/GennyOverhead.yml
+      test_control: genny_overhead
+  name: genny_overhead
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: batched_update_one_without_shard_key_with_id
+  name: batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: bulk_write_batched_update_one_without_shard_key_with_id
+  name: bulk_write_batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactions.yml
+      test_control: multi_shard_transactions
+  name: multi_shard_transactions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactionsWithManyNamespaces.yml
+      test_control: multi_shard_transactions_with_many_namespaces
+  name: multi_shard_transactions_with_many_namespaces
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollection.yml
+      test_control: reshard_collection
+  name: reshard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionMixed.yml
+      test_control: reshard_collection_mixed
+  name: reshard_collection_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+      test_control: reshard_collection_read_heavy
+  name: reshard_collection_read_heavy
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+      test_control: would_change_owning_shard_batch_write
+  name: would_change_owning_shard_batch_write
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneReplicaSet.yml
+      test_control: write_one_replica_set
+  name: write_one_replica_set
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyShardedCollection.yml
+      test_control: write_one_without_shard_key_sharded_collection
+  name: write_one_without_shard_key_sharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyUnshardedCollection.yml
+      test_control: write_one_without_shard_key_unsharded_collection
+  name: write_one_without_shard_key_unsharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations-ShardCollection.yml
+      test_control: multi_updates_multi_updates__pause_migrations__shard_collection
+  name: multi_updates_multi_updates__pause_migrations__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations.yml
+      test_control: multi_updates_multi_updates__pause_migrations
+  name: multi_updates_multi_updates__pause_migrations
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-ShardCollection.yml
+      test_control: multi_updates_multi_updates__shard_collection
+  name: multi_updates_multi_updates__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates.yml
+      test_control: multi_updates_multi_updates
+  name: multi_updates_multi_updates
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixed.yml
+      test_control: llt_mixed
+  name: llt_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixedSmall.yml
+      test_control: llt_mixed_small
+  name: llt_mixed_small
+  priority: 5

--- a/evergreen/system_perf/7.3/genny_tasks.yml
+++ b/evergreen/system_perf/7.3/genny_tasks.yml
@@ -1263,28 +1263,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
-      test_control: csi_fragmented_inserts_flat
-  name: csi_fragmented_inserts_flat
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
-      test_control: csi_fragmented_inserts_nested
-  name: csi_fragmented_inserts_nested
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
       test_control: cumulative_windows
   name: cumulative_windows

--- a/evergreen/system_perf/7.3/genny_tasks.yml
+++ b/evergreen/system_perf/7.3/genny_tasks.yml
@@ -282,7 +282,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
       test_control: device_monitoring
   name: device_monitoring
   priority: 5
@@ -293,7 +293,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
       test_control: coinbase_timeseries_group_date_trunc
   name: coinbase_timeseries_group_date_trunc
   priority: 5
@@ -304,7 +304,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
       test_control: coinbase_timeseries_group_date_trunc_memory_limit
   name: coinbase_timeseries_group_date_trunc_memory_limit
   priority: 5
@@ -315,7 +315,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
       test_control: coinbase_timeseries_group_date_trunc_sort
   name: coinbase_timeseries_group_date_trunc_sort
   priority: 5
@@ -326,7 +326,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
       test_control: coinbase_timeseries_match
   name: coinbase_timeseries_match
   priority: 5
@@ -337,7 +337,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
       test_control: coinbase_timeseries_match_count
   name: coinbase_timeseries_match_count
   priority: 5
@@ -348,7 +348,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
       test_control: coinbase_timeseries_query01
   name: coinbase_timeseries_query01
   priority: 5
@@ -359,7 +359,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
       test_control: coinbase_timeseries_query02
   name: coinbase_timeseries_query02
   priority: 5
@@ -370,7 +370,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
       test_control: coinbase_timeseries_query03
   name: coinbase_timeseries_query03
   priority: 5

--- a/evergreen/system_perf/8.0/genny_tasks.yml
+++ b/evergreen/system_perf/8.0/genny_tasks.yml
@@ -1328,28 +1328,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
-      test_control: csi_fragmented_inserts_flat
-  name: csi_fragmented_inserts_flat
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
-      test_control: csi_fragmented_inserts_nested
-  name: csi_fragmented_inserts_nested
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
       test_control: cumulative_windows
   name: cumulative_windows

--- a/evergreen/system_perf/8.0/genny_tasks.yml
+++ b/evergreen/system_perf/8.0/genny_tasks.yml
@@ -1,0 +1,2843 @@
+buildvariants:
+- name: perf-atlas-M60-real.arm.aws.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-atlas-M60-real.intel.azure.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-standalone.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: background_ttl_deletions
+  - name: create_big_index
+  - name: multi_planning
+  - name: ping_command
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: collection_level_diagnostic_commands
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series_group_stages_on_computed_fields
+  - name: union_with
+  - name: unwind_group
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: genny_overhead
+  - name: write_one_replica_set
+- name: perf-3-shard.arm.aws.2023-11
+  tasks:
+  - name: aggregations_output
+  - name: graph_lookup
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup
+  - name: lookup_colocated_data
+  - name: lookup_with_only_unsharded_colls
+  - name: ten_m_doc_collection__object_id__sharded
+  - name: reshard_collection_mixed
+  - name: reshard_collection_read_heavy
+  - name: multi_updates_multi_updates__shard_collection
+  - name: multi_updates_multi_updates
+- name: perf-3-node-replSet.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+- name: perf-3-node-replSet-intel.intel.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: array_traversal
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: metric_secondary_index_timeseries_collection
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: pipeline_update
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: bulk_loading
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+tasks:
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      test_control: device_monitoring
+  name: device_monitoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      test_control: coinbase_timeseries_group_date_trunc
+  name: coinbase_timeseries_group_date_trunc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      test_control: coinbase_timeseries_group_date_trunc_memory_limit
+  name: coinbase_timeseries_group_date_trunc_memory_limit
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      test_control: coinbase_timeseries_group_date_trunc_sort
+  name: coinbase_timeseries_group_date_trunc_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      test_control: coinbase_timeseries_match
+  name: coinbase_timeseries_match
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      test_control: coinbase_timeseries_match_count
+  name: coinbase_timeseries_match_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      test_control: coinbase_timeseries_query01
+  name: coinbase_timeseries_query01
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      test_control: coinbase_timeseries_query02
+  name: coinbase_timeseries_query02
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      test_control: coinbase_timeseries_query03
+  name: coinbase_timeseries_query03
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/basic/ReadOnlyMultiThreaded.yml
+      test_control: read_only_multi_threaded
+  name: read_only_multi_threaded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica
+      test_control: parallel_insert_replica
+  name: parallel_insert_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: parallel_insert_replica_delay_mixed
+  name: parallel_insert_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/ExponentialCompact.yml
+      test_control: exponential_compact
+  name: exponential_compact
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16.yml
+      test_control: ycsb_like_queryable_encrypt1_cf16
+  name: ycsb_like_queryable_encrypt1_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32.yml
+      test_control: ycsb_like_queryable_encrypt1_cf32
+  name: ycsb_like_queryable_encrypt1_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt1_cfdefault
+  name: ycsb_like_queryable_encrypt1_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16.yml
+      test_control: ycsb_like_queryable_encrypt5_cf16
+  name: ycsb_like_queryable_encrypt5_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32.yml
+      test_control: ycsb_like_queryable_encrypt5_cf32
+  name: ycsb_like_queryable_encrypt5_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt5_cfdefault
+  name: ycsb_like_queryable_encrypt5_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0-unencrypted.yml
+      test_control: medical_workload_diagnosis_100_0_unencrypted
+  name: medical_workload_diagnosis_100_0_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0.yml
+      test_control: medical_workload_diagnosis_100_0
+  name: medical_workload_diagnosis_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50-unencrypted.yml
+      test_control: medical_workload_diagnosis_50_50_unencrypted
+  name: medical_workload_diagnosis_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50.yml
+      test_control: medical_workload_diagnosis_50_50
+  name: medical_workload_diagnosis_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50-unencrypted.yml
+      test_control: medical_workload_guid_50_50_unencrypted
+  name: medical_workload_guid_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50.yml
+      test_control: medical_workload_guid_50_50
+  name: medical_workload_guid_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load-unencrypted.yml
+      test_control: medical_workload_load_unencrypted
+  name: medical_workload_load_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load.yml
+      test_control: medical_workload_load
+  name: medical_workload_load
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-100-0.yml
+      test_control: qe_range_age_100_0
+  name: qe_range_age_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-50-50.yml
+      test_control: qe_range_age_50_50
+  name: qe_range_age_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-100-0.yml
+      test_control: qe_range_balance_100_0
+  name: qe_range_balance_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-50-50.yml
+      test_control: qe_range_balance_50_50
+  name: qe_range_balance_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-100-0.yml
+      test_control: qe_range_timestamp_100_0
+  name: qe_range_timestamp_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-50-50.yml
+      test_control: qe_range_timestamp_50_50
+  name: qe_range_timestamp_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundIndexConstruction.yml
+      test_control: background_index_construction
+  name: background_index_construction
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundTTLDeletions.yml
+      test_control: background_ttl_deletions
+  name: background_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundValidateCmd.yml
+      test_control: background_validate_cmd
+  name: background_validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollection.yml
+      test_control: clustered_collection
+  name: clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+      test_control: clustered_collection_large_record_ids
+  name: clustered_collection_large_record_ids
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/CreateBigIndex.yml
+      test_control: create_big_index
+  name: create_big_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatched.yml
+      test_control: mixed_multi_deletes_batched
+  name: mixed_multi_deletes_batched
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatchedWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_batched_with_secondary_indexes
+  name: mixed_multi_deletes_batched_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDoc.yml
+      test_control: mixed_multi_deletes_doc_by_doc
+  name: mixed_multi_deletes_doc_by_doc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDocWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MultiPlanning.yml
+      test_control: multi_planning
+  name: multi_planning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/PingCommand.yml
+      test_control: ping_command
+  name: ping_command
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SecondaryReadsGenny.yml
+      test_control: secondary_reads_genny
+  name: secondary_reads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SinusoidalReadWrites.yml
+      test_control: sinusoidal_read_writes
+  name: sinusoidal_read_writes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesArbitraryUpdate.yml
+      test_control: time_series_arbitrary_update
+  name: time_series_arbitrary_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesRangeDelete.yml
+      test_control: time_series_range_delete
+  name: time_series_range_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/UpdateWithSecondaryIndexes.yml
+      test_control: update_with_secondary_indexes
+  name: update_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmd.yml
+      test_control: validate_cmd
+  name: validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmdFull.yml
+      test_control: validate_cmd_full
+  name: validate_cmd_full
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/filesystem/Flushing.yml
+      test_control: flushing
+  name: flushing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionPoolStress.yml
+      test_control: connection_pool_stress
+  name: connection_pool_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionsBuildup.yml
+      test_control: connections_buildup
+  name: connections_buildup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/MongosLatency.yml
+      test_control: mongos_latency
+  name: mongos_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatency.yml
+      test_control: commit_latency
+  name: commit_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatencySingleUpdate.yml
+      test_control: commit_latency_single_update
+  name: commit_latency_single_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/ServiceArchitectureWorkloads.yml
+      test_control: service_architecture_workloads
+  name: service_architecture_workloads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/TransportLayerConnectTiming.yml
+      test_control: transport_layer_connect_timing
+  name: transport_layer_connect_timing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregateExpressions.yml
+      test_control: aggregate_expressions
+  name: aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregationsOutput.yml
+      test_control: aggregations_output
+  name: aggregations_output
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ArrayTraversal.yml
+      test_control: array_traversal
+  name: array_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifier.yml
+      test_control: boolean_simplifier
+  name: boolean_simplifier
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifierSmallDataset.yml
+      test_control: boolean_simplifier_small_dataset
+  name: boolean_simplifier_small_dataset
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsDelete.yml
+      test_control: cpu_cycle_metrics_delete
+  name: cpu_cycle_metrics_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsFind.yml
+      test_control: cpu_cycle_metrics_find
+  name: cpu_cycle_metrics_find
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsInsert.yml
+      test_control: cpu_cycle_metrics_insert
+  name: cpu_cycle_metrics_insert
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsUpdate.yml
+      test_control: cpu_cycle_metrics_update
+  name: cpu_cycle_metrics_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateLarge.yml
+      test_control: coll_scan_complex_predicate_large
+  name: coll_scan_complex_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateMedium.yml
+      test_control: coll_scan_complex_predicate_medium
+  name: coll_scan_complex_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateSmall.yml
+      test_control: coll_scan_complex_predicate_small
+  name: coll_scan_complex_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
+      test_control: coll_scan_large_number_of_fields_large
+  name: coll_scan_large_number_of_fields_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
+      test_control: coll_scan_large_number_of_fields_medium
+  name: coll_scan_large_number_of_fields_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+      test_control: coll_scan_large_number_of_fields_small
+  name: coll_scan_large_number_of_fields_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
+      test_control: coll_scan_on_mixed_data_types_large
+  name: coll_scan_on_mixed_data_types_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
+      test_control: coll_scan_on_mixed_data_types_medium
+  name: coll_scan_on_mixed_data_types_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
+      test_control: coll_scan_on_mixed_data_types_small
+  name: coll_scan_on_mixed_data_types_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityLarge.yml
+      test_control: coll_scan_predicate_selectivity_large
+  name: coll_scan_predicate_selectivity_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityMedium.yml
+      test_control: coll_scan_predicate_selectivity_medium
+  name: coll_scan_predicate_selectivity_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivitySmall.yml
+      test_control: coll_scan_predicate_selectivity_small
+  name: coll_scan_predicate_selectivity_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionLarge.yml
+      test_control: coll_scan_projection_large
+  name: coll_scan_projection_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionMedium.yml
+      test_control: coll_scan_projection_medium
+  name: coll_scan_projection_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionSmall.yml
+      test_control: coll_scan_projection_small
+  name: coll_scan_projection_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+      test_control: coll_scan_simplifiable_predicate_large
+  name: coll_scan_simplifiable_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+      test_control: coll_scan_simplifiable_predicate_medium
+  name: coll_scan_simplifiable_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+      test_control: coll_scan_simplifiable_predicate_small
+  name: coll_scan_simplifiable_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollectionLevelDiagnosticCommands.yml
+      test_control: collection_level_diagnostic_commands
+  name: collection_level_diagnostic_commands
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ConstantFoldArithmetic.yml
+      test_control: constant_fold_arithmetic
+  name: constant_fold_arithmetic
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
+      test_control: csi_fragmented_inserts_flat
+  name: csi_fragmented_inserts_flat
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
+      test_control: csi_fragmented_inserts_nested
+  name: csi_fragmented_inserts_nested
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
+      test_control: cumulative_windows
+  name: cumulative_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindowsMultiAccums.yml
+      test_control: cumulative_windows_multi_accums
+  name: cumulative_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyFillCombo.yml
+      test_control: densify_fill_combo
+  name: densify_fill_combo
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyHours.yml
+      test_control: densify_hours
+  name: densify_hours
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMilliseconds.yml
+      test_control: densify_milliseconds
+  name: densify_milliseconds
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMonths.yml
+      test_control: densify_months
+  name: densify_months
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyNumeric.yml
+      test_control: densify_numeric
+  name: densify_numeric
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyTimeseriesCollection.yml
+      test_control: densify_timeseries_collection
+  name: densify_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExpressiveQueries.yml
+      test_control: expressive_queries
+  name: expressive_queries
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExternalSort.yml
+      test_control: external_sort
+  name: external_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FillTimeseriesCollection.yml
+      test_control: fill_timeseries_collection
+  name: fill_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpression.yml
+      test_control: filter_with_complex_logical_expression
+  name: filter_with_complex_logical_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
+      test_control: filter_with_complex_logical_expression_medium
+  name: filter_with_complex_logical_expression_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
+      test_control: filter_with_complex_logical_expression_small
+  name: filter_with_complex_logical_expression_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookup.yml
+      test_control: graph_lookup
+  name: graph_lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+      test_control: graph_lookup_with_only_unsharded_colls
+  name: graph_lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupLikeDistinct.yml
+      test_control: group_like_distinct
+  name: group_like_distinct
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupSpillToDisk.yml
+      test_control: group_spill_to_disk
+  name: group_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupStagesOnComputedFields.yml
+      test_control: group_stages_on_computed_fields
+  name: group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/InWithVariedArraySize.yml
+      test_control: in_with_varied_array_size
+  name: in_with_varied_array_size
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LimitSkip.yml
+      test_control: limit_skip
+  name: limit_skip
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/Lookup.yml
+      test_control: lookup
+  name: lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupColocatedData.yml
+      test_control: lookup_colocated_data
+  name: lookup_colocated_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupNLJ.yml
+      test_control: lookup_nlj
+  name: lookup_nlj
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupOnly.yml
+      test_control: lookup_only
+  name: lookup_only
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdown.yml
+      test_control: lookup_sbe_pushdown
+  name: lookup_sbe_pushdown
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+      test_control: lookup_sbe_pushdown_inlj_misc
+  name: lookup_sbe_pushdown_inlj_misc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupUnwind.yml
+      test_control: lookup_unwind
+  name: lookup_unwind
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+      test_control: lookup_with_only_unsharded_colls
+  name: lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFilters.yml
+      test_control: match_filters
+  name: match_filters
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersMedium.yml
+      test_control: match_filters_medium
+  name: match_filters_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersSmall.yml
+      test_control: match_filters_small
+  name: match_filters_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchWithLargeExpression.yml
+      test_control: match_with_large_expression
+  name: match_with_large_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+      test_control: metric_secondary_index_timeseries_collection
+  name: metric_secondary_index_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/NonSearchHybridScoring.yml
+      test_control: non_search_hybrid_scoring
+  name: non_search_hybrid_scoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+      test_control: one_m_doc_collection__large_doc_int_id
+  name: one_m_doc_collection__large_doc_int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesAgg.yml
+      test_control: percentiles_agg
+  name: percentiles_agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesExpr.yml
+      test_control: percentiles_expr
+  name: percentiles_expr
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindow.yml
+      test_control: percentiles_window
+  name: percentiles_window
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindowSpillToDisk.yml
+      test_control: percentiles_window_spill_to_disk
+  name: percentiles_window_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PipelineUpdate.yml
+      test_control: pipeline_update
+  name: pipeline_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ProjectParse.yml
+      test_control: project_parse
+  name: project_parse
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStats.yml
+      test_control: query_stats
+  name: query_stats
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStatsQueryShapes.yml
+      test_control: query_stats_query_shapes
+  name: query_stats_query_shapes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversal.yml
+      test_control: repeated_path_traversal
+  name: repeated_path_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalMedium.yml
+      test_control: repeated_path_traversal_medium
+  name: repeated_path_traversal_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalSmall.yml
+      test_control: repeated_path_traversal_small
+  name: repeated_path_traversal_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SetWindowFieldsUnbounded.yml
+      test_control: set_window_fields_unbounded
+  name: set_window_fields_unbounded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ShardFilter.yml
+      test_control: shard_filter
+  name: shard_filter
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindows.yml
+      test_control: sliding_windows
+  name: sliding_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindowsMultiAccums.yml
+      test_control: sliding_windows_multi_accums
+  name: sliding_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SortByExpression.yml
+      test_control: sort_by_expression
+  name: sort_by_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId.yml
+      test_control: ten_m_doc_collection__int_id
+  name: ten_m_doc_collection__int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+      test_control: ten_m_doc_collection__int_id__agg
+  name: ten_m_doc_collection__int_id__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+      test_control: ten_m_doc_collection__int_id__identity_view
+  name: ten_m_doc_collection__int_id__identity_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+      test_control: ten_m_doc_collection__int_id__identity_view__agg
+  name: ten_m_doc_collection__int_id__identity_view__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId.yml
+      test_control: ten_m_doc_collection__object_id
+  name: ten_m_doc_collection__object_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+      test_control: ten_m_doc_collection__object_id__sharded
+  name: ten_m_doc_collection__object_id__sharded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_SubDocId.yml
+      test_control: ten_m_doc_collection__sub_doc_id
+  name: ten_m_doc_collection__sub_doc_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeries2dsphere.yml
+      test_control: time_series2dsphere
+  name: time_series2dsphere
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
+      test_control: time_series_group_stages_on_computed_fields
+  name: time_series_group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
+      test_control: time_series_lastpoint
+  name: time_series_lastpoint
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
+      test_control: time_series_sort
+  name: time_series_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortCompound.yml
+      test_control: time_series_sort_compound
+  name: time_series_sort_compound
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
+      test_control: time_series_sort_overlapping_buckets
+  name: time_series_sort_overlapping_buckets
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesTelemetry.yml
+      test_control: time_series_telemetry
+  name: time_series_telemetry
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesBlockProcessing.yml
+      test_control: timeseries_block_processing
+  name: timeseries_block_processing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesCount.yml
+      test_control: timeseries_count
+  name: timeseries_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesEnum.yml
+      test_control: timeseries_enum
+  name: timeseries_enum
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesStressUnpacking.yml
+      test_control: timeseries_stress_unpacking
+  name: timeseries_stress_unpacking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnionWith.yml
+      test_control: union_with
+  name: union_with
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnwindGroup.yml
+      test_control: unwind_group
+  name: unwind_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UpdateLargeDocuments.yml
+      test_control: update_large_documents
+  name: update_large_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/VariadicAggregateExpressions.yml
+      test_control: variadic_aggregate_expressions
+  name: variadic_aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithComplexPartitionExpression.yml
+      test_control: window_with_complex_partition_expression
+  name: window_with_complex_partition_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithNestedFieldProjection.yml
+      test_control: window_with_nested_field_projection
+  name: window_with_nested_field_projection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/linearFill.yml
+      test_control: linear_fill
+  name: linear_fill
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/locf.yml
+      test_control: locf
+  name: locf
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/BlockingSort.yml
+      test_control: multiplanner_blocking_sort
+  name: multiplanner_blocking_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ClusteredCollection.yml
+      test_control: multiplanner_clustered_collection
+  name: multiplanner_clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/CompoundIndexes.yml
+      test_control: multiplanner_compound_indexes
+  name: multiplanner_compound_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+      test_control: multiplanner_many_index_seeks
+  name: multiplanner_many_index_seeks
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+      test_control: multiplanner_multi_planning_reads_a_lot_of_data
+  name: multiplanner_multi_planning_reads_a_lot_of_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultikeyIndexes.yml
+      test_control: multiplanner_multikey_indexes
+  name: multiplanner_multikey_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+      test_control: multiplanner_multiplanner_with_group
+  name: multiplanner_multiplanner_with_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoResults.yml
+      test_control: multiplanner_no_results
+  name: multiplanner_no_results
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoSuchField.yml
+      test_control: multiplanner_no_such_field
+  name: multiplanner_no_such_field
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+      test_control: multiplanner_non_blocking_vs_blocking
+  name: multiplanner_non_blocking_vs_blocking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Simple.yml
+      test_control: multiplanner_simple
+  name: multiplanner_simple
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Subplanning.yml
+      test_control: multiplanner_subplanning
+  name: multiplanner_subplanning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/UseClusteredIndex.yml
+      test_control: multiplanner_use_clustered_index
+  name: multiplanner_use_clustered_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/VariedSelectivity.yml
+      test_control: multiplanner_varied_selectivity
+  name: multiplanner_varied_selectivity
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/EmptyGroup.yml
+      test_control: plan_cache_empty_group
+  name: plan_cache_empty_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+      test_control: plan_cache_match_eq_varying_array
+  name: plan_cache_match_eq_varying_array
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BigUpdate.yml
+      test_control: big_update
+  name: big_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BulkLoading.yml
+      test_control: bulk_loading
+  name: bulk_loading
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ContentionTTLDeletions.yml
+      test_control: contention_ttl_deletions
+  name: contention_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/CreateDropView.yml
+      test_control: create_drop_view
+  name: create_drop_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InCacheSnapshotReads.yml
+      test_control: in_cache_snapshot_reads
+  name: in_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertBigDocs.yml
+      test_control: insert_big_docs
+  name: insert_big_docs
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertRemove.yml
+      test_control: insert_remove
+  name: insert_remove
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedIns.yml
+      test_control: large_indexed_ins
+  name: large_indexed_ins
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedInsMatchingDocuments.yml
+      test_control: large_indexed_ins_matching_documents
+  name: large_indexed_ins_matching_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeScaleLongLived.yml
+      test_control: large_scale_long_lived
+  name: large_scale_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LoadTest.yml
+      test_control: load_test
+  name: load_test
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MajorityWrites10KThreads.yml
+      test_control: majority_writes10_k_threads
+  name: majority_writes10_k_threads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ManyUpdate.yml
+      test_control: many_update
+  name: many_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MassDeleteRegression.yml
+      test_control: mass_delete_regression
+  name: mass_delete_regression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGenny.yml
+      test_control: mixed_workloads_genny
+  name: mixed_workloads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+      test_control: mixed_workloads_genny_rate_limited
+  name: mixed_workloads_genny_rate_limited
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStress.yml
+      test_control: mixed_workloads_genny_stress
+  name: mixed_workloads_genny_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
+      test_control: mixed_workloads_genny_stress_with_scans
+  name: mixed_workloads_genny_stress_with_scans
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica
+      test_control: mixed_writes_replica
+  name: mixed_writes_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: mixed_writes_replica_delay_mixed
+  name: mixed_writes_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheScanner.yml
+      test_control: out_of_cache_scanner
+  name: out_of_cache_scanner
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheSnapshotReads.yml
+      test_control: out_of_cache_snapshot_reads
+  name: out_of_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ScanWithLongLived.yml
+      test_control: scan_with_long_lived
+  name: scan_with_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/TimeSeriesSortScale.yml
+      test_control: time_series_sort_scale
+  name: time_series_sort_scale
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/selftests/GennyOverhead.yml
+      test_control: genny_overhead
+  name: genny_overhead
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: batched_update_one_without_shard_key_with_id
+  name: batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: bulk_write_batched_update_one_without_shard_key_with_id
+  name: bulk_write_batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactions.yml
+      test_control: multi_shard_transactions
+  name: multi_shard_transactions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactionsWithManyNamespaces.yml
+      test_control: multi_shard_transactions_with_many_namespaces
+  name: multi_shard_transactions_with_many_namespaces
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollection.yml
+      test_control: reshard_collection
+  name: reshard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionMixed.yml
+      test_control: reshard_collection_mixed
+  name: reshard_collection_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+      test_control: reshard_collection_read_heavy
+  name: reshard_collection_read_heavy
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+      test_control: would_change_owning_shard_batch_write
+  name: would_change_owning_shard_batch_write
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneReplicaSet.yml
+      test_control: write_one_replica_set
+  name: write_one_replica_set
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyShardedCollection.yml
+      test_control: write_one_without_shard_key_sharded_collection
+  name: write_one_without_shard_key_sharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyUnshardedCollection.yml
+      test_control: write_one_without_shard_key_unsharded_collection
+  name: write_one_without_shard_key_unsharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations-ShardCollection.yml
+      test_control: multi_updates_multi_updates__pause_migrations__shard_collection
+  name: multi_updates_multi_updates__pause_migrations__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations.yml
+      test_control: multi_updates_multi_updates__pause_migrations
+  name: multi_updates_multi_updates__pause_migrations
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-ShardCollection.yml
+      test_control: multi_updates_multi_updates__shard_collection
+  name: multi_updates_multi_updates__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates.yml
+      test_control: multi_updates_multi_updates
+  name: multi_updates_multi_updates
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixed.yml
+      test_control: llt_mixed
+  name: llt_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixedSmall.yml
+      test_control: llt_mixed_small
+  name: llt_mixed_small
+  priority: 5

--- a/evergreen/system_perf/8.0/genny_tasks.yml
+++ b/evergreen/system_perf/8.0/genny_tasks.yml
@@ -347,7 +347,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
       test_control: device_monitoring
   name: device_monitoring
   priority: 5
@@ -358,7 +358,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
       test_control: coinbase_timeseries_group_date_trunc
   name: coinbase_timeseries_group_date_trunc
   priority: 5
@@ -369,7 +369,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
       test_control: coinbase_timeseries_group_date_trunc_memory_limit
   name: coinbase_timeseries_group_date_trunc_memory_limit
   priority: 5
@@ -380,7 +380,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
       test_control: coinbase_timeseries_group_date_trunc_sort
   name: coinbase_timeseries_group_date_trunc_sort
   priority: 5
@@ -391,7 +391,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
       test_control: coinbase_timeseries_match
   name: coinbase_timeseries_match
   priority: 5
@@ -402,7 +402,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
       test_control: coinbase_timeseries_match_count
   name: coinbase_timeseries_match_count
   priority: 5
@@ -413,7 +413,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
       test_control: coinbase_timeseries_query01
   name: coinbase_timeseries_query01
   priority: 5
@@ -424,7 +424,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
       test_control: coinbase_timeseries_query02
   name: coinbase_timeseries_query02
   priority: 5
@@ -435,7 +435,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
       test_control: coinbase_timeseries_query03
   name: coinbase_timeseries_query03
   priority: 5

--- a/evergreen/system_perf/README.md
+++ b/evergreen/system_perf/README.md
@@ -1,0 +1,36 @@
+# Auto-generated Genny Tasks
+
+This folder contains the task defintions and buildvariant assignments for the
+Genny workloads with `AutoRun` sections. These files are automatically
+generated and should never be updated manually.
+
+## Patch-testing a new Genny Workload
+
+If you are patch testing a new test, you need to regenerate the files and run
+the patch with `--include-modules` as follows:
+
+```bash
+# In the Genny repository
+./run-genny auto-tasks-local
+
+# In the mongo repository
+evergreen patch -p sys-perf -u --include-modules
+```
+
+Make sure to specify the path to your local Genny repository when the second
+command asks for it.
+
+## Adding a new Variant in DSI
+
+If you are adding a new variant in DSI, you need to create a companion PR in
+the Genny repo that updates the task definitions so that the Genny `AutoRun`
+tasks are scheduled on it.
+
+For this companion PR, run the following command:
+
+```bash
+# In the Genny repository
+./run-genny auto-tasks-local
+```
+
+Then commit the changes to the auto-generated files in `evergreen/sys-perf`.

--- a/evergreen/system_perf/README.md
+++ b/evergreen/system_perf/README.md
@@ -18,7 +18,8 @@ evergreen patch -p sys-perf -u --include-modules
 ```
 
 Make sure to specify the path to your local Genny repository when the second
-command asks for it.
+command asks for it. Evergreen also caches this setting in your
+`~/.evergreen.yml` config
 
 ## Adding a new Variant in DSI
 

--- a/evergreen/system_perf/master/genny_tasks.yml
+++ b/evergreen/system_perf/master/genny_tasks.yml
@@ -1,0 +1,3516 @@
+buildvariants:
+- name: perf-atlas-M60-real.arm.aws.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-atlas-M60-real.intel.azure.2023-11
+  tasks:
+  - name: create_big_index
+  - name: service_architecture_workloads
+  - name: expressive_queries
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: pipeline_update
+  - name: union_with
+  - name: big_update
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+- name: perf-shard-lite-fle.arm.aws.2023-11
+  tasks:
+  - name: ycsb_like_queryable_encrypt1_cf16
+  - name: ycsb_like_queryable_encrypt1_cf32
+  - name: ycsb_like_queryable_encrypt1_cfdefault
+  - name: ycsb_like_queryable_encrypt5_cf16
+  - name: ycsb_like_queryable_encrypt5_cf32
+  - name: ycsb_like_queryable_encrypt5_cfdefault
+  - name: medical_workload_diagnosis_100_0_unencrypted
+  - name: medical_workload_diagnosis_100_0
+  - name: medical_workload_diagnosis_50_50_unencrypted
+  - name: medical_workload_diagnosis_50_50
+  - name: medical_workload_guid_50_50_unencrypted
+  - name: medical_workload_guid_50_50
+  - name: medical_workload_load_unencrypted
+  - name: medical_workload_load
+  - name: qe_range_age_100_0
+  - name: qe_range_age_50_50
+  - name: qe_range_balance_100_0
+  - name: qe_range_balance_50_50
+  - name: qe_range_timestamp_100_0
+  - name: qe_range_timestamp_50_50
+- name: perf-3-shard.arm.aws.2023-11
+  tasks:
+  - name: clustered_collection
+  - name: clustered_collection_large_record_ids
+  - name: aggregations_output
+  - name: graph_lookup
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup
+  - name: lookup_colocated_data
+  - name: lookup_with_only_unsharded_colls
+  - name: non_search_hybrid_scoring
+  - name: shard_filter
+  - name: ten_m_doc_collection__object_id__sharded
+  - name: batched_update_one_without_shard_key_with_id
+  - name: bulk_write_batched_update_one_without_shard_key_with_id
+  - name: multi_shard_transactions
+  - name: multi_shard_transactions_with_many_namespaces
+  - name: reshard_collection_mixed
+  - name: reshard_collection_read_heavy
+  - name: would_change_owning_shard_batch_write
+  - name: multi_updates_multi_updates__shard_collection
+  - name: multi_updates_multi_updates
+- name: perf-3-node-replSet.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: coinbase_timeseries_query01
+  - name: coinbase_timeseries_query02
+  - name: coinbase_timeseries_query03
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_index_construction
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: clustered_collection
+  - name: clustered_collection_large_record_ids
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: time_series_range_delete
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: flushing
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: aggregate_expressions
+  - name: array_traversal
+  - name: boolean_simplifier
+  - name: boolean_simplifier_small_dataset
+  - name: coll_scan_complex_predicate_large
+  - name: coll_scan_complex_predicate_medium
+  - name: coll_scan_complex_predicate_small
+  - name: coll_scan_large_number_of_fields_large
+  - name: coll_scan_large_number_of_fields_medium
+  - name: coll_scan_large_number_of_fields_small
+  - name: coll_scan_on_mixed_data_types_large
+  - name: coll_scan_on_mixed_data_types_medium
+  - name: coll_scan_on_mixed_data_types_small
+  - name: coll_scan_predicate_selectivity_large
+  - name: coll_scan_predicate_selectivity_medium
+  - name: coll_scan_predicate_selectivity_small
+  - name: coll_scan_projection_large
+  - name: coll_scan_projection_medium
+  - name: coll_scan_projection_small
+  - name: coll_scan_simplifiable_predicate_large
+  - name: coll_scan_simplifiable_predicate_medium
+  - name: coll_scan_simplifiable_predicate_small
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_like_distinct
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: in_with_varied_array_size
+  - name: limit_skip
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: match_with_large_expression
+  - name: metric_secondary_index_timeseries_collection
+  - name: non_search_hybrid_scoring
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: percentiles_agg
+  - name: pipeline_update
+  - name: project_parse
+  - name: query_stats
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: repeated_path_traversal_medium
+  - name: repeated_path_traversal_small
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_lastpoint
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: timeseries_block_processing
+  - name: timeseries_count
+  - name: timeseries_enum
+  - name: timeseries_stress_unpacking
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: multiplanner_blocking_sort
+  - name: multiplanner_clustered_collection
+  - name: multiplanner_compound_indexes
+  - name: multiplanner_many_index_seeks
+  - name: multiplanner_multi_planning_reads_a_lot_of_data
+  - name: multiplanner_multikey_indexes
+  - name: multiplanner_multiplanner_with_group
+  - name: multiplanner_no_results
+  - name: multiplanner_no_such_field
+  - name: multiplanner_non_blocking_vs_blocking
+  - name: multiplanner_simple
+  - name: multiplanner_subplanning
+  - name: multiplanner_use_clustered_index
+  - name: multiplanner_varied_selectivity
+  - name: plan_cache_empty_group
+  - name: plan_cache_match_eq_varying_array
+  - name: big_update
+  - name: bulk_loading
+  - name: contention_ttl_deletions
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+- name: perf-3-node-replSet-query-engine-classic.arm.aws.2023-11
+  tasks:
+  - name: multiplanner_blocking_sort
+  - name: multiplanner_clustered_collection
+  - name: multiplanner_compound_indexes
+  - name: multiplanner_many_index_seeks
+  - name: multiplanner_multi_planning_reads_a_lot_of_data
+  - name: multiplanner_multikey_indexes
+  - name: multiplanner_multiplanner_with_group
+  - name: multiplanner_no_results
+  - name: multiplanner_no_such_field
+  - name: multiplanner_non_blocking_vs_blocking
+  - name: multiplanner_simple
+  - name: multiplanner_subplanning
+  - name: multiplanner_use_clustered_index
+  - name: multiplanner_varied_selectivity
+- name: perf-3-node-replSet-query-engine-sbe.arm.aws.2023-11
+  tasks:
+  - name: multiplanner_blocking_sort
+  - name: multiplanner_clustered_collection
+  - name: multiplanner_compound_indexes
+  - name: multiplanner_many_index_seeks
+  - name: multiplanner_multi_planning_reads_a_lot_of_data
+  - name: multiplanner_multikey_indexes
+  - name: multiplanner_multiplanner_with_group
+  - name: multiplanner_no_results
+  - name: multiplanner_no_such_field
+  - name: multiplanner_non_blocking_vs_blocking
+  - name: multiplanner_simple
+  - name: multiplanner_subplanning
+  - name: multiplanner_use_clustered_index
+  - name: multiplanner_varied_selectivity
+- name: perf-3-node-replSet-intel.intel.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: coinbase_timeseries_query01
+  - name: coinbase_timeseries_query02
+  - name: coinbase_timeseries_query03
+  - name: read_only_multi_threaded
+  - name: parallel_insert_replica
+  - name: parallel_insert_replica_delay_mixed
+  - name: background_index_construction
+  - name: background_ttl_deletions
+  - name: background_validate_cmd
+  - name: clustered_collection
+  - name: clustered_collection_large_record_ids
+  - name: create_big_index
+  - name: mixed_multi_deletes_batched
+  - name: mixed_multi_deletes_batched_with_secondary_indexes
+  - name: mixed_multi_deletes_doc_by_doc
+  - name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  - name: multi_planning
+  - name: ping_command
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: time_series_range_delete
+  - name: update_with_secondary_indexes
+  - name: validate_cmd
+  - name: validate_cmd_full
+  - name: flushing
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: aggregate_expressions
+  - name: array_traversal
+  - name: boolean_simplifier
+  - name: boolean_simplifier_small_dataset
+  - name: coll_scan_complex_predicate_large
+  - name: coll_scan_complex_predicate_medium
+  - name: coll_scan_complex_predicate_small
+  - name: coll_scan_large_number_of_fields_large
+  - name: coll_scan_large_number_of_fields_medium
+  - name: coll_scan_large_number_of_fields_small
+  - name: coll_scan_on_mixed_data_types_large
+  - name: coll_scan_on_mixed_data_types_medium
+  - name: coll_scan_on_mixed_data_types_small
+  - name: coll_scan_predicate_selectivity_large
+  - name: coll_scan_predicate_selectivity_medium
+  - name: coll_scan_predicate_selectivity_small
+  - name: coll_scan_projection_large
+  - name: coll_scan_projection_medium
+  - name: coll_scan_projection_small
+  - name: coll_scan_simplifiable_predicate_large
+  - name: coll_scan_simplifiable_predicate_medium
+  - name: coll_scan_simplifiable_predicate_small
+  - name: collection_level_diagnostic_commands
+  - name: constant_fold_arithmetic
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_fill_combo
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: densify_timeseries_collection
+  - name: expressive_queries
+  - name: external_sort
+  - name: fill_timeseries_collection
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: group_like_distinct
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: in_with_varied_array_size
+  - name: limit_skip
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: lookup_with_only_unsharded_colls
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: match_with_large_expression
+  - name: metric_secondary_index_timeseries_collection
+  - name: non_search_hybrid_scoring
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: percentiles_agg
+  - name: pipeline_update
+  - name: project_parse
+  - name: query_stats
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: repeated_path_traversal_medium
+  - name: repeated_path_traversal_small
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_lastpoint
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: timeseries_block_processing
+  - name: timeseries_count
+  - name: timeseries_enum
+  - name: timeseries_stress_unpacking
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: multiplanner_blocking_sort
+  - name: multiplanner_clustered_collection
+  - name: multiplanner_compound_indexes
+  - name: multiplanner_many_index_seeks
+  - name: multiplanner_multi_planning_reads_a_lot_of_data
+  - name: multiplanner_multikey_indexes
+  - name: multiplanner_multiplanner_with_group
+  - name: multiplanner_no_results
+  - name: multiplanner_no_such_field
+  - name: multiplanner_non_blocking_vs_blocking
+  - name: multiplanner_simple
+  - name: multiplanner_subplanning
+  - name: multiplanner_use_clustered_index
+  - name: multiplanner_varied_selectivity
+  - name: plan_cache_empty_group
+  - name: plan_cache_match_eq_varying_array
+  - name: big_update
+  - name: bulk_loading
+  - name: contention_ttl_deletions
+  - name: create_drop_view
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mass_delete_regression
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: mixed_workloads_genny_stress
+  - name: mixed_workloads_genny_stress_with_scans
+  - name: mixed_writes_replica
+  - name: mixed_writes_replica_delay_mixed
+  - name: scan_with_long_lived
+  - name: time_series_sort_scale
+  - name: genny_overhead
+  - name: write_one_replica_set
+  - name: llt_mixed
+  - name: llt_mixed_small
+- name: perf-standalone-classic-query-engine.intel.aws.2023-11
+  tasks:
+  - name: multi_planning
+  - name: aggregate_expressions
+  - name: array_traversal
+  - name: boolean_simplifier
+  - name: boolean_simplifier_small_dataset
+  - name: coll_scan_complex_predicate_large
+  - name: coll_scan_complex_predicate_medium
+  - name: coll_scan_complex_predicate_small
+  - name: coll_scan_large_number_of_fields_large
+  - name: coll_scan_large_number_of_fields_medium
+  - name: coll_scan_large_number_of_fields_small
+  - name: coll_scan_on_mixed_data_types_large
+  - name: coll_scan_on_mixed_data_types_medium
+  - name: coll_scan_on_mixed_data_types_small
+  - name: coll_scan_predicate_selectivity_large
+  - name: coll_scan_predicate_selectivity_medium
+  - name: coll_scan_predicate_selectivity_small
+  - name: coll_scan_projection_large
+  - name: coll_scan_projection_medium
+  - name: coll_scan_projection_small
+  - name: coll_scan_simplifiable_predicate_large
+  - name: coll_scan_simplifiable_predicate_medium
+  - name: coll_scan_simplifiable_predicate_small
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: expressive_queries
+  - name: external_sort
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: in_with_varied_array_size
+  - name: limit_skip
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: match_with_large_expression
+  - name: percentiles_agg
+  - name: percentiles_expr
+  - name: percentiles_window
+  - name: percentiles_window_spill_to_disk
+  - name: project_parse
+  - name: repeated_path_traversal
+  - name: repeated_path_traversal_medium
+  - name: repeated_path_traversal_small
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: time_series_group_stages_on_computed_fields
+  - name: union_with
+  - name: unwind_group
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: large_scale_long_lived
+- name: perf-standalone-sbe.intel.aws.2023-11
+  tasks:
+  - name: multi_planning
+  - name: aggregate_expressions
+  - name: array_traversal
+  - name: coll_scan_complex_predicate_large
+  - name: coll_scan_complex_predicate_medium
+  - name: coll_scan_complex_predicate_small
+  - name: coll_scan_large_number_of_fields_large
+  - name: coll_scan_large_number_of_fields_medium
+  - name: coll_scan_large_number_of_fields_small
+  - name: coll_scan_on_mixed_data_types_large
+  - name: coll_scan_on_mixed_data_types_medium
+  - name: coll_scan_on_mixed_data_types_small
+  - name: coll_scan_predicate_selectivity_large
+  - name: coll_scan_predicate_selectivity_medium
+  - name: coll_scan_predicate_selectivity_small
+  - name: coll_scan_projection_large
+  - name: coll_scan_projection_medium
+  - name: coll_scan_projection_small
+  - name: coll_scan_simplifiable_predicate_large
+  - name: coll_scan_simplifiable_predicate_medium
+  - name: coll_scan_simplifiable_predicate_small
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: expressive_queries
+  - name: external_sort
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: in_with_varied_array_size
+  - name: limit_skip
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: match_with_large_expression
+  - name: percentiles_agg
+  - name: percentiles_expr
+  - name: percentiles_window
+  - name: percentiles_window_spill_to_disk
+  - name: project_parse
+  - name: repeated_path_traversal
+  - name: repeated_path_traversal_medium
+  - name: repeated_path_traversal_small
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: union_with
+  - name: unwind_group
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: large_scale_long_lived
+- name: perf-1-node-replSet-classic-query-engine.intel.aws.2023-11
+  tasks:
+  - name: constant_fold_arithmetic
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup_with_only_unsharded_colls
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: scan_with_long_lived
+  - name: llt_mixed
+- name: perf-1-node-replSet-sbe.intel.aws.2023-11
+  tasks:
+  - name: constant_fold_arithmetic
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup_with_only_unsharded_colls
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: scan_with_long_lived
+  - name: llt_mixed
+- name: perf-standalone-classic-query-engine.arm.aws.2023-11
+  tasks:
+  - name: multi_planning
+  - name: aggregate_expressions
+  - name: array_traversal
+  - name: boolean_simplifier
+  - name: boolean_simplifier_small_dataset
+  - name: coll_scan_complex_predicate_large
+  - name: coll_scan_complex_predicate_medium
+  - name: coll_scan_complex_predicate_small
+  - name: coll_scan_large_number_of_fields_large
+  - name: coll_scan_large_number_of_fields_medium
+  - name: coll_scan_large_number_of_fields_small
+  - name: coll_scan_on_mixed_data_types_large
+  - name: coll_scan_on_mixed_data_types_medium
+  - name: coll_scan_on_mixed_data_types_small
+  - name: coll_scan_predicate_selectivity_large
+  - name: coll_scan_predicate_selectivity_medium
+  - name: coll_scan_predicate_selectivity_small
+  - name: coll_scan_projection_large
+  - name: coll_scan_projection_medium
+  - name: coll_scan_projection_small
+  - name: coll_scan_simplifiable_predicate_large
+  - name: coll_scan_simplifiable_predicate_medium
+  - name: coll_scan_simplifiable_predicate_small
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: expressive_queries
+  - name: external_sort
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: in_with_varied_array_size
+  - name: limit_skip
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: match_with_large_expression
+  - name: percentiles_agg
+  - name: percentiles_expr
+  - name: percentiles_window
+  - name: percentiles_window_spill_to_disk
+  - name: project_parse
+  - name: repeated_path_traversal
+  - name: repeated_path_traversal_medium
+  - name: repeated_path_traversal_small
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: time_series_group_stages_on_computed_fields
+  - name: union_with
+  - name: unwind_group
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: large_scale_long_lived
+- name: perf-standalone-sbe.arm.aws.2023-11
+  tasks:
+  - name: multi_planning
+  - name: aggregate_expressions
+  - name: array_traversal
+  - name: coll_scan_complex_predicate_large
+  - name: coll_scan_complex_predicate_medium
+  - name: coll_scan_complex_predicate_small
+  - name: coll_scan_large_number_of_fields_large
+  - name: coll_scan_large_number_of_fields_medium
+  - name: coll_scan_large_number_of_fields_small
+  - name: coll_scan_on_mixed_data_types_large
+  - name: coll_scan_on_mixed_data_types_medium
+  - name: coll_scan_on_mixed_data_types_small
+  - name: coll_scan_predicate_selectivity_large
+  - name: coll_scan_predicate_selectivity_medium
+  - name: coll_scan_predicate_selectivity_small
+  - name: coll_scan_projection_large
+  - name: coll_scan_projection_medium
+  - name: coll_scan_projection_small
+  - name: coll_scan_simplifiable_predicate_large
+  - name: coll_scan_simplifiable_predicate_medium
+  - name: coll_scan_simplifiable_predicate_small
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: expressive_queries
+  - name: external_sort
+  - name: filter_with_complex_logical_expression
+  - name: filter_with_complex_logical_expression_medium
+  - name: filter_with_complex_logical_expression_small
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: in_with_varied_array_size
+  - name: limit_skip
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: match_with_large_expression
+  - name: percentiles_agg
+  - name: percentiles_expr
+  - name: percentiles_window
+  - name: percentiles_window_spill_to_disk
+  - name: project_parse
+  - name: repeated_path_traversal
+  - name: repeated_path_traversal_medium
+  - name: repeated_path_traversal_small
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: union_with
+  - name: unwind_group
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: big_update
+  - name: large_scale_long_lived
+- name: perf-1-node-replSet-classic-query-engine.arm.aws.2023-11
+  tasks:
+  - name: constant_fold_arithmetic
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup_with_only_unsharded_colls
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: scan_with_long_lived
+  - name: llt_mixed
+- name: perf-1-node-replSet-sbe.arm.aws.2023-11
+  tasks:
+  - name: constant_fold_arithmetic
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup_with_only_unsharded_colls
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: scan_with_long_lived
+  - name: llt_mixed
+- name: perf-1-node-replSet-fle.arm.aws.2023-11
+  tasks:
+  - name: exponential_compact
+  - name: ycsb_like_queryable_encrypt1_cf16
+  - name: ycsb_like_queryable_encrypt1_cf32
+  - name: ycsb_like_queryable_encrypt1_cfdefault
+  - name: ycsb_like_queryable_encrypt5_cf16
+  - name: ycsb_like_queryable_encrypt5_cf32
+  - name: ycsb_like_queryable_encrypt5_cfdefault
+  - name: qe_range_age_100_0
+  - name: qe_range_age_50_50
+  - name: qe_range_balance_100_0
+  - name: qe_range_balance_50_50
+  - name: qe_range_timestamp_100_0
+  - name: qe_range_timestamp_50_50
+- name: perf-1-node-15gbwtcache.arm.aws.2023-11
+  tasks:
+  - name: large_scale_long_lived
+  - name: out_of_cache_scanner
+- name: perf-3-node-1dayhistory-15gbwtcache.arm.aws.2023-11
+  tasks:
+  - name: big_update
+  - name: in_cache_snapshot_reads
+  - name: insert_remove
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: out_of_cache_snapshot_reads
+- name: perf-3-shard.intel.aws.2023-11
+  tasks:
+  - name: clustered_collection
+  - name: clustered_collection_large_record_ids
+  - name: aggregations_output
+  - name: graph_lookup
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup
+  - name: lookup_colocated_data
+  - name: lookup_with_only_unsharded_colls
+  - name: non_search_hybrid_scoring
+  - name: shard_filter
+  - name: ten_m_doc_collection__object_id__sharded
+  - name: batched_update_one_without_shard_key_with_id
+  - name: bulk_write_batched_update_one_without_shard_key_with_id
+  - name: multi_shard_transactions
+  - name: multi_shard_transactions_with_many_namespaces
+  - name: reshard_collection_mixed
+  - name: reshard_collection_read_heavy
+  - name: would_change_owning_shard_batch_write
+  - name: multi_updates_multi_updates__shard_collection
+  - name: multi_updates_multi_updates
+- name: perf-shard-all-feature-flags.arm.aws.2023-11
+  tasks:
+  - name: clustered_collection
+  - name: clustered_collection_large_record_ids
+  - name: aggregations_output
+  - name: graph_lookup
+  - name: graph_lookup_with_only_unsharded_colls
+  - name: lookup
+  - name: lookup_colocated_data
+  - name: lookup_with_only_unsharded_colls
+  - name: batched_update_one_without_shard_key_with_id
+  - name: bulk_write_batched_update_one_without_shard_key_with_id
+  - name: multi_shard_transactions
+  - name: multi_shard_transactions_with_many_namespaces
+  - name: reshard_collection
+  - name: reshard_collection_mixed
+  - name: reshard_collection_read_heavy
+  - name: would_change_owning_shard_batch_write
+  - name: multi_updates_multi_updates__pause_migrations__shard_collection
+  - name: multi_updates_multi_updates__pause_migrations
+  - name: multi_updates_multi_updates__shard_collection
+  - name: multi_updates_multi_updates
+- name: perf-shard-single.arm.aws.2023-11
+  tasks:
+  - name: read_only_multi_threaded
+  - name: connection_pool_stress
+  - name: connections_buildup
+  - name: query_stats
+  - name: write_one_without_shard_key_sharded_collection
+  - name: write_one_without_shard_key_unsharded_collection
+- name: perf-3-node-replSet-last-continuous-fcv.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+- name: perf-3-node-replSet-last-lts-fcv.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+- name: perf-3-node-replSet-all-feature-flags.arm.aws.2023-11
+  tasks:
+  - name: device_monitoring
+  - name: coinbase_timeseries_group_date_trunc
+  - name: coinbase_timeseries_group_date_trunc_memory_limit
+  - name: coinbase_timeseries_group_date_trunc_sort
+  - name: coinbase_timeseries_match
+  - name: coinbase_timeseries_match_count
+  - name: coinbase_timeseries_query01
+  - name: coinbase_timeseries_query02
+  - name: coinbase_timeseries_query03
+  - name: background_index_construction
+  - name: background_ttl_deletions
+  - name: clustered_collection
+  - name: clustered_collection_large_record_ids
+  - name: create_big_index
+  - name: multi_planning
+  - name: secondary_reads_genny
+  - name: sinusoidal_read_writes
+  - name: time_series_arbitrary_update
+  - name: time_series_range_delete
+  - name: update_with_secondary_indexes
+  - name: connections_buildup
+  - name: commit_latency
+  - name: commit_latency_single_update
+  - name: service_architecture_workloads
+  - name: aggregate_expressions
+  - name: boolean_simplifier
+  - name: boolean_simplifier_small_dataset
+  - name: coll_scan_complex_predicate_large
+  - name: coll_scan_complex_predicate_medium
+  - name: coll_scan_complex_predicate_small
+  - name: coll_scan_large_number_of_fields_large
+  - name: coll_scan_large_number_of_fields_medium
+  - name: coll_scan_large_number_of_fields_small
+  - name: coll_scan_on_mixed_data_types_large
+  - name: coll_scan_on_mixed_data_types_medium
+  - name: coll_scan_on_mixed_data_types_small
+  - name: coll_scan_predicate_selectivity_large
+  - name: coll_scan_predicate_selectivity_medium
+  - name: coll_scan_predicate_selectivity_small
+  - name: coll_scan_projection_large
+  - name: coll_scan_projection_medium
+  - name: coll_scan_projection_small
+  - name: coll_scan_simplifiable_predicate_large
+  - name: coll_scan_simplifiable_predicate_medium
+  - name: coll_scan_simplifiable_predicate_small
+  - name: csi_fragmented_inserts_flat
+  - name: csi_fragmented_inserts_nested
+  - name: cumulative_windows
+  - name: cumulative_windows_multi_accums
+  - name: densify_hours
+  - name: densify_milliseconds
+  - name: densify_months
+  - name: densify_numeric
+  - name: expressive_queries
+  - name: external_sort
+  - name: group_like_distinct
+  - name: group_spill_to_disk
+  - name: group_stages_on_computed_fields
+  - name: in_with_varied_array_size
+  - name: limit_skip
+  - name: lookup_nlj
+  - name: lookup_only
+  - name: lookup_sbe_pushdown
+  - name: lookup_sbe_pushdown_inlj_misc
+  - name: lookup_unwind
+  - name: match_filters
+  - name: match_filters_medium
+  - name: match_filters_small
+  - name: match_with_large_expression
+  - name: metric_secondary_index_timeseries_collection
+  - name: non_search_hybrid_scoring
+  - name: one_m_doc_collection__large_doc_int_id
+  - name: percentiles_agg
+  - name: percentiles_expr
+  - name: percentiles_window
+  - name: percentiles_window_spill_to_disk
+  - name: pipeline_update
+  - name: project_parse
+  - name: query_stats_query_shapes
+  - name: repeated_path_traversal
+  - name: repeated_path_traversal_medium
+  - name: repeated_path_traversal_small
+  - name: set_window_fields_unbounded
+  - name: sliding_windows
+  - name: sliding_windows_multi_accums
+  - name: sort_by_expression
+  - name: ten_m_doc_collection__int_id
+  - name: ten_m_doc_collection__int_id__agg
+  - name: ten_m_doc_collection__int_id__identity_view
+  - name: ten_m_doc_collection__int_id__identity_view__agg
+  - name: ten_m_doc_collection__object_id
+  - name: ten_m_doc_collection__sub_doc_id
+  - name: time_series2dsphere
+  - name: time_series_group_stages_on_computed_fields
+  - name: time_series_lastpoint
+  - name: time_series_sort
+  - name: time_series_sort_compound
+  - name: time_series_sort_overlapping_buckets
+  - name: time_series_telemetry
+  - name: timeseries_block_processing
+  - name: timeseries_count
+  - name: timeseries_enum
+  - name: timeseries_stress_unpacking
+  - name: union_with
+  - name: unwind_group
+  - name: update_large_documents
+  - name: variadic_aggregate_expressions
+  - name: window_with_complex_partition_expression
+  - name: window_with_nested_field_projection
+  - name: linear_fill
+  - name: locf
+  - name: multiplanner_blocking_sort
+  - name: multiplanner_clustered_collection
+  - name: multiplanner_compound_indexes
+  - name: multiplanner_many_index_seeks
+  - name: multiplanner_multi_planning_reads_a_lot_of_data
+  - name: multiplanner_multikey_indexes
+  - name: multiplanner_multiplanner_with_group
+  - name: multiplanner_no_results
+  - name: multiplanner_no_such_field
+  - name: multiplanner_non_blocking_vs_blocking
+  - name: multiplanner_simple
+  - name: multiplanner_subplanning
+  - name: multiplanner_use_clustered_index
+  - name: multiplanner_varied_selectivity
+  - name: big_update
+  - name: contention_ttl_deletions
+  - name: insert_big_docs
+  - name: insert_remove
+  - name: large_indexed_ins
+  - name: large_indexed_ins_matching_documents
+  - name: large_scale_long_lived
+  - name: load_test
+  - name: majority_writes10_k_threads
+  - name: many_update
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+  - name: time_series_sort_scale
+  - name: llt_mixed
+  - name: llt_mixed_small
+- name: perf-3-node-replSet-maintenance-events.arm.aws.2023-11
+  tasks:
+  - name: mixed_workloads_genny
+  - name: mixed_workloads_genny_rate_limited
+- name: perf-replSet-auth-delay.arm.aws.2023-11
+  tasks:
+  - name: transport_layer_connect_timing
+- name: perf-3-node-replSet-limited-1-query-stats.arm.aws.2023-11
+  tasks:
+  - name: non_search_hybrid_scoring
+- name: perf-3-node-replSet-limited-10-query-stats.arm.aws.2023-11
+  tasks:
+  - name: non_search_hybrid_scoring
+- name: perf-3-node-replSet-limited-1000-query-stats.arm.aws.2023-11
+  tasks:
+  - name: non_search_hybrid_scoring
+- name: perf-3-node-replSet-limited-10000-query-stats.arm.aws.2023-11
+  tasks:
+  - name: non_search_hybrid_scoring
+tasks:
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      test_control: device_monitoring
+  name: device_monitoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      test_control: coinbase_timeseries_group_date_trunc
+  name: coinbase_timeseries_group_date_trunc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      test_control: coinbase_timeseries_group_date_trunc_memory_limit
+  name: coinbase_timeseries_group_date_trunc_memory_limit
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      test_control: coinbase_timeseries_group_date_trunc_sort
+  name: coinbase_timeseries_group_date_trunc_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      test_control: coinbase_timeseries_match
+  name: coinbase_timeseries_match
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      test_control: coinbase_timeseries_match_count
+  name: coinbase_timeseries_match_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      test_control: coinbase_timeseries_query01
+  name: coinbase_timeseries_query01
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      test_control: coinbase_timeseries_query02
+  name: coinbase_timeseries_query02
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      test_control: coinbase_timeseries_query03
+  name: coinbase_timeseries_query03
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/basic/ReadOnlyMultiThreaded.yml
+      test_control: read_only_multi_threaded
+  name: read_only_multi_threaded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica
+      test_control: parallel_insert_replica
+  name: parallel_insert_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/docs/ParallelInsert.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: parallel_insert_replica_delay_mixed
+  name: parallel_insert_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/ExponentialCompact.yml
+      test_control: exponential_compact
+  name: exponential_compact
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf16.yml
+      test_control: ycsb_like_queryable_encrypt1_cf16
+  name: ycsb_like_queryable_encrypt1_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cf32.yml
+      test_control: ycsb_like_queryable_encrypt1_cf32
+  name: ycsb_like_queryable_encrypt1_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt1Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt1_cfdefault
+  name: ycsb_like_queryable_encrypt1_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf16.yml
+      test_control: ycsb_like_queryable_encrypt5_cf16
+  name: ycsb_like_queryable_encrypt5_cf16
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cf32.yml
+      test_control: ycsb_like_queryable_encrypt5_cf32
+  name: ycsb_like_queryable_encrypt5_cf32
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/YCSBLikeQueryableEncrypt5Cfdefault.yml
+      test_control: ycsb_like_queryable_encrypt5_cfdefault
+  name: ycsb_like_queryable_encrypt5_cfdefault
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0-unencrypted.yml
+      test_control: medical_workload_diagnosis_100_0_unencrypted
+  name: medical_workload_diagnosis_100_0_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-100-0.yml
+      test_control: medical_workload_diagnosis_100_0
+  name: medical_workload_diagnosis_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50-unencrypted.yml
+      test_control: medical_workload_diagnosis_50_50_unencrypted
+  name: medical_workload_diagnosis_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-diagnosis-50-50.yml
+      test_control: medical_workload_diagnosis_50_50
+  name: medical_workload_diagnosis_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50-unencrypted.yml
+      test_control: medical_workload_guid_50_50_unencrypted
+  name: medical_workload_guid_50_50_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-guid-50-50.yml
+      test_control: medical_workload_guid_50_50
+  name: medical_workload_guid_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load-unencrypted.yml
+      test_control: medical_workload_load_unencrypted
+  name: medical_workload_load_unencrypted
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/medical_workload-load.yml
+      test_control: medical_workload_load
+  name: medical_workload_load
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-100-0.yml
+      test_control: qe_range_age_100_0
+  name: qe_range_age_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-age-50-50.yml
+      test_control: qe_range_age_50_50
+  name: qe_range_age_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-100-0.yml
+      test_control: qe_range_balance_100_0
+  name: qe_range_balance_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-balance-50-50.yml
+      test_control: qe_range_balance_50_50
+  name: qe_range_balance_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-100-0.yml
+      test_control: qe_range_timestamp_100_0
+  name: qe_range_timestamp_100_0
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/encrypted/qe-range-timestamp-50-50.yml
+      test_control: qe_range_timestamp_50_50
+  name: qe_range_timestamp_50_50
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundIndexConstruction.yml
+      test_control: background_index_construction
+  name: background_index_construction
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundTTLDeletions.yml
+      test_control: background_ttl_deletions
+  name: background_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/BackgroundValidateCmd.yml
+      test_control: background_validate_cmd
+  name: background_validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollection.yml
+      test_control: clustered_collection
+  name: clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ClusteredCollectionLargeRecordIds.yml
+      test_control: clustered_collection_large_record_ids
+  name: clustered_collection_large_record_ids
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/CreateBigIndex.yml
+      test_control: create_big_index
+  name: create_big_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatched.yml
+      test_control: mixed_multi_deletes_batched
+  name: mixed_multi_deletes_batched
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesBatchedWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_batched_with_secondary_indexes
+  name: mixed_multi_deletes_batched_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDoc.yml
+      test_control: mixed_multi_deletes_doc_by_doc
+  name: mixed_multi_deletes_doc_by_doc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MixedMultiDeletesDocByDocWithSecondaryIndexes.yml
+      test_control: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  name: mixed_multi_deletes_doc_by_doc_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/MultiPlanning.yml
+      test_control: multi_planning
+  name: multi_planning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/PingCommand.yml
+      test_control: ping_command
+  name: ping_command
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SecondaryReadsGenny.yml
+      test_control: secondary_reads_genny
+  name: secondary_reads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/SinusoidalReadWrites.yml
+      test_control: sinusoidal_read_writes
+  name: sinusoidal_read_writes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesArbitraryUpdate.yml
+      test_control: time_series_arbitrary_update
+  name: time_series_arbitrary_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/TimeSeriesRangeDelete.yml
+      test_control: time_series_range_delete
+  name: time_series_range_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/UpdateWithSecondaryIndexes.yml
+      test_control: update_with_secondary_indexes
+  name: update_with_secondary_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmd.yml
+      test_control: validate_cmd
+  name: validate_cmd
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/execution/ValidateCmdFull.yml
+      test_control: validate_cmd_full
+  name: validate_cmd_full
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/filesystem/Flushing.yml
+      test_control: flushing
+  name: flushing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionPoolStress.yml
+      test_control: connection_pool_stress
+  name: connection_pool_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/ConnectionsBuildup.yml
+      test_control: connections_buildup
+  name: connections_buildup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/issues/MongosLatency.yml
+      test_control: mongos_latency
+  name: mongos_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatency.yml
+      test_control: commit_latency
+  name: commit_latency
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/CommitLatencySingleUpdate.yml
+      test_control: commit_latency_single_update
+  name: commit_latency_single_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/ServiceArchitectureWorkloads.yml
+      test_control: service_architecture_workloads
+  name: service_architecture_workloads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/networking/TransportLayerConnectTiming.yml
+      test_control: transport_layer_connect_timing
+  name: transport_layer_connect_timing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregateExpressions.yml
+      test_control: aggregate_expressions
+  name: aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/AggregationsOutput.yml
+      test_control: aggregations_output
+  name: aggregations_output
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ArrayTraversal.yml
+      test_control: array_traversal
+  name: array_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifier.yml
+      test_control: boolean_simplifier
+  name: boolean_simplifier
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/BooleanSimplifierSmallDataset.yml
+      test_control: boolean_simplifier_small_dataset
+  name: boolean_simplifier_small_dataset
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsDelete.yml
+      test_control: cpu_cycle_metrics_delete
+  name: cpu_cycle_metrics_delete
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsFind.yml
+      test_control: cpu_cycle_metrics_find
+  name: cpu_cycle_metrics_find
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsInsert.yml
+      test_control: cpu_cycle_metrics_insert
+  name: cpu_cycle_metrics_insert
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CPUCycleMetricsUpdate.yml
+      test_control: cpu_cycle_metrics_update
+  name: cpu_cycle_metrics_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateLarge.yml
+      test_control: coll_scan_complex_predicate_large
+  name: coll_scan_complex_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateMedium.yml
+      test_control: coll_scan_complex_predicate_medium
+  name: coll_scan_complex_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanComplexPredicateSmall.yml
+      test_control: coll_scan_complex_predicate_small
+  name: coll_scan_complex_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
+      test_control: coll_scan_large_number_of_fields_large
+  name: coll_scan_large_number_of_fields_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
+      test_control: coll_scan_large_number_of_fields_medium
+  name: coll_scan_large_number_of_fields_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+      test_control: coll_scan_large_number_of_fields_small
+  name: coll_scan_large_number_of_fields_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
+      test_control: coll_scan_on_mixed_data_types_large
+  name: coll_scan_on_mixed_data_types_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
+      test_control: coll_scan_on_mixed_data_types_medium
+  name: coll_scan_on_mixed_data_types_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
+      test_control: coll_scan_on_mixed_data_types_small
+  name: coll_scan_on_mixed_data_types_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityLarge.yml
+      test_control: coll_scan_predicate_selectivity_large
+  name: coll_scan_predicate_selectivity_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivityMedium.yml
+      test_control: coll_scan_predicate_selectivity_medium
+  name: coll_scan_predicate_selectivity_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanPredicateSelectivitySmall.yml
+      test_control: coll_scan_predicate_selectivity_small
+  name: coll_scan_predicate_selectivity_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionLarge.yml
+      test_control: coll_scan_projection_large
+  name: coll_scan_projection_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionMedium.yml
+      test_control: coll_scan_projection_medium
+  name: coll_scan_projection_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanProjectionSmall.yml
+      test_control: coll_scan_projection_small
+  name: coll_scan_projection_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+      test_control: coll_scan_simplifiable_predicate_large
+  name: coll_scan_simplifiable_predicate_large
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+      test_control: coll_scan_simplifiable_predicate_medium
+  name: coll_scan_simplifiable_predicate_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+      test_control: coll_scan_simplifiable_predicate_small
+  name: coll_scan_simplifiable_predicate_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CollectionLevelDiagnosticCommands.yml
+      test_control: collection_level_diagnostic_commands
+  name: collection_level_diagnostic_commands
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ConstantFoldArithmetic.yml
+      test_control: constant_fold_arithmetic
+  name: constant_fold_arithmetic
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
+      test_control: csi_fragmented_inserts_flat
+  name: csi_fragmented_inserts_flat
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
+      test_control: csi_fragmented_inserts_nested
+  name: csi_fragmented_inserts_nested
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindows.yml
+      test_control: cumulative_windows
+  name: cumulative_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/CumulativeWindowsMultiAccums.yml
+      test_control: cumulative_windows_multi_accums
+  name: cumulative_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyFillCombo.yml
+      test_control: densify_fill_combo
+  name: densify_fill_combo
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyHours.yml
+      test_control: densify_hours
+  name: densify_hours
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMilliseconds.yml
+      test_control: densify_milliseconds
+  name: densify_milliseconds
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyMonths.yml
+      test_control: densify_months
+  name: densify_months
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyNumeric.yml
+      test_control: densify_numeric
+  name: densify_numeric
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/DensifyTimeseriesCollection.yml
+      test_control: densify_timeseries_collection
+  name: densify_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExpressiveQueries.yml
+      test_control: expressive_queries
+  name: expressive_queries
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ExternalSort.yml
+      test_control: external_sort
+  name: external_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FillTimeseriesCollection.yml
+      test_control: fill_timeseries_collection
+  name: fill_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpression.yml
+      test_control: filter_with_complex_logical_expression
+  name: filter_with_complex_logical_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
+      test_control: filter_with_complex_logical_expression_medium
+  name: filter_with_complex_logical_expression_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
+      test_control: filter_with_complex_logical_expression_small
+  name: filter_with_complex_logical_expression_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookup.yml
+      test_control: graph_lookup
+  name: graph_lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+      test_control: graph_lookup_with_only_unsharded_colls
+  name: graph_lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupLikeDistinct.yml
+      test_control: group_like_distinct
+  name: group_like_distinct
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupSpillToDisk.yml
+      test_control: group_spill_to_disk
+  name: group_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/GroupStagesOnComputedFields.yml
+      test_control: group_stages_on_computed_fields
+  name: group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/InWithVariedArraySize.yml
+      test_control: in_with_varied_array_size
+  name: in_with_varied_array_size
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LimitSkip.yml
+      test_control: limit_skip
+  name: limit_skip
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/Lookup.yml
+      test_control: lookup
+  name: lookup
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupColocatedData.yml
+      test_control: lookup_colocated_data
+  name: lookup_colocated_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupNLJ.yml
+      test_control: lookup_nlj
+  name: lookup_nlj
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupOnly.yml
+      test_control: lookup_only
+  name: lookup_only
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdown.yml
+      test_control: lookup_sbe_pushdown
+  name: lookup_sbe_pushdown
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+      test_control: lookup_sbe_pushdown_inlj_misc
+  name: lookup_sbe_pushdown_inlj_misc
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupUnwind.yml
+      test_control: lookup_unwind
+  name: lookup_unwind
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+      test_control: lookup_with_only_unsharded_colls
+  name: lookup_with_only_unsharded_colls
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFilters.yml
+      test_control: match_filters
+  name: match_filters
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersMedium.yml
+      test_control: match_filters_medium
+  name: match_filters_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchFiltersSmall.yml
+      test_control: match_filters_small
+  name: match_filters_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MatchWithLargeExpression.yml
+      test_control: match_with_large_expression
+  name: match_with_large_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+      test_control: metric_secondary_index_timeseries_collection
+  name: metric_secondary_index_timeseries_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/NonSearchHybridScoring.yml
+      test_control: non_search_hybrid_scoring
+  name: non_search_hybrid_scoring
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+      test_control: one_m_doc_collection__large_doc_int_id
+  name: one_m_doc_collection__large_doc_int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesAgg.yml
+      test_control: percentiles_agg
+  name: percentiles_agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesExpr.yml
+      test_control: percentiles_expr
+  name: percentiles_expr
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindow.yml
+      test_control: percentiles_window
+  name: percentiles_window
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PercentilesWindowSpillToDisk.yml
+      test_control: percentiles_window_spill_to_disk
+  name: percentiles_window_spill_to_disk
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/PipelineUpdate.yml
+      test_control: pipeline_update
+  name: pipeline_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ProjectParse.yml
+      test_control: project_parse
+  name: project_parse
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStats.yml
+      test_control: query_stats
+  name: query_stats
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/QueryStatsQueryShapes.yml
+      test_control: query_stats_query_shapes
+  name: query_stats_query_shapes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversal.yml
+      test_control: repeated_path_traversal
+  name: repeated_path_traversal
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalMedium.yml
+      test_control: repeated_path_traversal_medium
+  name: repeated_path_traversal_medium
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/RepeatedPathTraversalSmall.yml
+      test_control: repeated_path_traversal_small
+  name: repeated_path_traversal_small
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SetWindowFieldsUnbounded.yml
+      test_control: set_window_fields_unbounded
+  name: set_window_fields_unbounded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/ShardFilter.yml
+      test_control: shard_filter
+  name: shard_filter
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindows.yml
+      test_control: sliding_windows
+  name: sliding_windows
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SlidingWindowsMultiAccums.yml
+      test_control: sliding_windows_multi_accums
+  name: sliding_windows_multi_accums
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/SortByExpression.yml
+      test_control: sort_by_expression
+  name: sort_by_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId.yml
+      test_control: ten_m_doc_collection__int_id
+  name: ten_m_doc_collection__int_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+      test_control: ten_m_doc_collection__int_id__agg
+  name: ten_m_doc_collection__int_id__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+      test_control: ten_m_doc_collection__int_id__identity_view
+  name: ten_m_doc_collection__int_id__identity_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+      test_control: ten_m_doc_collection__int_id__identity_view__agg
+  name: ten_m_doc_collection__int_id__identity_view__agg
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId.yml
+      test_control: ten_m_doc_collection__object_id
+  name: ten_m_doc_collection__object_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+      test_control: ten_m_doc_collection__object_id__sharded
+  name: ten_m_doc_collection__object_id__sharded
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TenMDocCollection_SubDocId.yml
+      test_control: ten_m_doc_collection__sub_doc_id
+  name: ten_m_doc_collection__sub_doc_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeries2dsphere.yml
+      test_control: time_series2dsphere
+  name: time_series2dsphere
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
+      test_control: time_series_group_stages_on_computed_fields
+  name: time_series_group_stages_on_computed_fields
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
+      test_control: time_series_lastpoint
+  name: time_series_lastpoint
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
+      test_control: time_series_sort
+  name: time_series_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortCompound.yml
+      test_control: time_series_sort_compound
+  name: time_series_sort_compound
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
+      test_control: time_series_sort_overlapping_buckets
+  name: time_series_sort_overlapping_buckets
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeSeriesTelemetry.yml
+      test_control: time_series_telemetry
+  name: time_series_telemetry
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesBlockProcessing.yml
+      test_control: timeseries_block_processing
+  name: timeseries_block_processing
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesCount.yml
+      test_control: timeseries_count
+  name: timeseries_count
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesEnum.yml
+      test_control: timeseries_enum
+  name: timeseries_enum
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/TimeseriesStressUnpacking.yml
+      test_control: timeseries_stress_unpacking
+  name: timeseries_stress_unpacking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnionWith.yml
+      test_control: union_with
+  name: union_with
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UnwindGroup.yml
+      test_control: unwind_group
+  name: unwind_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/UpdateLargeDocuments.yml
+      test_control: update_large_documents
+  name: update_large_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/VariadicAggregateExpressions.yml
+      test_control: variadic_aggregate_expressions
+  name: variadic_aggregate_expressions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithComplexPartitionExpression.yml
+      test_control: window_with_complex_partition_expression
+  name: window_with_complex_partition_expression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/WindowWithNestedFieldProjection.yml
+      test_control: window_with_nested_field_projection
+  name: window_with_nested_field_projection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/linearFill.yml
+      test_control: linear_fill
+  name: linear_fill
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/locf.yml
+      test_control: locf
+  name: locf
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/BlockingSort.yml
+      test_control: multiplanner_blocking_sort
+  name: multiplanner_blocking_sort
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ClusteredCollection.yml
+      test_control: multiplanner_clustered_collection
+  name: multiplanner_clustered_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/CompoundIndexes.yml
+      test_control: multiplanner_compound_indexes
+  name: multiplanner_compound_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+      test_control: multiplanner_many_index_seeks
+  name: multiplanner_many_index_seeks
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+      test_control: multiplanner_multi_planning_reads_a_lot_of_data
+  name: multiplanner_multi_planning_reads_a_lot_of_data
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultikeyIndexes.yml
+      test_control: multiplanner_multikey_indexes
+  name: multiplanner_multikey_indexes
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+      test_control: multiplanner_multiplanner_with_group
+  name: multiplanner_multiplanner_with_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoResults.yml
+      test_control: multiplanner_no_results
+  name: multiplanner_no_results
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NoSuchField.yml
+      test_control: multiplanner_no_such_field
+  name: multiplanner_no_such_field
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+      test_control: multiplanner_non_blocking_vs_blocking
+  name: multiplanner_non_blocking_vs_blocking
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Simple.yml
+      test_control: multiplanner_simple
+  name: multiplanner_simple
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/Subplanning.yml
+      test_control: multiplanner_subplanning
+  name: multiplanner_subplanning
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/UseClusteredIndex.yml
+      test_control: multiplanner_use_clustered_index
+  name: multiplanner_use_clustered_index
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/multiplanner/VariedSelectivity.yml
+      test_control: multiplanner_varied_selectivity
+  name: multiplanner_varied_selectivity
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/EmptyGroup.yml
+      test_control: plan_cache_empty_group
+  name: plan_cache_empty_group
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+      test_control: plan_cache_match_eq_varying_array
+  name: plan_cache_match_eq_varying_array
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BigUpdate.yml
+      test_control: big_update
+  name: big_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/BulkLoading.yml
+      test_control: bulk_loading
+  name: bulk_loading
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ContentionTTLDeletions.yml
+      test_control: contention_ttl_deletions
+  name: contention_ttl_deletions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/CreateDropView.yml
+      test_control: create_drop_view
+  name: create_drop_view
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InCacheSnapshotReads.yml
+      test_control: in_cache_snapshot_reads
+  name: in_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertBigDocs.yml
+      test_control: insert_big_docs
+  name: insert_big_docs
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/InsertRemove.yml
+      test_control: insert_remove
+  name: insert_remove
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedIns.yml
+      test_control: large_indexed_ins
+  name: large_indexed_ins
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeIndexedInsMatchingDocuments.yml
+      test_control: large_indexed_ins_matching_documents
+  name: large_indexed_ins_matching_documents
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LargeScaleLongLived.yml
+      test_control: large_scale_long_lived
+  name: large_scale_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/LoadTest.yml
+      test_control: load_test
+  name: load_test
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MajorityWrites10KThreads.yml
+      test_control: majority_writes10_k_threads
+  name: majority_writes10_k_threads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ManyUpdate.yml
+      test_control: many_update
+  name: many_update
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MassDeleteRegression.yml
+      test_control: mass_delete_regression
+  name: mass_delete_regression
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGenny.yml
+      test_control: mixed_workloads_genny
+  name: mixed_workloads_genny
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyRateLimited.yml
+      test_control: mixed_workloads_genny_rate_limited
+  name: mixed_workloads_genny_rate_limited
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStress.yml
+      test_control: mixed_workloads_genny_stress
+  name: mixed_workloads_genny_stress
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWorkloadsGennyStressWithScans.yml
+      test_control: mixed_workloads_genny_stress_with_scans
+  name: mixed_workloads_genny_stress_with_scans
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica
+      test_control: mixed_writes_replica
+  name: mixed_writes_replica
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/MixedWrites.yml
+      mongodb_setup: replica-delay-mixed
+      test_control: mixed_writes_replica_delay_mixed
+  name: mixed_writes_replica_delay_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheScanner.yml
+      test_control: out_of_cache_scanner
+  name: out_of_cache_scanner
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/OutOfCacheSnapshotReads.yml
+      test_control: out_of_cache_snapshot_reads
+  name: out_of_cache_snapshot_reads
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/ScanWithLongLived.yml
+      test_control: scan_with_long_lived
+  name: scan_with_long_lived
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/scale/TimeSeriesSortScale.yml
+      test_control: time_series_sort_scale
+  name: time_series_sort_scale
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/selftests/GennyOverhead.yml
+      test_control: genny_overhead
+  name: genny_overhead
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: batched_update_one_without_shard_key_with_id
+  name: batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/BulkWriteBatchedUpdateOneWithoutShardKeyWithId.yml
+      test_control: bulk_write_batched_update_one_without_shard_key_with_id
+  name: bulk_write_batched_update_one_without_shard_key_with_id
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactions.yml
+      test_control: multi_shard_transactions
+  name: multi_shard_transactions
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/MultiShardTransactionsWithManyNamespaces.yml
+      test_control: multi_shard_transactions_with_many_namespaces
+  name: multi_shard_transactions_with_many_namespaces
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollection.yml
+      test_control: reshard_collection
+  name: reshard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionMixed.yml
+      test_control: reshard_collection_mixed
+  name: reshard_collection_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/ReshardCollectionReadHeavy.yml
+      test_control: reshard_collection_read_heavy
+  name: reshard_collection_read_heavy
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WouldChangeOwningShardBatchWrite.yml
+      test_control: would_change_owning_shard_batch_write
+  name: would_change_owning_shard_batch_write
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneReplicaSet.yml
+      test_control: write_one_replica_set
+  name: write_one_replica_set
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyShardedCollection.yml
+      test_control: write_one_without_shard_key_sharded_collection
+  name: write_one_without_shard_key_sharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/WriteOneWithoutShardKeyUnshardedCollection.yml
+      test_control: write_one_without_shard_key_unsharded_collection
+  name: write_one_without_shard_key_unsharded_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations-ShardCollection.yml
+      test_control: multi_updates_multi_updates__pause_migrations__shard_collection
+  name: multi_updates_multi_updates__pause_migrations__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-PauseMigrations.yml
+      test_control: multi_updates_multi_updates__pause_migrations
+  name: multi_updates_multi_updates__pause_migrations
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates-ShardCollection.yml
+      test_control: multi_updates_multi_updates__shard_collection
+  name: multi_updates_multi_updates__shard_collection
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/sharding/multi_updates/MultiUpdates.yml
+      test_control: multi_updates_multi_updates
+  name: multi_updates_multi_updates
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixed.yml
+      test_control: llt_mixed
+  name: llt_mixed
+  priority: 5
+- commands:
+  - command: timeout.update
+    params:
+      exec_timeout_secs: 86400
+      timeout_secs: 86400
+  - func: f_run_dsi_workload
+    vars:
+      auto_workload_path: src/genny/src/workloads/transactions/LLTMixedSmall.yml
+      test_control: llt_mixed_small
+  name: llt_mixed_small
+  priority: 5

--- a/evergreen/system_perf/master/genny_tasks.yml
+++ b/evergreen/system_perf/master/genny_tasks.yml
@@ -1020,7 +1020,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
       test_control: device_monitoring
   name: device_monitoring
   priority: 5
@@ -1031,7 +1031,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTrunc.yml
       test_control: coinbase_timeseries_group_date_trunc
   name: coinbase_timeseries_group_date_trunc
   priority: 5
@@ -1042,7 +1042,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncMemoryLimit.yml
       test_control: coinbase_timeseries_group_date_trunc_memory_limit
   name: coinbase_timeseries_group_date_trunc_memory_limit
   priority: 5
@@ -1053,7 +1053,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/GroupDateTruncSort.yml
       test_control: coinbase_timeseries_group_date_trunc_sort
   name: coinbase_timeseries_group_date_trunc_sort
   priority: 5
@@ -1064,7 +1064,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Match.yml
       test_control: coinbase_timeseries_match
   name: coinbase_timeseries_match
   priority: 5
@@ -1075,7 +1075,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/MatchCount.yml
       test_control: coinbase_timeseries_match_count
   name: coinbase_timeseries_match_count
   priority: 5
@@ -1086,7 +1086,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query01.yml
       test_control: coinbase_timeseries_query01
   name: coinbase_timeseries_query01
   priority: 5
@@ -1097,7 +1097,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query02.yml
       test_control: coinbase_timeseries_query02
   name: coinbase_timeseries_query02
   priority: 5
@@ -1108,7 +1108,7 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
+      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/coinbase/timeseries/Query03.yml
       test_control: coinbase_timeseries_query03
   name: coinbase_timeseries_query03
   priority: 5

--- a/evergreen/system_perf/master/genny_tasks.yml
+++ b/evergreen/system_perf/master/genny_tasks.yml
@@ -898,8 +898,6 @@ buildvariants:
   - name: coll_scan_simplifiable_predicate_large
   - name: coll_scan_simplifiable_predicate_medium
   - name: coll_scan_simplifiable_predicate_small
-  - name: csi_fragmented_inserts_flat
-  - name: csi_fragmented_inserts_nested
   - name: cumulative_windows
   - name: cumulative_windows_multi_accums
   - name: densify_hours
@@ -1993,28 +1991,6 @@ tasks:
       auto_workload_path: src/genny/src/workloads/query/ConstantFoldArithmetic.yml
       test_control: constant_fold_arithmetic
   name: constant_fold_arithmetic
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsFlat.yml
-      test_control: csi_fragmented_inserts_flat
-  name: csi_fragmented_inserts_flat
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/genny/src/workloads/query/CsiFragmentedInsertsNested.yml
-      test_control: csi_fragmented_inserts_nested
-  name: csi_fragmented_inserts_nested
   priority: 5
 - commands:
   - command: timeout.update

--- a/src/lamplib/requirements.txt
+++ b/src/lamplib/requirements.txt
@@ -19,3 +19,5 @@ numpy==1.23.5
 numexpr==2.8.4
 
 jinja2==3.1.1
+
+gitpython==3.1.31

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -667,6 +667,24 @@ def auto_tasks_all(ctx: click.Context, project_files: List[str], no_activate: bo
     )
 
 
+@cli.command(
+    name="auto-tasks-local",
+    help=("Regenerate the auto-generated evergreen task defintions."),
+)
+@click.option(
+    "--evergreen", default=False, is_flag=True, help="Don't check out repositories, since we are running in evergreen"
+)
+@click.pass_context
+def auto_tasks_local(ctx: click.Context, evergreen: bool):
+    from genny.tasks import auto_tasks_local
+    import sys
+    print(sys.version)
+    auto_tasks_local.main(
+        workspace_root=ctx.obj["WORKSPACE_ROOT"],
+        running_in_evergreen=evergreen
+    )
+
+
 if __name__ == "__main__":
     sys.argv[0] = "run-genny"
     cli()

--- a/src/lamplib/src/genny/tasks/auto_tasks_all.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_all.py
@@ -98,9 +98,10 @@ def main(project_files: List[str], workspace_root: str, no_activate: bool) -> No
     for project_file in project_files:
         builds.extend(get_all_builds(global_expansions, project_file))
 
-    lister = WorkloadLister(workspace_root=workspace_root)
+    workload_file_pattern = os.path.join(workspace_root, "src", "*", "src", "workloads", "**", "*.yml")
+    lister = WorkloadLister(workspace_root=workspace_root, workload_file_pattern=workload_file_pattern)
     repo = Repo(lister=lister, reader=reader, workspace_root=workspace_root)
 
     config = create_configuration(repo, builds, no_activate, activate_tasks)
     output_file = os.path.join(workspace_root, "build", "TaskJSON", "Tasks.json")
-    ConfigWriter.write_config(execution, config, output_file)
+    ConfigWriter.write_config(execution, config, output_file, ConfigWriter.FileFormat.JSON)

--- a/src/lamplib/src/genny/tasks/auto_tasks_local.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_local.py
@@ -69,7 +69,7 @@ def main(workspace_root: str, running_in_evergreen: bool) -> None:
         SLOG.info("Cloning the PrivateWorkloads repo to look for tests")
         GitRepo.clone_from(PRIVATE_WORKLOADS_REPO_URL, PRIVATE_WORKLOADS_TMP_PATH)
 
-    for branch_name in PROJECT_FILES.keys():
+    for branch_name in PROJECT_FILES:
         SLOG.info("Creating the configuration", branch_name=branch_name)
         builds = get_builds(branch_name)
         lister = WorkloadLister(

--- a/src/lamplib/src/genny/tasks/auto_tasks_local.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_local.py
@@ -58,10 +58,8 @@ def get_builds(branch_name: str):
 def fix_auto_workload_path(command: CommandDefinition):
     if command._vars[WORKLOAD_PATH_KEY].startswith("src"):
         command._vars[WORKLOAD_PATH_KEY] = "src/genny/" + command._vars[WORKLOAD_PATH_KEY]
-    if command._vars[WORKLOAD_PATH_KEY].startswith("tmp-private-workloads"):
-        command._vars[WORKLOAD_PATH_KEY] = command._vars[WORKLOAD_PATH_KEY].replace(
-            "tmp-private-workloads", "src/PrivateWorkloads"
-        )
+    if command._vars[WORKLOAD_PATH_KEY].startswith("PrivateWorkloads"):
+        command._vars[WORKLOAD_PATH_KEY] = "src/" + command._vars[WORKLOAD_PATH_KEY]
 
 
 def main(workspace_root: str, running_in_evergreen: bool) -> None:

--- a/src/lamplib/src/genny/tasks/auto_tasks_local.py
+++ b/src/lamplib/src/genny/tasks/auto_tasks_local.py
@@ -1,0 +1,105 @@
+import os
+import shutil
+
+import structlog
+from git import Repo as GitRepo
+from shrub.command import CommandDefinition
+
+from genny.tasks.auto_tasks import (
+    ConfigWriter,
+    Repo,
+    WorkloadLister,
+    YamlReader,
+)
+from genny.tasks.auto_tasks_all import create_configuration, get_all_builds
+
+SLOG = structlog.get_logger("genny.tasks.auto_tasks.local")
+DSI_TMP_PATH = "./dsi"
+DSI_REPO_URL = "https://github.com/10gen/dsi.git"
+PRIVATE_WORKLOADS_TMP_PATH = "./PrivateWorkloads"
+PRIVATE_WORKLOADS_REPO_URL = "https://github.com/10gen/PrivateWorkloads.git"
+WORKLOAD_FILE_PATTERN = os.path.join("**", "src", "workloads", "**", "*.yml")
+FIRST_EXECUTION = 0
+WORKLOAD_PATH_KEY = "auto_workload_path"
+DSI_TASK_NAME = "f_run_dsi_workload"
+
+PROJECT_FILES = {
+    "master": [
+        os.path.join(DSI_TMP_PATH, "evergreen", "system_perf", "master", "variants.yml"),
+        os.path.join(DSI_TMP_PATH, "evergreen", "system_perf", "master", "master_variants.yml"),
+    ],
+    "8.0": [
+        os.path.join(DSI_TMP_PATH, "evergreen", "system_perf", "8.0", "variants.yml"),
+    ],
+    "7.3": [
+        os.path.join(DSI_TMP_PATH, "evergreen", "system_perf", "7.3", "variants.yml"),
+    ],
+    "7.0": [
+        os.path.join(DSI_TMP_PATH, "evergreen", "system_perf", "7.0", "variants.yml"),
+    ],
+    "6.0": [
+        os.path.join(DSI_TMP_PATH, "evergreen", "system_perf", "6.0", "variants.yml"),
+    ],
+    "5.0": [
+        os.path.join(DSI_TMP_PATH, "evergreen", "system_perf", "5.0", "variants.yml"),
+    ],
+}
+
+
+def get_builds(branch_name: str):
+    builds = []
+    expansions = {"branch_name": branch_name, "execution": FIRST_EXECUTION}
+    for project_file in PROJECT_FILES[branch_name]:
+        builds.extend(get_all_builds(expansions, project_file))
+
+    return builds
+
+
+def fix_auto_workload_path(command: CommandDefinition):
+    if command._vars[WORKLOAD_PATH_KEY].startswith("src"):
+        command._vars[WORKLOAD_PATH_KEY] = "src/genny/" + command._vars[WORKLOAD_PATH_KEY]
+    if command._vars[WORKLOAD_PATH_KEY].startswith("tmp-private-workloads"):
+        command._vars[WORKLOAD_PATH_KEY] = command._vars[WORKLOAD_PATH_KEY].replace(
+            "tmp-private-workloads", "src/PrivateWorkloads"
+        )
+
+
+def main(workspace_root: str, running_in_evergreen: bool) -> None:
+    if not running_in_evergreen:
+        SLOG.info("Cloning the DSI repo to look for variants")
+        GitRepo.clone_from(DSI_REPO_URL, DSI_TMP_PATH)
+        SLOG.info("Cloning the PrivateWorkloads repo to look for tests")
+        GitRepo.clone_from(PRIVATE_WORKLOADS_REPO_URL, PRIVATE_WORKLOADS_TMP_PATH)
+
+    for branch_name in PROJECT_FILES.keys():
+        SLOG.info("Creating the configuration", branch_name=branch_name)
+        builds = get_builds(branch_name)
+        lister = WorkloadLister(
+            workspace_root=workspace_root, workload_file_pattern=WORKLOAD_FILE_PATTERN
+        )
+        repo = Repo(lister=lister, reader=YamlReader(), workspace_root=workspace_root)
+        config = create_configuration(repo, builds, False, [])
+
+        SLOG.info("Removing global exec_timeout_secs as it is already in the main project")
+        config._exec_timeout_secs = None
+
+        SLOG.info("Fixing the auto_workload_path to match the DSI folder structure")
+        for task in config._tasks:
+            for command in task._commands._cmd_seq:
+                if command._function_name == DSI_TASK_NAME:
+                    fix_auto_workload_path(command)
+
+        SLOG.info("Writing the configuration", branch_name=branch_name)
+        output_file = os.path.join("evergreen", "system_perf", branch_name, "genny_tasks.yml")
+        ConfigWriter.write_config(
+            execution=FIRST_EXECUTION,
+            config=config,
+            output_file=output_file,
+            file_format=ConfigWriter.FileFormat.YAML,
+        )
+
+    if not running_in_evergreen:
+        SLOG.info("Removing the temporary DSI repo")
+        shutil.rmtree(DSI_TMP_PATH)
+        SLOG.info("Removing the temporary PrivateWorkloads repo")
+        shutil.rmtree(PRIVATE_WORKLOADS_TMP_PATH)

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -877,7 +877,7 @@ class AutoTasksTests(BaseTestClass):
             "os.path.exists", return_value=False
         ) as exists_mock:
             config = Configuration()
-            ConfigWriter.write_config(execution=5, config=config, output_file="fakefile123")
+            ConfigWriter.write_config(execution=5, config=config, output_file="fakefile123", file_format=ConfigWriter.FileFormat.JSON)
 
 
 def test_dry_run_all_tasks():

--- a/src/lamplib/src/tests/test_auto_tasks.py
+++ b/src/lamplib/src/tests/test_auto_tasks.py
@@ -893,7 +893,8 @@ def test_dry_run_all_tasks():
     try:
         build = CurrentBuildInfo({"build_variant": "Test Variant", "execution": 1})
         op = OpName.from_flag("all_tasks")
-        lister = WorkloadLister(workspace_root=workspace_root)
+        workload_file_pattern = os.path.join(workspace_root, "src", "*", "src", "workloads", "**", "*.yml")
+        lister = WorkloadLister(workspace_root=workspace_root, workload_file_pattern=workload_file_pattern)
         reader = YamlReader()
         repo = Repo(lister=lister, reader=reader, workspace_root=workspace_root)
         tasks = repo.tasks(op=op, build=build)


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-10486](https://jira.mongodb.org/browse/DEVPROD-10486)

### What's Changed

This PR replaces the task generation in evergreen with a locally pre-generated definition and a CI task that validates that the auto-generated task definitions are up to date.

The main driver here is that a lot of the analysis tooling gets more complicated with auto-generated tests. Additionally, this means that users can schedule Genny tasks directly through the evergreen UI like normal tasks. 

The downside is that users need to re-run the generation script if they are adding a new workload or if they are adding a new variant on which genny tasks are supposed to run (both of these should get rarer in the future since we are slowly moving away from Genny).

Companion PRs:
https://github.com/10gen/dsi/pull/1984
https://github.com/10gen/mongo/pull/26993

### Patch Testing Results
* Example of the Genny CI task detecting differences in the generated files:
https://spruce.mongodb.com/task/genny_validate_genny_tasks_validate_genny_tasks_patch_764d6015fe8100a4b0a58174ebb4ba778a248c02_66e2b399e435ee00074aee2e_24_09_12_09_25_52/logs?execution=0
* Patch that is running genny tasks from both the genny repo itself and the private workloads repo:
https://spruce.mongodb.com/version/66e2f21b9f86e70007412741
* To validate that the same tasks as before get scheduled, select all tasks in [this patch with the local taskgen](https://spruce.mongodb.com/patch/66e2f21b9f86e70007412741/configure/tasks) and in [this baseline patch](https://spruce.mongodb.com/patch/66e2e51e03471a0007c4f1d1/configure/tasks) where generate_all_variant_autotasks ran.
