### PR TITLE
PERF-5402: Convert shard-lite FLE variant to 3-Node

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -123,13 +123,13 @@ buildvariants:
     tasks:
       - name: tg_compile_and_test_with_server_on_macos
 
-  # - name: validate-genny-tasks
-  #   display_name: Validate Genny Tasks
-  #   modules: [dsi, PrivateWorkloads]
-  #   run_on:
-  #     - amazon2-arm64-latest-small
-  #   tasks:
-  #     - name: validate_genny_tasks
+# - name: validate-genny-tasks
+#   display_name: Validate Genny Tasks
+#   modules: [dsi, PrivateWorkloads]
+#   run_on:
+#     - amazon2-arm64-latest-small
+#   tasks:
+#     - name: validate_genny_tasks
 
 ##                ⚡️ Tasks ⚡️
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -123,13 +123,13 @@ buildvariants:
     tasks:
       - name: tg_compile_and_test_with_server_on_macos
 
-  - name: validate-genny-tasks
-    display_name: Validate Genny Tasks
-    modules: [dsi, PrivateWorkloads]
-    run_on:
-      - amazon2-arm64-latest-small
-    tasks:
-      - name: validate_genny_tasks
+  # - name: validate-genny-tasks
+  #   display_name: Validate Genny Tasks
+  #   modules: [dsi, PrivateWorkloads]
+  #   run_on:
+  #     - amazon2-arm64-latest-small
+  #   tasks:
+  #     - name: validate_genny_tasks
 
 ##                ⚡️ Tasks ⚡️
 

--- a/evergreen/system_perf/5.0/genny_tasks.yml
+++ b/evergreen/system_perf/5.0/genny_tasks.yml
@@ -43,7 +43,6 @@ buildvariants:
   - name: multi_updates_multi_updates
 - name: perf-3-node-replSet.arm.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: read_only_multi_threaded
   - name: parallel_insert_replica
   - name: parallel_insert_replica_delay_mixed
@@ -117,7 +116,6 @@ buildvariants:
   - name: llt_mixed_small
 - name: perf-3-node-replSet-intel.intel.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: read_only_multi_threaded
   - name: parallel_insert_replica
   - name: parallel_insert_replica_delay_mixed
@@ -190,17 +188,6 @@ buildvariants:
   - name: llt_mixed
   - name: llt_mixed_small
 tasks:
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
-      test_control: device_monitoring
-  name: device_monitoring
-  priority: 5
 - commands:
   - command: timeout.update
     params:

--- a/evergreen/system_perf/6.0/genny_tasks.yml
+++ b/evergreen/system_perf/6.0/genny_tasks.yml
@@ -55,7 +55,6 @@ buildvariants:
   - name: multi_updates_multi_updates
 - name: perf-3-node-replSet.arm.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -174,7 +173,6 @@ buildvariants:
   - name: llt_mixed_small
 - name: perf-3-node-replSet-intel.intel.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -292,17 +290,6 @@ buildvariants:
   - name: llt_mixed
   - name: llt_mixed_small
 tasks:
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
-      test_control: device_monitoring
-  name: device_monitoring
-  priority: 5
 - commands:
   - command: timeout.update
     params:

--- a/evergreen/system_perf/7.0/genny_tasks.yml
+++ b/evergreen/system_perf/7.0/genny_tasks.yml
@@ -335,7 +335,7 @@ buildvariants:
   - name: write_one_replica_set
   - name: llt_mixed
   - name: llt_mixed_small
-- name: perf-shard-lite-fle.arm.aws.2023-11
+- name: perf-3-shard-fle.arm.aws.2023-11
   tasks:
   - name: ycsb_like_queryable_encrypt1_cf16
   - name: ycsb_like_queryable_encrypt1_cf32

--- a/evergreen/system_perf/7.0/genny_tasks.yml
+++ b/evergreen/system_perf/7.0/genny_tasks.yml
@@ -333,7 +333,7 @@ buildvariants:
   - name: write_one_replica_set
   - name: llt_mixed
   - name: llt_mixed_small
