### PR TITLE
PERF-6583 Modify time_series_lastpoint to use different data set

### DIFF
--- a/evergreen/system_perf/5.0/genny_tasks.yml
+++ b/evergreen/system_perf/5.0/genny_tasks.yml
@@ -1706,17 +1706,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
-      test_control: time_series_lastpoint
-  name: time_series_lastpoint
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
       test_control: time_series_sort
   name: time_series_sort

--- a/evergreen/system_perf/6.0/genny_tasks.yml
+++ b/evergreen/system_perf/6.0/genny_tasks.yml
@@ -1806,17 +1806,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
-      test_control: time_series_lastpoint
-  name: time_series_lastpoint
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
       test_control: time_series_sort
   name: time_series_sort

--- a/evergreen/system_perf/7.0/genny_tasks.yml
+++ b/evergreen/system_perf/7.0/genny_tasks.yml
@@ -1864,17 +1864,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
-      test_control: time_series_lastpoint
-  name: time_series_lastpoint
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
       test_control: time_series_sort
   name: time_series_sort

--- a/evergreen/system_perf/8.0/genny_tasks.yml
+++ b/evergreen/system_perf/8.0/genny_tasks.yml
@@ -2132,17 +2132,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
-      test_control: time_series_lastpoint
-  name: time_series_lastpoint
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
       test_control: time_series_sort
   name: time_series_sort

--- a/evergreen/system_perf/master/genny_tasks.yml
+++ b/evergreen/system_perf/master/genny_tasks.yml
@@ -2359,17 +2359,6 @@ tasks:
       timeout_secs: 86400
   - func: f_run_dsi_workload
     vars:
-      auto_workload_path: src/genny/src/workloads/query/TimeSeriesLastpoint.yml
-      test_control: time_series_lastpoint
-  name: time_series_lastpoint
-  priority: 5
-- commands:
-  - command: timeout.update
-    params:
-      exec_timeout_secs: 86400
-      timeout_secs: 86400
-  - func: f_run_dsi_workload
-    vars:
       auto_workload_path: src/genny/src/workloads/query/TimeSeriesSort.yml
       test_control: time_series_sort
   name: time_series_sort

--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -39,7 +39,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "tags.hostname": {$regex: '/^host_(?![0-9]$)/' } } }, #hostname is from [host_0, host_99]
+            { $match: { "tags.hostname": {$regex: '^host_([1-9][0-9])$' } } }, # hostname is from [host_0, host_99], match host_10 through host_99
             *sortStage,
             *groupStage,
           ]
@@ -49,7 +49,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "tags.hostname": {$regex: 'host_(0|1|2|3|4|5|6|7|8|9)$'} } },
+            { $match: { "tags.hostname": {$regex: '^host_[0-9]$' } } }, # match hostname host_0 through host_9
             *sortStage,
             *groupStage,
           ]

--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -5,13 +5,13 @@ Description: |
 
 CreateIndex:
   Repeat: 1
-  Database: &db test
+  Database: &db cpu 
   Operation:
     OperationName: RunCommand
     OperationMetricsName: CreateIndex
     ReportMetrics: false
     OperationCommand:
-      createIndexes: &coll { ^Parameter: { Name: "Collection", Default: "Collection0" } }
+      createIndexes: &coll { ^Parameter: { Name: "Collection", Default: "point_data" } }
       indexes:
         - key: { ^Parameter: { Name: "IndexPattern", Default: {} } }
           name: { ^Parameter: { Name: "IndexName", Default: "" } }
@@ -39,7 +39,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "metadata.sensorId": { $gt: 10 } } },
+            { $match: { "tags.hostname": { $gt: 9 } } }, #hostname is from [0,99]
             *sortStage,
             *groupStage,
           ]
@@ -49,7 +49,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "metadata.sensorId": { $lt: 10 } } },
+            { $match: { "tags.hostname": { $lt: 10 } } },
             *sortStage,
             *groupStage,
           ]
