### PR TITLE
DEVPROD-20959 update toolchain url

### DIFF
--- a/docs/generated/phases.md
+++ b/docs/generated/phases.md
@@ -603,8 +603,11 @@ Common definitions to support the workloads in replication/startup.
 
 ## [DesignDocWorkloadPhases](https://www.github.com/mongodb/genny/blob/master/src/phases/scale/DesignDocWorkloadPhases.yml)
 ### Owner
-Performance Infrastructure
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description

--- a/docs/generated/workloads.md
+++ b/docs/generated/workloads.md
@@ -248,8 +248,11 @@ given database. It takes numerous configuration options to adjust its behaviour.
 
 ## [CrudActor](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/CrudActor.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -435,8 +438,11 @@ the other three states (also update operations).
 
 ## [CrudActorTransaction](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/CrudActorTransaction.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -502,8 +508,11 @@ collected to the specified metrics name (DefaultMetricsName as default)
 
 ## [Generators](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/Generators.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -516,8 +525,11 @@ Follow the inline commentary to learn more about them.
 
 ## [GeneratorsSeeded](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/GeneratorsSeeded.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -534,8 +546,11 @@ the same base workload Generators.yml and varies the RandomSeed and database nam
 
 ## [HelloWorld-ActorTemplate](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/HelloWorld-ActorTemplate.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -548,8 +563,11 @@ actor template which can then be instantiated with parameters substituted.
 
 ## [HelloWorld-LoadConfig](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/HelloWorld-LoadConfig.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -562,8 +580,11 @@ to load anything, even other workloads.
 
 ## [HelloWorld-MultiplePhases](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/HelloWorld-MultiplePhases.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -665,8 +686,11 @@ it takes B to do this.
 
 ## [HelloWorld](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/HelloWorld.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -779,8 +803,11 @@ docs, loader
 
 ## [LoggingActorExample](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/LoggingActorExample.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -919,8 +946,11 @@ TODO: TIG-3321
 
 ## [QuiesceActor](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/QuiesceActor.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -972,8 +1002,11 @@ This actor is intended to create a rolling window of collections.
 
 ## [RunCommand-Simple](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/RunCommand-Simple.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -986,8 +1019,11 @@ to execute a command against the server.
 
 ## [RunCommand](https://www.github.com/mongodb/genny/blob/master/src/workloads/docs/RunCommand.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -5710,8 +5746,11 @@ reads per second.
 
 ## [LargeScaleParallel](https://www.github.com/mongodb/genny/blob/master/src/workloads/scale/LargeScaleParallel.yml)
 ### Owner
-Performance Infrastructure
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -5728,8 +5767,11 @@ collections, oltp, update, query, scale
 
 ## [LargeScaleSerial](https://www.github.com/mongodb/genny/blob/master/src/workloads/scale/LargeScaleSerial.yml)
 ### Owner
-Performance Infrastructure
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -5850,8 +5892,11 @@ scale, insertMany, find
 
 ## [MixedWrites](https://www.github.com/mongodb/genny/blob/master/src/workloads/scale/MixedWrites.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -6090,8 +6135,11 @@ CrudActor, Loader, memory, scale, stress, updateOne, WriteConflict
 
 ## [GennyOverhead](https://www.github.com/mongodb/genny/blob/master/src/workloads/selftests/GennyOverhead.yml)
 ### Owner
-Performance Analysis
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description
@@ -6127,8 +6175,11 @@ be run with the smallest MongoDB setup.
 
 ## [IndexStress](https://www.github.com/mongodb/genny/blob/master/src/workloads/serverless/IndexStress.yml)
 ### Owner
-Atlas Serverless II
+DevProd Performance Infrastructure
 