-- name: perf-shard-lite-fle.arm.aws.2023-11
+- name: perf-3-shard-fle.arm.aws.2023-11
   tasks:
   - name: ycsb_like_queryable_encrypt1_cf16
   - name: ycsb_like_queryable_encrypt1_cf32

--- a/evergreen/system_perf/7.0/genny_tasks.yml
+++ b/evergreen/system_perf/7.0/genny_tasks.yml
@@ -57,7 +57,6 @@ buildvariants:
   - name: multi_updates_multi_updates
 - name: perf-3-node-replSet.arm.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -197,7 +196,6 @@ buildvariants:
   - name: llt_mixed_small
 - name: perf-3-node-replSet-intel.intel.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -335,7 +333,7 @@ buildvariants:
   - name: write_one_replica_set
   - name: llt_mixed
   - name: llt_mixed_small
-- name: perf-3-shard-fle.arm.aws.2023-11
+- name: perf-shard-lite-fle.arm.aws.2023-11
   tasks:
   - name: ycsb_like_queryable_encrypt1_cf16
   - name: ycsb_like_queryable_encrypt1_cf32
@@ -352,17 +350,6 @@ buildvariants:
   - name: medical_workload_load_unencrypted
   - name: medical_workload_load
 tasks:
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
-      test_control: device_monitoring
-  name: device_monitoring
-  priority: 5
 - commands:
   - command: timeout.update
     params:

--- a/evergreen/system_perf/8.0/genny_tasks.yml
+++ b/evergreen/system_perf/8.0/genny_tasks.yml
@@ -39,7 +39,6 @@ buildvariants:
   - name: mixed_workloads_genny_stress_with_scans
 - name: perf-standalone.arm.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -136,7 +135,7 @@ buildvariants:
   - name: mixed_workloads_genny_rate_limited
   - name: genny_overhead
   - name: write_one_replica_set
-- name: perf-3-shard-fle.arm.aws.2023-11
+- name: perf-shard-lite-fle.arm.aws.2023-11
   tasks:
   - name: ycsb_like_queryable_encrypt1_cf16
   - name: ycsb_like_queryable_encrypt1_cf32
@@ -182,7 +181,6 @@ buildvariants:
   - name: multi_updates_multi_updates
 - name: perf-3-node-replSet.arm.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -387,7 +385,6 @@ buildvariants:
   - name: multiplanner_varied_selectivity
 - name: perf-3-node-replSet-intel.intel.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -559,17 +556,6 @@ buildvariants:
   - name: llt_mixed
   - name: llt_mixed_small
 tasks:
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
-      test_control: device_monitoring
-  name: device_monitoring
-  priority: 5
 - commands:
   - command: timeout.update
     params:

--- a/evergreen/system_perf/8.0/genny_tasks.yml
+++ b/evergreen/system_perf/8.0/genny_tasks.yml
@@ -135,7 +135,7 @@ buildvariants:
   - name: mixed_workloads_genny_rate_limited
   - name: genny_overhead
   - name: write_one_replica_set
-- name: perf-shard-lite-fle.arm.aws.2023-11
+- name: perf-3-shard-fle.arm.aws.2023-11
   tasks:
   - name: ycsb_like_queryable_encrypt1_cf16
   - name: ycsb_like_queryable_encrypt1_cf32

--- a/evergreen/system_perf/8.0/genny_tasks.yml
+++ b/evergreen/system_perf/8.0/genny_tasks.yml
@@ -136,7 +136,7 @@ buildvariants:
   - name: mixed_workloads_genny_rate_limited
   - name: genny_overhead
   - name: write_one_replica_set
-- name: perf-shard-lite-fle.arm.aws.2023-11
+- name: perf-3-shard-fle.arm.aws.2023-11
   tasks:
   - name: ycsb_like_queryable_encrypt1_cf16
   - name: ycsb_like_queryable_encrypt1_cf32

