### PR TITLE
DEVPROD-13594 Adding an SLOG statement to the genny_runner to collect Python version info

### DIFF
--- a/src/lamplib/src/genny/tasks/genny_runner.py
+++ b/src/lamplib/src/genny/tasks/genny_runner.py
@@ -37,7 +37,7 @@ def main_genny_runner(
         # about what version of Python Genny is running
         # This will help inform whether upgrading packages that deprecate
         # use of Python versions that Genny supports will cause problems
-        SLOG.info(f"Genny is running the Python version: {sys.version}")
+        SLOG.info(f"Python version being used by Genny", python_version=f'"{sys.version}"')
 
         path = os.path.join(genny_repo_root, "dist", "bin", "genny_core")
         if not os.path.exists(path):

--- a/src/lamplib/src/genny/tasks/genny_runner.py
+++ b/src/lamplib/src/genny/tasks/genny_runner.py
@@ -1,9 +1,8 @@
-from typing import List, Optional
+from typing import Optional
 
 import structlog
-import tempfile
-import shutil
 import os
+import sys
 
 from genny.cmd_runner import run_command
 from genny.curator import poplar_grpc, calculate_rollups
@@ -34,6 +33,12 @@ def main_genny_runner(
         workspace_root=workspace_root,
         genny_repo_root=genny_repo_root,
     ):
+        # Inserting an Info log to gather some information 
+        # about what version of Python Genny is running
+        # This will help inform whether upgrading packages that deprecate
+        # use of Python versions that Genny supports will cause problems
+        SLOG.info(f"Genny is running the Python version: {sys.version}")
+
         path = os.path.join(genny_repo_root, "dist", "bin", "genny_core")
         if not os.path.exists(path):
             SLOG.error("genny_core not found. Run install first.", path=path)


### PR DESCRIPTION
### Whats Changed
As part of #1277 - upgrading the requests package drops support for Python 3.7. Lets check that Genny doesn't use 3.7 before accepting the upgrade. This should output a easy to discover log we can collate to see what versions of Python are being used by Genny.

Also removed some unused imports