### PR TITLE
PERF-6695 Fix timeseries lastpoint to use DISTINCT_SCAN

### DIFF
--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -4117,7 +4117,7 @@ timeseries, aggregate, sbe
 
 
 ### Description
-This test exercises the behavior of lastpoint type queries on time-series collections. The
+This test exercises the behavior of lastpoint-type queries on time-series collections. The
 currently supported lastpoint aggregate pipelines that are tested here include:
   1. a $sort on a meta field (both ascending and descending) and time (descending) and $group with _id on the meta
      field and only $first accumulators.

--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -251,9 +251,6 @@ given database. It takes numerous configuration options to adjust its behaviour.
 Performance Analysis
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 This is a demonstration of the CrudActor. It performs writes, updates, and drops
@@ -441,9 +438,6 @@ the other three states (also update operations).
 Performance Analysis
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 This workload provides an example of using the CrudActor with a transaction. The
@@ -511,9 +505,6 @@ collected to the specified metrics name (DefaultMetricsName as default)
 Performance Analysis
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 This workload exhibits various generators, performing insertions to show them off.
@@ -527,9 +518,6 @@ Follow the inline commentary to learn more about them.
 ### Owner
 Performance Analysis
 
-
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -549,9 +537,6 @@ the same base workload Generators.yml and varies the RandomSeed and database nam
 Performance Analysis
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 This workload shows off the actor template utility, which can be used to create a general
@@ -566,9 +551,6 @@ actor template which can then be instantiated with parameters substituted.
 Performance Analysis
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 This workload demonstrates the general workload substitution utility. You can use "LoadConfig"
@@ -582,9 +564,6 @@ to load anything, even other workloads.
 ### Owner
 Performance Analysis
 
-
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -688,9 +667,6 @@ it takes B to do this.
 ### Owner
 Performance Analysis
 
-
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -805,9 +781,6 @@ docs, loader
 ### Owner
 Performance Analysis
 
-
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -949,9 +922,6 @@ TODO: TIG-3321
 Performance Analysis
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 This workload demonstrates the quiesce actor, used to ensure stable
@@ -1005,9 +975,6 @@ This actor is intended to create a rolling window of collections.
 Performance Analysis
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 This workload demonstrates the RunCommand actor, which can be used
@@ -1021,9 +988,6 @@ to execute a command against the server.
 ### Owner
 Performance Analysis
 
-
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -5895,9 +5859,6 @@ scale, insertMany, find
 Performance Analysis
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 Does w:2 writes for a Phase followed
@@ -6137,9 +6098,6 @@ CrudActor, Loader, memory, scale, stress, updateOne, WriteConflict
 ### Owner
 Performance Analysis
 
-
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description

--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -4117,7 +4117,7 @@ timeseries, aggregate, sbe
 
 
 ### Description
-This test exercises the behavior of lastpoint-type queries on time-series collections. The
+This test exercises the behavior of lastpoint type queries on time-series collections. The
 currently supported lastpoint aggregate pipelines that are tested here include:
   1. a $sort on a meta field (both ascending and descending) and time (descending) and $group with _id on the meta
      field and only $first accumulators.

