### PR TITLE
Use Mothra represented group Query Execution in QE workloads in genny

### DIFF
--- a/src/phases/query/AggregateExpressions.yml
+++ b/src/phases/query/AggregateExpressions.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This file defines a template to use in aggregation expression performance tests.
 

--- a/src/phases/query/FilterWithComplexLogicalExpression.yml
+++ b/src/phases/query/FilterWithComplexLogicalExpression.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload stresses the query execution engine by running queries with complex logical
   expressions that never match a document in the collection.

--- a/src/phases/query/GroupStagesOnComputedFields.yml
+++ b/src/phases/query/GroupStagesOnComputedFields.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This file defines templates to use in workloads exercising aggregate stages on computed
   time fields.

--- a/src/phases/query/IDHack.yml
+++ b/src/phases/query/IDHack.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   Defines common configurations for IDHack query workloads.
 

--- a/src/phases/query/MatchFilters.yml
+++ b/src/phases/query/MatchFilters.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests a set of filters in the match language. The actors below offer basic
   performance coverage for said filters.

--- a/src/phases/query/RepeatedPathTraversal.yml
+++ b/src/phases/query/RepeatedPathTraversal.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload stresses the query execution engine by running queries over a set of paths which
   share a common prefix. Crucially, these queries never match a document in the collection.

--- a/src/phases/query/RunLargeArithmeticOp.yml
+++ b/src/phases/query/RunLargeArithmeticOp.yml
@@ -1,6 +1,6 @@
 
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This phase template constructs an aggregation pipeline that multiplies together
   the provided arguments.

--- a/src/workloads/docs/CrudActorAggregate.yml
+++ b/src/workloads/docs/CrudActorAggregate.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload demonstrates using the CrudActor to run an aggregate command. Like find operations,
   genny will exhaust the cursor, measuring the initial aggregate command and all subsequent getMore

--- a/src/workloads/docs/SamplingLoader.yml
+++ b/src/workloads/docs/SamplingLoader.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload demonstrates using the SamplingLoader to expand the contents of a collection. This
   actor will take a random sample of a configurable size and re-insert the same documents, with the

--- a/src/workloads/query/AggregationsOutput.yml
+++ b/src/workloads/query/AggregationsOutput.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises both $out and $merge aggregation stages. It does this based on all combinations of the following:
     A. The src collection is sharded or unsharded.

--- a/src/workloads/query/ArrayTraversal.yml
+++ b/src/workloads/query/ArrayTraversal.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload stresses path traversal over nested arrays. Crucially, these queries never match
   a document in the collection.

--- a/src/workloads/query/CollScanComplexPredicateLarge.yml
+++ b/src/workloads/query/CollScanComplexPredicateLarge.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries with complex predicates of
   various shapes against a collection of 1M items.

--- a/src/workloads/query/CollScanComplexPredicateMedium.yml
+++ b/src/workloads/query/CollScanComplexPredicateMedium.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries with complex predicates of
   various shapes against a collection of 10K items.

--- a/src/workloads/query/CollScanComplexPredicateSmall.yml
+++ b/src/workloads/query/CollScanComplexPredicateSmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries with complex predicates of
   various shapes against a collection of 100 items.

--- a/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsLarge.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries against a collection of 1M
   documents with a large number of fields.

--- a/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsMedium.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries against a collection of 10K
   documents with a large number of fields.

--- a/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+OOwner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries against a collection of 100
   documents with a large number of fields.

--- a/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
+++ b/src/workloads/query/CollScanLargeNumberOfFieldsSmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-OOwner: Query Execution
+Owner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries against a collection of 100
   documents with a large number of fields.

--- a/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
+++ b/src/workloads/query/CollScanOnMixedDataTypesLarge.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload runs collscan queries on different data type alone. The queries are run against a
   collection of 1M documents.