@@ -62,7 +62,7 @@ RunLastPointQuery:
             {
               $group:
                 {
-                  _id: "$metadata.sensorId",
+                  _id: "$tags.hostname",
                   mostRecent: { ^Parameter: { Name: "GroupPatternTopOrBottom", Default: {} } }
                 },
             },
@@ -76,7 +76,7 @@ DropIndex:
     OperationName: RunCommand
     ReportMetrics: false
     OperationCommand:
-      dropIndexes: { ^Parameter: { Name: "Collection", Default: "Collection0" } }
+      dropIndexes: { ^Parameter: { Name: "Collection", Default: "point_data" } }
       index: { ^Parameter: { Name: "IndexName", Default: "" } }
 
 QuiesceActor:
@@ -86,7 +86,7 @@ QuiesceActor:
   Database: { ^Parameter: { Name: "Database", Default: admin } }
   Phases:
     OnlyActiveInPhases:
-      Active: { ^Parameter: { Name: "Active", Default: [3, 6, 9, 12, 15, 18, 21, 24] } }
+      Active: { ^Parameter: { Name: "Active", Default: [2, 3, 6, 9, 12, 15, 18, 21, 24] } }
       NopInPhasesUpTo: { ^Parameter: { Name: "MaxPhases", Default: -1 } }
       PhaseConfig:
         SleepBefore: 1 seconds

--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -39,7 +39,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "tags.hostname": { $gt: 9 } } }, #hostname is from [0,99]
+            { $match: { "tags.hostname": {$regex: '/^host_(?![0-9]$)/' } } }, #hostname is from [host_0, host_99]
             *sortStage,
             *groupStage,
           ]
@@ -49,7 +49,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "tags.hostname": { $lt: 10 } } },
+            { $match: { "tags.hostname": {$regex: 'host_(0|1|2|3|4|5|6|7|8|9)$'} } },
             *sortStage,
             *groupStage,
           ]
@@ -86,7 +86,7 @@ QuiesceActor:
   Database: { ^Parameter: { Name: "Database", Default: admin } }
   Phases:
     OnlyActiveInPhases:
-      Active: { ^Parameter: { Name: "Active", Default: [2, 3, 6, 9, 12, 15, 18, 21, 24] } }
+      Active: { ^Parameter: { Name: "Active", Default: [0, 3, 6, 9, 12, 15, 18, 21, 24] } }
       NopInPhasesUpTo: { ^Parameter: { Name: "MaxPhases", Default: -1 } }
       PhaseConfig:
         SleepBefore: 1 seconds

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -10,8 +10,8 @@ Description: |
     3. any of the above pipelines with a preceding match predicate on a meta field.
 
 # Parameters reused in multiple Actors.
-db: &db test
-coll: &coll Collection0
+db: &db cpu
+coll: &coll point_data
 phasePath: &phasePath ../../phases/query/TimeSeriesLastpoint.yml
 MaxPhases: &MaxPhases 26
 
@@ -23,38 +23,51 @@ LastpointQueryMetaAscTimeDesc: &LastpointQueryMetaAscTimeDesc
     Key: RunLastPointQuery
     Parameters:
       Collection: *coll
-      SortPattern: &sortPatternMetaAscTimeDesc {"metadata.sensorId": 1, timestamp: -1}
-      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$first: "$timestamp"}, temp: {$first: "$temp"}}
+      SortPattern: &sortPatternMetaAscTimeDesc {"tags.hostname": 1, "time": -1}
+      GroupPattern: &groupByFirst {
+                          _id: { "hostname": "$tags.hostname" },
+                          time: { $first: "$time" },
+                          measurement: { $first: "$measurement" },
+                        }
       GroupPatternTopOrBottom:
         $top:
           sortBy: *sortPatternMetaAscTimeDesc
-          output: &output {timestamp: "$timestamp", temp: "$temp"}
+          output: &output {timestamp: "$time", 
+                           measurement: "$measurement",                           
+          }
+
 LastpointQueryMetaDescTimeDesc: &LastpointQueryMetaDescTimeDesc
   LoadConfig:
     Path: *phasePath
     Key: RunLastPointQuery
     Parameters:
       Collection: *coll
