### PR TITLE
DEVPROD-11940 Add a flag to suppress metrics from the RunCommand actor

### DIFF
--- a/src/lamplib/src/genny/curator.py
+++ b/src/lamplib/src/genny/curator.py
@@ -143,6 +143,13 @@ def calculate_rollups(output_dir: str, workspace_root: str, genny_repo_root: str
         for file in files:
             if file.endswith(".ftdc"):
                 ftdc_file_name = os.path.join(root, file)
+
+                # Curator produces invalid results for emtpy files.
+                # We also need to remove the files to prevent the ftdc_fallback in DSI.
+                if os.path.getsize(ftdc_file_name) == 0:
+                    os.remove(ftdc_file_name)
+                    continue
+
                 rollup_file_name = ftdc_file_name.replace(".ftdc", ".json")
                 SLOG.info(
                     "Creating perf rollup from FTDC file.",

--- a/src/phases/encrypted/ContinuousWritesWithExponentialCompactTemplate.yml
+++ b/src/phases/encrypted/ContinuousWritesWithExponentialCompactTemplate.yml
@@ -54,7 +54,7 @@ Actors:
           Database: *encrypted_db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: *encrypted_coll
                 indexes:

--- a/src/phases/encrypted/ContinuousWritesWithExponentialCompactTemplate.yml
+++ b/src/phases/encrypted/ContinuousWritesWithExponentialCompactTemplate.yml
@@ -54,6 +54,7 @@ Actors:
           Database: *encrypted_db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: *encrypted_coll
                 indexes:

--- a/src/phases/encrypted/YCSBLikeEncryptedTemplate.yml
+++ b/src/phases/encrypted/YCSBLikeEncryptedTemplate.yml
@@ -95,7 +95,7 @@ Actors:
         MetricsName: "indexSecondary"
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *encrypted_coll
               indexes:

--- a/src/phases/encrypted/YCSBLikeEncryptedTemplate.yml
+++ b/src/phases/encrypted/YCSBLikeEncryptedTemplate.yml
@@ -95,6 +95,7 @@ Actors:
         MetricsName: "indexSecondary"
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *encrypted_coll
               indexes:

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -116,6 +116,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 create: *Collection
                 clusteredIndex: { key: { _id: 1 }, unique: true }
@@ -252,6 +253,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: *Collection
                 indexes:

--- a/src/phases/execution/ClusteredCollection.yml
+++ b/src/phases/execution/ClusteredCollection.yml
@@ -116,7 +116,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 create: *Collection
                 clusteredIndex: { key: { _id: 1 }, unique: true }
@@ -253,7 +253,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: *Collection
                 indexes:

--- a/src/phases/execution/MixedMultiDeletes.yml
+++ b/src/phases/execution/MixedMultiDeletes.yml
@@ -231,6 +231,7 @@ Actors:
           Operation:
             OperationMetricsName: SelectDeleteExecutor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               setParameter: 1
               batchUserMultiDeletes: *UseBatchedDeleteStage

--- a/src/phases/execution/MixedMultiDeletes.yml
+++ b/src/phases/execution/MixedMultiDeletes.yml
@@ -231,7 +231,7 @@ Actors:
           Operation:
             OperationMetricsName: SelectDeleteExecutor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               setParameter: 1
               batchUserMultiDeletes: *UseBatchedDeleteStage

--- a/src/phases/execution/TimeSeriesUpdatesAndDeletes.yml
+++ b/src/phases/execution/TimeSeriesUpdatesAndDeletes.yml
@@ -35,7 +35,7 @@ CreateTimeSeriesCollectionPhase:
       Database: *db
       Operations:
         - OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand: {
             # Each bucket holds data within one hour time span.
             create: *coll, timeseries: {timeField: "t", metaField: "sensorId", granularity: "seconds"}}
@@ -112,6 +112,6 @@ CleanUpPhase:
       Database: *db
       Operation:
         OperationName: RunCommand
-        ReportMetrics: False
+        ReportMetrics: false
         OperationCommand:
           drop: *coll

--- a/src/phases/execution/TimeSeriesUpdatesAndDeletes.yml
+++ b/src/phases/execution/TimeSeriesUpdatesAndDeletes.yml
@@ -35,6 +35,7 @@ CreateTimeSeriesCollectionPhase:
       Database: *db
       Operations:
         - OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand: {
             # Each bucket holds data within one hour time span.
             create: *coll, timeseries: {timeField: "t", metaField: "sensorId", granularity: "seconds"}}
@@ -111,5 +112,6 @@ CleanUpPhase:
       Database: *db
       Operation:
         OperationName: RunCommand
+        ReportMetrics: False
         OperationCommand:
           drop: *coll

--- a/src/phases/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/phases/execution/UpdateWithSecondaryIndexes.yml
@@ -40,9 +40,9 @@ Actors:
         Operations:
           - OperationName: RunCommand
             OperationCommand: {dropDatabase: 1}
-            ReportMetrics: False
+            ReportMetrics: false
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *UpdateColl
               indexes:

--- a/src/phases/execution/UpdateWithSecondaryIndexes.yml
+++ b/src/phases/execution/UpdateWithSecondaryIndexes.yml
@@ -40,7 +40,9 @@ Actors:
         Operations:
           - OperationName: RunCommand
             OperationCommand: {dropDatabase: 1}
+            ReportMetrics: False
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *UpdateColl
               indexes:

--- a/src/phases/execution/config/MultiDeletes/Default.yml
+++ b/src/phases/execution/config/MultiDeletes/Default.yml
@@ -5,4 +5,5 @@ Description: |
 
 InitializeDatabaseOps:
   - OperationName: RunCommand
+    ReportMetrics: False
     OperationCommand: {dropDatabase: 1}

--- a/src/phases/execution/config/MultiDeletes/Default.yml
+++ b/src/phases/execution/config/MultiDeletes/Default.yml
@@ -5,5 +5,5 @@ Description: |
 
 InitializeDatabaseOps:
   - OperationName: RunCommand
-    ReportMetrics: False
+    ReportMetrics: false
     OperationCommand: {dropDatabase: 1}

--- a/src/phases/query/BooleanSimplifier.yml
+++ b/src/phases/query/BooleanSimplifier.yml
@@ -196,6 +196,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: *Coll
                 indexes:

--- a/src/phases/query/BooleanSimplifier.yml
+++ b/src/phases/query/BooleanSimplifier.yml
@@ -196,7 +196,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: *Coll
                 indexes:

--- a/src/phases/query/FilterWithComplexLogicalExpression.yml
+++ b/src/phases/query/FilterWithComplexLogicalExpression.yml
@@ -779,7 +779,7 @@ Actors:
           Collection: *Collection
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: *Collection
                 indexes:

--- a/src/phases/query/FilterWithComplexLogicalExpression.yml
+++ b/src/phases/query/FilterWithComplexLogicalExpression.yml
@@ -779,6 +779,7 @@ Actors:
           Collection: *Collection
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: *Collection
                 indexes:

--- a/src/phases/query/Multiplanner.yml
+++ b/src/phases/query/Multiplanner.yml
@@ -16,6 +16,7 @@ QueryKnobTemplate:
         Database: admin
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               setParameter: {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}}
               # Disable the plan cache so we multiplan on every request.
@@ -90,54 +91,54 @@ Hide48IndexesTemplate:
         Repeat: {^Parameter: {Name: "repeat", Default: {unused: "Invalid repeat count."}}}
         Database: {^Parameter: {Name: "database", Default: {unused: "Invalid database name."}}}
         Operations:
-          - {OperationName: RunCommand, OperationCommand: {collMod: &coll {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: &coll {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
                                                            index: {hidden: true, name: index17}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index18}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index19}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index20}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index21}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index22}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index23}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index24}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index25}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index26}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index27}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index28}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index29}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index30}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index31}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index32}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index33}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index34}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index35}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index36}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index37}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index38}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index39}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index40}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index41}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index42}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index43}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index44}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index45}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index46}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index47}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index48}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index49}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index50}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index51}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index52}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index53}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index54}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index55}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index56}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index57}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index58}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index59}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index60}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index61}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index62}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll, index: {hidden: true, name: index63}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index18}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index19}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index20}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index21}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index22}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index23}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index24}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index25}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index26}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index27}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index28}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index29}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index30}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index31}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index32}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index33}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index34}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index35}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index36}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index37}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index38}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index39}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index40}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index41}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index42}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index43}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index44}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index45}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index46}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index47}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index48}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index49}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index50}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index51}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index52}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index53}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index54}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index55}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index56}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index57}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index58}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index59}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index60}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index61}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index62}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index63}}}
 
 Hide14IndexesTemplate:
   Name: Hide14Indexes