--- a/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
+++ b/src/workloads/query/CollScanOnMixedDataTypesMedium.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload runs collscan queries on different data type alone. The queries are run against a
   collection of 10,000 documents.

--- a/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
+++ b/src/workloads/query/CollScanOnMixedDataTypesSmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload runs collscan queries on different data type alone. The queries are run against a
   collection of 100 documents.

--- a/src/workloads/query/CollScanPredicateSelectivityLarge.yml
+++ b/src/workloads/query/CollScanPredicateSelectivityLarge.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of conjunctive collection scan queries where the order of
   predicates matters due to selectivity of the predicates.

--- a/src/workloads/query/CollScanPredicateSelectivityMedium.yml
+++ b/src/workloads/query/CollScanPredicateSelectivityMedium.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of conjunctive collection scan queries where the order of
   predicates matters due to selectivity of the predicates.

--- a/src/workloads/query/CollScanPredicateSelectivitySmall.yml
+++ b/src/workloads/query/CollScanPredicateSelectivitySmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of conjunctive collection scan queries where the order of
   predicates matters due to selectivity of the predicates.

--- a/src/workloads/query/CollScanProjectionLarge.yml
+++ b/src/workloads/query/CollScanProjectionLarge.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload runs collscan queries with a large projection on around 20 fields against a
   collection of 1M documents.

--- a/src/workloads/query/CollScanProjectionMedium.yml
+++ b/src/workloads/query/CollScanProjectionMedium.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload runs collscan queries with a large projection on around 20 fields against a
   collection of 10,000 documents.

--- a/src/workloads/query/CollScanProjectionSmall.yml
+++ b/src/workloads/query/CollScanProjectionSmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload runs collscan queries with a large projection on around 20 fields against a
   collection of 100 documents.

--- a/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateLarge.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries with complex predicates
   that can be simplified by the optimizer against a large collection (1M documents).

--- a/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateMedium.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries with complex predicates
   that can be simplified by the optimizer against a collection of 10K documents.

--- a/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
+++ b/src/workloads/query/CollScanSimplifiablePredicateSmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of collection scan queries with complex predicates
   that can be simplified by the optimizer against a small collection (100 documents).

--- a/src/workloads/query/ExpressiveQueries.yml
+++ b/src/workloads/query/ExpressiveQueries.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload measures the performance of queries with rich filters. First, we issue a bunch of
   plain queries with rich filters to get the performance baseline. After that, we issue the same

--- a/src/workloads/query/ExternalSort.yml
+++ b/src/workloads/query/ExternalSort.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   Measures the performance of sort operations that spill to disk. Each benchmarked operation
   exercises the external sort algorithm by running a query that sorts a large collection without an

--- a/src/workloads/query/FilterWithComplexLogicalExpression.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpression.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload stresses the query execution engine by running queries with complex logical
   expressions that never match a document in the collection.

--- a/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpressionMedium.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload stresses the query execution engine by running queries with complex logical
   expressions that never match a document in the collection.

--- a/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
+++ b/src/workloads/query/FilterWithComplexLogicalExpressionSmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload stresses the query execution engine by running queries with complex logical
   expressions that never match a document in the collection.

--- a/src/workloads/query/GraphLookup.yml
+++ b/src/workloads/query/GraphLookup.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises the behavior of $graphLookup where either the local or foreign collection is
   sharded. When both collections are unsharded, the pipeline should be moved to the

--- a/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/GraphLookupWithOnlyUnshardedColls.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises the behavior of $graphLookup when both the local and foreign collections are
   unsharded. When one of the collections is sharded, the pipeline should be moved to the

--- a/src/workloads/query/GroupLikeDistinct.yml
+++ b/src/workloads/query/GroupLikeDistinct.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workloads covers $group queries with distinct-like semantics, meaning that only a single document
   is selected from each group. Depending on the details of the query and available indexes, the query might

--- a/src/workloads/query/GroupSpillToDisk.yml
+++ b/src/workloads/query/GroupSpillToDisk.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   Runs $group queries which are designed to require spilling to disk.
 Keywords:

