### PR TITLE
PERF-5143 Remove unused threads configuration

### DIFF
--- a/docs/generated/phases.md
+++ b/docs/generated/phases.md
@@ -606,9 +606,6 @@ Common definitions to support the workloads in replication/startup.
 Performance Infrastructure
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 Common definitions to support the workloads in scale/LargeScale. See

--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -5713,9 +5713,6 @@ reads per second.
 Performance Infrastructure
 
 
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
-
 
 ### Description
 See LargeScaleSerial.yml for a general overview of what this workload does. The main
@@ -5733,9 +5730,6 @@ collections, oltp, update, query, scale
 ### Owner
 Performance Infrastructure
 
-
-### Support Channel
-[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -6135,9 +6129,6 @@ be run with the smallest MongoDB setup.
 ### Owner
 Atlas Serverless II
 
-
-### Support Channel
-[#ask-cloud-atlas-serverless](https://mongodb.enterprise.slack.com/archives/C050UC5MF1Q)
 
 
 ### Description

--- a/src/workloads/query/UpdateLargeDocuments.yml
+++ b/src/workloads/query/UpdateLargeDocuments.yml
@@ -82,7 +82,6 @@ Actors:
       - *Nop
       - *Nop
       - Repeat: 1000
-        Threads: 50
         Duration: 3 minutes
         Collection: Collection0
         Operations:


### PR DESCRIPTION
<!---
Thanks for submitting a PR to the Genny repo. Please include the
following fields (if relevant) prior to submitting your PR.
--->

**Jira Ticket:** [PERF-5143](https://jira.mongodb.org/browse/PERF-5143)

### Whats Changed

<!---
High level explanation of changes
--->

Removed `Threads: 50` annotation as it is not applied anyway.

### Patch Testing Results

<!---
Linting YAML files

If you update/add any YAML files under the workload and/or resmoke directory or
the evergreen file, please lint them first: src/lamplib/src/genny/tasks/

cd <genny_repo_root>        # replace `<genny_repo_root>` with the actual directory
./run-genny -v lint-yaml --format

Note: it will report 'invalid config: no such rule: "anchors"' if the yamllint
in the genny venv is too old. To fix this issue, please `rm -r genny_venv` and
then re-run the aforementioned lint command.

--->

<!---
If applicable, link a patch test showing code changes running
successfully
--->

<!---
### Workload Submission form

If applicable, only required if there is a new workload being added. The
form is [here].

[here]: https://docs.google.com/forms/d/e/1FAIpQLSf1oh23Ddo1khjLZMqZ9DHbRdObnpeH20PSXTBuXVg-7mxxTA/viewform

### Merging and Linting

We currently have a manual linting stage required if you're
adding/modifying a workload YAML document. Evergreen will verify that
this has been run.

```bash
./run-genny generate-docs
```

Once (1) your PR is approved by a CODEOWNER and (2) all your CI tests
pass, you can initiate a merge by clicking "Add to merge queue".
This kicks your PR into the [Github Merge Queue]. Github will
automatically squash-merge your commit after checking that Evergreen's
CI tasks have returned a successful status.

[Github Merge Queue]: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Merge-Queue

--->