@@ -151,21 +152,21 @@ Hide14IndexesTemplate:
         Repeat: {^Parameter: {Name: "repeat", Default: {unused: "Invalid repeat count."}}}
         Database: {^Parameter: {Name: "database", Default: {unused: "Invalid database name."}}}
         Operations:
-          - {OperationName: RunCommand, OperationCommand: {collMod: &coll2 {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: &coll2 {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
                                                            index: {hidden: true, name: index3}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index4}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index5}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index6}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index7}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index8}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index9}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index10}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index11}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index12}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index13}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index14}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index15}}}
-          - {OperationName: RunCommand, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index16}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index4}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index5}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index6}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index7}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index8}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index9}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index10}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index11}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index12}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index13}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index14}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index15}}}
+          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index16}}}
 
 fraction: &frac {^NumExpr: {withExpression: "resultCount / docCount",
                             andValues: {resultCount: &resultCount {^Parameter: {Name: "resultCount", Default: {unused: "Invalid result count."}}},

--- a/src/phases/query/Multiplanner.yml
+++ b/src/phases/query/Multiplanner.yml
@@ -91,8 +91,9 @@ Hide48IndexesTemplate:
         Repeat: {^Parameter: {Name: "repeat", Default: {unused: "Invalid repeat count."}}}
         Database: {^Parameter: {Name: "database", Default: {unused: "Invalid database name."}}}
         Operations:
-          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: &coll {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
-                                                           index: {hidden: true, name: index17}}}
+          - {OperationName: RunCommand, ReportMetrics: false,
+             OperationCommand: {collMod: &coll {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
+                                index: {hidden: true, name: index17}}}
           - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index18}}}
           - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index19}}}
           - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index20}}}
@@ -152,8 +153,9 @@ Hide14IndexesTemplate:
         Repeat: {^Parameter: {Name: "repeat", Default: {unused: "Invalid repeat count."}}}
         Database: {^Parameter: {Name: "database", Default: {unused: "Invalid database name."}}}
         Operations:
-          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: &coll2 {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
-                                                           index: {hidden: true, name: index3}}}
+          - {OperationName: RunCommand, ReportMetrics: false,
+             OperationCommand: {collMod: &coll2 {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
+                                index: {hidden: true, name: index3}}}
           - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index4}}}
           - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index5}}}
           - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index6}}}

--- a/src/phases/query/Multiplanner.yml
+++ b/src/phases/query/Multiplanner.yml
@@ -16,7 +16,7 @@ QueryKnobTemplate:
         Database: admin
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               setParameter: {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}}
               # Disable the plan cache so we multiplan on every request.
@@ -91,54 +91,54 @@ Hide48IndexesTemplate:
         Repeat: {^Parameter: {Name: "repeat", Default: {unused: "Invalid repeat count."}}}
         Database: {^Parameter: {Name: "database", Default: {unused: "Invalid database name."}}}
         Operations:
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: &coll {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: &coll {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
                                                            index: {hidden: true, name: index17}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index18}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index19}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index20}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index21}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index22}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index23}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index24}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index25}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index26}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index27}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index28}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index29}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index30}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index31}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index32}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index33}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index34}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index35}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index36}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index37}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index38}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index39}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index40}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index41}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index42}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index43}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index44}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index45}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index46}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index47}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index48}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index49}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index50}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index51}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index52}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index53}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index54}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index55}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index56}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index57}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index58}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index59}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index60}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index61}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index62}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll, index: {hidden: true, name: index63}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index18}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index19}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index20}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index21}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index22}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index23}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index24}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index25}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index26}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index27}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index28}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index29}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index30}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index31}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index32}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index33}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index34}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index35}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index36}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index37}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index38}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index39}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index40}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index41}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index42}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index43}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index44}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index45}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index46}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index47}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index48}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index49}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index50}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index51}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index52}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index53}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index54}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index55}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index56}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index57}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index58}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index59}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index60}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index61}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index62}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll, index: {hidden: true, name: index63}}}
 
 Hide14IndexesTemplate:
   Name: Hide14Indexes
@@ -152,21 +152,21 @@ Hide14IndexesTemplate:
         Repeat: {^Parameter: {Name: "repeat", Default: {unused: "Invalid repeat count."}}}
         Database: {^Parameter: {Name: "database", Default: {unused: "Invalid database name."}}}
         Operations:
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: &coll2 {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: &coll2 {^Parameter: {Name: "collection", Default: {unused: "Invalid collection name."}}},
                                                            index: {hidden: true, name: index3}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index4}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index5}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index6}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index7}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index8}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index9}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index10}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index11}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index12}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index13}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index14}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index15}}}