--- a/src/workloads/query/GroupStagesOnComputedFields.yml
+++ b/src/workloads/query/GroupStagesOnComputedFields.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   The queries in this workload exercise group stage(s) after other stages ($addFields, $match, $sort)
   on computed date fields. The queries are motivated by the work on the SBE prefix pushdown project

--- a/src/workloads/query/Lookup.yml
+++ b/src/workloads/query/Lookup.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises the behavior of $lookup where either the local or foreign collection is
   sharded. When both collections are unsharded, the pipeline should be moved to the

--- a/src/workloads/query/LookupColocatedData.yml
+++ b/src/workloads/query/LookupColocatedData.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises the behavior of $lookup when the local and foreign collection data is
   co-located. In the queries below, for each local document on each shard, the $lookup subpipeline

--- a/src/workloads/query/LookupOnly.yml
+++ b/src/workloads/query/LookupOnly.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises the behavior of a $lookup-only pipeline. We use one "local" collection with
   20000 documents {_id, join_val}, and vary the "foreign" collection to test different document

--- a/src/workloads/query/LookupUnwind.yml
+++ b/src/workloads/query/LookupUnwind.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises the behavior of $lookup when followed by $unwind that immediately unwinds the
   lookup result array, which is optimized in the execution engine to avoid materializing this array

--- a/src/workloads/query/LookupWithOnlyUnshardedColls.yml
+++ b/src/workloads/query/LookupWithOnlyUnshardedColls.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises the behavior of $lookup when both the local and foreign collections are
   unsharded. When one of the collections is sharded, the pipeline should be moved to the

--- a/src/workloads/query/MatchFilters.yml
+++ b/src/workloads/query/MatchFilters.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests a set of filters in the match language. The actors below offer basic
   performance coverage for said filters.

--- a/src/workloads/query/MatchFiltersMedium.yml
+++ b/src/workloads/query/MatchFiltersMedium.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests a set of filters in the match language. The actors below offer basic
   performance coverage for said filters.

--- a/src/workloads/query/MatchFiltersSmall.yml
+++ b/src/workloads/query/MatchFiltersSmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests a set of filters in the match language. The actors below offer basic
   performance coverage for said filters.

--- a/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
+++ b/src/workloads/query/OneMDocCollection_LargeDocIntId.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests performance of IDHACK on queries with int _id. Since this workloads loads
   very large documents (average 10KB), you may need to free up disk space before running this

--- a/src/workloads/query/PipelineUpdate.yml
+++ b/src/workloads/query/PipelineUpdate.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload runs both classic and pipeline-based updates. It records and monitors the metrics of
   the two update types on documents of different sizes and shapes.

--- a/src/workloads/query/RepeatedPathTraversal.yml
+++ b/src/workloads/query/RepeatedPathTraversal.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload stresses the query execution engine by running queries over a set of paths which
   share a common prefix. Crucially, these queries never match a document in the collection.

--- a/src/workloads/query/RepeatedPathTraversalMedium.yml
+++ b/src/workloads/query/RepeatedPathTraversalMedium.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload stresses the query execution engine by running queries over a set of paths which
   share a common prefix. Crucially, these queries never match a document in the collection.

--- a/src/workloads/query/RepeatedPathTraversalSmall.yml
+++ b/src/workloads/query/RepeatedPathTraversalSmall.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload stresses the query execution engine by running queries over a set of paths which
   share a common prefix. Crucially, these queries never match a document in the collection.

--- a/src/workloads/query/ShardFilter.yml
+++ b/src/workloads/query/ShardFilter.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of queries which need to perform shard filtering.
 Keywords:

--- a/src/workloads/query/SortByExpression.yml
+++ b/src/workloads/query/SortByExpression.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises the scenario of sort by an expression with an $addFields preceding the $sort,
   followed by a $project removing that field. This workload is designed to avoid repeated materialization

