### PR TITLE
 BF-35535 Remove ReportMetrics for the startup test

### DIFF
--- a/src/phases/replication/startup/StartupPhasesTemplate.yml
+++ b/src/phases/replication/startup/StartupPhasesTemplate.yml
@@ -162,13 +162,11 @@ CreateIndexesTemplate:
         ThrowOnFailure: false
         Operations:
           - OperationName: RunCommand
-            ReportMetrics: false
             OperationCommand:
               dropIndexes: {^Parameter: {Name: "collection", Default: Collection0}}
               # This will drop all non-essential indexes (_id and any shard key index remain)
               index: '*'
           - OperationName: RunCommand
-            ReportMetrics: false
             OperationCommand:
               createIndexes: {^Parameter: {Name: "collection", Default: Collection0}}
               indexes: {^Parameter: {Name: "indexes", Default: *IndexesForCreateCmd}}


### PR DESCRIPTION
**Jira Ticket:** [BF-35535](https://jira.mongodb.org/browse/BF-35535)

### What's Changed

There seems to be a weird interaction with the code to suppress metrics from the RunCommand actor, and this test that [runs multiple genny tests in a single test_control file](https://github.com/10gen/dsi/blob/afedce8e11e4d23abecb699ba1d4c09aeca13095/configurations/test_control/test_control.startup.yml#L14-L75). Since we are going to deprecate Genny soon, this PR disables the metric suppression for this test rather than digging into the root cause.

### Patch Testing Results
[Baseline](https://spruce.mongodb.com/version/6722391725ee1400074813dc/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[Without ReportMetrics](https://spruce.mongodb.com/task/sys_perf_perf_1_node_replSet_test_commands.arm.aws.2023_11_startup_patch_7ffadf503022cac4b40f141ca524592f37a0857d_67223930bf46bb0007422b49_24_10_30_13_49_57/trend-charts?execution=0&sortBy=STATUS&sortDir=ASC)