### PR TITLE
SERVER-96485 Increase shard key space

### DIFF
--- a/src/workloads/sharding/ReshardCollection.yml
+++ b/src/workloads/sharding/ReshardCollection.yml
@@ -34,7 +34,7 @@ GlobalDefaults:
   DocumentCount: &DocumentCount 100000 # for an approximate total of 1GB
 
   ShardKeyValueMin: &ShardKeyValueMin 1
-  ShardKeyValueMax: &ShardKeyValueMax 100
+  ShardKeyValueMax: &ShardKeyValueMax 10000
 
   ReadWriteOperations: &ReadWriteOperations
     - OperationName: findOne


### PR DESCRIPTION
**Jira Ticket:** [SERVER-96485](https://jira.mongodb.org/browse/SERVER-96485)

### Whats Changed

The value of numInitialChunks in reshardCollection changed as a result of [SERVER-92762](https://jira.mongodb.org/browse/SERVER-92762). This PR fixes an issue where there isn't enough cardinality to create required number of chunks by increasing shard key space to allow more values in sampling.

### Patch Testing Results

Patch: https://spruce.mongodb.com/version/67291fe9d282fc00076f9c70/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