-      SortPattern: &sortPatternMetaDescTimeDesc {"metadata.sensorId": -1, timestamp: -1}
-      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$first: "$timestamp"}, temp: {$first: "$temp"}}
+      SortPattern: &sortPatternMetaDescTimeDesc {"tags.hostname": -1, "time": -1}
+      GroupPattern: *groupByFirst
       GroupPatternTopOrBottom: {$top: {sortBy: *sortPatternMetaDescTimeDesc, output: *output}}
+
 LastpointQueryMetaDescTimeAsc: &LastpointQueryMetaDescTimeAsc
   LoadConfig:
     Path: *phasePath
     Key: RunLastPointQuery
     Parameters:
       Collection: *coll
-      SortPattern: &sortPatternMetaDescTimeAsc {"metadata.sensorId": -1, timestamp: 1}
-      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$last: "$timestamp"}, temp: {$last: "$temp"}}
+      SortPattern: &sortPatternMetaDescTimeAsc {"tags.hostname": -1, "time": 1}
+      GroupPattern: &groupByLast {
+                          _id: { "hostname": "$tags.hostname" },
+                          time: { $last: "$time" },
+                          measurement: { $last: "$measurement" },
+                        }
       GroupPatternTopOrBottom: {$bottom: {sortBy: *sortPatternMetaDescTimeAsc, output: *output}}
+
 LastpointQueryMetaAscTimeAsc: &LastpointQueryMetaAscTimeAsc
   LoadConfig:
     Path: *phasePath
     Key: RunLastPointQuery
     Parameters:
       Collection: *coll
-      SortPattern: &sortPatternMetaAscTimeAsc {"metadata.sensorId": 1, timestamp: 1}
-      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$last: "$timestamp"}, temp: {$last: "$temp"}}
+      SortPattern: &sortPatternMetaAscTimeAsc {"tags.hostname": 1, "time": 1}
+      GroupPattern: *groupByLast
       GroupPatternTopOrBottom: {$bottom: {sortBy: *sortPatternMetaAscTimeAsc, output: *output}}
 
 LastpointQueryMetaAscTimeDescRepeat100: &LastpointQueryMetaAscTimeDescRepeat100
@@ -65,7 +78,7 @@ LastpointQueryMetaAscTimeDescRepeat100: &LastpointQueryMetaAscTimeDescRepeat100
       Repeat: 100
       Collection: *coll
       SortPattern: *sortPatternMetaAscTimeDesc
-      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$first: "$timestamp"}, temp: {$first: "$temp"}}
+      GroupPattern: *groupByFirst 
       GroupPatternTopOrBottom: {$top: {sortBy: *sortPatternMetaAscTimeDesc, output: *output}}
 LastpointQueryMetaDescTimeDescRepeat100: &LastpointQueryMetaDescTimeDescRepeat100
   LoadConfig:
@@ -75,7 +88,7 @@ LastpointQueryMetaDescTimeDescRepeat100: &LastpointQueryMetaDescTimeDescRepeat10
       Repeat: 100
       Collection: *coll
       SortPattern: *sortPatternMetaDescTimeDesc
-      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$first: "$timestamp"}, temp: {$first: "$temp"}}
+      GroupPattern: *groupByFirst 
       GroupPatternTopOrBottom: {$top: {sortBy: *sortPatternMetaDescTimeDesc, output: *output}}
 LastpointQueryMetaDescTimeAscRepeat100: &LastpointQueryMetaDescTimeAscRepeat100
   LoadConfig:
@@ -85,7 +98,7 @@ LastpointQueryMetaDescTimeAscRepeat100: &LastpointQueryMetaDescTimeAscRepeat100
       Repeat: 100
       Collection: *coll
       SortPattern: *sortPatternMetaDescTimeAsc