--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -39,7 +39,6 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            # hostname is from [host_0, host_99], match host_10 through host_99
             { $match: { "tags.hostname": { $nin: ["host_0", "host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } },
             *sortStage,
             *groupStage,
@@ -50,7 +49,6 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            # match hostname host_0 through host_9
             { $match: { "tags.hostname": { $in: ["host_0", "host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } },
             *sortStage,
             *groupStage,

--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -39,7 +39,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "tags.hostname": {$regex: '^host_([1-9][0-9])$' } } }, # hostname is from [host_0, host_99], match host_10 through host_99
+            { $match: { "tags.hostname": { $nin: ["host_0","host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } }, # hostname is from [host_0, host_99], match host_10 through host_99
             *sortStage,
             *groupStage,
           ]
@@ -49,7 +49,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "tags.hostname": {$regex: '^host_[0-9]$' } } }, # match hostname host_0 through host_9
+            { $match: { "tags.hostname": { $in: ["host_0","host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } },
             *sortStage,
             *groupStage,
           ]

--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -39,6 +39,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
+            # hostname is from [host_0, host_99], match host_10 through host_99
             { $match: { "tags.hostname": { $nin: ["host_0", "host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } },
             *sortStage,
             *groupStage,
@@ -49,6 +50,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
+            # match hostname host_0 through host_9
             { $match: { "tags.hostname": { $in: ["host_0", "host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } },
             *sortStage,
             *groupStage,

--- a/src/phases/query/TimeSeriesLastpoint.yml
+++ b/src/phases/query/TimeSeriesLastpoint.yml
@@ -39,7 +39,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "tags.hostname": { $nin: ["host_0","host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } }, # hostname is from [host_0, host_99], match host_10 through host_99
+            { $match: { "tags.hostname": { $nin: ["host_0", "host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } },
             *sortStage,
             *groupStage,
           ]
@@ -49,7 +49,7 @@ RunLastPointQuery:
       OperationCommand:
         Pipeline:
           [
-            { $match: { "tags.hostname": { $in: ["host_0","host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } },
+            { $match: { "tags.hostname": { $in: ["host_0", "host_1", "host_2", "host_3", "host_4", "host_5", "host_6", "host_7", "host_8", "host_9"] } } },
             *sortStage,
             *groupStage,
           ]

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -1,7 +1,7 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
 Description: |
-  This test exercises the behavior of lastpoint type queries on time-series collections. The
+  This test exercises the behavior of lastpoint-type queries on time-series collections. The
   currently supported lastpoint aggregate pipelines that are tested here include:
     1. a $sort on a meta field (both ascending and descending) and time (descending) and $group with _id on the meta
        field and only $first accumulators.
@@ -159,7 +159,7 @@ Actors:
 
   # Lastpoint query with a sort and group on meta subfield ascending and time descending.
   - Name: RunLastpointQueryWithMetaSubfieldAscendingTimeDescending
-    Type: CrudActor
+    Type: CrudActor CHECKED!!
     Database: *db
     Phases:
       OnlyActiveInPhases:
@@ -216,7 +216,7 @@ Actors:
 
   # Lastpoint query with a compound index with meta subfield descending and time descending.
   - Name: RunLastpointQueryWithMetaSubfieldDescendingTimeDescending
-    Type: CrudActor
+    Type: CrudActor #CHECKED
     Database: *db
     Phases:
       OnlyActiveInPhases:
@@ -273,7 +273,7 @@ Actors:
 
   # Lastpoint query with a compound index with meta subfield descending and time ascending.
   - Name: RunLastpointQueryWithMetaSubfieldDescendingTimeAscending
-    Type: CrudActor
+    Type: CrudActor #checked!
     Database: *db
     Phases:
       OnlyActiveInPhases:

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -1,7 +1,7 @@
 SchemaVersion: 2018-07-01
 Owner: "@mongodb/query"
 Description: |
-  This test exercises the behavior of lastpoint-type queries on time-series collections. The
+  This test exercises the behavior of lastpoint type queries on time-series collections. The
   currently supported lastpoint aggregate pipelines that are tested here include:
     1. a $sort on a meta field (both ascending and descending) and time (descending) and $group with _id on the meta
        field and only $first accumulators.

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -216,7 +216,7 @@ Actors:
 
   # Lastpoint query with a compound index with meta subfield descending and time descending.
   - Name: RunLastpointQueryWithMetaSubfieldDescendingTimeDescending
-    Type: CrudActor #CHECKED
+    Type: CrudActor
     Database: *db
     Phases:
       OnlyActiveInPhases:
@@ -273,7 +273,7 @@ Actors:
 
   # Lastpoint query with a compound index with meta subfield descending and time ascending.
   - Name: RunLastpointQueryWithMetaSubfieldDescendingTimeAscending
-    Type: CrudActor #checked!
+    Type: CrudActor
     Database: *db
     Phases:
       OnlyActiveInPhases:

--- a/src/workloads/query/TimeSeriesLastpoint.yml
+++ b/src/workloads/query/TimeSeriesLastpoint.yml
@@ -159,7 +159,7 @@ Actors:
 
   # Lastpoint query with a sort and group on meta subfield ascending and time descending.
   - Name: RunLastpointQueryWithMetaSubfieldAscendingTimeDescending
-    Type: CrudActor CHECKED!!
+    Type: CrudActor
     Database: *db
     Phases:
       OnlyActiveInPhases:


### PR DESCRIPTION
[PERF-6695](https://jira.mongodb.org/browse/PERF-6695)

### Whats Changed
The previous query used $regex which meant that the queries couldn't use DISTINCT_SCAN. Changing to $in/$nin allows the queries to use DISTINCT_SCAN, testing the optimizations we want. 