+
+### Support Channel
+[#ask-devprod-performance](https://mongodb.enterprise.slack.com/archives/C01VD0LQZED)
 
 
 ### Description

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -107,21 +107,21 @@ buildvariants:
     tasks:
       - name: tg_compile
 
-  - name: macos-1100
-    display_name: macOS Big Sur x64
-    modules: [mongo, mothra]
-    run_on:
-      - macos-1100
-    tasks:
-      - name: tg_compile_and_test_with_server_on_macos
+  # - name: macos-1100
+  #   display_name: macOS Big Sur x64
+  #   modules: [mongo, mothra]
+  #   run_on:
+  #     - macos-1100
+  #   tasks:
+  #     - name: tg_compile_and_test_with_server_on_macos
 
-  - name: macos-1100-arm64
-    display_name: macOS Big Sur arm64
-    modules: [mongo, mothra]
-    run_on:
-      - macos-1100-arm64
-    tasks:
-      - name: tg_compile_and_test_with_server_on_macos
+  # - name: macos-1100-arm64
+  #   display_name: macOS Big Sur arm64
+  #   modules: [mongo, mothra]
+  #   run_on:
+  #     - macos-1100-arm64
+  #   tasks:
+  #     - name: tg_compile_and_test_with_server_on_macos
 
 ##                ⚡️ Tasks ⚡️
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -107,22 +107,6 @@ buildvariants:
     tasks:
       - name: tg_compile
 
-  # - name: macos-1100
-  #   display_name: macOS Big Sur x64
-  #   modules: [mongo, mothra]
-  #   run_on:
-  #     - macos-1100
-  #   tasks:
-  #     - name: tg_compile_and_test_with_server_on_macos
-
-  # - name: macos-1100-arm64
-  #   display_name: macOS Big Sur arm64
-  #   modules: [mongo, mothra]
-  #   run_on:
-  #     - macos-1100-arm64
-  #   tasks:
-  #     - name: tg_compile_and_test_with_server_on_macos
-
 ##                ⚡️ Tasks ⚡️
 
 tasks:

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -217,7 +217,7 @@ class ToolchainDownloader(Downloader):
         else:
             prefix = self._linux_distro
         return (
-            "https://s3.amazonaws.com/mciuploads/genny-toolchain/"
+            "https://s3.amazonaws.com/mciuploads/dsi/genny-toolchain/"
             "genny_toolchain_{}_{}/gennytoolchain.tgz".format(
                 prefix, ToolchainDownloader.TOOLCHAIN_BUILD_ID
             )

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -173,9 +173,8 @@ class ToolchainDownloader(Downloader):
     # https://spruce.mongodb.com/task/genny_toolchain_macos_1100_arm64_t_compile_patch_87457e6fec1d98f270c84d915f83bec53554ecee_6451d23fc9ec4441c9ce233d_23_05_03_03_17_20
     # =>                                                                         patch_87457e6fec1d98f270c84d915f83bec53554ecee_6451d23fc9ec4441c9ce233d_23_05_03_03_17_20
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
-    #
 
-    TOOLCHAIN_BUILD_ID = "fd7e48a1ad502b2ee383583a099e1207f04c67fc_24_08_16_15_36_08"
+    TOOLCHAIN_BUILD_ID = "patch_fd7e48a1ad502b2ee383583a099e1207f04c67fc_68a3fbdb696f5b0007289fd8_25_08_19_04_22_17"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 
     def __init__(

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -174,7 +174,7 @@ class ToolchainDownloader(Downloader):
     # =>                                                                         patch_87457e6fec1d98f270c84d915f83bec53554ecee_6451d23fc9ec4441c9ce233d_23_05_03_03_17_20
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
 
-    TOOLCHAIN_BUILD_ID = "patch_fd7e48a1ad502b2ee383583a099e1207f04c67fc_68a42aaa7dd03f00074d7623_25_08_19_07_41_58"
+    TOOLCHAIN_BUILD_ID = "patch_fd7e48a1ad502b2ee383583a099e1207f04c67fc_68a43309339f6a0007de7520_25_08_19_08_18_56"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 
     def __init__(

--- a/src/lamplib/src/genny/toolchain.py
+++ b/src/lamplib/src/genny/toolchain.py
@@ -174,7 +174,7 @@ class ToolchainDownloader(Downloader):
     # =>                                                                         patch_87457e6fec1d98f270c84d915f83bec53554ecee_6451d23fc9ec4441c9ce233d_23_05_03_03_17_20
     # If we were 💅 we could do the string logic here in python, but we're not that fancy.
 
-    TOOLCHAIN_BUILD_ID = "patch_fd7e48a1ad502b2ee383583a099e1207f04c67fc_68a3fbdb696f5b0007289fd8_25_08_19_04_22_17"
+    TOOLCHAIN_BUILD_ID = "patch_fd7e48a1ad502b2ee383583a099e1207f04c67fc_68a42aaa7dd03f00074d7623_25_08_19_07_41_58"
     TOOLCHAIN_GIT_HASH = TOOLCHAIN_BUILD_ID.split("_")[0]
 
     def __init__(

--- a/src/phases/scale/DesignDocWorkloadPhases.yml
+++ b/src/phases/scale/DesignDocWorkloadPhases.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Infrastructure
+Owner: DevProd Performance Infrastructure
 Description: |
   Common definitions to support the workloads in scale/LargeScale. See
   LargeScaleSerial.yml for a general overview of what the large-scale workloads are

--- a/src/workloads/docs/CrudActor.yml
+++ b/src/workloads/docs/CrudActor.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This is a demonstration of the CrudActor. It performs writes, updates, and drops
   to demonstrate the actor.

--- a/src/workloads/docs/CrudActorTransaction.yml
+++ b/src/workloads/docs/CrudActorTransaction.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This workload provides an example of using the CrudActor with a transaction. The
   behavior is largely the same, nesting operations inside the transaction block.

--- a/src/workloads/docs/Generators.yml
+++ b/src/workloads/docs/Generators.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This workload exhibits various generators, performing insertions to show them off.
   Follow the inline commentary to learn more about them.

--- a/src/workloads/docs/GeneratorsSeeded.yml
+++ b/src/workloads/docs/GeneratorsSeeded.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This workload demonstrates the usage of RandomSeed. Genny uses a PRNG and defaults to the
   same seed (see RNG_SEED_BASE from context.cpp). As a result every execution of the same workload

--- a/src/workloads/docs/HelloWorld-ActorTemplate.yml
+++ b/src/workloads/docs/HelloWorld-ActorTemplate.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This workload shows off the actor template utility, which can be used to create a general
   actor template which can then be instantiated with parameters substituted.

--- a/src/workloads/docs/HelloWorld-LoadConfig.yml
+++ b/src/workloads/docs/HelloWorld-LoadConfig.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This workload demonstrates the general workload substitution utility. You can use "LoadConfig"
   to load anything, even other workloads.

--- a/src/workloads/docs/HelloWorld-MultiplePhases.yml
+++ b/src/workloads/docs/HelloWorld-MultiplePhases.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 
 Description: |
   This workload illustrates how to think of Phases happening

--- a/src/workloads/docs/HelloWorld.yml
+++ b/src/workloads/docs/HelloWorld.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This is an introductory workload that shows how to write a workload in Genny.
   This workload writes a few messages to the screen.

--- a/src/workloads/docs/LoggingActorExample.yml
+++ b/src/workloads/docs/LoggingActorExample.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   The LoggingActor exists so DSI and Evergreen don't quit
   your workload for not outputting anything to stdout.

--- a/src/workloads/docs/QuiesceActor.yml
+++ b/src/workloads/docs/QuiesceActor.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This workload demonstrates the quiesce actor, used to ensure stable
   database state and reduce noise.

--- a/src/workloads/docs/RunCommand-Simple.yml
+++ b/src/workloads/docs/RunCommand-Simple.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This workload demonstrates the RunCommand actor, which can be used
   to execute a command against the server.

--- a/src/workloads/docs/RunCommand.yml
+++ b/src/workloads/docs/RunCommand.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   This workload demonstrates the RunCommand and AdminCommand actors, which can be used to
   run commands against a target server.

--- a/src/workloads/scale/LargeScaleParallel.yml
+++ b/src/workloads/scale/LargeScaleParallel.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Infrastructure
+Owner: DevProd Performance Infrastructure
 Description: |
   See LargeScaleSerial.yml for a general overview of what this workload does. The main
   difference here is that the update is parallel with the long-running query and

--- a/src/workloads/scale/LargeScaleSerial.yml
+++ b/src/workloads/scale/LargeScaleSerial.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Infrastructure
+Owner: DevProd Performance Infrastructure
 Description: |
   This config simulates a "typical" large-scale OLTP workload running in parallel with a
   slower analytical operation. This is a use-case intended to improve with the addition of

--- a/src/workloads/scale/MixedWrites.yml
+++ b/src/workloads/scale/MixedWrites.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 Description: |
   Does w:2 writes for a Phase followed
   by w:3 writes for a second Phase.

--- a/src/workloads/selftests/GennyOverhead.yml
+++ b/src/workloads/selftests/GennyOverhead.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Performance Analysis
+Owner: DevProd Performance Infrastructure
 
 Description: |
   This workload measures the overhead of Genny itself. There are 2 different

--- a/src/workloads/serverless/IndexStress.yml
+++ b/src/workloads/serverless/IndexStress.yml
@@ -1,5 +1,5 @@
 SchemaVersion: 2018-07-01
-Owner: Atlas Serverless II
+Owner: DevProd Performance Infrastructure
 Description: |
   This workload is an extension of scale/LargeIndexedIns.yml to run the workload
   on multiple serverless tenants, with some slight variations. The Clients are


### PR DESCRIPTION
The previous genny toolchain binaries were deleted, and access to the S3 prefix ~mciuploads/genny-toolchain~ was lost.

As a workaround, this PR points to newly rebuilt binaries that have been uploaded to a different S3 path.

changes
---------

+ The S3 bucket path for the genny toolchain is updated to include the `dsi` prefix.
+ The `TOOLCHAIN_BUILD_ID` is updated to correspond with the new binaries.
+ To pass linter checks, workload owners have been updated and `./run-genny generate-docs` was run.