-          - {OperationName: RunCommand, ReportMetrics: False, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index16}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index4}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index5}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index6}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index7}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index8}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index9}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index10}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index11}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index12}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index13}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index14}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index15}}}
+          - {OperationName: RunCommand, ReportMetrics: false, OperationCommand: {collMod: *coll2, index: {hidden: true, name: index16}}}
 
 fraction: &frac {^NumExpr: {withExpression: "resultCount / docCount",
                             andValues: {resultCount: &resultCount {^Parameter: {Name: "resultCount", Default: {unused: "Invalid result count."}}},

--- a/src/phases/query/QueryStats.tmpl
+++ b/src/phases/query/QueryStats.tmpl
@@ -130,7 +130,7 @@ CacheSizeActor:
         Database: admin
         Operations:
         - OperationName: AdminCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand:
             # Configuring the queryStats store size to an arbitrary value which seems reasonable.
             # This ensures that if run on different sized machines, the test will remain the same.
@@ -150,7 +150,7 @@ RateLimitActor:
         Database: admin
         Operations:
         - OperationName: AdminCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand:
             setParameter: 1
             internalQueryStatsRateLimit: *RateLimitHz

--- a/src/phases/query/QueryStats.tmpl
+++ b/src/phases/query/QueryStats.tmpl
@@ -130,6 +130,7 @@ CacheSizeActor:
         Database: admin
         Operations:
         - OperationName: AdminCommand
+          ReportMetrics: False
           OperationCommand:
             # Configuring the queryStats store size to an arbitrary value which seems reasonable.
             # This ensures that if run on different sized machines, the test will remain the same.
@@ -149,6 +150,7 @@ RateLimitActor:
         Database: admin
         Operations:
         - OperationName: AdminCommand
+          ReportMetrics: False
           OperationCommand:
             setParameter: 1
             internalQueryStatsRateLimit: *RateLimitHz

--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -9,7 +9,7 @@ CreateIndex:
   Operation:
     OperationName: RunCommand
     OperationMetricsName: CreateIndex
-    ReportMetrics: False
+    ReportMetrics: false
     OperationCommand:
       createIndexes: &coll { ^Parameter: { Name: "Collection", Default: "Collection0" } }
       indexes:
@@ -74,7 +74,7 @@ DropIndex:
   Operation:
     OperationMetricsName: DropIndex
     OperationName: RunCommand
-    ReportMetrics: False
+    ReportMetrics: false
     OperationCommand:
       dropIndexes: { ^Parameter: { Name: "Collection", Default: "Collection0" } }
       index: { ^Parameter: { Name: "IndexName", Default: "" } }

--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -9,6 +9,7 @@ CreateIndex:
   Operation:
     OperationName: RunCommand
     OperationMetricsName: CreateIndex
+    ReportMetrics: False
     OperationCommand:
       createIndexes: &coll { ^Parameter: { Name: "Collection", Default: "Collection0" } }
       indexes:
@@ -73,6 +74,7 @@ DropIndex:
   Operation:
     OperationMetricsName: DropIndex
     OperationName: RunCommand
+    ReportMetrics: False
     OperationCommand:
       dropIndexes: { ^Parameter: { Name: "Collection", Default: "Collection0" } }
       index: { ^Parameter: { Name: "IndexName", Default: "" } }

--- a/src/phases/query/Views.yml
+++ b/src/phases/query/Views.yml
@@ -29,7 +29,7 @@ CreateIdentityView:
         Database: { ^Parameter: { Name: "Database", Default: test } }
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               {
                 create: { ^Parameter: { Name: "View", Default: Collection0 } },

--- a/src/phases/query/Views.yml
+++ b/src/phases/query/Views.yml
@@ -29,6 +29,7 @@ CreateIdentityView:
         Database: { ^Parameter: { Name: "Database", Default: test } }
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               {
                 create: { ^Parameter: { Name: "View", Default: Collection0 } },

--- a/src/phases/replication/startup/StartupPhasesTemplate.yml
+++ b/src/phases/replication/startup/StartupPhasesTemplate.yml
@@ -162,13 +162,13 @@ CreateIndexesTemplate:
         ThrowOnFailure: false
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               dropIndexes: {^Parameter: {Name: "collection", Default: Collection0}}
               # This will drop all non-essential indexes (_id and any shard key index remain)
               index: '*'
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: {^Parameter: {Name: "collection", Default: Collection0}}
               indexes: {^Parameter: {Name: "indexes", Default: *IndexesForCreateCmd}}

--- a/src/phases/replication/startup/StartupPhasesTemplate.yml
+++ b/src/phases/replication/startup/StartupPhasesTemplate.yml
@@ -162,11 +162,13 @@ CreateIndexesTemplate:
         ThrowOnFailure: false
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               dropIndexes: {^Parameter: {Name: "collection", Default: Collection0}}
               # This will drop all non-essential indexes (_id and any shard key index remain)
               index: '*'
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: {^Parameter: {Name: "collection", Default: Collection0}}
               indexes: {^Parameter: {Name: "indexes", Default: *IndexesForCreateCmd}}

--- a/src/workloads/basic/ReadOnlyMultiThreaded.yml
+++ b/src/workloads/basic/ReadOnlyMultiThreaded.yml
@@ -59,6 +59,7 @@ Actors:
         Collection: *Collection
         Operations:
           - OperationMetricsName: hello
+            ReportMetrics: False
             OperationName: RunCommand
             OperationIsQuiet: true
             OperationCommand:

--- a/src/workloads/basic/ReadOnlyMultiThreaded.yml
+++ b/src/workloads/basic/ReadOnlyMultiThreaded.yml
@@ -59,7 +59,7 @@ Actors:
         Collection: *Collection
         Operations:
           - OperationMetricsName: hello
-            ReportMetrics: False
+            ReportMetrics: false
             OperationName: RunCommand
             OperationIsQuiet: true
             OperationCommand:

--- a/src/workloads/contrib/qe_range_testing/templates/rc.yml.j2
+++ b/src/workloads/contrib/qe_range_testing/templates/rc.yml.j2
@@ -44,7 +44,7 @@ Clients:
 
 ActorTemplates:
 - TemplateName: InsertTemplate
-  Config: 
+  Config:
     Name: {^Parameter: {Name: "Name", Default: "unused"}}
     Type: CrudActor
     Threads: 1
@@ -73,7 +73,7 @@ ActorTemplates:
     Threads: 1
     Database: *encrypted_db
     ClientName: EncryptedPool
-    
+
     Phases: {% if not encrypt %}
     - *nop {% endif %}
     - *nop
@@ -118,27 +118,30 @@ Actors: {% if not encrypt %}
           Database: *encrypted_db
           Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *encrypted_coll
               indexes:
               - key: { tm_retail_tx: 1}
                 name: time_index
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *encrypted_coll
               indexes:
               - key: { age_hospitals: 1}
                 name: age_index
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *encrypted_coll
               indexes:
               - key: { bnk_bal: 1}
                 name: bal_index {% endif %}
   {% for t in range(insert_threads) %}
-  - ActorFromTemplate: 
+  - ActorFromTemplate:
       TemplateName: InsertTemplate
-      TemplateParameters: 
+      TemplateParameters:
         Name: InsertActor_Thread{{ t }}
         StartLine: {{t * document_count // insert_threads}}
     {% endfor %}

--- a/src/workloads/contrib/qe_range_testing/templates/rc.yml.j2
+++ b/src/workloads/contrib/qe_range_testing/templates/rc.yml.j2
@@ -118,21 +118,21 @@ Actors: {% if not encrypt %}
           Database: *encrypted_db
           Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *encrypted_coll
               indexes:
               - key: { tm_retail_tx: 1}
                 name: time_index
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *encrypted_coll
               indexes:
               - key: { age_hospitals: 1}
                 name: age_index
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *encrypted_coll
               indexes:

--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -118,6 +118,7 @@ Actors:
         Database: test
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               drop: myCollection
               writeConcern: {w: majority}

--- a/src/workloads/docs/ParallelInsert.yml
+++ b/src/workloads/docs/ParallelInsert.yml
@@ -118,7 +118,7 @@ Actors:
         Database: test
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               drop: myCollection
               writeConcern: {w: majority}

--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -17,7 +17,7 @@ Actors:
             OperationCommand:
               serverStatus: 1
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               insert: myCollection
               documents: [{name: {^RandomString: {length: {^RandomInt: {min: 2, max: 5}}}}, rating: 10, address: someAddress, cuisine: italian}]

--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -17,6 +17,7 @@ Actors:
             OperationCommand:
               serverStatus: 1
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               insert: myCollection
               documents: [{name: {^RandomString: {length: {^RandomInt: {min: 2, max: 5}}}}, rating: 10, address: someAddress, cuisine: italian}]

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -76,7 +76,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: *otherColl
                 indexes:
@@ -96,12 +96,12 @@ Actors:
           Database: admin
           Operations:
             - OperationName: AdminCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 setParameter: 1
                 throughputProbingMaxConcurrency: 32
             - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationName: RunCommand
               OperationCommand:
                 setParameter: 1

--- a/src/workloads/execution/BackgroundIndexConstruction.yml
+++ b/src/workloads/execution/BackgroundIndexConstruction.yml
@@ -76,6 +76,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: *otherColl
                 indexes:
@@ -95,10 +96,12 @@ Actors:
           Database: admin
           Operations:
             - OperationName: AdminCommand
+              ReportMetrics: False
               OperationCommand:
                 setParameter: 1
                 throughputProbingMaxConcurrency: 32
             - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
+              ReportMetrics: False
               OperationName: RunCommand
               OperationCommand:
                 setParameter: 1

--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -125,7 +125,7 @@ Actors:
         Database: admin
         Operations:
           - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationName: RunCommand
             OperationCommand:
               setParameter: 1

--- a/src/workloads/execution/CreateBigIndex.yml
+++ b/src/workloads/execution/CreateBigIndex.yml
@@ -125,6 +125,7 @@ Actors:
         Database: admin
         Operations:
           - OperationMetricsName: LimitIndexBuildMemoryUsageCommand
+            ReportMetrics: False
             OperationName: RunCommand
             OperationCommand:
               setParameter: 1

--- a/src/workloads/execution/MultiPlanning.yml
+++ b/src/workloads/execution/MultiPlanning.yml
@@ -16,6 +16,7 @@ Actors:
         Database: &Database test
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: &Collection Collection0
               indexes:
@@ -36,6 +37,7 @@ Actors:
         Database: *Database
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               planCacheClear: *Collection
       - *ClearPlanCacheRepeatedly

--- a/src/workloads/execution/MultiPlanning.yml
+++ b/src/workloads/execution/MultiPlanning.yml
@@ -16,7 +16,7 @@ Actors:
         Database: &Database test
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: &Collection Collection0
               indexes:
@@ -37,7 +37,7 @@ Actors:
         Database: *Database
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               planCacheClear: *Collection
       - *ClearPlanCacheRepeatedly

--- a/src/workloads/execution/SecondaryReadsGenny.yml
+++ b/src/workloads/execution/SecondaryReadsGenny.yml
@@ -170,6 +170,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: Collection0
 

--- a/src/workloads/execution/SecondaryReadsGenny.yml
+++ b/src/workloads/execution/SecondaryReadsGenny.yml
@@ -170,7 +170,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: Collection0
 

--- a/src/workloads/execution/UserAcquisition.yml
+++ b/src/workloads/execution/UserAcquisition.yml
@@ -28,7 +28,7 @@ Actors:
 
           # Simple leaf roles
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleA'
               roles: ['backup']
@@ -37,7 +37,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleB'
               roles: ['backup']
@@ -46,7 +46,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleC'
               roles: ['backup']
@@ -55,7 +55,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleD'
               roles: ['backup']
@@ -65,7 +65,7 @@ Actors:
 
           # First degree inheritors
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleAB'
               roles:
@@ -76,7 +76,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleBC'
               roles:
@@ -87,7 +87,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleCD'
               roles:
@@ -98,7 +98,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleDA'
               roles:
@@ -110,7 +110,7 @@ Actors:
 
           # 2nd degree inheritors
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleABCD'
               roles:
@@ -121,7 +121,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleBCDA'
               roles:
@@ -132,7 +132,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleCDAB'
               roles:
@@ -143,7 +143,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleDABC'
               roles:
@@ -155,7 +155,7 @@ Actors:
 
           # Composite of 2nd degree inheritors
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createRole: 'userAcquisitionRoleAll'
               roles:
@@ -168,7 +168,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createUser: 'testUserAcquisition'
               pwd: 'pwd'

--- a/src/workloads/execution/UserAcquisition.yml
+++ b/src/workloads/execution/UserAcquisition.yml
@@ -28,6 +28,7 @@ Actors:
 
           # Simple leaf roles
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleA'
               roles: ['backup']
@@ -36,6 +37,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleB'
               roles: ['backup']
@@ -44,6 +46,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleC'
               roles: ['backup']
@@ -52,6 +55,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleD'
               roles: ['backup']
@@ -61,6 +65,7 @@ Actors:
 
           # First degree inheritors
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleAB'
               roles:
@@ -71,6 +76,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleBC'
               roles:
@@ -81,6 +87,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleCD'
               roles:
@@ -91,6 +98,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleDA'
               roles:
@@ -102,6 +110,7 @@ Actors:
 
           # 2nd degree inheritors
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleABCD'
               roles:
@@ -112,6 +121,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleBCDA'
               roles:
@@ -122,6 +132,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleCDAB'
               roles:
@@ -132,6 +143,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleDABC'
               roles:
@@ -143,6 +155,7 @@ Actors:
 
           # Composite of 2nd degree inheritors
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createRole: 'userAcquisitionRoleAll'
               roles:
@@ -155,6 +168,7 @@ Actors:
                   actions: ['insert']
 
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createUser: 'testUserAcquisition'
               pwd: 'pwd'

--- a/src/workloads/networking/CommitLatencySingleUpdate.yml
+++ b/src/workloads/networking/CommitLatencySingleUpdate.yml
@@ -16,6 +16,7 @@ Actors:
       - Repeat: 1
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               insert: &Collection CommitLatencySingleUpdates
               documents: [{_id: 1, n: 0}]

--- a/src/workloads/networking/CommitLatencySingleUpdate.yml
+++ b/src/workloads/networking/CommitLatencySingleUpdate.yml
@@ -16,7 +16,7 @@ Actors:
       - Repeat: 1
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               insert: &Collection CommitLatencySingleUpdates
               documents: [{_id: 1, n: 0}]

--- a/src/workloads/query/CumulativeWindows.yml
+++ b/src/workloads/query/CumulativeWindows.yml
@@ -62,6 +62,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: *Collection
                 indexes: [{ key: { t: 1 }, name: "t" }]

--- a/src/workloads/query/CumulativeWindows.yml
+++ b/src/workloads/query/CumulativeWindows.yml
@@ -62,7 +62,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: *Collection
                 indexes: [{ key: { t: 1 }, name: "t" }]

--- a/src/workloads/query/CumulativeWindowsMultiAccums.yml
+++ b/src/workloads/query/CumulativeWindowsMultiAccums.yml
@@ -61,6 +61,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: *Collection
                 indexes: [{ key: { t: 1 }, name: "t" }]

--- a/src/workloads/query/CumulativeWindowsMultiAccums.yml
+++ b/src/workloads/query/CumulativeWindowsMultiAccums.yml
@@ -61,7 +61,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: *Collection
                 indexes: [{ key: { t: 1 }, name: "t" }]

--- a/src/workloads/query/DensifyFillCombo.yml
+++ b/src/workloads/query/DensifyFillCombo.yml
@@ -43,6 +43,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand:
             {
               create: &coll Collection0,
@@ -163,6 +164,7 @@ Actors:
         Operation:
           OperationMetricsName: internalQueryMaxAllowedDensifyDocs
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand:
             setParameter: 1
             internalQueryMaxAllowedDensifyDocs: 100000

--- a/src/workloads/query/DensifyFillCombo.yml
+++ b/src/workloads/query/DensifyFillCombo.yml
@@ -43,7 +43,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand:
             {
               create: &coll Collection0,
@@ -164,7 +164,7 @@ Actors:
         Operation:
           OperationMetricsName: internalQueryMaxAllowedDensifyDocs
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand:
             setParameter: 1
             internalQueryMaxAllowedDensifyDocs: 100000

--- a/src/workloads/query/DensifyTimeseriesCollection.yml
+++ b/src/workloads/query/DensifyTimeseriesCollection.yml
@@ -29,6 +29,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: false
           OperationCommand: {create: &coll Collection0, timeseries: {timeField: "timestamp", metaField: "numeric"}}
       - *Nop
       - *Nop

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -244,6 +244,7 @@ Actors:
         Database: *DB
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: Collection0
               indexes:

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -244,7 +244,7 @@ Actors:
         Database: *DB
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: Collection0
               indexes:

--- a/src/workloads/query/FillTimeseriesCollection.yml
+++ b/src/workloads/query/FillTimeseriesCollection.yml
@@ -21,7 +21,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand:
             {
               create: &coll Collection0,

--- a/src/workloads/query/FillTimeseriesCollection.yml
+++ b/src/workloads/query/FillTimeseriesCollection.yml
@@ -21,6 +21,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand:
             {
               create: &coll Collection0,

--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -34,6 +34,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand: {dropDatabase: 1}
 
   # Phase 1: Insert documents into the collection.

--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -34,7 +34,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand: {dropDatabase: 1}
 
   # Phase 1: Insert documents into the collection.

--- a/src/workloads/query/InWithVariedArraySize.yml
+++ b/src/workloads/query/InWithVariedArraySize.yml
@@ -185,6 +185,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: *Collection
                 indexes:

--- a/src/workloads/query/InWithVariedArraySize.yml
+++ b/src/workloads/query/InWithVariedArraySize.yml
@@ -185,7 +185,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: *Collection
                 indexes:

--- a/src/workloads/query/LookupColocatedData.yml
+++ b/src/workloads/query/LookupColocatedData.yml
@@ -160,7 +160,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: *UnshardedLocal
                 indexes:

--- a/src/workloads/query/LookupColocatedData.yml
+++ b/src/workloads/query/LookupColocatedData.yml
@@ -160,6 +160,7 @@ Actors:
           Database: *Database
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: *UnshardedLocal
                 indexes:

--- a/src/workloads/query/LookupNLJ.yml
+++ b/src/workloads/query/LookupNLJ.yml
@@ -254,7 +254,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..3
         Nop: true

--- a/src/workloads/query/LookupNLJ.yml
+++ b/src/workloads/query/LookupNLJ.yml
@@ -254,6 +254,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..3
         Nop: true

--- a/src/workloads/query/LookupOnly.yml
+++ b/src/workloads/query/LookupOnly.yml
@@ -291,7 +291,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..3
         Nop: true

--- a/src/workloads/query/LookupOnly.yml
+++ b/src/workloads/query/LookupOnly.yml
@@ -291,6 +291,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..3
         Nop: true

--- a/src/workloads/query/LookupSBEPushdown.yml
+++ b/src/workloads/query/LookupSBEPushdown.yml
@@ -242,6 +242,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..7
         Nop: true
@@ -397,22 +398,27 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *Foreign1500
               indexes: &IndexSpec [{key: {"int_key": 1}, name: "idx"}]
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *Foreign3500
               indexes: *IndexSpec
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *Foreign5500
               indexes: *IndexSpec
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *Foreign7500
               indexes: *IndexSpec
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *Foreign9500
               indexes: *IndexSpec

--- a/src/workloads/query/LookupSBEPushdown.yml
+++ b/src/workloads/query/LookupSBEPushdown.yml
@@ -242,7 +242,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..7
         Nop: true
@@ -398,27 +398,27 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *Foreign1500
               indexes: &IndexSpec [{key: {"int_key": 1}, name: "idx"}]
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *Foreign3500
               indexes: *IndexSpec
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *Foreign5500
               indexes: *IndexSpec
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *Foreign7500
               indexes: *IndexSpec
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *Foreign9500
               indexes: *IndexSpec

--- a/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/query/LookupSBEPushdownINLJMisc.yml
@@ -231,6 +231,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..4
         Nop: true
@@ -344,6 +345,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *Foreign
               indexes:

--- a/src/workloads/query/LookupSBEPushdownINLJMisc.yml
+++ b/src/workloads/query/LookupSBEPushdownINLJMisc.yml
@@ -231,7 +231,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..4
         Nop: true
@@ -345,7 +345,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *Foreign
               indexes:

--- a/src/workloads/query/LookupUnwind.yml
+++ b/src/workloads/query/LookupUnwind.yml
@@ -294,7 +294,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..3
         Nop: true

--- a/src/workloads/query/LookupUnwind.yml
+++ b/src/workloads/query/LookupUnwind.yml
@@ -294,6 +294,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
       - Phase: 1..3
         Nop: true

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -27,7 +27,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand: {create: &coll Collection0, timeseries: {timeField: "timestamp"}}
       - *Nop
       - *Nop

--- a/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
+++ b/src/workloads/query/MetricSecondaryIndexTimeseriesCollection.yml
@@ -27,6 +27,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand: {create: &coll Collection0, timeseries: {timeField: "timestamp"}}
       - *Nop
       - *Nop

--- a/src/workloads/query/SetWindowFieldsUnbounded.yml
+++ b/src/workloads/query/SetWindowFieldsUnbounded.yml
@@ -50,7 +50,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               update: Collection0
               updates:
@@ -74,7 +74,7 @@ Actors:
                   },
                 ]
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: Collection0
               indexes:

--- a/src/workloads/query/SetWindowFieldsUnbounded.yml
+++ b/src/workloads/query/SetWindowFieldsUnbounded.yml
@@ -50,6 +50,7 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               update: Collection0
               updates:
@@ -73,6 +74,7 @@ Actors:
                   },
                 ]
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: Collection0
               indexes:

--- a/src/workloads/query/TimeSeries2dsphere.yml
+++ b/src/workloads/query/TimeSeries2dsphere.yml
@@ -66,7 +66,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand: {
             # We have to call the collection 'Collection0' because that's the name that Loader
             # chooses implicitly.

--- a/src/workloads/query/TimeSeries2dsphere.yml
+++ b/src/workloads/query/TimeSeries2dsphere.yml
@@ -66,6 +66,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand: {
             # We have to call the collection 'Collection0' because that's the name that Loader
             # chooses implicitly.

--- a/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
+++ b/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
@@ -44,6 +44,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeSeriesCollection
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {create: *Collection, timeseries: {timeField: "time", metaField: "symbol", granularity: "seconds"}}
 
   - Name: DropAllIndexesUponCreation
@@ -59,6 +60,7 @@ Actors:
           Operation:
             OperationMetricsName: DropAllIndexesUponCreation
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               dropIndexes: *Collection
               index: "*"

--- a/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
+++ b/src/workloads/query/TimeSeriesGroupStagesOnComputedFields.yml
@@ -44,7 +44,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeSeriesCollection
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {create: *Collection, timeseries: {timeField: "time", metaField: "symbol", granularity: "seconds"}}
 
   - Name: DropAllIndexesUponCreation
@@ -60,7 +60,7 @@ Actors:
           Operation:
             OperationMetricsName: DropAllIndexesUponCreation
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               dropIndexes: *Collection
               index: "*"

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -126,7 +126,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeSeriesCollection
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {create: *coll, timeseries: {timeField: "timestamp", metaField: "metadata"}}
 
   - Name: InsertData

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -126,6 +126,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeSeriesCollection
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {create: *coll, timeseries: {timeField: "timestamp", metaField: "metadata"}}
 
   - Name: InsertData

--- a/src/workloads/query/TimeSeriesSort.yml
+++ b/src/workloads/query/TimeSeriesSort.yml
@@ -33,14 +33,14 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand: {create: &coll Collection0, timeseries: {timeField: "t", metaField: "m"}}
       - Repeat: 1 # Phase 1
         Database: *db
         Operations:
           - OperationMetricsName: DropAllIndexesUponCreation
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               dropIndexes: *coll
               index: "*"
@@ -78,7 +78,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateDescendingTimeIndex
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *coll
               indexes:

--- a/src/workloads/query/TimeSeriesSort.yml
+++ b/src/workloads/query/TimeSeriesSort.yml
@@ -33,12 +33,14 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand: {create: &coll Collection0, timeseries: {timeField: "t", metaField: "m"}}
       - Repeat: 1 # Phase 1
         Database: *db
         Operations:
           - OperationMetricsName: DropAllIndexesUponCreation
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               dropIndexes: *coll
               index: "*"
@@ -76,6 +78,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateDescendingTimeIndex
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *coll
               indexes:

--- a/src/workloads/query/TimeSeriesSortCompound.yml
+++ b/src/workloads/query/TimeSeriesSortCompound.yml
@@ -26,6 +26,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand: {create: *coll, timeseries: {timeField: "t", metaField: "m"}}
       - *Nop
       - *Nop
@@ -36,6 +37,7 @@ Actors:
         Database: test
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               drop: *coll
 

--- a/src/workloads/query/TimeSeriesSortCompound.yml
+++ b/src/workloads/query/TimeSeriesSortCompound.yml
@@ -26,7 +26,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand: {create: *coll, timeseries: {timeField: "t", metaField: "m"}}
       - *Nop
       - *Nop
@@ -37,7 +37,7 @@ Actors:
         Database: test
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               drop: *coll
 

--- a/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
+++ b/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
@@ -33,7 +33,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand: {create: *coll, timeseries: {timeField: "t", metaField: "m"}}
       - *Nop
       - *Nop

--- a/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
+++ b/src/workloads/query/TimeSeriesSortOverlappingBuckets.yml
@@ -33,6 +33,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand: {create: *coll, timeseries: {timeField: "t", metaField: "m"}}
       - *Nop
       - *Nop

--- a/src/workloads/query/TimeSeriesTelemetry.yml
+++ b/src/workloads/query/TimeSeriesTelemetry.yml
@@ -42,6 +42,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand:
             {
               create: *coll,

--- a/src/workloads/query/TimeSeriesTelemetry.yml
+++ b/src/workloads/query/TimeSeriesTelemetry.yml
@@ -42,7 +42,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand:
             {
               create: *coll,

--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -54,6 +54,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeseriesCollection
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               {
                 create: *collection,

--- a/src/workloads/query/TimeseriesBlockProcessing.yml
+++ b/src/workloads/query/TimeseriesBlockProcessing.yml
@@ -54,7 +54,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeseriesCollection
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               {
                 create: *collection,

--- a/src/workloads/query/TimeseriesCount.yml
+++ b/src/workloads/query/TimeseriesCount.yml
@@ -49,6 +49,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeseriesCollection
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               {
                 create: *collection,

--- a/src/workloads/query/TimeseriesCount.yml
+++ b/src/workloads/query/TimeseriesCount.yml
@@ -49,7 +49,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeseriesCollection
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               {
                 create: *collection,

--- a/src/workloads/query/TimeseriesEnum.yml
+++ b/src/workloads/query/TimeseriesEnum.yml
@@ -62,7 +62,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeseriesCollection
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               {
                 create: *tsCollection,

--- a/src/workloads/query/TimeseriesEnum.yml
+++ b/src/workloads/query/TimeseriesEnum.yml
@@ -62,6 +62,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeseriesCollection
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               {
                 create: *tsCollection,

--- a/src/workloads/query/TimeseriesStressUnpacking.yml
+++ b/src/workloads/query/TimeseriesStressUnpacking.yml
@@ -131,6 +131,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeSeriesCollection
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               { create: *collection, timeseries: { timeField: "time" } }
 

--- a/src/workloads/query/TimeseriesStressUnpacking.yml
+++ b/src/workloads/query/TimeseriesStressUnpacking.yml
@@ -131,7 +131,7 @@ Actors:
           Operation:
             OperationMetricsName: CreateTimeSeriesCollection
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               { create: *collection, timeseries: { timeField: "time" } }
 

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -48,19 +48,19 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               aggregate: Collection0
               pipeline: [{ $out: "Collection0_copy" }]
               cursor: { batchSize: *batchSize }
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               aggregate: Collection1
               pipeline: [{ $out: "Collection1_copy" }]
               cursor: { batchSize: *batchSize }
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               aggregate: Collection0
               pipeline:
@@ -74,7 +74,7 @@ Actors:
                 ]
               cursor: { batchSize: *batchSize }
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               aggregate: Collection0
               pipeline:
@@ -88,7 +88,7 @@ Actors:
                 ]
               cursor: { batchSize: *batchSize }
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               aggregate: Collection1
               pipeline:

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -48,16 +48,19 @@ Actors:
         Database: *db
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               aggregate: Collection0
               pipeline: [{ $out: "Collection0_copy" }]
               cursor: { batchSize: *batchSize }
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               aggregate: Collection1
               pipeline: [{ $out: "Collection1_copy" }]
               cursor: { batchSize: *batchSize }
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               aggregate: Collection0
               pipeline:
@@ -71,6 +74,7 @@ Actors:
                 ]
               cursor: { batchSize: *batchSize }
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               aggregate: Collection0
               pipeline:
@@ -84,6 +88,7 @@ Actors:
                 ]
               cursor: { batchSize: *batchSize }
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               aggregate: Collection1
               pipeline:

--- a/src/workloads/query/multiplanner/BlockingSort.yml
+++ b/src/workloads/query/multiplanner/BlockingSort.yml
@@ -31,6 +31,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/BlockingSort.yml
+++ b/src/workloads/query/multiplanner/BlockingSort.yml
@@ -31,7 +31,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -42,9 +42,11 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 create: *coll
                 clusteredIndex: { "key": { _id: 1 }, "unique": true }

--- a/src/workloads/query/multiplanner/ClusteredCollection.yml
+++ b/src/workloads/query/multiplanner/ClusteredCollection.yml
@@ -42,11 +42,11 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 create: *coll
                 clusteredIndex: { "key": { _id: 1 }, "unique": true }

--- a/src/workloads/query/multiplanner/CompoundIndexes.yml
+++ b/src/workloads/query/multiplanner/CompoundIndexes.yml
@@ -46,7 +46,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/CompoundIndexes.yml
+++ b/src/workloads/query/multiplanner/CompoundIndexes.yml
@@ -46,6 +46,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+++ b/src/workloads/query/multiplanner/ManyIndexSeeks.yml
@@ -40,7 +40,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/ManyIndexSeeks.yml
+++ b/src/workloads/query/multiplanner/ManyIndexSeeks.yml
@@ -40,6 +40,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+++ b/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
@@ -30,7 +30,7 @@ Actors:
           Database: &Database test
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: &Collection Collection0
                 indexes:

--- a/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
+++ b/src/workloads/query/multiplanner/MultiPlanningReadsALotOfData.yml
@@ -30,6 +30,7 @@ Actors:
           Database: &Database test
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: &Collection Collection0
                 indexes:

--- a/src/workloads/query/multiplanner/MultikeyIndexes.yml
+++ b/src/workloads/query/multiplanner/MultikeyIndexes.yml
@@ -36,7 +36,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/MultikeyIndexes.yml
+++ b/src/workloads/query/multiplanner/MultikeyIndexes.yml
@@ -36,6 +36,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+++ b/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
@@ -33,7 +33,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
+++ b/src/workloads/query/multiplanner/MultiplannerWithGroup.yml
@@ -33,6 +33,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/NoResults.yml
+++ b/src/workloads/query/multiplanner/NoResults.yml
@@ -27,7 +27,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/NoResults.yml
+++ b/src/workloads/query/multiplanner/NoResults.yml
@@ -27,6 +27,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/NoSuchField.yml
+++ b/src/workloads/query/multiplanner/NoSuchField.yml
@@ -40,7 +40,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/NoSuchField.yml
+++ b/src/workloads/query/multiplanner/NoSuchField.yml
@@ -40,6 +40,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+++ b/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
@@ -38,7 +38,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
+++ b/src/workloads/query/multiplanner/NonBlockingVsBlocking.yml
@@ -38,6 +38,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/Simple.yml
+++ b/src/workloads/query/multiplanner/Simple.yml
@@ -41,7 +41,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/Simple.yml
+++ b/src/workloads/query/multiplanner/Simple.yml
@@ -41,6 +41,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/Subplanning.yml
+++ b/src/workloads/query/multiplanner/Subplanning.yml
@@ -39,6 +39,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/Subplanning.yml
+++ b/src/workloads/query/multiplanner/Subplanning.yml
@@ -39,7 +39,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/UseClusteredIndex.yml
+++ b/src/workloads/query/multiplanner/UseClusteredIndex.yml
@@ -41,9 +41,11 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 create: *coll
                 clusteredIndex: { "key": { _id: 1 }, "unique": true }

--- a/src/workloads/query/multiplanner/UseClusteredIndex.yml
+++ b/src/workloads/query/multiplanner/UseClusteredIndex.yml
@@ -41,11 +41,11 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 create: *coll
                 clusteredIndex: { "key": { _id: 1 }, "unique": true }

--- a/src/workloads/query/multiplanner/VariedSelectivity.yml
+++ b/src/workloads/query/multiplanner/VariedSelectivity.yml
@@ -43,6 +43,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/multiplanner/VariedSelectivity.yml
+++ b/src/workloads/query/multiplanner/VariedSelectivity.yml
@@ -43,7 +43,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
 

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -45,13 +45,13 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
             # Explicitly create the collection, to avoid a special case where empty collections
             # give you an EOF plan.
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 create: *coll
 

--- a/src/workloads/query/plan_cache/EmptyGroup.yml
+++ b/src/workloads/query/plan_cache/EmptyGroup.yml
@@ -45,11 +45,13 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
             # Explicitly create the collection, to avoid a special case where empty collections
             # give you an EOF plan.
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 create: *coll
 

--- a/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+++ b/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
@@ -33,13 +33,13 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 drop: *coll
             # Explicitly create the collection, to avoid a special case where empty collections
             # give you an EOF plan.
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 create: *coll
 

--- a/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
+++ b/src/workloads/query/plan_cache/MatchEqVaryingArray.yml
@@ -33,11 +33,13 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 drop: *coll
             # Explicitly create the collection, to avoid a special case where empty collections
             # give you an EOF plan.
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 create: *coll
 

--- a/src/workloads/scale/ContentionTTLDeletions.yml
+++ b/src/workloads/scale/ContentionTTLDeletions.yml
@@ -64,7 +64,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 createIndexes: &otherColl otherColl
                 indexes:

--- a/src/workloads/scale/ContentionTTLDeletions.yml
+++ b/src/workloads/scale/ContentionTTLDeletions.yml
@@ -64,6 +64,7 @@ Actors:
           Database: *db
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 createIndexes: &otherColl otherColl
                 indexes:

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -59,7 +59,7 @@ Actors:
           Database: *DBName
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand: {dropDatabase: 1}
 
   # Create collection.
@@ -75,7 +75,7 @@ Actors:
           Database: *DBName
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand:
                 # Loader default collection name.
                 create: Collection0

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -59,6 +59,7 @@ Actors:
           Database: *DBName
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand: {dropDatabase: 1}
 
   # Create collection.
@@ -74,6 +75,7 @@ Actors:
           Database: *DBName
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand:
                 # Loader default collection name.
                 create: Collection0

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -32,6 +32,7 @@ Actors:
         Database: &DB test
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
       - &Nop {Nop: true}
       - *Nop

--- a/src/workloads/scale/ManyUpdate.yml
+++ b/src/workloads/scale/ManyUpdate.yml
@@ -32,7 +32,7 @@ Actors:
         Database: &DB test
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
       - &Nop {Nop: true}
       - *Nop

--- a/src/workloads/scale/ReadMemoryStressUntilFailure.yml
+++ b/src/workloads/scale/ReadMemoryStressUntilFailure.yml
@@ -77,6 +77,7 @@ Actors:
           Database: *DBName
           Operations:
             - OperationName: RunCommand
+              ReportMetrics: False
               OperationCommand: {dropDatabase: 1}
 
   # Load 20,096 documents around 520KB as described by the structure in GlobalDefaults.

--- a/src/workloads/scale/ReadMemoryStressUntilFailure.yml
+++ b/src/workloads/scale/ReadMemoryStressUntilFailure.yml
@@ -77,7 +77,7 @@ Actors:
           Database: *DBName
           Operations:
             - OperationName: RunCommand
-              ReportMetrics: False
+              ReportMetrics: false
               OperationCommand: {dropDatabase: 1}
 
   # Load 20,096 documents around 520KB as described by the structure in GlobalDefaults.

--- a/src/workloads/scale/TimeSeriesSortScale.yml
+++ b/src/workloads/scale/TimeSeriesSortScale.yml
@@ -32,7 +32,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
-          ReportMetrics: False
+          ReportMetrics: false
           OperationCommand: {create: *coll, timeseries: {timeField: "t", metaField: "m"}}
       - *Nop
       - *Nop

--- a/src/workloads/scale/TimeSeriesSortScale.yml
+++ b/src/workloads/scale/TimeSeriesSortScale.yml
@@ -32,6 +32,7 @@ Actors:
         Operation:
           OperationMetricsName: CreateTimeSeriesCollection
           OperationName: RunCommand
+          ReportMetrics: False
           OperationCommand: {create: *coll, timeseries: {timeField: "t", metaField: "m"}}
       - *Nop
       - *Nop

--- a/src/workloads/scale/UniqueIndexStress.yml
+++ b/src/workloads/scale/UniqueIndexStress.yml
@@ -28,10 +28,10 @@ Actors:
         Collection: &coll test
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -55,10 +55,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -83,10 +83,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -112,10 +112,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -142,10 +142,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -173,10 +173,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -205,10 +205,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -238,10 +238,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               createIndexes: *coll
               indexes:

--- a/src/workloads/scale/UniqueIndexStress.yml
+++ b/src/workloads/scale/UniqueIndexStress.yml
@@ -28,8 +28,10 @@ Actors:
         Collection: &coll test
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -53,8 +55,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -79,8 +83,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -106,8 +112,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -134,8 +142,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -163,8 +173,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -193,8 +205,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *coll
               indexes:
@@ -224,8 +238,10 @@ Actors:
         Collection: *coll
         Operations:
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand: {dropDatabase: 1}
           - OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               createIndexes: *coll
               indexes:

--- a/src/workloads/streams/AddFields.yml
+++ b/src/workloads/streams/AddFields.yml
@@ -64,7 +64,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -125,7 +125,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/AddFields.yml
+++ b/src/workloads/streams/AddFields.yml
@@ -64,6 +64,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -124,6 +125,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/LargeHoppingWindow.yml
+++ b/src/workloads/streams/LargeHoppingWindow.yml
@@ -69,6 +69,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -110,6 +111,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/LargeHoppingWindow.yml
+++ b/src/workloads/streams/LargeHoppingWindow.yml
@@ -69,7 +69,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -111,7 +111,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/LargeTumblingWindow.yml
+++ b/src/workloads/streams/LargeTumblingWindow.yml
@@ -68,6 +68,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -109,6 +110,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/LargeTumblingWindow.yml
+++ b/src/workloads/streams/LargeTumblingWindow.yml
@@ -68,7 +68,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -110,7 +110,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/LargeWindowMixed.yml
+++ b/src/workloads/streams/LargeWindowMixed.yml
@@ -66,6 +66,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -97,6 +98,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/LargeWindowMixed.yml
+++ b/src/workloads/streams/LargeWindowMixed.yml
@@ -66,7 +66,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -98,7 +98,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/LargeWindowUniqueAndExistingKeys.yml
+++ b/src/workloads/streams/LargeWindowUniqueAndExistingKeys.yml
@@ -69,7 +69,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -104,7 +104,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/LargeWindowUniqueAndExistingKeys.yml
+++ b/src/workloads/streams/LargeWindowUniqueAndExistingKeys.yml
@@ -69,6 +69,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -103,6 +104,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/Passthrough.yml
+++ b/src/workloads/streams/Passthrough.yml
@@ -54,6 +54,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -74,6 +75,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/Passthrough.yml
+++ b/src/workloads/streams/Passthrough.yml
@@ -54,7 +54,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -75,7 +75,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/Passthrough_ChangeStreamSource.yml
+++ b/src/workloads/streams/Passthrough_ChangeStreamSource.yml
@@ -82,7 +82,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -104,7 +104,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/Passthrough_ChangeStreamSource.yml
+++ b/src/workloads/streams/Passthrough_ChangeStreamSource.yml
@@ -82,6 +82,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -103,6 +104,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/Passthrough_MongoSink.yml
+++ b/src/workloads/streams/Passthrough_MongoSink.yml
@@ -57,7 +57,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -85,7 +85,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/Passthrough_MongoSink.yml
+++ b/src/workloads/streams/Passthrough_MongoSink.yml
@@ -57,6 +57,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -84,6 +85,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/Search.yml
+++ b/src/workloads/streams/Search.yml
@@ -56,7 +56,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -86,7 +86,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/Search.yml
+++ b/src/workloads/streams/Search.yml
@@ -56,6 +56,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -85,6 +86,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/StreamsLookup.yml
+++ b/src/workloads/streams/StreamsLookup.yml
@@ -94,6 +94,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -145,6 +146,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/StreamsLookup.yml
+++ b/src/workloads/streams/StreamsLookup.yml
@@ -94,7 +94,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -146,7 +146,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/TopKPerWindow.yml
+++ b/src/workloads/streams/TopKPerWindow.yml
@@ -60,7 +60,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -89,7 +89,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
-            ReportMetrics: False
+            ReportMetrics: false
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId

--- a/src/workloads/streams/TopKPerWindow.yml
+++ b/src/workloads/streams/TopKPerWindow.yml
@@ -60,6 +60,7 @@ Actors:
         Operations:
           - OperationMetricsName: CreateStreamProcessor
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_startStreamProcessor: ""
               tenantId: *TenantId
@@ -88,6 +89,7 @@ Actors:
         Operations:
           - OperationMetricsName: Stop
             OperationName: RunCommand
+            ReportMetrics: False
             OperationCommand:
               streams_stopStreamProcessor: ""
               tenantId: *TenantId


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-11940](https://jira.mongodb.org/browse/DEVPROD-11940)

### What's Changed

This PR adds a `ReportMetrics ` flag to the RunCommand actor that is true by default. Additionally, I went through all uses of the RunCommand actor and labeled anything that was clearly not a measurement as `ReportMetrics: false`. This is usually indicated by Repeat: 1, and the command creating indexes/dropping index/creating collections or setting database parameters.

### Patch Testing Results
https://spruce.mongodb.com/version/670690abed45040007c733dc/