-      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$last: "$timestamp"}, temp: {$last: "$temp"}}
+      GroupPattern: *groupByLast
       GroupPatternTopOrBottom: {$bottom: {sortBy: *sortPatternMetaDescTimeAsc, output: *output}}
 LastpointQueryMetaAscTimeAscRepeat100: &LastpointQueryMetaAscTimeAscRepeat100
   LoadConfig:
@@ -95,61 +108,42 @@ LastpointQueryMetaAscTimeAscRepeat100: &LastpointQueryMetaAscTimeAscRepeat100
       Repeat: 100
       Collection: *coll
       SortPattern: *sortPatternMetaAscTimeAsc
-      GroupPattern: {_id: "$metadata.sensorId", timestamp: {$last: "$timestamp"}, temp: {$last: "$temp"}}
+      GroupPattern: *groupByLast
       GroupPatternTopOrBottom: {$bottom: {sortBy: *sortPatternMetaAscTimeAsc, output: *output}}
 
 Actors:
-  - Name: DropTimeSeriesCollection
-    Type: CrudActor
-    Threads: 1
+  - Name: DropExistingIndexForMetaTime
+    Type: RunCommand
+    Database: *db
     Phases:
       OnlyActiveInPhases:
         Active: [0]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Repeat: 1
-          Database: *db
-          Collection: *coll
-          Operation:
-            OperationName: drop
+          LoadConfig:
+            Path: *phasePath
+            Key: DropIndex
+            Parameters:
+              Collection: *coll
+              IndexName: "tags_1_time_1"
 
-  - Name: CreateTimeSeriesCollection
+  - Name: DropExistingIndexForMetaHostNameTime
     Type: RunCommand
-    Threads: 1
+    Database: *db
     Phases:
       OnlyActiveInPhases:
         Active: [1]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
-          Repeat: 1
-          Database: *db
-          Operation:
-            OperationMetricsName: CreateTimeSeriesCollection
-            OperationName: RunCommand
-            ReportMetrics: false
-            OperationCommand: {create: *coll, timeseries: {timeField: "timestamp", metaField: "metadata"}}
+          LoadConfig:
+            Path: *phasePath
+            Key: DropIndex
+            Parameters:
+              Collection: *coll
+              IndexName: "tags.hostname_1_time_-1"
 
-  - Name: InsertData
-    Type: Loader
-    Threads: 1
-    Phases:
-      OnlyActiveInPhases:
-        Active: [2]
-        NopInPhasesUpTo: *MaxPhases
-        PhaseConfig:
-          Repeat: 1
-          Database: *db
-          Collection: *coll
-          Threads: 1
-          CollectionCount: 1
-          DocumentCount: 1_000_000
-          BatchSize: 100
-          Document:
-            timestamp: {^RandomDate: {min: "2022-01-01", max: "2022-03-01"}}
-            metadata: {sensorId: {^RandomInt: {min: 0, max: 100}}, type: "temperature"}
-            temp: {^RandomDouble: {min: -30, max: 120}}
 
-  # QuiesceActor will run in phase 3.
+  # QuiesceActor will run in phase 2 and 3.
 
   # Lastpoint query with a sort and group with meta subfield descending and time ascending, but no index.
   - Name: RunLastpointQueryWithMetaSubfieldAscendingTimeDescendingNoIndex

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -112,12 +112,14 @@ LastpointQueryMetaAscTimeAscRepeat100: &LastpointQueryMetaAscTimeAscRepeat100
       GroupPatternTopOrBottom: {$bottom: {sortBy: *sortPatternMetaAscTimeAsc, output: *output}}
 
 Actors:
+  # The data is already loaded into the collection from the dsi configuration.
+  # QuiesceActor will run for phase 0.
   - Name: DropExistingIndexForMetaTime
     Type: RunCommand
     Database: *db
     Phases:
       OnlyActiveInPhases:
-        Active: [0]
+        Active: [1]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
           LoadConfig:
@@ -132,7 +134,7 @@ Actors:
     Database: *db
     Phases:
       OnlyActiveInPhases:
-        Active: [1]
+        Active: [2]
         NopInPhasesUpTo: *MaxPhases
         PhaseConfig:
           LoadConfig:
@@ -143,8 +145,8 @@ Actors:
               IndexName: "tags.hostname_1_time_-1"
 
 
-  # QuiesceActor will run in phase 2 and 3.
-
+  # QuiesceActor will run in phase 3.
+  
   # Lastpoint query with a sort and group with meta subfield descending and time ascending, but no index.
   - Name: RunLastpointQueryWithMetaSubfieldAscendingTimeDescendingNoIndex
     Type: CrudActor
@@ -375,15 +377,5 @@ Actors:
       Path: *phasePath
       Key: QuiesceActor
       Parameters:
-        Active: [3, 6, 9, 12, 15, 18, 21, 24]
+        Active: [0, 3, 6, 9, 12, 15, 18, 21, 24]
         MaxPhases: *MaxPhases
-
-AutoRun:
-  - When:
-      branch_name:
-        $gte: v5.3
-      mongodb_setup:
-        $eq:
-          - replica
-          - replica-80-feature-flags
-          - replica-all-feature-flags

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -27,13 +27,13 @@ LastpointQueryMetaAscTimeDesc: &LastpointQueryMetaAscTimeDesc
       GroupPattern: &groupByFirst {
                           _id: { "hostname": "$tags.hostname" },
                           time: { $first: "$time" },
-                          measurement: { $first: "$measurement" },
+                          usage_system: { $first: "$usage_system" },
                         }
       GroupPatternTopOrBottom:
         $top:
           sortBy: *sortPatternMetaAscTimeDesc
           output: &output {timestamp: "$time", 
-                           measurement: "$measurement",                           
+                           usage_system: "$usage_system",                           
           }
 
 LastpointQueryMetaDescTimeDesc: &LastpointQueryMetaDescTimeDesc
@@ -56,7 +56,7 @@ LastpointQueryMetaDescTimeAsc: &LastpointQueryMetaDescTimeAsc
       GroupPattern: &groupByLast {
                           _id: { "hostname": "$tags.hostname" },
                           time: { $last: "$time" },
-                          measurement: { $last: "$measurement" },
+                          usage_system: { $last: "$usage_system" },
                         }
       GroupPatternTopOrBottom: {$bottom: {sortBy: *sortPatternMetaDescTimeAsc, output: *output}}
 


### PR DESCRIPTION
<!---
Thanks for submitting a PR to the Genny repo. Please include the
following fields (if relevant) prior to submitting your PR.
--->

**Jira Ticket:** [FOO-123](https://jira.mongodb.org/browse/FOO-123)

### Whats Changed

<!---
High level explanation of changes
--->

### Patch Testing Results

<!---
Linting YAML files

If you update/add any YAML files under the workload and/or resmoke directory or
the evergreen file, please lint them first: src/lamplib/src/genny/tasks/

cd <genny_repo_root>        # replace `<genny_repo_root>` with the actual directory
./run-genny -v lint-yaml --format

Note: it will report 'invalid config: no such rule: "anchors"' if the yamllint
in the genny venv is too old. To fix this issue, please `rm -r genny_venv` and
then re-run the aforementioned lint command.

--->

<!---
If applicable, link a patch test showing code changes running
successfully
--->

<!---
### Workload Submission form

If applicable, only required if there is a new workload being added. The
form is [here].

[here]: https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform

### Merging and Linting

We currently have a manual linting stage required if you're
adding/modifying a workload YAML document. Evergreen will verify that
this has been run.

```bash
./run-genny generate-docs
```

Once (1) your PR is approved by a CODEOWNER and (2) all your CI tests
pass, you can initiate a merge by clicking "Add to merge queue".
This kicks your PR into the [Github Merge Queue]. Github will
automatically squash-merge your commit after checking that Evergreen's
CI tasks have returned a successful status.

[Github Merge Queue]: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Merge-Queue

--->
