### PR TITLE
Updating documentation and checks to use Python 3.8 as the earliest version allowed

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -79,7 +79,7 @@ sudo chown $USER /opt/data/mci
 
 ### All Operating Systems
 
-Make sure you have a C++17 compatible compiler and Python 3.7 or newer.
+Make sure you have a C++17 compatible compiler and Python 3.8 or newer.
 The ones from mongodbtoolchain v4 are safe bets if you're
 unsure. (mongodbtoolchain is internal to MongoDB).
 

--- a/run-genny
+++ b/run-genny
@@ -39,9 +39,9 @@ _print_diagnostics() {
 }
 
 
-if ! python3 -c 'import sys; sys.exit(1 if sys.version_info < (3, 7) else 0)' >/dev/null 2>&1; then
+if ! python3 -c 'import sys; sys.exit(1 if sys.version_info < (3, 8) else 0)' >/dev/null 2>&1; then
     actual_version=$(python3 -c 'import sys; print(sys.version)')
-    echo >&2 "You must have python3.7+ installed."
+    echo >&2 "You must have python3.8+ installed."
     echo >&2 "Detected version $actual_version."
     echo >&2 ""
     echo >&2 "On macOS you can run:"
@@ -71,7 +71,7 @@ if which pyenv >/dev/null 2>&1; then
         echo >&2 "This can be problematic. Will try to proceed, but the operation may fail."
         echo >&2 "If it does, please change your python version by doing something like this:"
         echo >&2 ""
-        echo >&2 "    echo '3.7.0' > ~/.python-version"
+        echo >&2 "    echo '3.8.0' > ~/.python-version"
         echo >&2 "    pyenv install"
         echo >&2 ""
         _print_diagnostics

--- a/src/lamplib/src/genny/tasks/pytest.py
+++ b/src/lamplib/src/genny/tasks/pytest.py
@@ -48,9 +48,9 @@ def _python_version_string():
 
 def _validate_python_installation():
     # Check Python version
-    if not sys.version_info >= (3, 7):
+    if not sys.version_info >= (3, 8):
         raise OSError(
-            f"Detected Python version {_python_version_string()} less than 3.7. Please delete "
+            f"Detected Python version {_python_version_string()} less than 3.8. Please delete "
             "the virtualenv and run lamp again."
         )
 


### PR DESCRIPTION
### Whats Changed
As discussed in #1277, the requests library drops support for Python 3.7. This version of Python is also EOL (for more than 12 months) and Genny does not explicitly rely on it, so this PR makes sure the docs are also up to date in that regard.