--- a/evergreen/system_perf/master/genny_tasks.yml
+++ b/evergreen/system_perf/master/genny_tasks.yml
@@ -37,7 +37,7 @@ buildvariants:
   - name: mixed_workloads_genny
   - name: mixed_workloads_genny_stress
   - name: mixed_workloads_genny_stress_with_scans
-- name: perf-shard-lite-fle.arm.aws.2023-11
+- name: perf-3-shard-fle.arm.aws.2023-11
   tasks:
   - name: ycsb_like_queryable_encrypt1_cf16
   - name: ycsb_like_queryable_encrypt1_cf32

--- a/evergreen/system_perf/master/genny_tasks.yml
+++ b/evergreen/system_perf/master/genny_tasks.yml
@@ -37,7 +37,7 @@ buildvariants:
   - name: mixed_workloads_genny
   - name: mixed_workloads_genny_stress
   - name: mixed_workloads_genny_stress_with_scans
-- name: perf-3-shard-fle.arm.aws.2023-11
+- name: perf-shard-lite-fle.arm.aws.2023-11
   tasks:
   - name: ycsb_like_queryable_encrypt1_cf16
   - name: ycsb_like_queryable_encrypt1_cf32
@@ -83,7 +83,6 @@ buildvariants:
   - name: multi_updates_multi_updates
 - name: perf-3-node-replSet.arm.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -288,7 +287,6 @@ buildvariants:
   - name: multiplanner_varied_selectivity
 - name: perf-3-node-replSet-intel.intel.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -845,15 +843,8 @@ buildvariants:
   - name: query_stats
   - name: write_one_without_shard_key_sharded_collection
   - name: write_one_without_shard_key_unsharded_collection
-- name: perf-3-node-replSet-last-continuous-fcv.arm.aws.2023-11
-  tasks:
-  - name: device_monitoring
-- name: perf-3-node-replSet-last-lts-fcv.arm.aws.2023-11
-  tasks:
-  - name: device_monitoring
 - name: perf-3-node-replSet-all-feature-flags.arm.aws.2023-11
   tasks:
-  - name: device_monitoring
   - name: coinbase_timeseries_group_date_trunc
   - name: coinbase_timeseries_group_date_trunc_memory_limit
   - name: coinbase_timeseries_group_date_trunc_sort
@@ -1011,17 +1002,6 @@ buildvariants:
   tasks:
   - name: non_search_hybrid_scoring
 tasks:
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
-      auto_workload_path: src/PrivateWorkloads/src/workloads/customer_representative/DeviceMonitoring.yml
-      test_control: device_monitoring
-  name: device_monitoring
-  priority: 5
 - commands:
   - command: timeout.update
     params:

--- a/src/workloads/contrib/qe_range_testing/templates/rc-perfconfig.yml.j2
+++ b/src/workloads/contrib/qe_range_testing/templates/rc-perfconfig.yml.j2
@@ -1,10 +1,10 @@
 workload_name: rc_experiment
 patches:
-  {{ patch_id }}: 
-    perf-shard-lite-fle.arm.aws.2023-11: {% for exp_name in experiments %}
+  {{ patch_id }}:
+    perf-3-shard-fle.arm.aws.2023-11: {% for exp_name in experiments %}
     - "qe_range_testing_workloads_evergreen_{{ exp_name }}"{% endfor %}
 genny_metrics:
-  tests: 
+  tests:
 {% for i in range(n_threads) %}
   - "InsertActor_Thread{{i}}.load.inserts"
   - "FSMActor_Thread{{i}}.FSM.range_query"


### PR DESCRIPTION
[PERF-5402](https://jira.mongodb.org/browse/PERF-5402): Convert shard-lite FLE variant to 3-Node

Converting FLE shard lite to shard.
Manually editing docs to get passed failed self test in [related DSI PR](https://github.com/10gen/dsi/pull/2046)

[7.0 Patch](https://spruce.mongodb.com/version/670553c9f049bf00071eb7e5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[8.0 Patch](https://spruce.mongodb.com/version/6705364e77c87f0007a32030/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[Master Patch](https://spruce.mongodb.com/version/670534dccb2efd0007ed57b7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)