--- a/src/workloads/query/TenMDocCollection_IntId.yml
+++ b/src/workloads/query/TenMDocCollection_IntId.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of IDHACK on queries with int _id versus non-IDHACK queries
   on regular int indices.

--- a/src/workloads/query/TenMDocCollection_IntId_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_Agg.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of IDHACK on queries with int _id, using the aggregation
   framework.

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of IDHACK on queries with int _id over a no-op identity view.
 

--- a/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
+++ b/src/workloads/query/TenMDocCollection_IntId_IdentityView_Agg.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests the performance of IDHACK on queries with int _id over a no-op identity view,
   using the aggregation framework.

--- a/src/workloads/query/TenMDocCollection_ObjectId.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests performance of IDHACK on queries with OID _id.
 

--- a/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
+++ b/src/workloads/query/TenMDocCollection_ObjectId_Sharded.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests performance of IDHACK on queries with OID _id on a sharded collection.
 

--- a/src/workloads/query/TenMDocCollection_SubDocId.yml
+++ b/src/workloads/query/TenMDocCollection_SubDocId.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload tests performance of IDHACK on queries with sub-document _id.
 

--- a/src/workloads/query/UnionWith.yml
+++ b/src/workloads/query/UnionWith.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload exercises '$unionWith' with two or more collections in multiple scenarios, including
   collections of high overlap, disjoint collections, multiple sequential unions, nested unions, and

--- a/src/workloads/query/UnwindGroup.yml
+++ b/src/workloads/query/UnwindGroup.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This test exercises a simple [$unwind, $group] aggregation pipeline to enable performance
   comparison between the Classic and SBE execution engines when pushing $unwind down to SBE is

--- a/src/workloads/query/UpdateLargeDocuments.yml
+++ b/src/workloads/query/UpdateLargeDocuments.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   This workload measures the performance of updating large documents in a replica set. First, it
   inserts large documents, each containing 100 nested objects with 1K fields inside of them. Then it

--- a/src/workloads/scale/CursorStormMongos.yml
+++ b/src/workloads/scale/CursorStormMongos.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   Used to test performance of the router under memory pressure caused by accumulating
   many heavy cursors. The workload is expected to fail due to host(s) being unreachable as a

--- a/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
+++ b/src/workloads/scale/UpdateSingleLargeDocumentWith10kThreads.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: "@mongodb/query"
+Owner: Query Execution
 Description: |
   The workload inserts a single large document, and tests concurrently updating the same document
   with many threads. This is intended to test the behavior of the server under heave memory pressure


### PR DESCRIPTION

**Jira Ticket:** [DEVPROD-6803](https://jira.mongodb.org/browse/DEVPROD-6803)

### Whats Changed

Updated all QE owned workloads using Mothra team "Query Execution"

### Patch Testing Results

Unable to complete ./run-genny lint-yaml due to issue with Mothra:
FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/genny/mothra/mothra/teams/rnd_dev_prod.yaml' 

After temporarily fixing src/lamplib/src/genny/tasks/mothra_service.py  (not part of this PR), lint-yaml runs with no error coming from the changed files. There are however uncomfoorming owner specifications in other files not part of this PR. eg:

The Owner field, Performance Infrastructure, in the workload at /home/ubuntu/genny/src/workloads/scale/LargeScaleSerial.yml does not match any team in the Mothra repository.

### Merging and Linting

We currently have a manual linting stage required if you're
adding/modifying a workload YAML document. Evergreen will verify that
this has been run.

```bash
./run-genny generate-docs
```

Once (1) your PR is approved by a CODEOWNER and (2) all your CI tests
pass, you can initiate a merge by clicking "Add to merge queue".
This kicks your PR into the [Github Merge Queue]. Github will
automatically squash-merge your commit after checking that Evergreen's
CI tasks have returned a successful status.

[Github Merge Queue]: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Merge-Queue

--->
