### PR TITLE
DEVPROD-11908 Allow custom DSI repo in auto-tasks-local

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -522,7 +522,7 @@ functions:
           done
 
           # Regenerate the genny task files
-          ./run-genny auto-tasks-local --evergreen
+          ./run-genny auto-tasks-local --dsi-path modules/dsi --private-workloads-path modules/PrivateWorkloads
 
           # Validate that the files are identical
           for version in $versions; do
@@ -557,10 +557,12 @@ modules:
   - name: dsi
     owner: 10gen
     repo: dsi
+    prefix: modules
     branch: master
     auto_update: true
   - name: PrivateWorkloads
     owner: 10gen
     repo: PrivateWorkloads
+    prefix: modules
     branch: production
     auto_update: true

--- a/src/lamplib/src/genny/cli.py
+++ b/src/lamplib/src/genny/cli.py
@@ -672,16 +672,22 @@ def auto_tasks_all(ctx: click.Context, project_files: List[str], no_activate: bo
     help=("Regenerate the auto-generated evergreen task defintions."),
 )
 @click.option(
-    "--evergreen", default=False, is_flag=True, help="Don't check out repositories, since we are running in evergreen"
+    "--dsi-path", "dsi_path", default=None,
+    help="Use an existing DSI repo instead of cloning."
+)
+@click.option(
+    "--private-workloads-path", "private_workloads_path", default=None,
+    help="Use an existing PrivateWorkloads repo instead of cloning."
 )
 @click.pass_context
-def auto_tasks_local(ctx: click.Context, evergreen: bool):
+def auto_tasks_local(ctx: click.Context, dsi_path: Optional[str], private_workloads_path: Optional[str]):
     from genny.tasks import auto_tasks_local
     import sys
     print(sys.version)
     auto_tasks_local.main(
         workspace_root=ctx.obj["WORKSPACE_ROOT"],
-        running_in_evergreen=evergreen
+        dsi_path=dsi_path,
+        private_workloads_path=private_workloads_path,
     )
 
 


### PR DESCRIPTION
**Jira Ticket:** [DEVPROD-11908](https://jira.mongodb.org/browse/DEVPROD-11908)

### What's Changed
This PR allows users to configure a custom dsi/private_workloads repo when generating the genny tasks. This allows users to prepare fast-follow PRs for DSI changes that affect genny task scheduling.