### PR TITLE
DEVPROD-11966: Reinstate InsertRemove.yml for DSI commit queue

### DIFF
--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -4963,6 +4963,27 @@ TODO: TIG-3321
 
 
 
+## [InsertRemove](https://www.github.com/mongodb/genny/blob/master/src/workloads/scale/InsertRemove.yml)
+### Owner 
+Product Performance 
+
+
+### Support Channel
+[#performance](https://mongodb.enterprise.slack.com/archives/C0V3KSB52)
+
+
+### Description
+Demonstrate the InsertRemove actor. The InsertRemove actor is a simple actor that inserts and then
+removes the same document from a collection in a loop. Each instance of the actor uses a different
+document, indexed by an integer _id field. The actor records the latency of each insert and each
+remove.
+
+  
+
+### Keywords
+docs, actorInsertRemove, insert, delete 
+
+
 ## [LargeIndexedInsMatchingDocuments](https://www.github.com/mongodb/genny/blob/master/src/workloads/scale/LargeIndexedInsMatchingDocuments.yml)
 ### Owner 
 Product Performance 

--- a/src/workloads/scale/InsertRemove.yml
+++ b/src/workloads/scale/InsertRemove.yml
@@ -1,0 +1,37 @@
+SchemaVersion: 2018-07-01
+Owner: Product Performance
+Description: |
+  Demonstrate the InsertRemove actor. The InsertRemove actor is a simple actor that inserts and then
+  removes the same document from a collection in a loop. Each instance of the actor uses a different
+  document, indexed by an integer _id field. The actor records the latency of each insert and each
+  remove.
+
+Keywords:
+  - docs
+  - actorInsertRemove
+  - insert
+  - delete
+
+Actors:
+  - Name: InsertRemoveTest
+    Type: InsertRemove
+    Threads: 100
+    Phases:
+      - Collection: inserts
+        Duration: 3 minutes
+        Database: test
+
+AutoRun:
+  - When:
+      mongodb_setup:
+        $eq:
+          - atlas
+          - atlas-like-replica.2022-10
+          - replica
+          - standalone
+          - replica-1dayhistory-15gbwtcache
+          - replica-80-feature-flags
+          - replica-all-feature-flags
+      atlas_setup:
+        $neq:
+          - M30-repl


### PR DESCRIPTION
### What's changed

Reinstating "src/workloads/scale/InsertRemove.yml" as the task `mongo_perf_standalone_genny_InsertRemove` in the DSI merge queue requires this file.


### Testing
- [DSI patch](https://spruce.mongodb.com/version/67077a8b83beda0007c6898b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) with this PR.